### PR TITLE
Avoid asyncio.CanceledError failure when flushing spans

### DIFF
--- a/nucliadb_telemetry/nucliadb_telemetry/batch_span.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/batch_span.py
@@ -259,8 +259,10 @@ class BatchSpanProcessor(SpanProcessor):
             # Ignore type b/c the Optional[None]+slicing is too "clever"
             # for mypy
             await self.span_exporter.export(self.spans_list[:idx])  # type: ignore
+        except (asyncio.CancelledError):
+            logger.exception("Task was canceled while exporting Span batch")
         except Exception:  # pylint: disable=broad-except
-            logger.exception("Exception while exporting Span batch.")
+            logger.exception("Exception while exporting Span batch)")
         detach(token)
 
         # clean up list

--- a/nucliadb_telemetry/nucliadb_telemetry/utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/utils.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import os
 from typing import Dict, Optional, Sequence, Union
 
@@ -62,6 +63,8 @@ async def clean_telemetry(service_name: str):
     if service_name in GLOBAL_PROVIDER and service_name:
         tracer_provider = GLOBAL_PROVIDER[service_name]
         await tracer_provider.force_flush()
+        # Without this sleep, force_flush fails on exporting pending spans
+        await asyncio.sleep(1)
         tracer_provider.shutdown()
         del GLOBAL_PROVIDER[service_name]
 


### PR DESCRIPTION
### Description
Exporting pending spans was failing on a cronjob, and the error was silently swalloed. Original issue was that when doing this in `batch_span._export_batch`:
```
        try:
            # Ignore type b/c the Optional[None]+slicing is too "clever"
            # for mypy
            await self.span_exporter.export(self.spans_list[:idx])  # type: ignore
        except Exception as exc:  # pylint: disable=broad-except
            logger.exception("Exception while exporting Span batch.")
```
the export call was raising an asyncio.CancelledError, that forced the process to stop, and was not handled by the generic except. It seems that have something to do with the `on_con_lost` future that is created in `jaeger.AgentCLientUDPAsync.emit`, because just at that point the `asyncio.CanceledError` raises, and the `_sendto` function related to the future completion is never executed.

As it seemed like that, even if the future is correctly awaited, the process was ending before having the chance to execute the _sendto, we put an sleep just as a wild try, and it worked.

Probably this is not the proper fix, but it helps identifying the real problem

### How was this PR tested?
Executing the idp agent accounting cron against stage, after doing some searches. Expected output was jaeger-agent.tools to receive the pending traces