### PR TITLE
Forbid use of slash (/) in field ids

### DIFF
--- a/nucliadb/nucliadb/ingest/processing.py
+++ b/nucliadb/nucliadb/ingest/processing.py
@@ -151,7 +151,7 @@ class ProcessingEngine:
 
     def generate_file_token_from_cloudfile(self, cf: CloudFile) -> str:
         if self.nuclia_jwt_key is None:
-            raise AttributeError()
+            raise AttributeError("Nuclia JWT key not set")
         now = datetime.datetime.now(tz=datetime.timezone.utc)
         expiration = now + datetime.timedelta(days=self.days_to_keep)
 
@@ -175,7 +175,7 @@ class ProcessingEngine:
 
     def generate_file_token_from_fieldfile(self, file: FieldFilePB) -> str:
         if self.nuclia_jwt_key is None:
-            raise AttributeError()
+            raise AttributeError("Nuclia JWT key not set")
         now = datetime.datetime.now(tz=datetime.timezone.utc)
         expiration = now + datetime.timedelta(days=self.days_to_keep)
 
@@ -218,7 +218,7 @@ class ProcessingEngine:
 
     def convert_external_filefield_to_str(self, file_field: models.FileField) -> str:
         if self.nuclia_jwt_key is None:
-            raise AttributeError()
+            raise AttributeError("Nuclia JWT key not set")
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
         expiration = now + datetime.timedelta(days=self.days_to_keep)

--- a/nucliadb/nucliadb/models/utils.py
+++ b/nucliadb/nucliadb/models/utils.py
@@ -23,4 +23,4 @@ import pydantic
 
 
 class SlugString(pydantic.ConstrainedStr):
-    regex = re.compile(r"[a-z0-9_-]+")
+    regex = re.compile(r"^[a-z0-9_-]+$")

--- a/nucliadb/nucliadb/models/utils.py
+++ b/nucliadb/nucliadb/models/utils.py
@@ -22,5 +22,9 @@ import re
 import pydantic
 
 
+class FieldIdString(pydantic.ConstrainedStr):
+    regex = re.compile(r"^[^/]+$")
+
+
 class SlugString(pydantic.ConstrainedStr):
     regex = re.compile(r"^[a-z0-9_-]+$")

--- a/nucliadb/nucliadb/models/writer.py
+++ b/nucliadb/nucliadb/models/writer.py
@@ -35,7 +35,7 @@ from nucliadb.models.metadata import (
 )
 from nucliadb.models.processing import PushProcessingOptions
 from nucliadb.models.text import TextField
-from nucliadb.models.utils import SlugString
+from nucliadb.models.utils import FieldIdString, SlugString
 
 
 class CreateResourcePayload(BaseModel):
@@ -50,13 +50,13 @@ class CreateResourcePayload(BaseModel):
     fieldmetadata: Optional[List[UserFieldMetadata]] = None
     origin: Optional[Origin] = None
 
-    files: Dict[str, FileField] = {}
-    links: Dict[str, LinkField] = {}
-    texts: Dict[str, TextField] = {}
-    layouts: Dict[str, InputLayoutField] = {}
-    conversations: Dict[str, InputConversationField] = {}
-    keywordsets: Dict[str, FieldKeywordset] = {}
-    datetimes: Dict[str, FieldDatetime] = {}
+    files: Dict[FieldIdString, FileField] = {}
+    links: Dict[FieldIdString, LinkField] = {}
+    texts: Dict[FieldIdString, TextField] = {}
+    layouts: Dict[FieldIdString, InputLayoutField] = {}
+    conversations: Dict[FieldIdString, InputConversationField] = {}
+    keywordsets: Dict[FieldIdString, FieldKeywordset] = {}
+    datetimes: Dict[FieldIdString, FieldDatetime] = {}
 
     # Processing options
     processing_options: Optional[PushProcessingOptions] = PushProcessingOptions()
@@ -83,13 +83,13 @@ class UpdateResourcePayload(BaseModel):
     usermetadata: Optional[UserMetadata] = None
     fieldmetadata: Optional[List[UserFieldMetadata]] = None
 
-    files: Dict[str, FileField] = {}
-    links: Dict[str, LinkField] = {}
-    texts: Dict[str, TextField] = {}
-    layouts: Dict[str, InputLayoutField] = {}
-    conversations: Dict[str, InputConversationField] = {}
-    keywordsets: Dict[str, FieldKeywordset] = {}
-    datetimes: Dict[str, FieldDatetime] = {}
+    files: Dict[FieldIdString, FileField] = {}
+    links: Dict[FieldIdString, LinkField] = {}
+    texts: Dict[FieldIdString, TextField] = {}
+    layouts: Dict[FieldIdString, InputLayoutField] = {}
+    conversations: Dict[FieldIdString, InputConversationField] = {}
+    keywordsets: Dict[FieldIdString, FieldKeywordset] = {}
+    datetimes: Dict[FieldIdString, FieldDatetime] = {}
 
     # Processing options
     processing_options: Optional[PushProcessingOptions] = PushProcessingOptions()
@@ -119,4 +119,4 @@ ComminResourcePayload = Union[CreateResourcePayload, UpdateResourcePayload]
 class ResourceFileUploaded(BaseModel):
     seqid: Optional[int] = None
     uuid: Optional[str] = None
