### PR TITLE
filtering invalid facets during indexing

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -141,7 +141,7 @@ class ResourceBrain:
                 )
                 for classification in paragraph.classifications:
                     p.labels.append(
-                        f"l/{classification.labelset}/{classification.label}"
+                        f"/l/{classification.labelset}/{classification.label}"
                     )
 
                 self.brain.paragraphs[field_key].paragraphs[key].CopyFrom(p)
@@ -170,7 +170,7 @@ class ResourceBrain:
                 metadata=ParagraphMetadata(position=position),
             )
             for classification in paragraph.classifications:
-                p.labels.append(f"l/{classification.labelset}/{classification.label}")
+                p.labels.append(f"/l/{classification.labelset}/{classification.label}")
 
             self.brain.paragraphs[field_key].paragraphs[key].CopyFrom(p)
 

--- a/nucliadb_paragraphs_tantivy2/src/schema.rs
+++ b/nucliadb_paragraphs_tantivy2/src/schema.rs
@@ -47,7 +47,8 @@ pub struct ParagraphSchema {
 }
 
 pub fn timestamp_to_datetime_utc(timestamp: &prost_types::Timestamp) -> DateTime<Utc> {
-    let naive = NaiveDateTime::from_timestamp_opt(timestamp.seconds, timestamp.nanos as u32).unwrap();
+    let naive =
+        NaiveDateTime::from_timestamp_opt(timestamp.seconds, timestamp.nanos as u32).unwrap();
     DateTime::from_utc(naive, tantivy::chrono::Utc)
 }
 

--- a/nucliadb_paragraphs_tantivy2/src/writer.rs
+++ b/nucliadb_paragraphs_tantivy2/src/writer.rs
@@ -225,7 +225,8 @@ impl ParagraphWriterService {
                     .iter()
                     .chain(text_info.labels.iter())
                     .chain(labels.iter())
-                    .map(Facet::from)
+                    .map(Facet::from_text)
+                    .flat_map(|v| v.map_err(|e| info!("Invalid label {e:?}")).ok())
                     .for_each(|facet| doc.add_facet(self.schema.facets, facet));
 
                 doc.add_facet(self.schema.field, Facet::from(&facet_field));
@@ -323,6 +324,7 @@ mod tests {
                 "/tantivy".to_string(),
                 "/test".to_string(),
                 "/label1".to_string(),
+                "l/papers/medicine".to_string(),
             ],
             index: 1,
             split: "".to_string(),

--- a/nucliadb_paragraphs_tantivy2/src/writer.rs
+++ b/nucliadb_paragraphs_tantivy2/src/writer.rs
@@ -226,7 +226,7 @@ impl ParagraphWriterService {
                     .chain(text_info.labels.iter())
                     .chain(labels.iter())
                     .map(Facet::from_text)
-                    .flat_map(|v| v.map_err(|e| info!("Invalid label {e:?}")).ok())
+                    .flat_map(|v| v.map_err(|e| error!("Invalid label {e:?}")).ok())
                     .for_each(|facet| doc.add_facet(self.schema.facets, facet));
 
                 doc.add_facet(self.schema.field, Facet::from(&facet_field));


### PR DESCRIPTION
### Description
Invalid facets while indexing will cause the node to panic, now they will be ignored and the error reported.

### How was this PR tested?
Local tests 
Added nucliadb - node e2e test in nucliadb/tests