### PR TITLE
Fix UT in `nucliadb_vectors` crate

### DIFF
--- a/nucliadb_vectors/src/service/reader.rs
+++ b/nucliadb_vectors/src/service/reader.rs
@@ -193,6 +193,7 @@ mod tests {
             page_number: 0,
             result_per_page: 20,
             reload: false,
+            with_duplicates: false,
         };
         let result = reader.search(&request).unwrap();
         assert_eq!(result.documents.len(), 3);


### PR DESCRIPTION
### Description
For some reason, the UTs in `nucliadb_vectors` crate were not compiling anymore and this PR fixes that.

### How was this PR tested?
Run `cargo test -p nucliadb_vectors`.
