### PR TITLE
Use pydantic 'default_factory' initialization method

### DIFF
--- a/nucliadb_writer/nucliadb_writer/processing.py
+++ b/nucliadb_writer/nucliadb_writer/processing.py
@@ -79,7 +79,9 @@ class PushPayload(BaseModel):
     partition: int
 
     # List of available processing options (with default values)
-    processing_options: Optional[PushProcessingOptions] = Field(default_factory=PushProcessingOptions)
+    processing_options: Optional[PushProcessingOptions] = Field(
+        default_factory=PushProcessingOptions
+    )
 
 
 class PushResponse(BaseModel):

--- a/nucliadb_writer/nucliadb_writer/processing.py
+++ b/nucliadb_writer/nucliadb_writer/processing.py
@@ -27,7 +27,7 @@ import aiohttp
 import jwt
 from nucliadb_protos.resources_pb2 import CloudFile
 from nucliadb_protos.resources_pb2 import FieldFile as FieldFilePB
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import nucliadb_models as models
 from nucliadb_utils.storages.storage import Storage
@@ -79,7 +79,7 @@ class PushPayload(BaseModel):
     partition: int
 
     # List of available processing options (with default values)
-    processing_options: Optional[PushProcessingOptions] = PushProcessingOptions()
+    processing_options: Optional[PushProcessingOptions] = Field(default_factory=PushProcessingOptions)
 
 
 class PushResponse(BaseModel):


### PR DESCRIPTION
### Description
To avoid a potential unexpected behaviour when using the default value of field 'processing_options' (model PushPayload), I changed the current approach to instantiate a default PushProcessingOptions model, using the 'default_factory' that Pydantic provides, which is the more apropiate way.

### How was this PR tested?
Describe how you tested this PR.
