### PR TITLE
Add nucliadb tests for paragraph page position and duplicates

### DIFF
--- a/nucliadb/nucliadb/ingest/fields/base.py
+++ b/nucliadb/nucliadb/ingest/fields/base.py
@@ -66,7 +66,7 @@ class Field:
             raise InvalidFieldClass()
 
         self.value = None
-        self.extracted_text = None
+        self.extracted_text: Optional[ExtractedText] = None
         self.extracted_vectors = None
         self.computed_metadata = None
         self.large_computed_metadata = None

--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -260,8 +260,14 @@ class Resource:
                 if type_id == FieldType.FILE and isinstance(field, File):
                     page_positions = await get_file_page_positions(field)
 
+                extracted_text = await field.get_extracted_text()
                 brain.apply_field_metadata(
-                    field_key, field_metadata, [], {}, page_positions=page_positions
+                    field_key,
+                    field_metadata,
+                    [],
+                    {},
+                    page_positions=page_positions,
+                    extracted_text=extracted_text,
                 )
 
             if self.disable_vectors is False:
@@ -553,8 +559,20 @@ class Resource:
                 replace_splits,
             ) = await field_obj.set_field_metadata(field_metadata)
             field_key = self.generate_field_id(field_metadata.field)
+
+            page_positions: Optional[FilePagePositions] = None
+            if field_metadata.field.field_type == FieldType.FILE and isinstance(
+                field_obj, File
+            ):
+                page_positions = await get_file_page_positions(field_obj)
+
             self.indexer.apply_field_metadata(
-                field_key, metadata, replace_field, replace_splits
+                field_key,
+                metadata,
+                replace_field,
+                replace_splits,
+                page_positions=page_positions,
+                extracted_text=await field_obj.get_extracted_text(),
             )
 
             if (

--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -260,14 +260,13 @@ class Resource:
                 if type_id == FieldType.FILE and isinstance(field, File):
                     page_positions = await get_file_page_positions(field)
 
-                extracted_text = await field.get_extracted_text()
                 brain.apply_field_metadata(
                     field_key,
                     field_metadata,
-                    [],
-                    {},
+                    replace_field=[],
+                    replace_splits={},
                     page_positions=page_positions,
-                    extracted_text=extracted_text,
+                    extracted_text=await field.get_extracted_text(),
                 )
 
             if self.disable_vectors is False:
@@ -569,8 +568,8 @@ class Resource:
             self.indexer.apply_field_metadata(
                 field_key,
                 metadata,
-                replace_field,
-                replace_splits,
+                replace_field=replace_field,
+                replace_splits=replace_splits,
                 page_positions=page_positions,
                 extracted_text=await field_obj.get_extracted_text(),
             )

--- a/nucliadb/nucliadb/ingest/tests/orm/test_brain.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_brain.py
@@ -29,7 +29,7 @@ from nucliadb_protos.resources_pb2 import (
     Sentence,
 )
 
-from nucliadb.ingest.orm.brain import DuplicateParagraphsChecker, ResourceBrain
+from nucliadb.ingest.orm.brain import ResourceBrain
 
 
 def test_apply_field_metadata_marks_duplicated_paragraphs():
@@ -55,7 +55,14 @@ def test_apply_field_metadata_marks_duplicated_paragraphs():
     fcmw.metadata.metadata.paragraphs.append(p1)
     fcmw.metadata.metadata.paragraphs.append(p2)
 
-    br.apply_field_metadata(field_key, fcmw.metadata, [], {}, extracted_text=et)
+    br.apply_field_metadata(
+        field_key,
+        fcmw.metadata,
+        replace_field=[],
+        replace_splits={},
+        page_positions={},
+        extracted_text=et,
+    )
 
     assert len(br.brain.paragraphs[field_key].paragraphs) == 2
     for key, paragraph in br.brain.paragraphs[field_key].paragraphs.items():
@@ -91,7 +98,17 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
     fcmw.metadata.split_metadata[split_key].paragraphs.append(p1)
     fcmw.metadata.split_metadata[split_key].paragraphs.append(p2)
 
-    br.apply_field_metadata(field_key, fcmw.metadata, [], {}, extracted_text=et)
+    import pdb
+
+    pdb.set_trace()
+    br.apply_field_metadata(
+        field_key,
+        fcmw.metadata,
+        replace_field=[],
+        replace_splits={},
+        page_positions={},
+        extracted_text=et,
+    )
 
     assert len(br.brain.paragraphs[field_key].paragraphs) == 2
     for key, paragraph in br.brain.paragraphs[field_key].paragraphs.items():
@@ -100,16 +117,6 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
             assert paragraph.repeated_in_field is False
         else:
             assert paragraph.repeated_in_field is True
-
-
-def test_duplicate_paragraph_checker():
-    dupcheck = DuplicateParagraphsChecker()
-
-    assert dupcheck.check("repeated_text") is False
-    assert dupcheck.check("some_text") is False
-    assert dupcheck.check("repeated_text") is True
-    assert dupcheck.check("") is False
-    assert dupcheck.check("") is False
 
 
 def test_get_paragraph_page_number():
@@ -148,7 +155,12 @@ def test_apply_field_metadata_populates_page_number():
         2: (40, 100),
     }
     br.apply_field_metadata(
-        field_key, fcmw.metadata, [], {}, page_positions=page_positions
+        field_key,
+        fcmw.metadata,
+        replace_field=[],
+        replace_splits={},
+        page_positions=page_positions,
+        extracted_text=None,
     )
 
     assert len(br.brain.paragraphs[field_key].paragraphs) == 2

