### PR TITLE
Remove unused Rust dependencies

### DIFF
--- a/.github/workflows/nucliadb_cluster.yml
+++ b/.github/workflows/nucliadb_cluster.yml
@@ -41,6 +41,24 @@ jobs:
           log-level: warn
           command: check licenses
 
+  udeps-rust:
+    name: Check unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions:checkout@v3
+
+      - uses: action-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - uses: aig787/cargo-udeps-action@v1
+        with:
+          version: "latest"
+          args: "-p nucliadb_cluster --all-targets --all-features"
+
+
   format-rust:
     name: Code Format
     runs-on: ubuntu-latest
@@ -77,7 +95,7 @@ jobs:
   tests-rust:
     name: Tests
     runs-on: ubuntu-latest
-    needs: [clippy-rust, format-rust, licenses]
+    needs: [clippy-rust, format-rust, licenses, udeps-rust]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nucliadb_node.yml
+++ b/.github/workflows/nucliadb_node.yml
@@ -93,6 +93,23 @@ jobs:
           log-level: warn
           command: check licenses
 
+  udeps-rust:
+    name: Check unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions:checkout@v3
+
+      - uses: action-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - uses: aig787/cargo-udeps-action@v1
+        with:
+          version: "latest"
+          args: "--workspace --all-targets --all-features"
+
   format-rust:
     name: Code Format
     runs-on: ubuntu-latest
@@ -129,7 +146,7 @@ jobs:
   tests-rust:
     name: Tests
     runs-on: ubuntu-latest
-    needs: [clippy-rust, format-rust, licenses]
+    needs: [clippy-rust, format-rust, licenses, udeps-rust]
 
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
-name = "arc-swap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
-
-[[package]]
 name = "async-channel"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,19 +762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,12 +809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "dockertest"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,12 +835,6 @@ name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "downcast-rs"
@@ -982,28 +951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,12 +981,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-
-[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,26 +995,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "function_name"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef632c665dc6e2b99ffa4d913f7160bd902c4d3e4cb732d81dc3d221f848512"
-dependencies = [
- "function_name-proc-macro",
-]
-
-[[package]]
-name = "function_name-proc-macro"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569d2238870f92cff64fc810013b61edaf446ebcfba36b649b96bc5b4078328a"
-dependencies = [
- "proc-macro-crate",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures"
@@ -1187,10 +1108,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1573,12 +1492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
-name = "libm"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,12 +1499,6 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lmdb-rkv-sys"
@@ -1722,33 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,15 +1641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d736ff882f0e85fe9689fb23db229616c4c00aee2b3ac282f666d8f20eb25d4a"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1789,12 +1660,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1822,19 +1687,15 @@ dependencies = [
  "crc32fast",
  "dockertest",
  "env_logger 0.9.3",
- "flume",
- "itertools",
  "log",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "structopt",
  "strum",
- "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
  "tracing",
  "uuid 1.2.2",
 ]
@@ -1856,7 +1717,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bincode",
- "dashmap",
  "dotenvy",
  "env_logger 0.9.3",
  "futures",
@@ -1866,7 +1726,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
- "mockall",
  "nucliadb_cluster",
  "nucliadb_protos",
  "nucliadb_services",
@@ -1887,7 +1746,6 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
- "serde_yaml",
  "tantivy",
  "tempdir",
  "tempfile",
@@ -1902,7 +1760,6 @@ dependencies = [
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "unicode-segmentation",
  "uuid 1.2.2",
 ]
 
@@ -1919,7 +1776,6 @@ dependencies = [
  "prost",
  "prost-types",
  "pyo3",
- "pyo3-log",
  "serde",
  "tokio",
  "tracing",
@@ -2019,11 +1875,8 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "clap 3.2.23",
- "env_logger 0.9.3",
  "fs2",
- "function_name",
  "heed",
- "libm",
  "log",
  "memmap2",
  "nucliadb_byte_rpr",
@@ -2034,7 +1887,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
- "uuid 1.2.2",
 ]
 
 [[package]]
@@ -2042,10 +1894,8 @@ name = "nucliadb_vectors2"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "env_logger 0.9.3",
  "fs2",
  "lazy_static",
- "libm",
  "log",
  "memmap2",
  "nucliadb_service_interface",
@@ -2466,36 +2316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "predicates"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,15 +2335,6 @@ checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
 ]
 
 [[package]]
