### PR TITLE
Add some contexts on LMDB opening failure

### DIFF
--- a/nucliadb_relations/src/search_engine/mod.rs
+++ b/nucliadb_relations/src/search_engine/mod.rs
@@ -186,7 +186,7 @@ mod tests {
 
     fn generate_graph() -> StorageSystem {
         let dir = tempfile::tempdir().unwrap();
-        let system = StorageSystem::create(dir.path());
+        let system = StorageSystem::create(dir.path()).unwrap();
         let mut txn = system.rw_txn();
         {
             system.add_node(&mut txn, NA.to_string());

--- a/nucliadb_relations/src/service/reader.rs
+++ b/nucliadb_relations/src/service/reader.rs
@@ -131,9 +131,9 @@ impl RelationsReaderService {
     pub fn start(config: &RelationConfig) -> InternalResult<Self> {
         let path = std::path::Path::new(&config.path);
         if !path.exists() {
-            Ok(RelationsReaderService::new(config).unwrap())
+            Ok(RelationsReaderService::new(config)?)
         } else {
-            Ok(RelationsReaderService::open(config).unwrap())
+            Ok(RelationsReaderService::open(config)?)
         }
     }
     pub fn new(config: &RelationConfig) -> InternalResult<Self> {
@@ -144,7 +144,7 @@ impl RelationsReaderService {
             std::fs::create_dir_all(path).unwrap();
 
             Ok(RelationsReaderService {
-                index: StorageSystem::create(path),
+                index: StorageSystem::create(path)?,
             })
         }
     }
@@ -155,7 +155,7 @@ impl RelationsReaderService {
             Err(Box::new("Shard does not exist".to_string()))
         } else {
             Ok(RelationsReaderService {
-                index: StorageSystem::open(path),
+                index: StorageSystem::open(path)?,
             })
         }
     }

--- a/nucliadb_relations/src/service/writer.rs
+++ b/nucliadb_relations/src/service/writer.rs
@@ -97,7 +97,7 @@ impl RelationsWriterService {
     pub fn start(config: &RelationConfig) -> InternalResult<Self> {
         let path = std::path::Path::new(&config.path);
         Ok(RelationsWriterService {
-            index: StorageSystem::start(path),
+            index: StorageSystem::start(path)?,
         })
     }
     pub fn new(config: &RelationConfig) -> InternalResult<Self> {
@@ -108,7 +108,7 @@ impl RelationsWriterService {
             std::fs::create_dir_all(path).unwrap();
 
             Ok(RelationsWriterService {
-                index: StorageSystem::create(path),
+                index: StorageSystem::create(path)?,
             })
         }
     }
@@ -119,7 +119,7 @@ impl RelationsWriterService {
             Err(Box::new("Shard does not exist".to_string()))
         } else {
             Ok(RelationsWriterService {
-                index: StorageSystem::open(path),
+                index: StorageSystem::open(path)?,
             })
         }
     }

--- a/nucliadb_relations/src/storage_system/mod.rs
+++ b/nucliadb_relations/src/storage_system/mod.rs
@@ -318,15 +318,14 @@ mod tests {
     use super::*;
     fn initialize_storage_system() -> StorageSystem {
         let dir = tempfile::tempdir().unwrap();
-        StorageSystem::create(dir.path())
+        StorageSystem::create(dir.path()).unwrap()
     }
 
     #[test]
     fn open_and_create() {
         let dir = tempfile::tempdir().unwrap();
-        StorageSystem::create(dir.path());
-        StorageSystem::open(dir.path());
-        assert!(true);
+        StorageSystem::create(dir.path()).unwrap();
+        StorageSystem::open(dir.path()).unwrap();
     }
 
     const CHILD: &str = "child";


### PR DESCRIPTION
### Description
This PR aims to replace the `unwrap` calls which cause a panic after a  node cleaning.

### How was this PR tested?
Tests are green.
