### PR TITLE
constant detection of stopwords

### DIFF
--- a/nucliadb_paragraphs_tantivy/build.rs
+++ b/nucliadb_paragraphs_tantivy/build.rs
@@ -44,12 +44,11 @@ fn main() -> io::Result<()> {
     fs::write(
         &Path::new("./src/stop_words.rs"),
         format!(
-            "pub const STOP_WORDS: [&str;{}] = [{}];\n",
-            stop_words.len(),
+            "pub fn is_stop_word(x:&str) -> bool {{\n {} \n}}",
             stop_words
                 .into_iter()
-                .map(|word| format!(r#""{}""#, word))
-                .join(", ")
+                .map(|word| format!(r#"x == "{}""#, word))
+                .join("\n|| ")
         ),
     )?;
 

--- a/nucliadb_paragraphs_tantivy/src/reader.rs
+++ b/nucliadb_paragraphs_tantivy/src/reader.rs
@@ -677,7 +677,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 0);
@@ -695,7 +695,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 1);
@@ -713,7 +713,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 0);
@@ -731,7 +731,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 1);
@@ -749,7 +749,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 1);
@@ -767,7 +767,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 1);
@@ -785,7 +785,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.query, "\"shoupd + enaugh\"");
@@ -804,7 +804,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.query, "\"shoupd + enaugh\"");
@@ -823,7 +823,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 0);
@@ -841,7 +841,7 @@ mod tests {
             result_per_page: 20,
             timestamps: Some(timestamps.clone()),
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 3);
@@ -857,7 +857,7 @@ mod tests {
             result_per_page: 20,
             timestamps: Some(timestamps),
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 1);
@@ -875,7 +875,7 @@ mod tests {
             result_per_page: 20,
             timestamps: None,
             reload: false,
-            with_duplicates: false
+            with_duplicates: false,
         };
         let result = paragraph_reader_service.search(&search).unwrap();
         assert_eq!(result.total, 0);

--- a/nucliadb_paragraphs_tantivy/src/search_query.rs
+++ b/nucliadb_paragraphs_tantivy/src/search_query.rs
@@ -30,7 +30,7 @@ use tantivy::{DocId, InvertedIndexReader, Term};
 
 use crate::fuzzy_query::FuzzyTermQuery;
 use crate::schema::ParagraphSchema;
-use crate::stop_words::STOP_WORDS;
+use crate::stop_words::is_stop_word;
 
 type QueryP = (Occur, Box<dyn Query>);
 
@@ -213,11 +213,11 @@ fn parse_query(parser: &QueryParser, text: &str) -> Box<dyn Query> {
 /// - Is **NOT** the last term in the query
 ///
 /// The last term of the query is a prefix fuzzy term and must be preserved.
-fn remove_stop_words<'a>(query: &'a str, stop_words: &[&str]) -> Cow<'a, str> {
+fn remove_stop_words(query: &str) -> Cow<'_, str> {
     match query.rsplit_once(' ') {
         Some((query, last_term)) => query
             .split(' ')
-            .filter(|term| !stop_words.contains(term))
+            .filter(|term| !is_stop_word(term))
             .chain([last_term])
             .join(" ")
             .into(),
@@ -264,7 +264,7 @@ fn preprocess_raw_query(query: &str, tc: &mut TermCollector) -> ProcessedQuery {
     }
     ProcessedQuery {
         regular_query: query.to_string(),
-        fuzzy_query: remove_stop_words(fuzzy_query.trim(), &STOP_WORDS[..]).to_string(),
+        fuzzy_query: remove_stop_words(fuzzy_query.trim()).to_string(),
     }
 }
 pub fn suggest_query(
@@ -416,7 +416,7 @@ mod tests {
         ];
 
         for (query, expected_fuzzy_query) in tests {
-            let fuzzy_query = remove_stop_words(query, &stop_words[..]);
+            let fuzzy_query = remove_stop_words(query);
 
             assert_eq!(fuzzy_query, expected_fuzzy_query);
         }

--- a/nucliadb_paragraphs_tantivy/src/search_query.rs
+++ b/nucliadb_paragraphs_tantivy/src/search_query.rs
@@ -401,7 +401,6 @@ mod tests {
 
     #[test]
     fn it_removes_stop_word_fterms() {
-        let stop_words = &["is", "a", "for", "and"];
         let tests = [
             (
                 "nuclia is a database for unstructured data",

--- a/nucliadb_paragraphs_tantivy/src/writer.rs
+++ b/nucliadb_paragraphs_tantivy/src/writer.rs
@@ -300,7 +300,7 @@ mod tests {
             labels: vec!["/nsfw".to_string()],
             index: 0,
             split: "".to_string(),
-            repeated_in_field: false
+            repeated_in_field: false,
         };
         let p1_uuid = format!("{}/{}/{}-{}", UUID, "body", 0, DOC1_P1.len());
 
@@ -334,7 +334,7 @@ mod tests {
             labels: vec!["/three".to_string(), "/label2".to_string()],
             index: 2,
             split: "".to_string(),
-            repeated_in_field: false
+            repeated_in_field: false,
         };
         let p3_uuid = format!(
             "{}/{}/{}-{}",
@@ -358,7 +358,7 @@ mod tests {
             labels: vec!["/cool".to_string()],
             index: 3,
             split: "".to_string(),
-            repeated_in_field: false
+            repeated_in_field: false,
         };
         let p4_uuid = format!("{}/{}/{}-{}", UUID, "body", 0, DOC1_TI.len());
 


### PR DESCRIPTION
### Description
Previously nucliadb_paragraphs_tantivy/src/build.rs built an array containing all the stopwords recorded in the the stop_words dictionary, this caused  stopword detection by traversing the array.
With this PR the array is substituted by a function "is_a_stopword", built at compile time. This function's body is a boolean expression with each stopword variant. 

### How was this PR tested?
Local test
