### PR TITLE
Updated nucliadb_writer API path regex [sc-1830]

### DIFF
--- a/charts/nucliadb_writer/templates/writer.vs.yaml
+++ b/charts/nucliadb_writer/templates/writer.vs.yaml
@@ -15,7 +15,7 @@ spec:
       method:
         regex: 'PUT|DELETE|POST|PATCH|OPTIONS'
     - uri:
-        regex: '^/api/v\d+/kb/.*'
+        regex: '^/api/v\d+/kb/[^/]/(resource|resources|entitiesgroup|labelset|widget)/.*'
       method:
         regex: 'PUT|DELETE|POST|PATCH|OPTIONS'
     route:

--- a/charts/nucliadb_writer/templates/writer.vs.yaml
+++ b/charts/nucliadb_writer/templates/writer.vs.yaml
@@ -11,10 +11,6 @@ spec:
   - name: nucliadb_writer
     match:
     - uri:
-        regex: '^/api/v\d+/kbs$'
-      method:
-        regex: 'PUT|DELETE|POST|PATCH|OPTIONS'
-    - uri:
         regex: '^/api/v\d+/kb/[^/]/(resource|resources|entitiesgroup|labelset|widget)/.*'
       method:
         regex: 'PUT|DELETE|POST|PATCH|OPTIONS'

--- a/nucliadb_one/nucliadb_one/tests/fixtures.py
+++ b/nucliadb_one/nucliadb_one/tests/fixtures.py
@@ -31,7 +31,7 @@ from starlette.routing import Mount
 from nucliadb_ingest.cache import clear_ingest_cache
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_search import API_PREFIX
-from nucliadb_search.api.v1.router import KB_PREFIX
+from nucliadb_search.api.v1.router import KB_PREFIX, KBS_PREFIX
 from nucliadb_utils.utilities import clear_global_cache
 
 
@@ -127,7 +127,7 @@ async def knowledgebox_one(nucliadb_api):
     kbslug = str(uuid.uuid4())
     async with nucliadb_api(roles=[NucliaDBRoles.MANAGER]) as client:
         data = {"slug": kbslug}
-        resp = await client.post(f"/{KB_PREFIX}", json=data)
+        resp = await client.post(f"/{KBS_PREFIX}", json=data)
         assert resp.status_code == 201
         kbid = resp.json()["uuid"]
     yield kbid

--- a/nucliadb_writer/nucliadb_writer/api/v1/knowledgebox.py
+++ b/nucliadb_writer/nucliadb_writer/api/v1/knowledgebox.py
@@ -38,11 +38,11 @@ from nucliadb_models.resource import (
 )
 from nucliadb_utils.authentication import requires
 from nucliadb_utils.utilities import get_ingest
-from nucliadb_writer.api.v1.router import KB_PREFIX, api
+from nucliadb_writer.api.v1.router import KB_PREFIX, KBS_PREFIX, api
 
 
 @api.post(
-    f"/{KB_PREFIX}",
+    f"/{KBS_PREFIX}",
     status_code=201,
     name="Create Knowledge Box",
     response_model=KnowledgeBoxObj,

--- a/nucliadb_writer/nucliadb_writer/tests/fixtures.py
+++ b/nucliadb_writer/nucliadb_writer/tests/fixtures.py
@@ -29,7 +29,7 @@ from nucliadb_ingest.tests.fixtures import IngestFixture
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.settings import nuclia_settings, nucliadb_settings, storage_settings
 from nucliadb_writer import API_PREFIX
-from nucliadb_writer.api.v1.router import KB_PREFIX
+from nucliadb_writer.api.v1.router import KB_PREFIX, KBS_PREFIX
 from nucliadb_writer.settings import settings
 from nucliadb_writer.tus import clear_storage
 from nucliadb_writer.utilities import get_processing
@@ -89,7 +89,7 @@ async def gcs_storage_writer(gcs):
 async def knowledgebox_writer(writer_api):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(
-            f"/{KB_PREFIX}",
+            f"/{KBS_PREFIX}",
             json={
                 "slug": "kbid1",
                 "title": "My Knowledge Box",

--- a/nucliadb_writer/nucliadb_writer/tests/test_knowledgebox.py
+++ b/nucliadb_writer/nucliadb_writer/tests/test_knowledgebox.py
@@ -20,14 +20,14 @@
 import pytest
 
 from nucliadb_models.resource import NucliaDBRoles
-from nucliadb_writer.api.v1.router import KB_PREFIX
+from nucliadb_writer.api.v1.router import KB_PREFIX, KBS_PREFIX
 
 
 @pytest.mark.asyncio
 async def test_knowledgebox_lifecycle(writer_api):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(
-            f"/{KB_PREFIX}",
+            f"/{KBS_PREFIX}",
             json={
                 "slug": "kbid1",
                 "title": "My Knowledge Box",

--- a/nucliadb_writer/nucliadb_writer/tests/test_service.py
+++ b/nucliadb_writer/nucliadb_writer/tests/test_service.py
@@ -24,14 +24,14 @@ from nucliadb_models.labels import Label, LabelSet
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_protos import knowledgebox_pb2, writer_pb2
 from nucliadb_utils.utilities import get_ingest
-from nucliadb_writer.api.v1.router import KB_PREFIX
+from nucliadb_writer.api.v1.router import KB_PREFIX, KBS_PREFIX
 
 
 @pytest.mark.asyncio
 async def test_service_lifecycle_entities(writer_api):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(
-            f"/{KB_PREFIX}",
+            f"/{KBS_PREFIX}",
             json={
                 "slug": "kbid1",
                 "title": "My Knowledge Box",
@@ -75,7 +75,7 @@ async def test_service_lifecycle_entities(writer_api):
 async def test_service_lifecycle_labels(writer_api):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(
-            f"/{KB_PREFIX}",
+            f"/{KBS_PREFIX}",
             json={
                 "slug": "kbid1",
                 "title": "My Knowledge Box",


### PR DESCRIPTION
### Description
Update the nucliadb_writer API path regex in the Virtual Service config file. Previous regex was too much generic, it causes some collisions with similar endpoints defined in other services (for instance, supervisor_ml). Current regex is more specific to nucliadb_writer.

### How was this PR tested?
Describe how you tested this PR.
