### PR TITLE
Bump Rust version to 1.65

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.65.0"


### PR DESCRIPTION
### Description
This PR indicates to use the latest release of Rust then we can eventually use GATs :cat: 

### How was this PR tested?
`cargo build --all-targets --all-features`
