### PR TITLE
Remove all clippy warnings

### DIFF
--- a/nucliadb_cluster/src/cluster.rs
+++ b/nucliadb_cluster/src/cluster.rs
@@ -228,11 +228,11 @@ impl Cluster {
                     let guard = chitchat_clone.lock().await;
                     let update_members: Vec<Member> = live_nodes
                         .iter()
-                        .map(|node_id| Member::build(node_id, &*guard).unwrap())
+                        .map(|node_id| Member::build(node_id, &guard).unwrap())
                         .collect();
                     let dead: Vec<Member> = guard
                         .dead_nodes()
-                        .map(|node_id| Member::build(node_id, &*guard).unwrap())
+                        .map(|node_id| Member::build(node_id, &guard).unwrap())
                         .collect();
                     debug!(updated_memberlist=?update_members);
                     debug!(dead_nodes=?dead);

--- a/nucliadb_fields_tantivy/src/reader.rs
+++ b/nucliadb_fields_tantivy/src/reader.rs
@@ -415,7 +415,7 @@ impl FieldReaderService {
             .map(|v| {
                 v.tags
                     .iter()
-                    .filter(|s| FieldReaderService::is_valid_facet(*s))
+                    .filter(|s| FieldReaderService::is_valid_facet(s))
                     .cloned()
                     .collect()
             })

--- a/nucliadb_fields_tantivy/src/schema.rs
+++ b/nucliadb_fields_tantivy/src/schema.rs
@@ -37,7 +37,7 @@ pub struct FieldSchema {
 }
 
 pub fn timestamp_to_datetime_utc(timestamp: &prost_types::Timestamp) -> DateTime<Utc> {
-    let naive = NaiveDateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32);
+    let naive = NaiveDateTime::from_timestamp_opt(timestamp.seconds, timestamp.nanos as u32).unwrap();
     DateTime::from_utc(naive, tantivy::chrono::Utc)
 }
 

--- a/nucliadb_node/src/bin/payload_test.rs
+++ b/nucliadb_node/src/bin/payload_test.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     let new_shard = writer.new_shard();
     let shard_id = ShardId { id: new_shard.id };
     assert!(resources_dir.exists());
-    for file_path in std::fs::read_dir(&resources_dir).unwrap() {
+    for file_path in std::fs::read_dir(resources_dir).unwrap() {
         let file_path = file_path.unwrap().path();
         println!("processing {file_path:?}");
         let content = std::fs::read(&file_path).unwrap();

--- a/nucliadb_node/src/services/config.rs
+++ b/nucliadb_node/src/services/config.rs
@@ -109,7 +109,7 @@ impl ShardConfig {
         }
     }
     fn read_config(json_file: &path::Path) -> ConfigState {
-        let content = fs::read_to_string(&json_file).unwrap();
+        let content = fs::read_to_string(json_file).unwrap();
         let mut raw: StoredConfig = serde_json::from_str(&content).unwrap();
         if raw.fill_gaps() {
             ConfigState::Modified(ShardConfig::from(raw))

--- a/nucliadb_paragraphs_tantivy/build.rs
+++ b/nucliadb_paragraphs_tantivy/build.rs
@@ -42,7 +42,7 @@ fn main() -> io::Result<()> {
         .collect::<Result<Vec<_>, _>>()?;
 
     fs::write(
-        &Path::new("./src/stop_words.rs"),
+        Path::new("./src/stop_words.rs"),
         format!(
             "pub fn is_stop_word(x:&str) -> bool {{\n {} \n}}",
             stop_words

--- a/nucliadb_paragraphs_tantivy/src/fuzzy_query.rs
+++ b/nucliadb_paragraphs_tantivy/src/fuzzy_query.rs
@@ -63,7 +63,7 @@ where
         &'a self,
         term_dict: &'a TermDictionary,
     ) -> io::Result<TermStreamer<'a, &'a A>> {
-        let automaton: &A = &*self.automaton;
+        let automaton: &A = &self.automaton;
         let term_stream_builder = term_dict.search(automaton);
         term_stream_builder.into_stream()
     }

--- a/nucliadb_paragraphs_tantivy/src/reader.rs
+++ b/nucliadb_paragraphs_tantivy/src/reader.rs
@@ -108,7 +108,7 @@ impl ReaderChild for ParagraphReaderService {
             .map(|v| {
                 v.tags
                     .iter()
-                    .filter(|s| ParagraphReaderService::is_valid_facet(*s))
+                    .filter(|s| ParagraphReaderService::is_valid_facet(s))
                     .cloned()
                     .collect()
             })

--- a/nucliadb_paragraphs_tantivy/src/schema.rs
+++ b/nucliadb_paragraphs_tantivy/src/schema.rs
@@ -42,7 +42,8 @@ pub struct ParagraphSchema {
 }
 
 pub fn timestamp_to_datetime_utc(timestamp: &prost_types::Timestamp) -> DateTime<Utc> {
-    let naive = NaiveDateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32);
+    let naive =
+        NaiveDateTime::from_timestamp_opt(timestamp.seconds, timestamp.nanos as u32).unwrap();
     DateTime::from_utc(naive, tantivy::chrono::Utc)
 }
 

--- a/nucliadb_paragraphs_tantivy2/build.rs
+++ b/nucliadb_paragraphs_tantivy2/build.rs
@@ -42,7 +42,7 @@ fn main() -> io::Result<()> {
         .collect::<Result<Vec<_>, _>>()?;
 
     fs::write(
-        &Path::new("./src/stop_words.rs"),
+        Path::new("./src/stop_words.rs"),
         format!(
             "pub fn is_stop_word(x:&str) -> bool {{\n {} \n}}",
             stop_words

--- a/nucliadb_paragraphs_tantivy2/src/fuzzy_query.rs
+++ b/nucliadb_paragraphs_tantivy2/src/fuzzy_query.rs
@@ -63,7 +63,7 @@ where
         &'a self,
         term_dict: &'a TermDictionary,
     ) -> io::Result<TermStreamer<'a, &'a A>> {
-        let automaton: &A = &*self.automaton;
+        let automaton: &A = &self.automaton;
         let term_stream_builder = term_dict.search(automaton);
         term_stream_builder.into_stream()
     }

--- a/nucliadb_paragraphs_tantivy2/src/reader.rs
+++ b/nucliadb_paragraphs_tantivy2/src/reader.rs
@@ -107,7 +107,7 @@ impl ReaderChild for ParagraphReaderService {
             .map(|v| {
                 v.tags
                     .iter()
-                    .filter(|s| ParagraphReaderService::is_valid_facet(*s))
+                    .filter(|s| ParagraphReaderService::is_valid_facet(s))
                     .cloned()
                     .collect()
             })

--- a/nucliadb_paragraphs_tantivy2/src/schema.rs
+++ b/nucliadb_paragraphs_tantivy2/src/schema.rs
@@ -47,7 +47,7 @@ pub struct ParagraphSchema {
 }
 
 pub fn timestamp_to_datetime_utc(timestamp: &prost_types::Timestamp) -> DateTime<Utc> {
-    let naive = NaiveDateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32);
+    let naive = NaiveDateTime::from_timestamp_opt(timestamp.seconds, timestamp.nanos as u32).unwrap();
     DateTime::from_utc(naive, tantivy::chrono::Utc)
 }
 

--- a/nucliadb_protos/rust/build.rs
+++ b/nucliadb_protos/rust/build.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut prost_config = prost_build::Config::default();
 
     prost_config
-        .out_dir(&"src/")
+        .out_dir("src/")
         .compile_protos(
             &[
                 "nucliadb_protos/utils.proto",

--- a/nucliadb_relations/src/storage_system/mod.rs
+++ b/nucliadb_relations/src/storage_system/mod.rs
@@ -317,7 +317,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         StorageSystem::create(dir.path());
         StorageSystem::open(dir.path());
-        assert!(true);
     }
 
     const CHILD: &str = "child";

--- a/nucliadb_vectors/src/memory_system/mmap_driver/mod.rs
+++ b/nucliadb_vectors/src/memory_system/mmap_driver/mod.rs
@@ -48,7 +48,7 @@ struct DiskStack {
 }
 impl DiskStack {
     pub fn new(path: &Path) -> DiskStack {
-        std::fs::create_dir_all(&path).unwrap();
+        std::fs::create_dir_all(path).unwrap();
         let path = path.to_path_buf();
         DiskStack {
             stack: path.join(STACK),
@@ -139,7 +139,7 @@ impl SegmentWriter for Storage {
 
 impl Storage {
     pub fn create(path: &Path) -> Storage {
-        std::fs::create_dir_all(&path).unwrap();
+        std::fs::create_dir_all(path).unwrap();
         let nuclia_stamp = path.join(NUCLIA_STAMP);
         let path_storage = path.join(STORAGE);
         let path_lock = path.join(STORAGE_LOCK);

--- a/nucliadb_vectors/src/service/reader.rs
+++ b/nucliadb_vectors/src/service/reader.rs
@@ -109,7 +109,7 @@ impl VectorReaderService {
         if path.exists() {
             Err(Box::new("Shard already created".to_string()))
         } else {
-            std::fs::create_dir_all(&path).unwrap();
+            std::fs::create_dir_all(path).unwrap();
             Ok(VectorReaderService {
                 index: RwLock::new(Reader::new(&config.path)),
             })

--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -95,7 +95,7 @@ impl VectorWriterService {
         if path.exists() {
             Err(Box::new("Shard already created".to_string()))
         } else {
-            std::fs::create_dir_all(&path).unwrap();
+            std::fs::create_dir_all(path).unwrap();
             Ok(VectorWriterService {
                 index: Writer::new(&config.path),
             })

--- a/nucliadb_vectors/src/tests/mod.rs
+++ b/nucliadb_vectors/src/tests/mod.rs
@@ -119,7 +119,7 @@ fn single_graph() {
     writer.commit();
     writer.delete_vector(key.clone());
     writer.commit();
-    writer.insert(key.clone(), vec.clone(), vec![]);
+    writer.insert(key, vec.clone(), vec![]);
     writer.commit();
     assert_eq!(writer.no_vectors(), 1);
     assert_eq!(reader.no_vectors(), 0);

--- a/nucliadb_vectors2/src/disk/trie.rs
+++ b/nucliadb_vectors2/src/disk/trie.rs
@@ -55,7 +55,7 @@ pub fn serialize_into<W: io::Write>(mut buf: W, trie: Trie) -> io::Result<()> {
     byte_offset += USIZE_LEN;
     for (node, (is_final, adjacency)) in trie.into_iter().enumerate() {
         indexing.insert(node, byte_offset);
-        buf.write_all(&[if is_final { 1 } else { 0 }])?;
+        buf.write_all(&[u8::from(is_final)])?;
         buf.write_all(&adjacency.len().to_le_bytes())?;
         byte_offset += ADJ_HEADER;
         for (edge, node) in adjacency {

--- a/nucliadb_vectors2/src/vectors/service/writer.rs
+++ b/nucliadb_vectors2/src/vectors/service/writer.rs
@@ -110,7 +110,7 @@ impl VectorWriterService {
         if path.exists() {
             Err(Box::new("Shard already created".to_string()))
         } else {
-            std::fs::create_dir_all(&path).unwrap();
+            std::fs::create_dir_all(path).unwrap();
             Ok(VectorWriterService {
                 index: Index::writer(path)?,
             })

--- a/vectors_benchmark/src/file_vectors.rs
+++ b/vectors_benchmark/src/file_vectors.rs
@@ -104,10 +104,10 @@ mod test {
         let vec_reader = VecReader { idx: 0, buf: &buf };
         let mut iter = FileVectors::new(vec_reader);
         let v1 = iter.next();
-        assert_eq!(v1.as_ref().map(|v| v.as_slice()), Some(V1.as_slice()));
+        assert_eq!(v1.as_deref(), Some(V1.as_slice()));
         let v2 = iter.next();
-        assert_eq!(v2.as_ref().map(|v| v.as_slice()), Some(V2.as_slice()));
+        assert_eq!(v2.as_deref(), Some(V2.as_slice()));
         let v3 = iter.next();
-        assert_eq!(v3.as_ref().map(|v| v.as_slice()), Some(V3.as_slice()));
+        assert_eq!(v3.as_deref(), Some(V3.as_slice()));
     }
 }


### PR DESCRIPTION
### Description
This PR aims to remove all the `clippy` warnings for all features and all targets.  
Plus, all the warnings issued from the latest stable Rust version have been treated as well.

### How was this PR tested?
Run `cargo clippy --all-features --all-targets` on Rust version 1.64 and 1.65
