### PR TITLE
Rename search query param: max-score to min-score

### DIFF
--- a/nucliadb_search/nucliadb_search/api/models.py
+++ b/nucliadb_search/nucliadb_search/api/models.py
@@ -252,7 +252,7 @@ class SearchRequest(BaseModel):
     sort: SortOption = SortOption.CREATED
     page_number: int = 0
     page_size: int = 20
-    max_score: float = 0.70
+    min_score: float = 0.70
     range_creation_start: Optional[datetime] = None
     range_creation_end: Optional[datetime] = None
     range_modification_start: Optional[datetime] = None

--- a/nucliadb_search/nucliadb_search/api/v1/search.py
+++ b/nucliadb_search/nucliadb_search/api/v1/search.py
@@ -74,7 +74,7 @@ async def search_knowledgebox(
     sort: SortOption = SortOption.CREATED,
     page_number: int = Query(default=0),
     page_size: int = Query(default=20),
-    max_score: float = Query(default=0.70),
+    min_score: float = Query(default=0.70),
     range_creation_start: Optional[datetime] = Query(default=None),
     range_creation_end: Optional[datetime] = Query(default=None),
     range_modification_start: Optional[datetime] = Query(default=None),
@@ -109,7 +109,7 @@ async def search_knowledgebox(
         sort=sort,
         page_number=page_number,
         page_size=page_size,
-        max_score=max_score,
+        min_score=min_score,
         range_creation_end=range_creation_end,
         range_creation_start=range_creation_start,
         range_modification_end=range_modification_end,
@@ -263,7 +263,7 @@ async def search(
         show=item.show,
         field_type_filter=item.field_type_filter,
         extracted=item.extracted,
-        max_score=item.max_score,
+        min_score=item.min_score,
         highlight=item.highlight,
     )
     await abort_transaction()

--- a/nucliadb_search/nucliadb_search/search/merge.py
+++ b/nucliadb_search/nucliadb_search/search/merge.py
@@ -180,14 +180,14 @@ async def merge_vectors_results(
     kbid: str,
     count: int,
     page: int,
-    max_score: float = 0.70,
+    min_score: float = 0.70,
 ):
     facets: Dict[str, Any] = {}
     raw_vectors_list: List[DocumentScored] = []
 
     for vector_response in vector_responses:
         for document in vector_response.documents:
-            if document.score < max_score:
+            if document.score < min_score:
                 continue
             if math.isnan(document.score):
                 continue
@@ -326,7 +326,7 @@ async def merge_results(
     show: List[ResourceProperties],
     field_type_filter: List[FieldTypeName],
     extracted: List[ExtractedDataTypeName],
-    max_score: float = 0.85,
+    min_score: float = 0.85,
     highlight: bool = False,
 ) -> KnowledgeboxSearchResults:
     paragraphs = []
@@ -352,7 +352,7 @@ async def merge_results(
     )
 
     api_results.sentences = await merge_vectors_results(
-        vectors, resources, kbid, count, page, max_score=max_score
+        vectors, resources, kbid, count, page, min_score=min_score
     )
 
     api_results.resources = await fetch_resources(


### PR DESCRIPTION
### Description
Naming of the query param was wrong. Conceptually, we want to filter out results which have a score lower than `min-score`

### How was this PR tested?
Existing tests should cover it
