### PR TITLE
Send Node metrics to Prometheus

### DIFF
--- a/nucliadb_node/Cargo.toml
+++ b/nucliadb_node/Cargo.toml
@@ -97,8 +97,9 @@ tracing-log = { version = "0.1.3", features = ["env_logger"] }
 opentelemetry-zipkin = "0.15.0"
 sentry-tracing = "0.27.0"
 
-# Prometheus client
+# Metrics related-dependencies
 prometheus = { version = "0.13.3", features = ["push"] }
+parse_duration = "2.1.1"
 
 # indra
 # indradb-lib = { version = "1", features = ["rocksdb-datastore"] }

--- a/nucliadb_node/Cargo.toml
+++ b/nucliadb_node/Cargo.toml
@@ -97,6 +97,9 @@ tracing-log = { version = "0.1.3", features = ["env_logger"] }
 opentelemetry-zipkin = "0.15.0"
 sentry-tracing = "0.27.0"
 
+# Prometheus client
+prometheus = { version = "0.13.3", features = ["push"] }
+
 # indra
 # indradb-lib = { version = "1", features = ["rocksdb-datastore"] }
 

--- a/nucliadb_node/binding/src/lib.rs
+++ b/nucliadb_node/binding/src/lib.rs
@@ -18,6 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::io::Cursor;
+
 use nucliadb_node::config::Configuration;
 use nucliadb_node::reader::NodeReaderService as RustReaderService;
 use nucliadb_node::writer::NodeWriterService as RustWriterService;
@@ -247,7 +248,11 @@ impl NodeWriter {
         }
     }
 
-    pub fn remove_resource<'p>(&mut self, resource: RawProtos, py: Python<'p>) -> PyResult<&'p PyAny> {
+    pub fn remove_resource<'p>(
+        &mut self,
+        resource: RawProtos,
+        py: Python<'p>,
+    ) -> PyResult<&'p PyAny> {
         let resource = ResourceId::decode(&mut Cursor::new(resource)).unwrap();
         let shard_id = ShardId {
             id: resource.shard_id.clone(),

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -98,6 +98,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     if let Some(prometheus_url) = Configuration::get_prometheus_url() {
+        info!("Start metrics task");
+
         let report = NodeReport::new(host_key.to_string())?;
         let mut metrics_publisher = metrics::Publisher::new("node_metrics", prometheus_url);
 
@@ -131,8 +133,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 report.shard_count.set(shard_count);
                 report.paragraph_count.set(paragraph_count as i64);
 
-                if let Err(e) = metrics_publisher.publish(&report) {
-                    error!("Cannot publish Node metrics: {:?}", e);
+                if let Err(e) = metrics_publisher.publish(&report).await {
+                    error!("Cannot publish Node metrics: {}", e);
+                } else {
+                    info!(
+                        "Publish Node metrics: shard_count {}, paragraph_count {}",
+                        shard_count, paragraph_count
+                    )
                 }
             }
         });

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -23,6 +23,9 @@ use std::time::Instant;
 
 use nucliadb_cluster::cluster::{read_or_create_host_key, Cluster, NucliaDBNodeType};
 use nucliadb_node::config::Configuration;
+use nucliadb_node::metrics;
+use nucliadb_node::metrics::report::NodeReport;
+use nucliadb_node::reader::NodeReaderService;
 use nucliadb_node::telemetry::init_telemetry;
 use nucliadb_node::writer::grpc_driver::NodeWriterGRPCDriver;
 use nucliadb_node::writer::NodeWriterService;