@@ -2672,17 +2483,6 @@ checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
 dependencies = [
  "libc",
  "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-log"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5695ccff5060c13ca1751cf8c857a12da9b0bf0378cb071c5e0326f7c7e4c1b"
-dependencies = [
- "arc-swap",
- "log",
- "pyo3",
 ]
 
 [[package]]
@@ -3185,18 +2985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,15 +3025,6 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -3474,12 +3253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,15 +3446,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4301,15 +4065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/nucliadb_cluster/Cargo.toml
+++ b/nucliadb_cluster/Cargo.toml
@@ -16,13 +16,11 @@ path = "src/bin/manager.rs"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-flume = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0"
 tokio = { version = "1.7", features = ["full"] }
 tokio-stream = { version = "0.1.6", features = ["sync"] }
-tonic = "0.7"
 tracing = "0.1"
 uuid = { version = "1.1", features = ["v4"] }
 log = "0.4.14"
@@ -35,10 +33,6 @@ crc32fast = "1.3.2"
 rand = "0.8.5"
 strum = { version = "0.24.1", features = ["derive"] }
 structopt = "0.3.26"
-
-[dev-dependencies]
-itertools = '0.10'
-tempfile = "3"
 
 [[test]]
 name = "integration"

--- a/nucliadb_node/Cargo.toml
+++ b/nucliadb_node/Cargo.toml
@@ -45,10 +45,8 @@ log = "0.4.14"
 env_logger = "0.9.0"
 serde_json = "1"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.8.21"
 uuid = { version = "1.1", features = ["serde", "v4"] }
 bincode = "1.3.3"
-dashmap = "5.2.0"
 async-trait = "0.1.51"
 time = "0.3.3"
 itertools = "0.10"
@@ -56,10 +54,8 @@ anyhow = "1"
 http = "0.2"
 tracing = { version = "0.1.29" }
 thiserror = "1"
-mockall = "0.11"
 opentelemetry = { version = "0.17", features = ["rt-tokio", "trace"] }
 tracing-opentelemetry = "0.17.2"
-unicode-segmentation = "1.9.0"
 # Test dependencies
 tempfile = "3.2.0"
 regex = "1.5.5"

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.17.1", features = ["extension-module"] }
-pyo3-log = "0.7.0"
 nucliadb_node = { path = "../../nucliadb_node" }
 nucliadb_protos = { path = "../../nucliadb_protos/rust" }
 serde = { version = "1.0", features = ["derive"] }

--- a/nucliadb_vectors/Cargo.toml
+++ b/nucliadb_vectors/Cargo.toml
@@ -11,11 +11,8 @@ heed = { version = "0.11.0", default-features = false, features = ["lmdb", "sync
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1.1", features = ["serde", "v4"] }
 log = "0.4"
 tempfile = "3"
-function_name = "0.2.0"
-libm = "0.2.2"
 rand = "0.8.4"
 tracing = "0.1.29"
 rayon = "1.5.2"
@@ -24,8 +21,6 @@ fs2 = "0.4.3"
 nucliadb_service_interface = { path = "../nucliadb_service_interface" }
 nucliadb_byte_rpr = { path = "../nucliadb_byte_rpr" }
 clap = { version = "3.1.18", features = ["derive"] }
-[dev-dependencies]
-env_logger = "0.9.0"
 
 [lib]
 name = "nucliadb_vectors"

--- a/nucliadb_vectors2/Cargo.toml
+++ b/nucliadb_vectors2/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1.1", features = ["serde", "v4"] }
 log = "0.4"
 tempfile = "3"
-libm = "0.2.2"
 rand = "0.8.4"
 tracing = "0.1.29"
 rayon = "1.5.2"
@@ -22,9 +21,6 @@ thiserror = "1.0.31"
 serde_json = "1.0.82"
 nucliadb_service_interface = { path = "../nucliadb_service_interface" }
 lazy_static = "1.4.0"
-
-[dev-dependencies]
-env_logger = "0.9.0"
 
 [lib]
 name = "nucliadb_vectors2"


### PR DESCRIPTION
### Description
This PR aims to remove all the unused Rust dependencies in order to speed up compilation and have proper `Cargo.{lock|toml}` files.

### How was this PR tested?
`cargo +nightly udeps --all-targets --all-features`
