### PR TITLE
Fix clippy warnings

### DIFF
--- a/nucliadb_protos/rust/src/lib.rs
+++ b/nucliadb_protos/rust/src/lib.rs
@@ -18,6 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 pub mod fdbwriter;
 mod knowledgebox;
 mod nodereader;

--- a/vectors_benchmark/src/writer.rs
+++ b/vectors_benchmark/src/writer.rs
@@ -47,7 +47,7 @@ pub fn write_benchmark<Eng, QIter, Plot>(
             println!("Written {x}");
         }
     }
-    if vbatch.len() > 0 {
+    if !vbatch.is_empty() {
         engine.add_batch(batch_id, kbatch, vbatch);
         plotw.report().unwrap();
     }


### PR DESCRIPTION
### Description
This PR aims to remove all the clippy warnings.  
One of them, `clippy::derive_partial_eq_without_eq`, was due to generated codes. However, these clippy warnings have been fixed by the `tonic` team in the version `0.8+` but needs more requirements than the version `0.7` to work properly:
> In order to build tonic >= 0.8.0, you need the protoc Protocol Buffers compiler, along with Protocol Buffers resource files. 

### How was this PR tested?
I ran `cargo clippy --all-features` locally and all the warnings disappeared.