@@ -93,6 +96,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     });
+
+    if let Some(prometheus_url) = Configuration::get_prometheus_url() {
+        let report = NodeReport::new(host_key.to_string())?;
+        let mut metrics_publisher = metrics::Publisher::new("node_metrics", prometheus_url);
+
+        if let Some((username, password)) =
+            Configuration::get_prometheus_username().zip(Configuration::get_prometheus_password())
+        {
+            metrics_publisher = metrics_publisher.with_credentials(username, password);
+        }
+
+        let mut node_reader = NodeReaderService::new();
+        node_reader.load_shards()?;
+
+        let push_timing = Configuration::get_prometheus_push_timing();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(push_timing);
+
+            loop {
+                interval.tick().await;
+
+                let (shard_count, paragraph_count) = node_reader.shards.values().fold(
+                    (0, 0),
+                    |(shard_count, paragraph_count), shard| {
+                        (
+                            shard_count + 1,
+                            paragraph_count + shard.get_info().paragraphs,
+                        )
+                    },
+                );
+
+                report.shard_count.set(shard_count);
+                report.paragraph_count.set(paragraph_count as i64);
+
+                if let Err(e) = metrics_publisher.publish(&report) {
+                    error!("Cannot publish Node metrics: {:?}", e);
+                }
+            }
+        });
+    }
 
     info!("Bootstrap complete in: {:?}", start_bootstrap.elapsed());
     eprintln!("Running");

--- a/nucliadb_node/src/config.rs
+++ b/nucliadb_node/src/config.rs
@@ -261,6 +261,28 @@ impl Configuration {
         }
     }
 
+    /// Returns the Prometheus username, if any.
+    pub fn get_prometheus_username() -> Option<String> {
+        match env::var("PROMETHEUS_USERNAME") {
+            Ok(value) => Some(value),
+            Err(_) => {
+                error!("PROMETHEUS_USERNAME not defined. No defaulted");
+                None
+            }
+        }
+    }
+
+    /// Returns the Prometheus password, if any.
+    pub fn get_prometheus_password() -> Option<String> {
+        match env::var("PROMETHEUS_PASSWORD") {
+            Ok(value) => Some(value),
+            Err(_) => {
+                error!("PROMETHEUS_PASSWORD not defined. No defaulted");
+                None
+            }
+        }
+    }
+
     /// Retuns the Promethus push timing, defaulted to 1h if not defined.
     pub fn get_prometheus_push_timing() -> Duration {
         const DEFAULT_TIMING_PLACEHOLDER: &str = "1h";

--- a/nucliadb_node/src/config.rs
+++ b/nucliadb_node/src/config.rs
@@ -251,14 +251,15 @@ impl Configuration {
 
     /// Returns the Prometheus endpoint, if any.
     pub fn get_prometheus_url() -> Option<String> {
-        match env::var("PROMETHEUS_URL") {
-            Ok(value) => Some(value),
-            Err(_) => {
-                error!("PROMETHEUS_URL not defined. No defaulted");
+        let error = match env::var("PROMETHEUS_URL") {
+            Ok(value) if !value.is_empty() => return Some(value),
+            Ok(_) => "PROMETHEUS_URL defined incorrectly. No defaulted",
+            Err(_) => "PROMETHEUS_URL not defined. No defaulted",
+        };
 
-                None
-            }
-        }
+        error!(error);
+
+        None
     }
 
     /// Returns the Prometheus username, if any.

--- a/nucliadb_node/src/config.rs
+++ b/nucliadb_node/src/config.rs
@@ -27,6 +27,7 @@ use crate::utils::{parse_log_level, reliable_lookup_host};
 
 const SENTRY_PROD: &str = "prod";
 const SENTRY_DEV: &str = "stage";
+
 /// Global configuration options
 pub struct Configuration {}
 
@@ -245,5 +246,18 @@ impl Configuration {
                 default
             }
         }
+    }
+
+    /// Returns the Prometheus endpoint, if any.
+    pub fn get_prometheus_url() -> Option<String> {
+        match env::var("PROMETHEUS_URL") {
+            Ok(value) => Some(value),
+            Err(_) => {
+                error!("PROMETHEUS_URL not defined. No defaulted");
+
+                None
+            }
+        }
+    }
     }
 }

