### PR TITLE
lmdb features changed

### DIFF
--- a/nucliadb_vectors/Cargo.toml
+++ b/nucliadb_vectors/Cargo.toml
@@ -7,7 +7,7 @@ license = "AGPL-3.0-or-later"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heed = "0.11.0"
+heed = { version = "0.11.0", default-features = false, features = ["lmdb", "sync-read-txn"] }
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/nucliadb_vectors/src/graph_disk/database.rs
+++ b/nucliadb_vectors/src/graph_disk/database.rs
@@ -54,7 +54,7 @@ where
         env_builder.map_size(MAP_SIZE);
         unsafe {
             env_builder.flag(Flags::MdbNoLock);
-            env_builder.flag(Flags::MdbNoSync);
+            // env_builder.flag(Flags::MdbNoSync);
         }
         let env = unwrapping!(env_builder.open(path));
         let db = match env.open_database(Some(db)) {

--- a/nucliadb_vectors/src/graph_elems/mod.rs
+++ b/nucliadb_vectors/src/graph_elems/mod.rs
@@ -50,13 +50,10 @@ pub trait Distance {
 #[derive(
     Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash, Debug, Default, Serialize, Deserialize,
 )]
-pub struct NodeId(u128);
+pub struct NodeId(usize);
 impl NodeId {
     pub fn new() -> NodeId {
         NodeId(0)
-    }
-    pub fn null() -> NodeId {
-        NodeId(u128::MAX)
     }
     pub fn fresh(&mut self) -> NodeId {
         let prev = *self;

--- a/nucliadb_vectors/src/heuristics/heuristic_paper.rs
+++ b/nucliadb_vectors/src/heuristics/heuristic_paper.rs
@@ -64,7 +64,7 @@ mod test_heuristic_simple {
         for _ in 0..100 {
             let v = rand::random::<f32>();
             solution.push(v);
-            candidates.push((NodeId::null(), v));
+            candidates.push((NodeId::new(), v));
         }
         solution.sort_by(|a, b| {
             if *a > *b {

--- a/nucliadb_vectors/src/utils/mod.rs
+++ b/nucliadb_vectors/src/utils/mod.rs
@@ -108,10 +108,11 @@ mod test_utils {
     fn test_utils__right_order() {
         let mut inverse_heap = BinaryHeap::new();
         let mut standard_heap = BinaryHeap::new();
+        let mut id = NodeId::new();
         let len = 10;
         for i in 0..len {
-            inverse_heap.push(InverseElem(NodeId::null(), i as f32));
-            standard_heap.push(StandardElem(NodeId::null(), i as f32));
+            inverse_heap.push(InverseElem(id.fresh(), i as f32));
+            standard_heap.push(StandardElem(id.fresh(), i as f32));
         }
         let mut inverse = LinkedList::new();
         let mut standard = LinkedList::new();


### PR DESCRIPTION
### Description
NoSync flag is avoided by disabling lmdb's default features and including "lmdb" and "sync-read-txn".

### How was this PR tested?
Local test
