### PR TITLE
Update licences.yml

### DIFF
--- a/.github/workflows/licences.yml
+++ b/.github/workflows/licences.yml
@@ -13,11 +13,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check License Header
-        uses: apache/skywalking-eyes@main # always prefer to use a revision instead of `main`.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # needed only when you want License-Eye to comment on the pull request.
-        # with:
-        # Optional: set the log level. The default value is `info`.
-        # log: debug
-        # Optional: set the config file. The default value is `.licenserc.yaml`.
-        # config: .licenserc.yaml
+        uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff


### PR DESCRIPTION
We have a dedicate GitHub actions for header check so this should be updated, and we don't recommend using `@main` so there is no unexpected behaviors when we have changes in our codebase.

See https://github.com/apache/skywalking-eyes/pull/123