--- a/nucliadb_node/src/config.rs
+++ b/nucliadb_node/src/config.rs
@@ -266,7 +266,7 @@ impl Configuration {
         match env::var("PROMETHEUS_USERNAME") {
             Ok(value) => Some(value),
             Err(_) => {
-                error!("PROMETHEUS_USERNAME not defined. No defaulted");
+                warn!("PROMETHEUS_USERNAME not defined. No defaulted");
                 None
             }
         }
@@ -277,7 +277,7 @@ impl Configuration {
         match env::var("PROMETHEUS_PASSWORD") {
             Ok(value) => Some(value),
             Err(_) => {
-                error!("PROMETHEUS_PASSWORD not defined. No defaulted");
+                warn!("PROMETHEUS_PASSWORD not defined. No defaulted");
                 None
             }
         }
@@ -293,13 +293,19 @@ impl Configuration {
                 if let Ok(duration) = parse_duration::parse(&value) {
                     duration
                 } else {
-                    error!("PROMETHEUS_PUSH_TIMING defined incorrectly. Defaulting to {DEFAULT_TIMING_PLACEHOLDER}");
+                    error!(
+                        "PROMETHEUS_PUSH_TIMING defined incorrectly. Defaulting to \
+                         {DEFAULT_TIMING_PLACEHOLDER}"
+                    );
 
                     DEFAULT_TIMING
                 }
             }
             Err(_) => {
-                error!("PROMETHEUS_PUSH_TIMING not defined. Defaulting to {DEFAULT_TIMING_PLACEHOLDER}");
+                warn!(
+                    "PROMETHEUS_PUSH_TIMING not defined. Defaulting to \
+                     {DEFAULT_TIMING_PLACEHOLDER}"
+                );
 
                 DEFAULT_TIMING
             }

--- a/nucliadb_node/src/config.rs
+++ b/nucliadb_node/src/config.rs
@@ -20,6 +20,7 @@
 use std::env;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
+use std::time::Duration;
 
 use tracing::*;
 
@@ -259,5 +260,27 @@ impl Configuration {
             }
         }
     }
+
+    /// Retuns the Promethus push timing, defaulted to 1h if not defined.
+    pub fn get_prometheus_push_timing() -> Duration {
+        const DEFAULT_TIMING_PLACEHOLDER: &str = "1h";
+        const DEFAULT_TIMING: Duration = Duration::from_secs(60 * 60);
+
+        match env::var("PROMETHEUS_PUSH_TIMING") {
+            Ok(value) => {
+                if let Ok(duration) = parse_duration::parse(&value) {
+                    duration
+                } else {
+                    error!("PROMETHEUS_PUSH_TIMING defined incorrectly. Defaulting to {DEFAULT_TIMING_PLACEHOLDER}");
+
+                    DEFAULT_TIMING
+                }
+            }
+            Err(_) => {
+                error!("PROMETHEUS_PUSH_TIMING not defined. Defaulting to {DEFAULT_TIMING_PLACEHOLDER}");
+
+                DEFAULT_TIMING
+            }
+        }
     }
 }

--- a/nucliadb_node/src/metrics/error.rs
+++ b/nucliadb_node/src/metrics/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    BackendError(#[from] prometheus::Error),
+}

--- a/nucliadb_node/src/metrics/error.rs
+++ b/nucliadb_node/src/metrics/error.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/nucliadb_node/src/metrics/mod.rs
+++ b/nucliadb_node/src/metrics/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Bosutech XXI S.L.
+// Copyright (C) 2022 Bosutech XXI S.L.
 //
 // nucliadb is offered under the AGPL v3.0 and as commercial software.
 // For commercial licensing, contact us at info@nuclia.com.
@@ -17,30 +17,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
-// NucliaDB Node component
 
-// #![warn(missing_docs)]
-#![allow(clippy::bool_assert_comparison)]
+pub mod error;
+pub mod publisher;
+pub mod report;
 
-pub mod services;
-
-/// Global configuration enviromental variables
-pub mod config;
-
-/// Global stats struct
-pub mod stats;
-
-/// GRPC reading service
-pub mod reader;
-
-/// Utilities
-pub mod utils;
-
-// Telemetry
-pub mod telemetry;
-
-/// GRPC writing service
-pub mod writer;
-
-/// Prometheus publishing
-pub mod metrics;
+pub use error::Error;
+pub use publisher::Publisher;
+pub use report::Report;