-    field_id: Optional[str] = None
+    field_id: Optional[FieldIdString] = None

--- a/nucliadb/nucliadb/one/tests/test_field_external_file.py
+++ b/nucliadb/nucliadb/one/tests/test_field_external_file.py
@@ -92,3 +92,26 @@ async def test_external_file_field(nuclia_jwt_key, nucliadb_api, knowledgebox_on
         assert data["files"]["field3"]["value"]["file"]["uri"] == EXTERNAL_FILE_URL
         assert "extra_headers" not in data["files"]["field3"]["value"]["file"]
         assert data["files"]["field3"]["value"]["external"] is True
+
+
+@pytest.mark.asyncio
+async def test_field_with_slashes(nuclia_jwt_key, nucliadb_api, knowledgebox_one):
+    async with nucliadb_api(roles=[NucliaDBRoles.WRITER]) as client:
+        # Create a resource
+        resp = await client.post(
+            f"/{KB_PREFIX}/{knowledgebox_one}/{RESOURCES_PREFIX}",
+            headers={"X-Synchronous": "True"},
+            json={
+                "slug": "resource1",
+                "title": "Resource 1",
+                "files": {
+                    "field/with/slashes": {
+                        "file": {
+                            "uri": EXTERNAL_FILE_URL,
+                            "extra_headers": {"Authorization": "Bearer foo1234"},
+                        }
+                    },
+                },
+            },
+        )
+        assert resp.status_code == 422

--- a/nucliadb_client/examples/stackoverflow.py
+++ b/nucliadb_client/examples/stackoverflow.py
@@ -42,6 +42,7 @@ from nucliadb.models.conversation import (
     InputMessageContent,
 )
 from nucliadb.models.metadata import InputMetadata, Origin
+from nucliadb.models.utils import FieldIdString
 from nucliadb.models.writer import CreateResourcePayload
 from nucliadb_client.client import NucliaDBClient
 from nucliadb_client.knowledgebox import KnowledgeBox
@@ -110,7 +111,7 @@ class StreamHandler(xml.sax.handler.ContentHandler):
         icf = InputConversationField()
         icf.messages.append(imq)
         icf.messages.append(ima)
-        payload.conversations["stack"] = icf
+        payload.conversations[FieldIdString("stack")] = icf
 
         # Create the resource with the row value
         if kb is None:

--- a/nucliadb_client/nucliadb_client/tests/test_export.py
+++ b/nucliadb_client/nucliadb_client/tests/test_export.py
@@ -25,6 +25,7 @@ import pytest
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
 from nucliadb.models.text import TextField
+from nucliadb.models.utils import FieldIdString
 from nucliadb.models.writer import CreateResourcePayload
 from nucliadb_client.client import NucliaDBClient
 from nucliadb_client.exceptions import ConflictError
@@ -54,7 +55,7 @@ async def test_export_import(nucliadb_client: NucliaDBClient):
     payload.title = "My Resource"
     payload.summary = "My long summary of the resource"
     payload.slug = "myresource"  # type: ignore
-    payload.texts["text1"] = TextField(body="My text")
+    payload.texts[FieldIdString("text1")] = TextField(body="My text")
     kb.create_resource(payload)
 
     async for line in kb.generator():

--- a/nucliadb_client/nucliadb_client/tests/test_resource.py
+++ b/nucliadb_client/nucliadb_client/tests/test_resource.py
@@ -28,6 +28,7 @@ from nucliadb.models.conversation import (
 )
 from nucliadb.models.datetime import FieldDatetime
 from nucliadb.models.text import TextField
+from nucliadb.models.utils import FieldIdString
 from nucliadb.models.writer import CreateResourcePayload
 from nucliadb_client.knowledgebox import KnowledgeBox
 
@@ -39,7 +40,7 @@ def test_resource_creation(nucliadb_knowledgebox: KnowledgeBox):
     payload.summary = "My long summary of the resource"
     payload.slug = "myresource"  # type: ignore
 
-    payload.conversations["conv1"] = InputConversationField(
+    payload.conversations[FieldIdString("conv1")] = InputConversationField(
         message=[
             InputMessage(
                 timestamp=datetime.now(),
@@ -62,11 +63,11 @@ def test_resource_creation(nucliadb_knowledgebox: KnowledgeBox):
         ]
     )
 
-    payload.texts["text1"] = TextField(body="My lovely text")
-    payload.texts["text2"] = TextField(body="My second lovely text")
+    payload.texts[FieldIdString("text1")] = TextField(body="My lovely text")
+    payload.texts[FieldIdString("text2")] = TextField(body="My second lovely text")
 
-    payload.datetimes["date1"] = FieldDatetime(value=datetime.now())
-    payload.datetimes["date2"] = FieldDatetime(value=datetime.now())
+    payload.datetimes[FieldIdString("date1")] = FieldDatetime(value=datetime.now())
+    payload.datetimes[FieldIdString("date2")] = FieldDatetime(value=datetime.now())
 
     res = nucliadb_knowledgebox.create_resource(payload)
 


### PR DESCRIPTION
- NucliaDB API validates field ids and don't allow use of the slash character (`/`) on any model
- Fix slug validation