### PR TITLE
charts | unify istio config across pods

### DIFF
--- a/charts/nucliadb_ingest/templates/ingest-headless.svc.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-headless.svc.yaml
@@ -15,7 +15,11 @@ spec:
     chart: "{{ .Chart.Name }}"
   clusterIP: None
   ports:
-  - name: grpc-ingest
-    port: {{ .Values.serving.grpc }}
-    protocol: TCP
-    appProtocol: grpc
+    - name: grpc-ingest
+      port: {{ .Values.serving.grpc }}
+      protocol: TCP
+      appProtocol: grpc
+    - name: cluster-monitor
+      port: {{ .Values.chitchat.cluster_manager.port }}
+      protocol: TCP
+      appProtocol: tcp

--- a/charts/nucliadb_ingest/templates/ingest.svc.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.svc.yaml
@@ -15,6 +15,9 @@ spec:
   ports:
     - name: grpc-ingest
       port: {{ .Values.serving.grpc }}
+      protocol: TCP
       appProtocol: grpc
     - name: cluster-monitor
       port: {{ .Values.chitchat.cluster_manager.port }}
+      protocol: TCP
+      appProtocol: tcp

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -25,8 +25,6 @@ spec:
   template:
     metadata:
       name: node
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: node
         app.kubernetes.io/name: node

--- a/charts/nucliadb_reader/templates/reader.svc.yaml
+++ b/charts/nucliadb_reader/templates/reader.svc.yaml
@@ -15,5 +15,9 @@ spec:
   ports:
     - name: http-reader
       port: {{ .Values.serving.port }}
+      protocol: TCP
+      appProtocol: http
     - name: metrics
       port: {{ .Values.serving.metricsPort}}
+      protocol: TCP
+      appProtocol: http

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -20,8 +20,8 @@ spec:
     metadata:
       name: search
       annotations:
-        traffic.sidecar.istio.io/excludeOutboundPorts: "{{ .Values.chitchat.cluster_manager.port }},{{ .Values.chitchat.node.chitchat_port}},{{ .Values.services.nats }},{{ .Values.services.maindb }}"
-        traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.chitchat.cluster_manager.port }},{{ .Values.chitchat.node.chitchat_port}},{{ .Values.serving.metricsPort }}"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "{{ .Values.services.nats }},{{ .Values.services.maindb }}"
+        traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.serving.metricsPort }}"
       labels:
         app: search
         version: "{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/nucliadb_search/templates/search.svc.yaml
+++ b/charts/nucliadb_search/templates/search.svc.yaml
@@ -15,7 +15,13 @@ spec:
   ports:
     - name: http-search
       port: {{ .Values.serving.port }}
+      protocol: TCP
+      appProtocol: http
     - name: metrics
       port: {{ .Values.serving.metricsPort}}
+      protocol: TCP
+      appProtocol: http
     - name: cluster-monitor
       port: {{ .Values.chitchat.cluster_manager.port }}
+      protocol: TCP
+      appProtocol: tcp

--- a/charts/nucliadb_writer/templates/writer.svc.yaml
+++ b/charts/nucliadb_writer/templates/writer.svc.yaml
@@ -15,5 +15,9 @@ spec:
   ports:
     - name: http-writer
       port: {{ .Values.serving.port }}
+      protocol: TCP
+      appProtocol: http
     - name: metrics
       port: {{ .Values.serving.metricsPort}}
+      protocol: TCP
+      appProtocol: http


### PR DESCRIPTION
### Description
Adds Istio sidecar (envoy) to NucliaDB Node pods.


### How was this PR tested?
This configuration was manually applied on Stage and End-2-End are passing.
In addition, we have verified that both Search and Ingest are seeing all 4 Nodes through ChitChat