### PR TITLE
Vectors2 delete update

### DIFF
--- a/nucliadb_vectors2/src/disk/key_value.rs
+++ b/nucliadb_vectors2/src/disk/key_value.rs
@@ -163,6 +163,7 @@ pub fn get_value<S: Slot>(interface: S, src: &[u8], id: usize) -> &[u8] {
     interface.read_exact(&src[pointer..]).0
 }
 
+// Returns all the keys stored at the serialized key-value 'x'
 // O(1)
 pub fn get_keys<'a, S: Slot + Copy + 'a>(
     interface: S,

--- a/nucliadb_vectors2/src/vectors/data_point/mod.rs
+++ b/nucliadb_vectors2/src/vectors/data_point/mod.rs
@@ -209,6 +209,13 @@ impl DataPoint {
     pub fn meta(&self) -> Journal {
         self.journal
     }
+    pub fn get_keys<Dlog: DeleteLog>(&self, delete_log: &Dlog) -> Vec<String> {
+        key_value::get_keys(Node, &self.nodes)
+            .map(String::from_utf8_lossy)
+            .map(|s| s.to_string())
+            .filter(|k| !delete_log.is_deleted(k.as_str()))
+            .collect()
+    }
     pub fn search<Dlog: DeleteLog>(
         &self,
         delete_log: &Dlog,

--- a/nucliadb_vectors2/src/vectors/data_point/tests.rs
+++ b/nucliadb_vectors2/src/vectors/data_point/tests.rs
@@ -43,12 +43,14 @@ fn simple_flow() {
     for i in 0..50 {
         labels.push(format!("LABEL_{}", i));
     }
+    let mut expected_keys = vec![];
     let label_dictionary = LabelDictionary::new(labels.clone());
     for i in 0..50 {
         let key = format!("KEY_{}", i);
         let vector = vec![rand::random::<f32>(); 8];
         let labels = label_dictionary.clone();
-        elems.push(Elem::new(key, vector, labels));
+        elems.push(Elem::new(key.clone(), vector, labels));
+        expected_keys.push(key);
     }
     let reader = DataPoint::new(temp_dir.path(), elems).unwrap();
     let id = reader.get_id();
@@ -56,6 +58,9 @@ fn simple_flow() {
     let query = vec![rand::random::<f32>(); 8];
     let no_results = 10;
     let result = reader.search(&HashSet::new(), &query, &labels[..20], true, no_results);
+    let got_keys = reader.get_keys(&HashSet::new());
+    assert!(got_keys.iter().all(|k| expected_keys.contains(k)));
+    assert_eq!(got_keys.len(), expected_keys.len());
     assert_eq!(result.len(), no_results);
 }
 

--- a/nucliadb_vectors2/src/vectors/data_point_provider/mod.rs
+++ b/nucliadb_vectors2/src/vectors/data_point_provider/mod.rs
@@ -98,10 +98,6 @@ impl Index {
         std::mem::drop(lock);
         Ok(index)
     }
-    pub fn has_resource(&self, resource: impl AsRef<str>, _: &ELock) -> bool {
-        let state = self.state.read().unwrap();
-        state.has_id(resource.as_ref())
-    }
     pub fn delete(&mut self, prefix: impl AsRef<str>, _: &ELock) {
         let mut state = self.state.write().unwrap();
         state.remove(prefix.as_ref());
@@ -110,13 +106,8 @@ impl Index {
         let mut state = self.state.write().unwrap();
         state.add(resource, dp);
     }
-    pub fn get_keys(&self, _: &Lock) -> Vec<String> {
-        self.state
-            .read()
-            .unwrap()
-            .get_keys()
-            .map(|k| k.to_string())
-            .collect()
+    pub fn get_keys(&self, _: &Lock) -> VectorR<Vec<String>> {
+        self.state.read().unwrap().get_keys()
     }
     pub fn search(&self, request: &dyn SearchRequest, _: &Lock) -> VectorR<Vec<(String, f32)>> {
         let state = self.state.read().unwrap();

--- a/nucliadb_vectors2/src/vectors/data_point_provider/state.rs
+++ b/nucliadb_vectors2/src/vectors/data_point_provider/state.rs
@@ -200,9 +200,6 @@ impl State {
         if let Some(no_nodes) = self.resources.remove(id) {
             self.no_nodes -= no_nodes;
             self.delete_log.insert(id.as_bytes(), SystemTime::now());
-            if self.current.size() > 0 {
-                self.close_work_unit();
-            }
         }
     }
     pub fn add(&mut self, id: String, dp: DataPoint) {

--- a/nucliadb_vectors2/src/vectors/data_point_provider/state.rs
+++ b/nucliadb_vectors2/src/vectors/data_point_provider/state.rs
@@ -119,6 +119,10 @@ pub struct State {
     delete_log: DTrie<SystemTime>,
     work_stack: LinkedList<WorkUnit>,
     data_points: HashMap<DpId, SystemTime>,
+    // Deprecated field, not all vector clusters are
+    // identified by a resource.
+    #[serde(skip)]
+    #[allow(unused)]
     resources: HashMap<String, usize>,
 }
 impl State {
@@ -133,6 +137,7 @@ impl State {
     fn add_dp(&mut self, dp: DataPoint, time: SystemTime) {
         let mut meta = dp.meta();
         meta.update_time(time);
+        self.no_nodes += meta.no_nodes();
         self.data_points.insert(meta.id(), meta.time());
         self.current.add_unit(meta);
         if self.current.size() == BUFFER_CAP {
@@ -161,8 +166,19 @@ impl State {
     pub fn get_no_nodes(&self) -> usize {
         self.no_nodes
     }
-    pub fn get_keys(&self) -> impl Iterator<Item = &str> {
-        self.resources.keys().map(|k| k.as_str())
+    pub fn get_keys(&self) -> VectorR<Vec<String>> {
+        let mut keys = vec![];
+        let mut delete_log = TimeSensitiveDLog {
+            dlog: &self.delete_log,
+            time: SystemTime::now(),
+        };
+        for (dp_id, time) in self.data_points.iter() {
+            delete_log.time = *time;
+            let data_point = DataPoint::open(&self.location, *dp_id)?;
+            let mut results = data_point.get_keys(&delete_log);
+            keys.append(&mut results);
+        }
+        Ok(keys)
     }
     pub fn create_dlog(&self, journal: Journal) -> impl DeleteLog + '_ {
         TimeSensitiveDLog {
@@ -193,19 +209,11 @@ impl State {
         }
         Ok(ffsv.into())
     }
-    pub fn has_id(&self, id: &str) -> bool {
-        self.resources.contains_key(id)
-    }
     pub fn remove(&mut self, id: &str) {
-        if let Some(no_nodes) = self.resources.remove(id) {
-            self.no_nodes -= no_nodes;
-            self.delete_log.insert(id.as_bytes(), SystemTime::now());
-        }
+        self.delete_log.insert(id.as_bytes(), SystemTime::now());
     }
     pub fn add(&mut self, id: String, dp: DataPoint) {
         self.remove(&id);
-        self.resources.insert(id, dp.meta().no_nodes());
-        self.no_nodes += dp.meta().no_nodes();
         self.add_dp(dp, SystemTime::now());
     }
     pub fn replace_work_unit(&mut self, new: DataPoint, ctime: SystemTime) {
@@ -222,6 +230,7 @@ impl State {
                 .collect::<Vec<_>>();
             older.iter().for_each(|v| self.delete_log.delete(v));
             unit.load.iter().cloned().for_each(|dp| {
+                self.no_nodes -= dp.no_nodes();
                 self.data_points.remove(&dp.id());
             });
             self.add_dp(new, ctime);

--- a/nucliadb_vectors2/src/vectors/service/reader.rs
+++ b/nucliadb_vectors2/src/vectors/service/reader.rs
@@ -99,7 +99,10 @@ impl ReaderChild for VectorReaderService {
     }
     fn stored_ids(&self) -> Vec<String> {
         let lock = self.index.get_slock().unwrap();
-        self.index.get_keys(&lock)
+        self.index.get_keys(&lock).unwrap_or_else(|err| {
+            error!("Error while getting keys {err}");
+            vec![]
+        })
     }
     fn reload(&self) {}
 }
@@ -220,6 +223,8 @@ mod tests {
             with_duplicates: false,
         };
         let result = reader.search(&request).unwrap();
+        let no_nodes = reader.count();
+        assert_eq!(no_nodes, 4);
         assert_eq!(result.documents.len(), 3);
     }
 }

--- a/nucliadb_vectors2/src/vectors/service/writer.rs
+++ b/nucliadb_vectors2/src/vectors/service/writer.rs
@@ -63,9 +63,8 @@ impl WriterChild for VectorWriterService {
             for paragraph in resource.paragraphs.values() {
                 for (key, index) in paragraph.paragraphs.iter() {
                     let index_key = key.clone();
-                    let mut labels = resource.labels.clone();
-                    labels.append(&mut index.labels.clone());
-                    let labels = LabelDictionary::new(labels);
+                    let labels = resource.labels.iter().chain(index.labels.iter()).cloned();
+                    let labels = LabelDictionary::new(labels.collect());
                     let elems = index
                         .sentences
                         .iter()


### PR DESCRIPTION
### Description
Delete logic in vectors2 must be updated to handle vectors clusters at prefix level, not only at resource level.
This PR also removes an unnecessary sanity check that was splitting work units after deletion.

### How was this PR tested?
Local tests
