### PR TITLE
Fixing CORS concerning Writer and Reader virtual services

### DIFF
--- a/charts/nucliadb_reader/templates/reader.vs.yaml
+++ b/charts/nucliadb_reader/templates/reader.vs.yaml
@@ -46,3 +46,7 @@ spec:
         allowMethods:
         - GET
         - OPTIONS
+        - POST
+        - PATCH
+        - PUT
+        - DELETE

--- a/charts/nucliadb_writer/templates/writer.vs.yaml
+++ b/charts/nucliadb_writer/templates/writer.vs.yaml
@@ -17,7 +17,7 @@ spec:
     - uri:
         regex: '^/api/v\d+/kb/[^/]+/(resource|resources|entitiesgroup|labelset|widget).*'
       method:
-        regex: 'POST|PATCH|PUT|DELETE'
+        regex: 'POST|PATCH|PUT|DELETE|OPTIONS'
     route:
     - destination:
         port:

--- a/charts/nucliadb_writer/templates/writer.vs.yaml
+++ b/charts/nucliadb_writer/templates/writer.vs.yaml
@@ -15,9 +15,9 @@ spec:
       method:
         regex: 'POST|PATCH|PUT|DELETE|OPTIONS'
     - uri:
-        regex: '^/api/v\d+/kb/[^/]+/(resource|resources|entitiesgroup|labelset|widget)/.*'
+        regex: '^/api/v\d+/kb/[^/]+/(resource|resources|entitiesgroup|labelset|widget).*'
       method:
-        regex: 'PUT|DELETE|POST|PATCH|OPTIONS'
+        regex: 'POST|PATCH|PUT|DELETE'
     route:
     - destination:
         port:


### PR DESCRIPTION
### Description
Defining different operations (methods) for same API paths across different virtual services (writer, reader, even supervisor-ml) is legit but leads to issues related to CORS. For instance, Writer defines put, post, patch, delete operations, and Reader defines get and OPTIONS on the same API paths.

When an incoming OPTIONS http requests matches both Writer and Reader path rules then k8s decides to prioritize and take in consideration the corsPolicy defined in the Reader vs. This is the reason to allow patch, put, delete and post in the corsPolicy of the Reader vs. Let’s just be aware of that.

### How was this PR tested?
Describe how you tested this PR.