--- a/nucliadb_node/src/metrics/mod.rs
+++ b/nucliadb_node/src/metrics/mod.rs
@@ -16,7 +16,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-//
 
 pub mod error;
 pub mod publisher;

--- a/nucliadb_node/src/metrics/publisher.rs
+++ b/nucliadb_node/src/metrics/publisher.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+use prometheus::BasicAuthentication;
+
+use super::{Report, Error};
+
+/// `Credentials`, a tiny wrapper around `prometheus::BasicAuthentication` with cloneable ability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Credentials {
+    username: String,
+    password: String,
+}
+
+impl From<Credentials> for BasicAuthentication {
+    fn from(Credentials { username, password }: Credentials) -> Self {
+        BasicAuthentication { username, password }
+    }
+}
+
+/// `Publisher`, a layer of abstraction over prometheus crate.
+pub struct Publisher {
+    job: Cow<'static, str>,
+    url: Cow<'static, str>,
+    credentials: Option<Credentials>,
+}
+
+impl Publisher {
+    // Creates a new `Publisher` bound to the given Prometheus URL.
+    pub fn new(job: impl Into<Cow<'static, str>>, url: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            job: job.into(),
+            url: url.into(),
+            credentials: None,
+        }
+    }
+
+    /// Adds authority to the `Publisher`.
+    pub fn with_credentials(mut self, username: String, password: String) -> Self {
+        self.credentials = Some(Credentials { username, password });
+
+        self
+    }
+
+    /// Publish any report to the Prometheus.
+    pub fn publish<R: Report>(&self, report: &R) -> Result<(), Error> {
+        prometheus::push_metrics(
+            &self.job,
+            report.labels(),
+            &self.url,
+            report.metrics(),
+            self.credentials.clone().map(Into::into),
+        )?;
+
+        Ok(())
+    }
+}

--- a/nucliadb_node/src/metrics/publisher.rs
+++ b/nucliadb_node/src/metrics/publisher.rs
@@ -42,14 +42,16 @@ impl Publisher {
     }
 
     /// Publish any report to the Prometheus.
