### PR TITLE
github actions | disable arm64 builds

### DIFF
--- a/.github/workflows/nucliadb.yml
+++ b/.github/workflows/nucliadb.yml
@@ -162,8 +162,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -178,6 +178,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: nuclia/nucliadb:latest
+          cache-from: type=registry,ref=nuclia/nucliadb:buildcache
+          cache-to: type=registry,ref=nuclia/nucliadb:buildcache,mode=max


### PR DESCRIPTION
### Description
Disable arm64 builds on nucliadb docker images, as it's taking ours to compile.
We will re-enable when a better solution is found.

### How was this PR tested?
