### PR TITLE
loading shards if lazy loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "nucliadb_node_binding"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bincode",
  "env_logger 0.8.4",

--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## 0.4.2
 
+- Lazy loading fix
+## 0.4.2
+
 - Parallel search enabled
 ## 0.4.1
 

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucliadb_node_binding"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nucliadb_node/src/reader/grpc_driver.rs
+++ b/nucliadb_node/src/reader/grpc_driver.rs
@@ -38,11 +38,11 @@ impl From<NodeReaderService> for NodeReaderGRPCDriver {
 }
 impl NodeReaderGRPCDriver {
     // The GRPC reader will only request the reader to bring a shard
-    // to memory if lazy loading is not enabled. Otherwise all the
+    // to memory if lazy loading is enabled. Otherwise all the
     // shards on disk would have been brought to memory before the driver is online.
     async fn shard_loading(&self, id: &ShardId) {
-        let mut writer = self.0.write().await;
-        if !Configuration::lazy_loading() {
+        if Configuration::lazy_loading() {
+            let mut writer = self.0.write().await;
             writer.load_shard(id);
         }
     }

--- a/nucliadb_node/src/writer/grpc_driver.rs
+++ b/nucliadb_node/src/writer/grpc_driver.rs
@@ -40,11 +40,11 @@ impl From<NodeWriterService> for NodeWriterGRPCDriver {
 }
 impl NodeWriterGRPCDriver {
     // The GRPC writer will only request the writer to bring a shard
-    // to memory if lazy loading is not enabled. Otherwise all the
+    // to memory if lazy loading is enabled. Otherwise all the
     // shards on disk would have been brought to memory before the driver is online.
     async fn shard_loading(&self, id: &ShardId) {
-        let mut writer = self.0.write().await;
-        if !Configuration::lazy_loading() {
+        if Configuration::lazy_loading() {
+            let mut writer = self.0.write().await;
             writer.load_shard(id);
         }
     }


### PR DESCRIPTION
### Description
Bug on [03b94bd](https://github.com/nuclia/nucliadb/commit/03b94bd42aba3f537b5357997d5ff3eaba9d951a), shards where not loaded when lazy loading was enabled.

### How was this PR tested?
Local test
