### PR TITLE
Add slug support on search endpoints

### DIFF
--- a/charts/nucliadb_search/templates/search.vs.yaml
+++ b/charts/nucliadb_search/templates/search.vs.yaml
@@ -19,6 +19,10 @@ spec:
       method:
         regex: 'GET|OPTIONS'
     - uri:
+        regex: '^/api/v\d+/kb/[^/]+/slug/[^/]+/search$'
+      method:
+        regex: 'GET|OPTIONS'
+    - uri:
         regex: '^/api/v\d+/kb/[^/]+/counters'
       method:
         regex: 'GET|OPTIONS'

--- a/nucliadb_ingest/nucliadb_ingest/tests/fixtures.py
+++ b/nucliadb_ingest/nucliadb_ingest/tests/fixtures.py
@@ -769,12 +769,16 @@ def partition_settings():
     yield settings
 
 
-def broker_resource(knowledgebox):
-    rid = str(uuid.uuid4())
+def broker_resource(knowledgebox, rid=None, slug=None):
+    if rid is None:
+        rid = str(uuid.uuid4())
+    if slug is None:
+        slug = f"{rid}slug1"
+
     message1: BrokerMessage = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,
-        slug=f"{rid}slug1",
+        slug=slug,
         type=BrokerMessage.AUTOCOMMIT,
     )
 

--- a/nucliadb_search/nucliadb_search/api/v1/router.py
+++ b/nucliadb_search/nucliadb_search/api/v1/router.py
@@ -24,4 +24,4 @@ api = APIRouter()
 KB_PREFIX = "kb"
 KBS_PREFIX = "kbs"
 RESOURCE_PREFIX = "resource"
-RESOURCE_PREFIX = "field"
+RSLUG_PREFIX = "slug"

--- a/nucliadb_search/nucliadb_search/tests/fixtures.py
+++ b/nucliadb_search/nucliadb_search/tests/fixtures.py
@@ -163,9 +163,22 @@ async def test_search_resource(
     """
     Create a resource that has every possible bit of information
     """
-    message1 = broker_resource(knowledgebox)
+    message1 = broker_resource(knowledgebox, rid="foobar", slug="foobar-slug")
 
     return await inject_message(processor, knowledgebox, message1)
+
+
+@pytest.fixture(scope="function")
+async def test_resource_deterministic_ids(
+    indexing_utility_registered,
+    processor,
+    knowledgebox,
+):
+    rid = "foobar"
+    slug = "foobar-slug"
+    message1 = broker_resource(knowledgebox, rid=rid, slug=slug)
+    kb = await inject_message(processor, knowledgebox, message1)
+    return kb, rid, slug
 
 
 @pytest.fixture(scope="function")

--- a/nucliadb_search/nucliadb_search/tests/test_basic_search.py
+++ b/nucliadb_search/nucliadb_search/tests/test_basic_search.py
@@ -36,7 +36,7 @@ from nucliadb_ingest.tests.vectors import Q
 from nucliadb_ingest.utils import get_driver
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_search.api.models import NucliaDBClientType
-from nucliadb_search.api.v1.router import KB_PREFIX
+from nucliadb_search.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX
 from nucliadb_utils.keys import KB_SHARDS
 
 RUNNING_IN_GH_ACTIONS = os.environ.get("CI", "").lower() == "true"
@@ -295,3 +295,26 @@ async def test_search_pagination(
         # Check that we iterated over all matching resources
         unique_results = set(results)
         assert len(unique_results) == n_results_expected
+
+
+@pytest.mark.asyncio()
+async def test_resource_search_by_slug(search_api, test_resource_deterministic_ids):
+    async with search_api(roles=[NucliaDBRoles.READER]) as client:
+        kb, rid, slug = test_resource_deterministic_ids
+
+        # Happy path
+        resource_slug_url = f"/{KB_PREFIX}/{kb}/{RSLUG_PREFIX}/{slug}"
+        by_slug_resp = await client.get(f"{resource_slug_url}/search?query=foo")
+        assert by_slug_resp.status_code == 200
+
+        # Check response is the same as by rid
+        resource_uuid_url = f"/{KB_PREFIX}/{kb}/{RESOURCE_PREFIX}/{rid}"
+        by_uuid_resp = await client.get(f"{resource_uuid_url}/search?query=foo")
+        assert by_uuid_resp.status_code == 200
+        assert by_uuid_resp.json()["paragraphs"] == by_slug_resp.json()["paragraphs"]
+
+        # Check 404 on non-existing slug
+        invalid_slug_url = f"/{KB_PREFIX}/{kb}/{RSLUG_PREFIX}/idonotexist"
+        resp = await client.get(f"{invalid_slug_url}/search?query=foo")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Resource does not exist"


### PR DESCRIPTION
### Description
This PR makes it possible to search on a resource by its slug:

`GET /kbs/mykb/slug/resource-slug/search?query=foobar`

### How was this PR tested?
Added integration tests