-    pub fn publish<R: Report>(&self, report: &R) -> Result<(), Error> {
-        prometheus::push_metrics(
-            &self.job,
-            report.labels(),
-            &self.url,
-            report.metrics(),
-            self.credentials.clone().map(Into::into),
-        )?;
+    pub async fn publish<R: Report>(&self, report: &R) -> Result<(), Error> {
+        tokio::task::block_in_place(|| {
+            prometheus::push_metrics(
+                &self.job,
+                report.labels(),
+                &self.url,
+                report.metrics(),
+                self.credentials.clone().map(Into::into),
+            )
+        })?;
 
         Ok(())
     }

--- a/nucliadb_node/src/metrics/publisher.rs
+++ b/nucliadb_node/src/metrics/publisher.rs
@@ -1,8 +1,27 @@
+// Copyright (C) 2022 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::borrow::Cow;
 
 use prometheus::BasicAuthentication;
 
-use super::{Report, Error};
+use super::{Error, Report};
 
 /// `Credentials`, a tiny wrapper around `prometheus::BasicAuthentication` with cloneable ability.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nucliadb_node/src/metrics/report.rs
+++ b/nucliadb_node/src/metrics/report.rs
@@ -1,3 +1,22 @@
+// Copyright (C) 2022 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 

--- a/nucliadb_node/src/metrics/report.rs
+++ b/nucliadb_node/src/metrics/report.rs
@@ -1,0 +1,45 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use prometheus::proto::MetricFamily;
+use prometheus::{labels, opts, IntGauge, Registry};
+
+use super::Error;
+
+/// A trait to provide mandatory report data to the `Publisher`.
+pub trait Report {
+    fn metrics(&self) -> Vec<MetricFamily>;
+    fn labels(&self) -> HashMap<String, String>;
+}
+
+/// `NodeReport`, a structured representation of a node metrics.
+pub struct NodeReport {
+    id: Cow<'static, str>,
+    registry: Registry,
+    pub shard_count: IntGauge,
+    pub paragraph_count: IntGauge,
+}
+
+impl NodeReport {
+    pub fn new(id: impl Into<Cow<'static, str>>) -> Result<Self, Error> {
+        Ok(Self {
+            id: id.into(),
+            registry: Registry::new(),
+            shard_count: IntGauge::with_opts(opts!("shard_count", "Number of shards in the node"))?,
+            paragraph_count: IntGauge::with_opts(opts!(
+                "paragraph_count",
+                "The sum of all shard paragraphs in the node"
+            ))?,
+        })
+    }
+}
+
+impl Report for NodeReport {
+    fn metrics(&self) -> Vec<MetricFamily> {
+        self.registry.gather()
+    }
+
+    fn labels(&self) -> HashMap<String, String> {
+        labels! { "node_id".to_string() => self.id.to_string() }
+    }
+}

--- a/nucliadb_node/src/metrics/report.rs
+++ b/nucliadb_node/src/metrics/report.rs
@@ -22,14 +22,23 @@ pub struct NodeReport {
 
 impl NodeReport {
     pub fn new(id: impl Into<Cow<'static, str>>) -> Result<Self, Error> {
+        let id = id.into();
+        let registry = Registry::new();
+        let shard_count =
+            IntGauge::with_opts(opts!("shard_count", "Number of shards in the node"))?;
+        let paragraph_count = IntGauge::with_opts(opts!(
+            "paragraph_count",
+            "The sum of all shard paragraphs in the node"
+        ))?;
+
+        registry.register(Box::new(shard_count.clone()))?;
+        registry.register(Box::new(paragraph_count.clone()))?;
+
         Ok(Self {
-            id: id.into(),
-            registry: Registry::new(),
-            shard_count: IntGauge::with_opts(opts!("shard_count", "Number of shards in the node"))?,
-            paragraph_count: IntGauge::with_opts(opts!(
-                "paragraph_count",
-                "The sum of all shard paragraphs in the node"
-            ))?,
+            id,
+            registry,
+            shard_count,
+            paragraph_count,
         })
     }
 }

--- a/nucliadb_relations/src/storage_system/mod.rs
+++ b/nucliadb_relations/src/storage_system/mod.rs
@@ -20,12 +20,13 @@
 
 use std::path::Path;
 
-use crate::edge::*;
-use crate::node::*;
 use heed::flags::Flags;
 use heed::types::{ByteSlice, Str, Unit};
 use heed::{Database, Env, EnvOpenOptions, RoIter, RoPrefix, RoTxn, RwTxn};
 use nucliadb_byte_rpr::*;
+
+use crate::edge::*;
+use crate::node::*;
 
 mod db_name {
     pub const KEYS: &str = "KEYS_LMDB";


### PR DESCRIPTION
### Description
This PR aims to send Node metrics (shard/paragraph count for now, more metrics will be added later) to Prometheus using the push gateway.

This new **metrics** task is added to the Node writer (but should definitely be put to a new kind of Node).

### How was this PR tested?
- Create these two files locally:
1. `docker-compose.yml`
```yml
version: '3.2'
services:
  prom-pushgateway:
    image: prom/pushgateway
    ports:
      - 9091:9091
  prometheus:
    image: prom/prometheus
    volumes:
      - ./prometheus.yml:/etc/prometheus/prometheus.yml
    command:
      - '--config.file=/etc/prometheus/prometheus.yml'
      - '--storage.tsdb.path=/prometheus'
    ports:
      - 9090:9090
    network_mode: host
```
2. `prometheus.yml` 
```yml
global:
  scrape_interval: 15s
  scrape_timeout: 1s
  evaluation_interval: 15s
scrape_configs:
- job_name: dev-push-gateway
  metrics_path: /metrics
  scheme: http
  static_configs:
  - targets: ['localhost:9091']
    labels:
      service: 'prom-pushgateway'
```
- Run `docker compose up -d`
- Export these variables in environment:
```sh
HOSTNAME="localhost"
PROMETHEUS_URL="localhost:9091"
PROMETHEUS_PUSH_TIMING="15s"
```
- Run Node writer `cargo run --bin node_writer`
- Open `http://localhost:9091` and check the metrics in the interface