### PR TITLE
using create_database when opening

### DIFF
--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1
+
+- Fix `create` function in `nucliadb_relations` index
 ## 0.4.0
 
 - Add `clean_and_upgrade_shard` function

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucliadb_node_binding"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nucliadb_relations/src/service/reader.rs
+++ b/nucliadb_relations/src/service/reader.rs
@@ -155,7 +155,7 @@ impl RelationsReaderService {
             Err(Box::new("Shard does not exist".to_string()))
         } else {
             Ok(RelationsReaderService {
-                index: StorageSystem::open(path),
+                index: StorageSystem::create(path),
             })
         }
     }

--- a/nucliadb_relations/src/service/writer.rs
+++ b/nucliadb_relations/src/service/writer.rs
@@ -97,7 +97,7 @@ impl RelationsWriterService {
     pub fn start(config: &RelationConfig) -> InternalResult<Self> {
         let path = std::path::Path::new(&config.path);
         Ok(RelationsWriterService {
-            index: StorageSystem::start(path),
+            index: StorageSystem::create(path),
         })
     }
     pub fn new(config: &RelationConfig) -> InternalResult<Self> {
@@ -119,7 +119,7 @@ impl RelationsWriterService {
             Err(Box::new("Shard does not exist".to_string()))
         } else {
             Ok(RelationsWriterService {
-                index: StorageSystem::open(path),
+                index: StorageSystem::create(path),
             })
         }
     }

--- a/nucliadb_relations/src/storage_system/mod.rs
+++ b/nucliadb_relations/src/storage_system/mod.rs
@@ -137,13 +137,23 @@ impl StorageSystem {
         unsafe {
             env_builder.flag(Flags::MdbNoLock);
         }
-        let env = env_builder.open(&env_path).unwrap();
-        let keys = env.create_database(Some(db_name::KEYS)).unwrap();
-        let inv_keys = env.create_database(Some(db_name::INVERSE_KEYS)).unwrap();
-        let edges = env.create_database(Some(db_name::EDGES)).unwrap();
-        let in_edges = env.create_database(Some(db_name::INVERSE_EDGES)).unwrap();
-        let state = env.create_database(Some(db_name::STATE)).unwrap();
-        std::fs::File::create(path.join(env_config::STAMP)).unwrap();
+        let env = env_builder.open(&env_path).expect("Opening env failed");
+        let keys = env
+            .create_database(Some(db_name::KEYS))
+            .expect("Keys db could not be created");
+        let inv_keys = env
+            .create_database(Some(db_name::INVERSE_KEYS))
+            .expect("InvKeys db could not be created");
+        let edges = env
+            .create_database(Some(db_name::EDGES))
+            .expect("Edges db could not be created");
+        let in_edges = env
+            .create_database(Some(db_name::INVERSE_EDGES))
+            .expect("InEdges db could not be created");
+        let state = env
+            .create_database(Some(db_name::STATE))
+            .expect("State db could not be created");
+        std::fs::File::create(path.join(env_config::STAMP)).expect("Stamp could not be created");
         StorageSystem {
             env,
             keys,

--- a/nucliadb_relations/src/storage_system/mod.rs
+++ b/nucliadb_relations/src/storage_system/mod.rs
@@ -128,66 +128,22 @@ pub struct StorageSystem {
 }
 
 impl StorageSystem {
-    pub fn start(path: &Path) -> StorageSystem {
-        if !path.join(env_config::STAMP).exists() {
-            StorageSystem::create(path)
-        } else {
-            StorageSystem::open(path)
-        }
-    }
     pub fn create(path: &Path) -> StorageSystem {
-        if !path.join(env_config::STAMP).exists() {
-            let env_path = path.join(env_config::ENV);
-            std::fs::create_dir_all(&env_path).unwrap();
-            let mut env_builder = EnvOpenOptions::new();
-            env_builder.max_dbs(env_config::MAX_DBS);
-            env_builder.map_size(env_config::MAP_SIZE);
-            unsafe {
-                env_builder.flag(Flags::MdbNoLock);
-            }
-            let env = env_builder.open(&env_path).unwrap();
-            let keys = env.create_database(Some(db_name::KEYS)).unwrap();
-            let inv_keys = env.create_database(Some(db_name::INVERSE_KEYS)).unwrap();
-            let edges = env.create_database(Some(db_name::EDGES)).unwrap();
-            let in_edges = env.create_database(Some(db_name::INVERSE_EDGES)).unwrap();
-            let state = env.create_database(Some(db_name::STATE)).unwrap();
-            std::fs::File::create(path.join(env_config::STAMP)).unwrap();
-            StorageSystem {
-                env,
-                keys,
-                inv_keys,
-                edges,
-                in_edges,
-                state,
-            }
-        } else {
-            StorageSystem::open(path)
-        }
-    }
-
-    pub fn open(path: &Path) -> StorageSystem {
         let env_path = path.join(env_config::ENV);
-        if !path.join(env_config::STAMP).exists() {
-            panic!("{:?} is not a valid index", path);
-        }
+        std::fs::create_dir_all(&env_path).unwrap();
         let mut env_builder = EnvOpenOptions::new();
+        env_builder.max_dbs(env_config::MAX_DBS);
+        env_builder.map_size(env_config::MAP_SIZE);
         unsafe {
             env_builder.flag(Flags::MdbNoLock);
         }
-        env_builder.max_dbs(env_config::MAX_DBS);
-        env_builder.map_size(env_config::MAP_SIZE);
         let env = env_builder.open(&env_path).unwrap();
-        let keys = env.open_database(Some(db_name::KEYS)).unwrap().unwrap();
-        let inv_keys = env
-            .open_database(Some(db_name::INVERSE_KEYS))
-            .unwrap()
-            .unwrap();
-        let edges = env.open_database(Some(db_name::EDGES)).unwrap().unwrap();
-        let in_edges = env
-            .open_database(Some(db_name::INVERSE_EDGES))
-            .unwrap()
-            .unwrap();
-        let state = env.open_database(Some(db_name::STATE)).unwrap().unwrap();
+        let keys = env.create_database(Some(db_name::KEYS)).unwrap();
+        let inv_keys = env.create_database(Some(db_name::INVERSE_KEYS)).unwrap();
+        let edges = env.create_database(Some(db_name::EDGES)).unwrap();
+        let in_edges = env.create_database(Some(db_name::INVERSE_EDGES)).unwrap();
+        let state = env.create_database(Some(db_name::STATE)).unwrap();
+        std::fs::File::create(path.join(env_config::STAMP)).unwrap();
         StorageSystem {
             env,
             keys,
@@ -316,7 +272,7 @@ mod tests {
     fn open_and_create() {
         let dir = tempfile::tempdir().unwrap();
         StorageSystem::create(dir.path());
-        StorageSystem::open(dir.path());
+        StorageSystem::create(dir.path());
     }
 
     const CHILD: &str = "child";


### PR DESCRIPTION
### Description
When the clean function appeared a  new scenario appeared for the index. A shard that is not yet created (this is done by the query) may be queried by the reader. In the old version of relations this causes a lot of problems because I didn't knew that "create_database" in heed opens or creates a db. In the new version this is fixed.

### How was this PR tested?
Local test