--- a/nucliadb/nucliadb/ingest/tests/orm/test_brain.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_brain.py
@@ -98,9 +98,6 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
     fcmw.metadata.split_metadata[split_key].paragraphs.append(p1)
     fcmw.metadata.split_metadata[split_key].paragraphs.append(p2)
 
-    import pdb
-
-    pdb.set_trace()
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -56,12 +56,13 @@ async def test_search_sc_2062(
     assert len(resp.json()["paragraphs"]["results"]) == 1
 
 
-def broker_resource_with_duplicates(knowledgebox, sentence):
+def broker_resource(knowledgebox):
     import uuid
     from datetime import datetime
 
     from nucliadb_protos.writer_pb2 import BrokerMessage
 
+    from nucliadb.ingest.tests.vectors import V1
     from nucliadb_protos import resources_pb2 as rpb
 
     rid = str(uuid.uuid4())
@@ -85,10 +86,8 @@ def broker_resource_with_duplicates(knowledgebox, sentence):
     bm.basic.modified.FromDatetime(datetime.now())
     bm.origin.source = rpb.Origin.Source.WEB
 
-    paragraph = sentence
-    text = f"{paragraph}{paragraph}"
     etw = rpb.ExtractedTextWrapper()
-    etw.body.text = text
+    etw.body.text = "My own text Ramon. This is great to be here. \n Where is my beer?"
     etw.field.field = "file"
     etw.field.field_type = rpb.FieldType.FILE
     bm.extracted_text.append(etw)
@@ -111,18 +110,19 @@ def broker_resource_with_duplicates(knowledgebox, sentence):
     fcm = rpb.FieldComputedMetadataWrapper()
     fcm.field.field = "file"
     fcm.field.field_type = rpb.FieldType.FILE
+    dup_text = "My own text Ramon"
     p1 = rpb.Paragraph(
         start=0,
-        end=len(paragraph),
-        text=paragraph,
+        end=len(dup_text),
+        text=dup_text,
     )
     p1.start_seconds.append(0)
     p1.end_seconds.append(10)
 
     p2 = rpb.Paragraph(
-        start=len(paragraph),
-        end=len(paragraph) * 2,
-        text=paragraph,
+        start=len(dup_text),
+        end=len(dup_text) * 2,
+        text=dup_text,
     )
     p2.start_seconds.append(10)
     p2.end_seconds.append(20)
@@ -131,13 +131,33 @@ def broker_resource_with_duplicates(knowledgebox, sentence):
 
     fcm.metadata.metadata.paragraphs.append(p1)
     fcm.metadata.metadata.paragraphs.append(p2)
-
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
 
     bm.field_metadata.append(fcm)
 
+    ev = rpb.ExtractedVectorsWrapper()
+    ev.field.field = "file"
+    ev.field.field_type = rpb.FieldType.FILE
+
+    v1 = rpb.Vector()
+    v1.start = 0
+    v1.end = len(dup_text)
+    v1.start_paragraph = 0
+    v1.end_paragraph = len(dup_text)
+    v1.vector.extend(V1)
+    ev.vectors.vectors.vectors.append(v1)
+
+    v2 = rpb.Vector()
+    v2.start = len(dup_text)
+    v2.end = len(dup_text) * 2
+    v2.start_paragraph = len(dup_text)
+    v2.end_paragraph = len(dup_text) * 2
+    v2.vector.extend(V1)
+    ev.vectors.vectors.vectors.append(v2)
+
+    bm.field_vectors.append(ev)
     bm.source = BrokerMessage.MessageSource.WRITER
     return bm
 
@@ -147,134 +167,33 @@ async def inject_message(writer: WriterStub, message):
     return
 
 
-async def create_resource_with_duplicates(
-    knowledgebox, writer: WriterStub, sentence: str
-):
-    bm = broker_resource_with_duplicates(knowledgebox, sentence=sentence)
-    await inject_message(writer, bm)
-    return bm.uuid
-
-
-async def create_resource_with_text_not_in_paragraphs(knowledgebox, writer: WriterStub):
-    import uuid
-    from datetime import datetime
-
-    from nucliadb_protos.writer_pb2 import BrokerMessage
-
-    from nucliadb_protos import resources_pb2 as rpb
-
-    rid = str(uuid.uuid4())
-    slug = f"{rid}slug1"
-
-    bm: BrokerMessage = BrokerMessage(
-        kbid=knowledgebox,
-        uuid=rid,
-        slug=slug,
-        type=BrokerMessage.AUTOCOMMIT,
-    )
-
-    bm.basic.icon = "text/plain"
-    bm.basic.title = "Title Resource"
-    bm.basic.summary = "Summary of document"
-    bm.basic.thumbnail = "doc"
-    bm.basic.layout = "default"
-    bm.basic.metadata.useful = True
-    bm.basic.metadata.language = "es"
-    bm.basic.created.FromDatetime(datetime.now())
-    bm.basic.modified.FromDatetime(datetime.now())
-    bm.origin.source = rpb.Origin.Source.WEB
-
-    paragraph = "Some text over here. "
-    text = f"{paragraph}{paragraph}"
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = text
-    etw.field.field = "file"
-    etw.field.field_type = rpb.FieldType.FILE
-    bm.extracted_text.append(etw)
-
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = "Summary of document"
-    etw.field.field = "summary"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
-
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = "Title Resource"
-    etw.field.field = "title"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
-
-    bm.files["file"].added.FromDatetime(datetime.now())
-    bm.files["file"].file.source = rpb.CloudFile.Source.EXTERNAL
-
-    fcm = rpb.FieldComputedMetadataWrapper()
-    fcm.field.field = "file"
-    fcm.field.field_type = rpb.FieldType.FILE
-    p1 = rpb.Paragraph(
-        start=0,
-        end=len(paragraph),
-    )
-    p1.start_seconds.append(0)
-    p1.end_seconds.append(10)
-
-    p2 = rpb.Paragraph(
-        start=len(paragraph),
-        end=len(paragraph) * 2,
-    )
-    p2.start_seconds.append(10)
-    p2.end_seconds.append(20)
-    p2.start_seconds.append(20)
-    p2.end_seconds.append(30)
-
-    fcm.metadata.metadata.paragraphs.append(p1)
-    fcm.metadata.metadata.paragraphs.append(p2)
-
-    fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
-    fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
-    fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
-
-    bm.field_metadata.append(fcm)
-
-    bm.source = BrokerMessage.MessageSource.WRITER
-
+async def create_resource_with_duplicates(knowledgebox, writer: WriterStub):
+    bm = broker_resource(knowledgebox)
     await inject_message(writer, bm)
     return bm.uuid
 
 
 @pytest.mark.asyncio
-async def test_search_filters_out_duplicate_paragraphs(
+async def test_seach_filters_out_duplicates(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
     nucliadb_grpc: WriterStub,
     knowledgebox,
 ):
-    await create_resource_with_duplicates(
-        knowledgebox, nucliadb_grpc, sentence="My own text Ramon. "
-    )
-    await create_resource_with_duplicates(
-        knowledgebox, nucliadb_grpc, sentence="Another different paragraph with text"
-    )
-    await create_resource_with_text_not_in_paragraphs(knowledgebox, nucliadb_grpc)
+    await create_resource_with_duplicates(knowledgebox, nucliadb_grpc)
 
-    query = "text"
-    # It should filter out duplicates by default
-    resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/search?query={query}")
+    # PUBLIC API
+    resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/search?query=Ramon")
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 4
-
-    # It should filter out duplicates if specified
-    resp = await nucliadb_reader.get(
-        f"/kb/{knowledgebox}/search?query={query}&with_duplicates=false"
-    )
-    assert resp.status_code == 200
-    content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 4
+    assert len(content["paragraphs"]["results"]) == 1
+    assert len(content["sentences"]["results"]) == 1
 
     # It should return duplicates if specified
     resp = await nucliadb_reader.get(
-        f"/kb/{knowledgebox}/search?query={query}&with_duplicates=true"
+        f"/kb/{knowledgebox}/search?query=Ramon&with_duplicates=true"
     )
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 6
+    assert len(content["paragraphs"]["results"]) == 2
+    assert len(content["sentences"]["results"]) == 2

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -189,3 +189,23 @@ async def test_search_filters_out_duplicate_paragraphs(
     assert resp.status_code == 200
     content = resp.json()
     assert len(content["paragraphs"]["results"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_search_returns_paragraph_positions(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    nucliadb_grpc: WriterStub,
+    knowledgebox,
+):
+    sentence = "My own text Ramon."
+    await create_resource_with_duplicates(
+        knowledgebox, nucliadb_grpc, sentence=sentence
+    )
+    resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/search?query=Ramon")
+    assert resp.status_code == 200
+    content = resp.json()
+    position = content["paragraphs"]["results"][0]["position"]
+    assert position["start"] == 0
+    assert position["end"] == len(sentence)
+    assert position["index"] == 0

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -155,6 +155,92 @@ async def create_resource_with_duplicates(
     return bm.uuid
 
 
+async def create_resource_with_text_not_in_paragraphs(knowledgebox, writer: WriterStub):
+    import uuid
+    from datetime import datetime
+
+    from nucliadb_protos.writer_pb2 import BrokerMessage
+
+    from nucliadb_protos import resources_pb2 as rpb
+
+    rid = str(uuid.uuid4())
+    slug = f"{rid}slug1"
+
+    bm: BrokerMessage = BrokerMessage(
+        kbid=knowledgebox,
+        uuid=rid,
+        slug=slug,
+        type=BrokerMessage.AUTOCOMMIT,
+    )
+
+    bm.basic.icon = "text/plain"
+    bm.basic.title = "Title Resource"
+    bm.basic.summary = "Summary of document"
+    bm.basic.thumbnail = "doc"
+    bm.basic.layout = "default"
+    bm.basic.metadata.useful = True
+    bm.basic.metadata.language = "es"
+    bm.basic.created.FromDatetime(datetime.now())
+    bm.basic.modified.FromDatetime(datetime.now())
+    bm.origin.source = rpb.Origin.Source.WEB
+
+    paragraph = "Some text over here. "
+    text = f"{paragraph}{paragraph}"
+    etw = rpb.ExtractedTextWrapper()
+    etw.body.text = text
+    etw.field.field = "file"
+    etw.field.field_type = rpb.FieldType.FILE
+    bm.extracted_text.append(etw)
+
+    etw = rpb.ExtractedTextWrapper()
+    etw.body.text = "Summary of document"
+    etw.field.field = "summary"
+    etw.field.field_type = rpb.FieldType.GENERIC
+    bm.extracted_text.append(etw)
+
+    etw = rpb.ExtractedTextWrapper()
+    etw.body.text = "Title Resource"
+    etw.field.field = "title"
+    etw.field.field_type = rpb.FieldType.GENERIC
+    bm.extracted_text.append(etw)
+
+    bm.files["file"].added.FromDatetime(datetime.now())
+    bm.files["file"].file.source = rpb.CloudFile.Source.EXTERNAL
+
+    fcm = rpb.FieldComputedMetadataWrapper()
+    fcm.field.field = "file"
+    fcm.field.field_type = rpb.FieldType.FILE
+    p1 = rpb.Paragraph(
+        start=0,
+        end=len(paragraph),
+    )
+    p1.start_seconds.append(0)
+    p1.end_seconds.append(10)
+
+    p2 = rpb.Paragraph(
+        start=len(paragraph),
+        end=len(paragraph) * 2,
+    )
+    p2.start_seconds.append(10)
+    p2.end_seconds.append(20)
+    p2.start_seconds.append(20)
+    p2.end_seconds.append(30)
+
+    fcm.metadata.metadata.paragraphs.append(p1)
+    fcm.metadata.metadata.paragraphs.append(p2)
+
+    fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
+    fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
+    fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
+
+    bm.field_metadata.append(fcm)
+
+    bm.source = BrokerMessage.MessageSource.WRITER
+
+    await inject_message(writer, bm)
+    return bm.uuid
+
+
 @pytest.mark.asyncio
 async def test_search_filters_out_duplicate_paragraphs(
     nucliadb_reader: AsyncClient,
@@ -168,13 +254,14 @@ async def test_search_filters_out_duplicate_paragraphs(
     await create_resource_with_duplicates(
         knowledgebox, nucliadb_grpc, sentence="Another different paragraph with text"
     )
+    await create_resource_with_text_not_in_paragraphs(knowledgebox, nucliadb_grpc)
 
-    query = "Ramon"
+    query = "text"
     # It should filter out duplicates by default
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/search?query={query}")
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 1
+    assert len(content["paragraphs"]["results"]) == 4
 
     # It should filter out duplicates if specified
     resp = await nucliadb_reader.get(
@@ -182,7 +269,7 @@ async def test_search_filters_out_duplicate_paragraphs(
     )
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 1
+    assert len(content["paragraphs"]["results"]) == 4
 
     # It should return duplicates if specified
     resp = await nucliadb_reader.get(
@@ -190,4 +277,4 @@ async def test_search_filters_out_duplicate_paragraphs(
     )
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 2
+    assert len(content["paragraphs"]["results"]) == 6

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -114,7 +114,6 @@ def broker_resource_with_duplicates(knowledgebox, sentence):
     p1 = rpb.Paragraph(
         start=0,
         end=len(paragraph),
-        text=paragraph,
     )
     p1.start_seconds.append(0)
     p1.end_seconds.append(10)
@@ -122,7 +121,6 @@ def broker_resource_with_duplicates(knowledgebox, sentence):
     p2 = rpb.Paragraph(
         start=len(paragraph),
         end=len(paragraph) * 2,
-        text=paragraph,
     )
     p2.start_seconds.append(10)
     p2.end_seconds.append(20)
@@ -155,92 +153,6 @@ async def create_resource_with_duplicates(
     return bm.uuid
 
 
-async def create_resource_with_text_not_in_paragraphs(knowledgebox, writer: WriterStub):
-    import uuid
-    from datetime import datetime
-
-    from nucliadb_protos.writer_pb2 import BrokerMessage
-
-    from nucliadb_protos import resources_pb2 as rpb
-
-    rid = str(uuid.uuid4())
-    slug = f"{rid}slug1"
-
-    bm: BrokerMessage = BrokerMessage(
-        kbid=knowledgebox,
-        uuid=rid,
-        slug=slug,
-        type=BrokerMessage.AUTOCOMMIT,
-    )
-
-    bm.basic.icon = "text/plain"
-    bm.basic.title = "Title Resource"
-    bm.basic.summary = "Summary of document"
-    bm.basic.thumbnail = "doc"
-    bm.basic.layout = "default"
-    bm.basic.metadata.useful = True
-    bm.basic.metadata.language = "es"
-    bm.basic.created.FromDatetime(datetime.now())
-    bm.basic.modified.FromDatetime(datetime.now())
-    bm.origin.source = rpb.Origin.Source.WEB
-
-    paragraph = "Some text over here. "
-    text = f"{paragraph}{paragraph}"
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = text
-    etw.field.field = "file"
-    etw.field.field_type = rpb.FieldType.FILE
-    bm.extracted_text.append(etw)
-
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = "Summary of document"
-    etw.field.field = "summary"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
-
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = "Title Resource"
-    etw.field.field = "title"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
-
-    bm.files["file"].added.FromDatetime(datetime.now())
-    bm.files["file"].file.source = rpb.CloudFile.Source.EXTERNAL
-
-    fcm = rpb.FieldComputedMetadataWrapper()
-    fcm.field.field = "file"
-    fcm.field.field_type = rpb.FieldType.FILE
-    p1 = rpb.Paragraph(
-        start=0,
-        end=len(paragraph),
-    )
-    p1.start_seconds.append(0)
-    p1.end_seconds.append(10)
-
-    p2 = rpb.Paragraph(
-        start=len(paragraph),
-        end=len(paragraph) * 2,
-    )
-    p2.start_seconds.append(10)
-    p2.end_seconds.append(20)
-    p2.start_seconds.append(20)
-    p2.end_seconds.append(30)
-
-    fcm.metadata.metadata.paragraphs.append(p1)
-    fcm.metadata.metadata.paragraphs.append(p2)
-
-    fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
-    fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
-    fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
-
-    bm.field_metadata.append(fcm)
-
-    bm.source = BrokerMessage.MessageSource.WRITER
-
-    await inject_message(writer, bm)
-    return bm.uuid
-
-
 @pytest.mark.asyncio
 async def test_search_filters_out_duplicate_paragraphs(
     nucliadb_reader: AsyncClient,
@@ -254,14 +166,13 @@ async def test_search_filters_out_duplicate_paragraphs(
     await create_resource_with_duplicates(
         knowledgebox, nucliadb_grpc, sentence="Another different paragraph with text"
     )
-    await create_resource_with_text_not_in_paragraphs(knowledgebox, nucliadb_grpc)
 
     query = "text"
     # It should filter out duplicates by default
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/search?query={query}")
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 4
+    assert len(content["paragraphs"]["results"]) == 2
 
     # It should filter out duplicates if specified
     resp = await nucliadb_reader.get(
@@ -269,7 +180,7 @@ async def test_search_filters_out_duplicate_paragraphs(
     )
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 4
+    assert len(content["paragraphs"]["results"]) == 2
 
     # It should return duplicates if specified
     resp = await nucliadb_reader.get(
@@ -277,4 +188,4 @@ async def test_search_filters_out_duplicate_paragraphs(
     )
     assert resp.status_code == 200
     content = resp.json()
-    assert len(content["paragraphs"]["results"]) == 6
+    assert len(content["paragraphs"]["results"]) == 4

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -56,7 +56,7 @@ async def test_search_sc_2062(
     assert len(resp.json()["paragraphs"]["results"]) == 1
 
 
-def broker_resource(knowledgebox):
+def broker_resource_with_duplicates(knowledgebox):
     import uuid
     from datetime import datetime
 
@@ -168,7 +168,7 @@ async def inject_message(writer: WriterStub, message):
 
 
 async def create_resource_with_duplicates(knowledgebox, writer: WriterStub):
-    bm = broker_resource(knowledgebox)
+    bm = broker_resource_with_duplicates(knowledgebox)
     await inject_message(writer, bm)
     return bm.uuid
 


### PR DESCRIPTION
### Description
- Adds nucliadb e2e tests for:
  - paragraph deduplication on search results
  - paragraph positions on search results

- Fixes computing duplicates paragraphs

