### PR TITLE
Simplify shards query params on search endpoint

### DIFF
--- a/nucliadb_ingest/nucliadb_ingest/tests/ingest/test_ingest.py
+++ b/nucliadb_ingest/nucliadb_ingest/tests/ingest/test_ingest.py
@@ -200,7 +200,8 @@ async def test_ingest_error_message(
     assert field_obj.value.body == message0.texts["wikipedia_ml"].body
 
 
-def add_filefields(message, items=[]):
+def add_filefields(message, items=None):
+    items = items or []
     for (fieldid, filename) in items:
         file_path = f"{dirname(__file__)}/assets/{filename}"
         cf1 = CloudFile(
@@ -214,7 +215,8 @@ def add_filefields(message, items=[]):
         message.files[fieldid].file.CopyFrom(cf1)
 
 
-def add_textfields(message, items=[]):
+def add_textfields(message, items=None):
+    items = items or []
     for fieldid in items:
         message.texts[fieldid].body = "some random text"
 

--- a/nucliadb_search/nucliadb_search/api/models.py
+++ b/nucliadb_search/nucliadb_search/api/models.py
@@ -265,7 +265,6 @@ class SearchRequest(BaseModel):
     ]
     reload: bool = True
     debug: bool = False
-    shards: bool = False
     highlight: bool = False
     show: List[ResourceProperties] = [ResourceProperties.BASIC]
     field_type_filter: List[FieldTypeName] = list(FieldTypeName)

--- a/nucliadb_search/nucliadb_search/api/models.py
+++ b/nucliadb_search/nucliadb_search/api/models.py
@@ -269,5 +269,5 @@ class SearchRequest(BaseModel):
     show: List[ResourceProperties] = [ResourceProperties.BASIC]
     field_type_filter: List[FieldTypeName] = list(FieldTypeName)
     extracted: List[ExtractedDataTypeName] = list(ExtractedDataTypeName)
-    shard: List[str] = []
+    shards: List[str] = []
     vector: Optional[List[float]] = None

--- a/nucliadb_search/nucliadb_search/api/v1/resource.py
+++ b/nucliadb_search/nucliadb_search/api/v1/resource.py
@@ -89,7 +89,7 @@ async def search(
     extracted: List[ExtractedDataTypeName] = Query(list(ExtractedDataTypeName)),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     debug: bool = Query(False),
-    shard: List[str] = [],
+    shards: List[str] = [],
 ) -> ResourceSearchResults:
     # We need the nodes/shards that are connected to the KB
     nodemanager = get_nodes()
@@ -126,7 +126,7 @@ async def search(
     queried_shards = []
     for shard_obj in shard_groups:
         try:
-            node, shard_id, node_id = nodemanager.choose_node(shard_obj, shard)
+            node, shard_id, node_id = nodemanager.choose_node(shard_obj, shards)
         except KeyError:
             incomplete_results = True
         else:

--- a/nucliadb_search/nucliadb_search/api/v1/resource.py
+++ b/nucliadb_search/nucliadb_search/api/v1/resource.py
@@ -89,7 +89,6 @@ async def search(
     extracted: List[ExtractedDataTypeName] = Query(list(ExtractedDataTypeName)),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     debug: bool = Query(False),
-    shards: bool = Query(False),
     shard: List[str] = [],
 ) -> ResourceSearchResults:
     # We need the nodes/shards that are connected to the KB
@@ -190,6 +189,6 @@ async def search(
     response.status_code = 206 if incomplete_results else 200
     if debug:
         search_results.nodes = queried_nodes
-    if shards:
-        search_results.shards = queried_shards
+
+    search_results.shards = queried_shards
     return search_results

--- a/nucliadb_search/nucliadb_search/api/v1/search.py
+++ b/nucliadb_search/nucliadb_search/api/v1/search.py
@@ -95,7 +95,7 @@ async def search_knowledgebox(
         list(FieldTypeName), alias="field_type"
     ),
     extracted: List[ExtractedDataTypeName] = Query(list(ExtractedDataTypeName)),
-    shard: List[str] = Query([]),
+    shards: List[str] = Query([]),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),
     x_forwarded_for: str = Header(""),
@@ -120,7 +120,7 @@ async def search_knowledgebox(
         show=show,
         field_type_filter=field_type_filter,
         extracted=extracted,
-        shard=shard,
+        shards=shards,
     )
     return await search(
         response, kbid, item, x_ndb_client, x_nucliadb_user, x_forwarded_for
@@ -204,7 +204,7 @@ async def search(
     queried_nodes = []
     for shard_obj in shard_groups:
         try:
-            node, shard_id, node_id = nodemanager.choose_node(shard_obj, item.shard)
+            node, shard_id, node_id = nodemanager.choose_node(shard_obj, item.shards)
         except KeyError:
             incomplete_results = True
         else:

--- a/nucliadb_search/nucliadb_search/api/v1/search.py
+++ b/nucliadb_search/nucliadb_search/api/v1/search.py
@@ -89,7 +89,6 @@ async def search_knowledgebox(
     ),
     reload: bool = Query(default=True),
     debug: bool = Query(False),
-    shards: bool = Query(False),
     highlight: bool = Query(default=False),
     show: List[ResourceProperties] = Query([ResourceProperties.BASIC]),
     field_type_filter: List[FieldTypeName] = Query(
@@ -117,7 +116,6 @@ async def search_knowledgebox(
         features=features,
         reload=reload,
         debug=debug,
-        shards=shards,
         highlight=highlight,
         show=show,
         field_type_filter=field_type_filter,
@@ -281,6 +279,6 @@ async def search(
         )
     if item.debug:
         search_results.nodes = queried_nodes
-    if item.shards:
-        search_results.shards = queried_shards
+
+    search_results.shards = queried_shards
     return search_results

--- a/nucliadb_search/nucliadb_search/tests/test_basic_search.py
+++ b/nucliadb_search/nucliadb_search/tests/test_basic_search.py
@@ -99,7 +99,7 @@ async def test_multiple_search_resource_all(
         pos_35 = resp.json()["paragraphs"]["results"][35]
 
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/search?query=own+text&highlight=true&page_number=3&page_size=10&shard={shards[0]}",  # noqa
+            f"/{KB_PREFIX}/{kbid}/search?query=own+text&highlight=true&page_number=3&page_size=10&shards={shards[0]}",  # noqa
         )
         if resp.status_code != 200:
             print(resp.content)

--- a/nucliadb_search/nucliadb_search/tests/test_basic_search.py
+++ b/nucliadb_search/nucliadb_search/tests/test_basic_search.py
@@ -84,7 +84,7 @@ async def test_multiple_search_resource_all(
     async with search_api(roles=[NucliaDBRoles.READER]) as client:
         await asyncio.sleep(5)
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/search?query=own+text&highlight=true&page_number=0&page_size=40&shards=true",
+            f"/{KB_PREFIX}/{kbid}/search?query=own+text&highlight=true&page_number=0&page_size=40",
         )
         if resp.status_code != 200:
             print(resp.content)
@@ -99,7 +99,7 @@ async def test_multiple_search_resource_all(
         pos_35 = resp.json()["paragraphs"]["results"][35]
 
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/search?query=own+text&highlight=true&page_number=3&page_size=10&shard={shards[0]}&shards=true",  # noqa
+            f"/{KB_PREFIX}/{kbid}/search?query=own+text&highlight=true&page_number=3&page_size=10&shard={shards[0]}",  # noqa
         )
         if resp.status_code != 200:
             print(resp.content)

--- a/nucliadb_utils/nucliadb_utils/tests/nats.py
+++ b/nucliadb_utils/nucliadb_utils/tests/nats.py
@@ -46,7 +46,7 @@ class Gnatsd(object):
         debug=False,
         tls=False,
         cluster_listen=None,
-        routes=[],
+        routes=None,
         config_file=None,
     ):
         self.port = port
@@ -59,7 +59,7 @@ class Gnatsd(object):
         self.tls = tls
         self.token = token
         self.cluster_listen = cluster_listen
-        self.routes = routes
+        self.routes = routes or []
         self.bin_name = "gnatsd"
         self.config_file = config_file
         self.folder = None


### PR DESCRIPTION
### Description
- `shards` param is removed, and now we always return the shards on the response
- `shard` param is renamed to `shards`, as it makes more sense since it's expecting a list strings
Linked to this ticket: https://app.shortcut.com/flaps/story/2381/shards-params-on-search-endpoint

Additionally, I also fixed some antipatterns: mutable objects should not be set as default params of functions.

### How was this PR tested?
Existing tests cover the changes, and thus shouldn't break.
