### PR TITLE
Exclude Cargo.lock file from licensing check

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -40,6 +40,7 @@ header:
 
   paths-ignore:
     - "**/Cargo.toml"
+    - "**/Cargo.lock"
     - "**/*.sh"
     - "**/*.pb"
     - "**/setup.cfg"


### PR DESCRIPTION
### Description
As the PR title mentions, it only excludes the `Cargo.lock` file from the licensing check and makes the CI happy again.

### How was this PR tested?
~
