### PR TITLE
Reader endpoints by slug

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -2,7 +2,7 @@ ignore:
   - "**/tests"
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
-    carryforward: true
+    carryforward: true  # needed for monorepos: total coverage is not uploaded at every commit.
     statuses:
       - type: project
         target: auto
@@ -27,7 +27,7 @@ flag_management:
         - type: project
           target: 20%
         - type: patch
-          target: 100%
+          target: 80%
     - name: utils
       paths:
         - nucliadb_utils/**
@@ -70,27 +70,27 @@ flag_management:
       carryforward: true
       statuses:
         - type: project
-          target: 20%
+          target: 75%
         - type: patch
-          target: 100%
+          target: 80%
     - name: writer
       paths:
         - nucliadb_writer/**
       carryforward: true
       statuses:
         - type: project
-          target: 20%
+          target: 75%
         - type: patch
-          target: 100%
+          target: 80%
     - name: reader
       paths:
         - nucliadb_reader/**
       carryforward: true
       statuses:
         - type: project
-          target: 20%
+          target: 60%
         - type: patch
-          target: 100%
+          target: 80%
     - name: node-sidecar
       paths:
         - nucliadb_node/nucliadb_node/**

--- a/charts/nucliadb_reader/templates/reader.vs.yaml
+++ b/charts/nucliadb_reader/templates/reader.vs.yaml
@@ -30,6 +30,14 @@ spec:
         regex: 'GET|OPTIONS'
       uri:
         regex: '^/api/v\d+/kb/[^/]+/resource/[^/]+/(text|file|link|layout|conversation|keywordset|datetime).*'
+    - method:
+        regex: 'GET|OPTIONS'
+      uri:
+        regex: '^/api/v\d+/kb/[^/]+/slug/[^/]+$'
+    - method:
+        regex: 'GET|OPTIONS'
+      uri:
+        regex: '^/api/v\d+/kb/[^/]+/slug/[^/]+/(text|file|link|layout|conversation|keywordset|datetime).*'
     - uri:
         regex: '^/api/v\d+/kb/[^/]+/resources'
       method:

--- a/nucliadb_ingest/nucliadb_ingest/orm/knowledgebox.py
+++ b/nucliadb_ingest/nucliadb_ingest/orm/knowledgebox.py
@@ -522,7 +522,7 @@ class KnowledgeBox:
         if basic is None:
             basic = Basic()
         if slug == "":
-            slug = uuid4().hex
+            slug = uuid
         slug = await self.get_unique_slug(uuid, slug)
         basic.slug = slug
         await set_basic(self.txn, self.kbid, uuid, basic)

--- a/nucliadb_ingest/nucliadb_ingest/orm/resource.py
+++ b/nucliadb_ingest/nucliadb_ingest/orm/resource.py
@@ -397,10 +397,7 @@ class Resource:
         if field not in self.fields:
             field_obj: Field = KB_FIELDS[type](id=key, resource=self)
             if load:
-                value = await field_obj.get_value()
-                if value is None:
-                    # Value of the field could not be found!
-                    return None
+                await field_obj.get_value()
             self.fields[field] = field_obj
         return self.fields[field]
 

--- a/nucliadb_ingest/nucliadb_ingest/orm/resource.py
+++ b/nucliadb_ingest/nucliadb_ingest/orm/resource.py
@@ -397,7 +397,10 @@ class Resource:
         if field not in self.fields:
             field_obj: Field = KB_FIELDS[type](id=key, resource=self)
             if load:
-                await field_obj.get_value()
+                value = await field_obj.get_value()
+                if value is None:
+                    # Value of the field could not be found!
+                    return None
             self.fields[field] = field_obj
         return self.fields[field]
 

--- a/nucliadb_ingest/nucliadb_ingest/serialize.py
+++ b/nucliadb_ingest/nucliadb_ingest/serialize.py
@@ -27,6 +27,7 @@ from nucliadb_ingest.fields.conversation import Conversation
 from nucliadb_ingest.fields.file import File
 from nucliadb_ingest.fields.link import Link
 from nucliadb_ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb_ingest.orm.resource import Resource as ORMResource
 from nucliadb_ingest.utils import get_driver
 from nucliadb_models.common import FIELD_TYPES_MAP, FieldTypeName
 from nucliadb_models.resource import (
@@ -130,25 +131,22 @@ async def set_resource_field_extracted_data(
 
 async def serialize(
     kbid: str,
-    rid: str,
+    rid: Optional[str],
     show: List[ResourceProperties],
     field_type_filter: List[FieldTypeName],
     extracted: List[ExtractedDataTypeName],
     service_name: Optional[str] = None,
+    slug: Optional[str] = None,
 ) -> Optional[Resource]:
 
-    storage = await get_storage(service_name=service_name)
-    cache = await get_cache()
-    driver = await get_driver()
-
-    txn = await driver.begin()
-    kb = KnowledgeBox(txn, storage, cache, kbid)
-    orm_resource = await kb.get(rid)
+    orm_resource = await get_orm_resource(
+        kbid, rid=rid, slug=slug, service_name=service_name
+    )
     if orm_resource is None:
-        await txn.abort()
+        # Resource not found
         return None
 
-    resource = Resource(id=rid)
+    resource = Resource(id=orm_resource.uuid)
 
     include_values = ResourceProperties.VALUES in show
 
@@ -361,5 +359,48 @@ async def serialize(
                         field_type_name,
                         extracted,
                     )
-    await txn.abort()
     return resource
+
+
+async def get_orm_resource(
+    kbid: str,
+    rid: Optional[str],
+    slug: Optional[str] = None,
+    service_name: Optional[str] = None,
+) -> Optional[ORMResource]:
+
+    storage = await get_storage(service_name=service_name)
+    cache = await get_cache()
+    driver = await get_driver()
+
+    txn = await driver.begin()
+    kb = KnowledgeBox(txn, storage, cache, kbid)
+
+    if rid is None:
+        if slug is None:
+            raise ValueError("Either rid or slug parameters should be used")
+
+        rid = await kb.get_resource_uuid_by_slug(slug)
+        if rid is None:
+            # Could not find resource uuid from slug
+            await txn.abort()
+            return None
+
+    orm_resource = await kb.get(rid)
+    if orm_resource is None:
+        await txn.abort()
+        return None
+
+    await txn.abort()
+    return orm_resource
+
+
+async def get_resource_uuid_by_slug(
+    kbid: str, slug: str, service_name: Optional[str] = None
+) -> Optional[str]:
+    storage = await get_storage(service_name=service_name)
+    cache = await get_cache()
+    driver = await get_driver()
+    txn = await driver.begin()
+    kb = KnowledgeBox(txn, storage, cache, kbid)
+    return await kb.get_resource_uuid_by_slug(slug)

--- a/nucliadb_ingest/nucliadb_ingest/tests/fixtures.py
+++ b/nucliadb_ingest/nucliadb_ingest/tests/fixtures.py
@@ -877,6 +877,7 @@ async def create_resource(storage, driver, cache, knowledgebox):
     rid = str(uuid.uuid4())
     kb_obj = KnowledgeBox(txn, storage, cache, kbid=knowledgebox)
     test_resource = await kb_obj.add_resource(uuid=rid, slug="slug")
+    await test_resource.set_slug()
 
     # 1.  ROOT ELEMENTS
     # 1.1 BASIC

--- a/nucliadb_reader/nucliadb_reader/api/v1/resource.py
+++ b/nucliadb_reader/nucliadb_reader/api/v1/resource.py
@@ -251,7 +251,6 @@ async def get_resource_field(
 
     resource = ORMResource(txn, storage, kb, rid)
     field = await resource.get_field(field_id, pb_field_id, load=True)
-
     if field is None:
         raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
 

--- a/nucliadb_reader/nucliadb_reader/api/v1/router.py
+++ b/nucliadb_reader/nucliadb_reader/api/v1/router.py
@@ -24,4 +24,4 @@ api = APIRouter()
 KB_PREFIX = "kb"
 KBS_PREFIX = "kbs"
 RESOURCE_PREFIX = "resource"
-RESOURCE_PREFIX = "field"
+RSLUG_PREFIX = "slug"

--- a/nucliadb_reader/nucliadb_reader/tests/test_reader_file_download.py
+++ b/nucliadb_reader/nucliadb_reader/tests/test_reader_file_download.py
@@ -179,6 +179,14 @@ async def test_download_fields_by_resource_slug(
         )
         assert resp.status_code == 200
 
+        # Check that 404 is returned when a slug does not exist
+        unexisting_resource_path = f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/idonotexist"
+        resp = await client.get(
+            f"{unexisting_resource_path}/{endpoint}",
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Resource does not exist"
+
 
 async def _get_message_with_file(test_resource):
     conversation_field = await test_resource.get_field("conv1", FieldType.CONVERSATION)

--- a/nucliadb_reader/nucliadb_reader/tests/test_reader_file_download.py
+++ b/nucliadb_reader/nucliadb_reader/tests/test_reader_file_download.py
@@ -28,7 +28,7 @@ import nucliadb_ingest.tests.fixtures
 from nucliadb_ingest.orm.resource import Resource
 from nucliadb_ingest.tests.fixtures import TEST_CLOUDFILE, THUMBNAIL
 from nucliadb_models.resource import NucliaDBRoles
-from nucliadb_reader.api.v1.router import KB_PREFIX
+from nucliadb_reader.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX
 
 BASE = ("field_id", "field_type")
 VALUE = ("value",)
@@ -49,7 +49,7 @@ async def test_resource_download_extracted_file(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/{field_type}/{field_id}/download/{download_type}/{download_field}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}/download/{download_type}/{download_field}",  # noqa
         )
         assert resp.status_code == 200
         filename = f"{os.path.dirname(nucliadb_ingest.tests.fixtures.__file__)}{THUMBNAIL.bucket_name}/{THUMBNAIL.uri}"
@@ -68,7 +68,7 @@ async def test_resource_download_field_file(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}?show=values",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}?show=values",
         )
         assert (
             resp.json()["data"]["files"]["file1"]["value"]["file"]["filename"]
@@ -76,7 +76,7 @@ async def test_resource_download_field_file(
         )
 
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/file/{field_id}/download/field",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/file/{field_id}/download/field",
         )
         assert resp.status_code == 200
         assert resp.headers["Content-Disposition"]
@@ -86,7 +86,7 @@ async def test_resource_download_field_file(
         open(filename, "rb").read() == resp.content
 
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}?show=values",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}?show=values",
         )
         assert resp.status_code == 200
 
@@ -112,7 +112,7 @@ async def test_resource_download_field_layout(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/layout/{field_id}/download/field/{download_field}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/layout/{field_id}/download/field/{download_field}",
         )
         assert resp.status_code == 200
         filename = f"{os.path.dirname(nucliadb_ingest.tests.fixtures.__file__)}/{TEST_CLOUDFILE.bucket_name}/{TEST_CLOUDFILE.uri}"  # noqa
@@ -129,16 +129,60 @@ async def test_resource_download_field_conversation(
     rid = rsc.uuid
     field_id = "conv1"
 
-    conversation_field = await test_resource.get_field("conv1", FieldType.CONVERSATION)
-    conversations = await conversation_field.get_value(page=1)
-    message_with_files = conversations.messages[33]
-
-    msg_id, file_id = message_with_files.content.attachments[1].uri.split("/")[-2:]
+    msg_id, file_id = await _get_message_with_file(test_resource)
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/conversation/{field_id}/download/field/{msg_id}/{file_id}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/conversation/{field_id}/download/field/{msg_id}/{file_id}",
         )
         assert resp.status_code == 200
         filename = f"{os.path.dirname(nucliadb_ingest.tests.fixtures.__file__)}/{THUMBNAIL.bucket_name}/{THUMBNAIL.uri}"  # noqa
-        open(filename, "rb").read() == resp.content
+        assert open(filename, "rb").read() == resp.content
+
+
+@pytest.mark.parametrize(
+    "endpoint_part,endpoint_params",
+    [
+        [
+            "{field_type}/{field_id}/download/extracted/{download_field}",
+            {"field_type": "text", "field_id": "text1", "download_field": "thumbnail"},
+        ],  # noqa
+        ["file/{field_id}/download/field", {"field_id": "file1"}],
+        [
+            "layout/{field_id}/download/field/{download_field}",
+            {"field_id": "layout1", "download_field": "field1"},
+        ],
+        [
+            "conversation/{field_id}/download/field/{message_id}/{file_num}",
+            {"field_id": "conv1"},
+        ],
+    ],
+)
+@pytest.mark.asyncio
+async def test_download_fields_by_resource_slug(
+    reader_api, test_resource, endpoint_part, endpoint_params
+):
+    rsc = test_resource
+    kbid = rsc.kb.kbid
+    slug = rsc.basic.slug
+    if endpoint_part.startswith("conversation"):
+        # For conversations, we need to get a message id and a file number
+        msg_id, file_num = await _get_message_with_file(test_resource)
+        endpoint_params["message_id"] = msg_id
+        endpoint_params["file_num"] = file_num
+
+    async with reader_api(roles=[NucliaDBRoles.READER]) as client:
+        resource_path = f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{slug}"
+        endpoint = endpoint_part.format(**endpoint_params)
+        resp = await client.get(
+            f"{resource_path}/{endpoint}",
+        )
+        assert resp.status_code == 200
+
+
+async def _get_message_with_file(test_resource):
+    conversation_field = await test_resource.get_field("conv1", FieldType.CONVERSATION)
+    conversations = await conversation_field.get_value(page=1)
+    message_with_files = conversations.messages[33]
+    msg_id, file_num = message_with_files.content.attachments[1].uri.split("/")[-2:]
+    return msg_id, file_num

--- a/nucliadb_reader/nucliadb_reader/tests/test_reader_resource.py
+++ b/nucliadb_reader/nucliadb_reader/tests/test_reader_resource.py
@@ -297,3 +297,4 @@ async def test_resource_endpoints_by_slug(reader_api, test_resource):
             f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{non_existent_slug}/text/text1",
         )
         assert resp.status_code == 404
+        assert resp.json()["detail"] == "Resource does not exist"

--- a/nucliadb_reader/nucliadb_reader/tests/test_reader_resource.py
+++ b/nucliadb_reader/nucliadb_reader/tests/test_reader_resource.py
@@ -24,7 +24,7 @@ from httpx import AsyncClient
 
 from nucliadb_ingest.orm.resource import Resource
 from nucliadb_models.resource import NucliaDBRoles
-from nucliadb_reader.api.v1.router import KB_PREFIX
+from nucliadb_reader.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX
 
 ID = ("id",)
 BASIC = (
@@ -56,7 +56,7 @@ async def test_get_resource_inexistent(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
         )
         assert resp.status_code == 404
 
@@ -71,7 +71,7 @@ async def test_get_resource_default_options(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
         )
         assert resp.status_code == 200
 
@@ -97,7 +97,7 @@ async def test_get_resource_all(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
             params={
                 "show": ["basic", "origin", "relations", "values", "extracted"],
                 "field_type": [
@@ -176,7 +176,7 @@ async def test_get_resource_filter_root_fields(reader_api, test_resource):
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
             params={"show": ["basic", "values"]},
         )
         assert resp.status_code == 200
@@ -215,7 +215,7 @@ async def test_get_resource_filter_field_types(reader_api, test_resource):
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
             params={"show": ["values", "extracted"], "field_type": ["text", "link"]},
         )
         assert resp.status_code == 200
@@ -240,7 +240,7 @@ async def test_get_resource_filter_field_types_and_extracted(reader_api, test_re
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
             params={
                 "show": ["extracted"],
                 "field_type": ["text"],
@@ -262,3 +262,38 @@ async def test_get_resource_filter_field_types_and_extracted(reader_api, test_re
             "metadata",
             "vectors",
         }
+
+
+@pytest.mark.asyncio
+async def test_resource_endpoints_by_slug(reader_api, test_resource):
+    rsc = test_resource
+    kbid = rsc.kb.kbid
+    rslug = rsc.basic.slug
+
+    non_existent_slug = "foobar"
+
+    async with reader_api(roles=[NucliaDBRoles.READER]) as client:
+
+        # Regular GET
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{rslug}",
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{non_existent_slug}",
+        )
+        assert resp.status_code == 404
+
+        # Field endpoint
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{rslug}/text/text1",
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{non_existent_slug}/text/text1",
+        )
+        assert resp.status_code == 404

--- a/nucliadb_reader/nucliadb_reader/tests/test_reader_resource_field.py
+++ b/nucliadb_reader/nucliadb_reader/tests/test_reader_resource_field.py
@@ -24,7 +24,7 @@ from httpx import AsyncClient
 
 from nucliadb_ingest.orm.resource import Resource
 from nucliadb_models.resource import NucliaDBRoles
-from nucliadb_reader.api.v1.router import KB_PREFIX
+from nucliadb_reader.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX
 
 BASE = ("field_id", "field_type")
 VALUE = ("value",)
@@ -43,7 +43,7 @@ async def test_get_resource_field_default_options(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/{field_type}/{field_id}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}",
         )
         assert resp.status_code == 200
 
@@ -69,7 +69,7 @@ async def test_get_resource_field_all(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/{field_type}/{field_id}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}",
             params={
                 "show": ["value", "extracted"],
                 "field_type": [
@@ -120,7 +120,7 @@ async def test_get_resource_field_filter_root_fields(reader_api, test_resource):
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/{field_type}/{field_id}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}",
             params={"show": ["value"]},
         )
 
@@ -142,7 +142,7 @@ async def test_get_resource_field_filter_extracted(reader_api, test_resource):
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/{field_type}/{field_id}",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}",
             params={
                 "show": ["extracted"],
                 "extracted": ["metadata", "vectors"],
@@ -171,7 +171,7 @@ async def test_get_resource_field_conversation(
 
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         resp = await client.get(
-            f"/{KB_PREFIX}/{kbid}/resource/{rid}/{field_type}/{field_id}?page=last",
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}?page=last",
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -183,3 +183,38 @@ async def test_get_resource_field_conversation(
         expected_root_fields = set(BASE + VALUE)
         assert set(data.keys()) == expected_root_fields
         assert "messages" in data["value"]
+
+
+@pytest.mark.asyncio
+async def test_resource_endpoints_by_slug(reader_api, test_resource):
+    rsc = test_resource
+    kbid = rsc.kb.kbid
+    rslug = rsc.basic.slug
+
+    non_existent_slug = "foobar"
+
+    async with reader_api(roles=[NucliaDBRoles.READER]) as client:
+
+        # Regular GET
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{rslug}",
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{non_existent_slug}",
+        )
+        assert resp.status_code == 404
+
+        # Field endpoint
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{rslug}/text/text1",
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RSLUG_PREFIX}/{non_existent_slug}/text/text1",
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
Description
This PR aims to provide API support to do READ operations on resources by the resource slug, instead of the resource uuid.

List of changes:

- New url prefix can be used: `/kbs/{kb}/slug/{res-slug}`
- When slug is not set by the user, it defaults to uuid.

Endpoints changed:

- [x] get_resource_field
- [x] get_resource
- [x] download_field_conversation
- [x] download_field_layout
- [x] download_field_file
- [x] download_extract_field
 
Out of scope: writer and search changes. Will come in other PRs.

How was this PR tested?
Added new integration tests to check access by slug.
Existing tests should ensure we don't break anything.