### PR TITLE
Helm charts refactor

### DIFF
--- a/.github/workflows/nucliadb_ingest.yml
+++ b/.github/workflows/nucliadb_ingest.yml
@@ -31,6 +31,13 @@ on:
       - "nucliadb_protos/python/**"
       - "nucliadb_cluster/nucliadb_cluster/**"
 
+env:
+  HASH: $(git rev-parse --short "$GITHUB_SHA")
+  BRANCH: ${GITHUB_REF##*/}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  CONTAINER_REGISTRY: eu.gcr.io/${{ secrets.PROJECT_ID }}
+  IMAGE_NAME: ingest
+
 jobs:
   # Job to run pre-checks
   pre-checks:
@@ -108,12 +115,6 @@ jobs:
     needs: tests
     if: github.event_name == 'push'
 
-    env:
-      HASH: $(git rev-parse --short "$GITHUB_SHA")
-      BRANCH: ${GITHUB_REF##*/}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/ingest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -132,27 +133,24 @@ jobs:
       # Build docker image
       - name: Image
         run: |-
-          docker build -t $IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.ingest
+          docker build -t $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.ingest
       - name: Tag
         run: |-
-          docker tag $IMAGE_NAME:$GITHUB_SHA $IMAGE_NAME:latest
+          docker tag $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA $CONTAINER_REGISTRY/$IMAGE_NAME:latest
       - name: Push sha
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:$GITHUB_SHA
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA
       - name: Push latest
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:latest
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:latest
 
   deploy:
     name: Deploy Helm chart and trigger internal CI
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push'
-
-    env:
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/ingest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/nucliadb_node.yml
+++ b/.github/workflows/nucliadb_node.yml
@@ -40,6 +40,12 @@ env:
   CARGO_TERM_COLOR: always
   API_VERSION: 1
   COMPONENT: nucliadb-node
+  HASH: $(git rev-parse --short "$GITHUB_SHA")
+  BRANCH: ${GITHUB_REF##*/}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  CONTAINER_REGISTRY: eu.gcr.io/${{ secrets.PROJECT_ID }}
+  IMAGE_NAME: node
+  IMAGE_NAME_SIDECAR: node_sidecar
 
 jobs:
   pre-checks-python:
@@ -193,12 +199,6 @@ jobs:
     needs: tests-rust
     if: github.event_name == 'push'
 
-    env:
-      HASH: $(git rev-parse --short "$GITHUB_SHA")
-      BRANCH: ${GITHUB_REF##*/}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/node
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -217,30 +217,24 @@ jobs:
       # Build docker image
       - name: Image
         run: |-
-          docker build -t $IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.node
+          docker build -t $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.node
       - name: Tag
         run: |-
-          docker tag $IMAGE_NAME:$GITHUB_SHA $IMAGE_NAME:latest
+          docker tag $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA $CONTAINER_REGISTRY/$IMAGE_NAME:latest
       - name: Push sha
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:$GITHUB_SHA
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA
       - name: Push latest
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:latest
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:latest
 
   build-python:
     name: Build image and push
     runs-on: ubuntu-latest
     needs: tests-python
     if: github.event_name == 'push'
-
-    env:
-      HASH: $(git rev-parse --short "$GITHUB_SHA")
-      BRANCH: ${GITHUB_REF##*/}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/node_sidecar
 
     steps:
       - name: Checkout repository
@@ -260,28 +254,24 @@ jobs:
       # Build docker image
       - name: Image
         run: |-
-          docker build -t $IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.node_sidecar
+          docker build -t $CONTAINER_REGISTRY/$IMAGE_NAME_SIDECAR:$GITHUB_SHA . -f Dockerfile.node_sidecar
       - name: Tag
         run: |-
-          docker tag $IMAGE_NAME:$GITHUB_SHA $IMAGE_NAME:latest
+          docker tag $CONTAINER_REGISTRY/$IMAGE_NAME_SIDECAR:$GITHUB_SHA $CONTAINER_REGISTRY/$IMAGE_NAME_SIDECAR:latest
       - name: Push sha
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:$GITHUB_SHA
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME_SIDECAR:$GITHUB_SHA
       - name: Push latest
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:latest
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME_SIDECAR:latest
 
   deploy:
     name: Deploy Helm chart and trigger internal CI
     runs-on: ubuntu-latest
     needs: [build-rust, build-python]
     if: github.event_name == 'push'
-
-    env:
-      IMAGE_NAME_NODE: eu.gcr.io/${{ secrets.PROJECT_ID }}/node
-      IMAGE_NAME_NODE_SIDECAR: eu.gcr.io/${{ secrets.PROJECT_ID }}/node_sidecar
 
     steps:
       - name: Checkout repository
@@ -290,8 +280,8 @@ jobs:
       - name: Set helm package image
         id: version_step
         run: |-
-          sed -i.bak "s#IMAGE_TO_REPLACE#$IMAGE_NAME_NODE:$GITHUB_SHA#" ./charts/nucliadb_node/values.yaml
-          sed -i.bak "s#IMAGE_SIDECAR_TO_REPLACE#$IMAGE_NAME_NODE_SIDECAR:$GITHUB_SHA#" ./charts/nucliadb_node/values.yaml
+          sed -i.bak "s#IMAGE_TO_REPLACE#$IMAGE_NAME:$GITHUB_SHA#" ./charts/nucliadb_node/values.yaml
+          sed -i.bak "s#IMAGE_SIDECAR_TO_REPLACE#$IMAGE_NAME_SIDECAR:$GITHUB_SHA#" ./charts/nucliadb_node/values.yaml
           VERSION=`cat nucliadb_node/VERSION`
           VERSION_SHA=$VERSION+$(echo $GITHUB_SHA | cut -c1-6)
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_node/Chart.yaml

--- a/.github/workflows/nucliadb_reader.yml
+++ b/.github/workflows/nucliadb_reader.yml
@@ -1,7 +1,5 @@
 name: nucliadb Reader (py)
-env:
-  API_VERSION: 1
-  COMPONENT: nucliadb-reader
+
 on:
   pull_request:
     branches:
@@ -26,6 +24,15 @@ on:
       - "nucliadb_ingest/**"
       - "nucliadb_models/**"
       - "Dockerfile.reader"
+
+env:
+  API_VERSION: 1
+  COMPONENT: nucliadb-reader
+  HASH: $(git rev-parse --short "$GITHUB_SHA")
+  BRANCH: ${GITHUB_REF##*/}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  IMAGE_NAME: reader
+  CONTAINER_REGISTRY: eu.gcr.io/${{ secrets.PROJECT_ID }}
 
 jobs:
   # Job to run pre-checks
@@ -113,12 +120,6 @@ jobs:
     needs: tests
     if: github.event_name == 'push'
 
-    env:
-      HASH: $(git rev-parse --short "$GITHUB_SHA")
-      BRANCH: ${GITHUB_REF##*/}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/reader
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -137,27 +138,24 @@ jobs:
       # Build docker image
       - name: Image
         run: |-
-          docker build -t $IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.reader
+          docker build -t $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.reader
       - name: Tag
         run: |-
-          docker tag $IMAGE_NAME:$GITHUB_SHA $IMAGE_NAME:latest
+          docker tag $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA $CONTAINER_REGISTRY/$IMAGE_NAME:latest
       - name: Push sha
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:$GITHUB_SHA
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA
       - name: Push latest
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:latest
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:latest
 
   deploy:
     name: Deploy Helm chart and trigger internal CI
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push'
-
-    env:
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/reader
 
     steps:
       - name: Checkout repository
@@ -197,9 +195,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     if: github.event_name == 'push'
-
-    env:
-      API_VERSION: 1
 
     steps:
       - name: Cache extracted docs

--- a/.github/workflows/nucliadb_search.yml
+++ b/.github/workflows/nucliadb_search.yml
@@ -1,7 +1,5 @@
 name: nucliadb Search (py)
-env:
-  API_VERSION: 1
-  COMPONENT: nucliadb-search
+
 on:
   pull_request:
     branches:
@@ -33,6 +31,15 @@ on:
       - "nucliadb_protos/python/**"
       - "nucliadb_cluster/nucliadb_cluster/**"
       - "nucliadb_models/**"
+
+env:
+  API_VERSION: 1
+  COMPONENT: nucliadb-search
+  HASH: $(git rev-parse --short "$GITHUB_SHA")
+  BRANCH: ${GITHUB_REF##*/}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  IMAGE_NAME: search
+  CONTAINER_REGISTRY: eu.gcr.io/${{ secrets.PROJECT_ID }}
 
 jobs:
   # Job to run pre-checks
@@ -132,12 +139,6 @@ jobs:
     needs: tests
     if: github.event_name == 'push'
 
-    env:
-      HASH: $(git rev-parse --short "$GITHUB_SHA")
-      BRANCH: ${GITHUB_REF##*/}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/search
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -156,27 +157,24 @@ jobs:
       # Build docker image
       - name: Image
         run: |-
-          docker build -t $IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.search
+          docker build -t $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.search
       - name: Tag
         run: |-
-          docker tag $IMAGE_NAME:$GITHUB_SHA $IMAGE_NAME:latest
+          docker tag $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA $CONTAINER_REGISTRY/$IMAGE_NAME:latest
       - name: Push sha
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:$GITHUB_SHA
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA
       - name: Push latest
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:latest
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:latest
 
   deploy:
     name: Deploy Helm chart and trigger internal CI
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push'
-
-    env:
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/search
 
     steps:
       - name: Checkout repository
@@ -216,9 +214,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     if: github.event_name == 'push'
-
-    env:
-      API_VERSION: 1
 
     steps:
       - name: Cache extracted docs

--- a/.github/workflows/nucliadb_writer.yml
+++ b/.github/workflows/nucliadb_writer.yml
@@ -1,7 +1,5 @@
 name: nucliadb Writer (py)
-env:
-  API_VERSION: 1
-  COMPONENT: nucliadb-writer
+
 on:
   pull_request:
     branches:
@@ -23,6 +21,15 @@ on:
       - "nucliadb_utils/**"
       - "nucliadb_models/**"
       - "Dockerfile.writer"
+
+env:
+  API_VERSION: 1
+  COMPONENT: nucliadb-writer
+  HASH: $(git rev-parse --short "$GITHUB_SHA")
+  BRANCH: ${GITHUB_REF##*/}
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  IMAGE_NAME: writer
+  CONTAINER_REGISTRY: eu.gcr.io/${{ secrets.PROJECT_ID }}
 
 jobs:
   # Job to run pre-checks
@@ -111,12 +118,6 @@ jobs:
     needs: tests
     if: github.event_name == 'push'
 
-    env:
-      HASH: $(git rev-parse --short "$GITHUB_SHA")
-      BRANCH: ${GITHUB_REF##*/}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/writer
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -135,27 +136,24 @@ jobs:
       # Build docker image
       - name: Image
         run: |-
-          docker build -t $IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.writer
+          docker build -t $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA . -f Dockerfile.writer
       - name: Tag
         run: |-
-          docker tag $IMAGE_NAME:$GITHUB_SHA $IMAGE_NAME:latest
+          docker tag $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA $CONTAINER_REGISTRY/$IMAGE_NAME:latest
       - name: Push sha
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:$GITHUB_SHA
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:$GITHUB_SHA
       - name: Push latest
         if: github.event_name == 'push'
         run: |-
-          docker push $IMAGE_NAME:latest
+          docker push $CONTAINER_REGISTRY/$IMAGE_NAME:latest
 
   deploy:
     name: Deploy Helm chart and trigger internal CI
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push'
-
-    env:
-      IMAGE_NAME: eu.gcr.io/${{ secrets.PROJECT_ID }}/writer
 
     steps:
       - name: Checkout repository
@@ -195,9 +193,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy
     if: github.event_name == 'push'
-
-    env:
-      API_VERSION: 1
 
     steps:
       - name: Cache extracted docs

--- a/charts/nucliadb_ingest/templates/_cronjob.tpl
+++ b/charts/nucliadb_ingest/templates/_cronjob.tpl
@@ -44,7 +44,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: "{{ .cronname }}"
-            image: "{{ .Values.image }}"
+            image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
             envFrom:
             - configMapRef:
                 name: nucliadb-config

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -50,7 +50,7 @@ spec:
       - name: ingest
         securityContext:
           privileged: true
-        image: {{ .Values.image }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         readinessProbe:
           exec:

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -11,6 +11,7 @@ nodeSelector: {}
 tolerations: []
 replicaCount: 2
 revisionHistoryLimit: 2
+containerRegistry: eu.gcr.io/stashify-218417
 imagePullPolicy: IfNotPresent
 image: IMAGE_TO_REPLACE
 debug: False

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -50,7 +50,7 @@ spec:
 {{- end }}
       containers:
       - name: sidecar
-        image: {{ .Values.image_sidecar }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image_sidecar }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         readinessProbe:
           exec:
@@ -83,7 +83,7 @@ spec:
       - name: writer
         securityContext:
           privileged: true
-        image: {{ .Values.image }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         readinessProbe:
           exec:
@@ -115,7 +115,7 @@ spec:
       - name: reader
         securityContext:
           privileged: true
-        image: {{ .Values.image }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         readinessProbe:
           exec:

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -10,6 +10,7 @@ replicaCount: 2
 revisionHistoryLimit: 2
 debug: False
 imagePullPolicy: IfNotPresent
+containerRegistry: eu.gcr.io/stashify-218417
 image: IMAGE_TO_REPLACE
 image_sidecar: IMAGE_SIDECAR_TO_REPLACE
 resources:

--- a/charts/nucliadb_reader/templates/reader.deploy.yaml
+++ b/charts/nucliadb_reader/templates/reader.deploy.yaml
@@ -37,7 +37,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: reader
-        image: {{ .Values.image }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         securityContext:
           privileged: true
         imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/charts/nucliadb_reader/values.yaml
+++ b/charts/nucliadb_reader/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 2
 revisionHistoryLimit: 2
 debug: False
 imagePullPolicy: IfNotPresent
+containerRegistry: eu.gcr.io/stashify-218417
 image: IMAGE_TO_REPLACE
 resources: {}
 #  limits:

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -38,7 +38,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: search
-        image: {{ .Values.image }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         securityContext:
           privileged: true
         imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/charts/nucliadb_search/values.yaml
+++ b/charts/nucliadb_search/values.yaml
@@ -5,6 +5,7 @@ replicaCount: 2
 revisionHistoryLimit: 2
 debug: False
 imagePullPolicy: IfNotPresent
+containerRegistry: eu.gcr.io/stashify-218417
 image: IMAGE_TO_REPLACE
 resources: {}
 #  limits:

--- a/charts/nucliadb_writer/templates/writer.deploy.yaml
+++ b/charts/nucliadb_writer/templates/writer.deploy.yaml
@@ -37,7 +37,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: writer
-        image: {{ .Values.image }}
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         securityContext:
           privileged: true
         imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/charts/nucliadb_writer/values.yaml
+++ b/charts/nucliadb_writer/values.yaml
@@ -11,6 +11,7 @@ replicaCount: 2
 revisionHistoryLimit: 2
 debug: False
 imagePullPolicy: IfNotPresent
+containerRegistry: eu.gcr.io/stashify-218417
 image: IMAGE_TO_REPLACE
 resources: {}
 #  limits:


### PR DESCRIPTION
isolate containerRegistry from containerImage, so we can operate on each independently (eg. when moving to production, we want to use a different registry, with the same image and tag than in stage)