### PR TITLE
Send cluster members at fix interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "dockertest",
  "env_logger 0.9.3",
  "log",
+ "parse_duration",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,15 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +198,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -441,34 +432,34 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.0.21",
+ "clap_lex 0.3.0",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -477,7 +468,20 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -489,6 +493,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -721,7 +734,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -735,7 +748,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -899,6 +912,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1182,15 +1216,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1238,6 +1263,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1457,10 +1491,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1521,6 +1577,12 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lmdb-rkv-sys"
@@ -1728,6 +1790,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chitchat",
+ "clap 4.0.29",
  "crc32fast",
  "dockertest",
  "env_logger 0.9.3",
@@ -1736,7 +1799,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "structopt",
  "strum",
  "thiserror",
  "tokio",
@@ -2027,7 +2089,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -2459,7 +2521,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
- "heck 0.4.0",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -2794,6 +2856,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,39 +3190,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "strum"
@@ -3163,7 +3209,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3407,15 +3453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -3852,12 +3889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3934,12 +3965,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vectors_benchmark"

--- a/charts/nucliadb_ingest/templates/ingest.cm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.cm.yaml
@@ -42,3 +42,4 @@ data:
   LISTEN_PORT: {{ .Values.chitchat.node.chitchat_port | quote }}
   NODE_TYPE: {{ .Values.chitchat.node.node_type }}
   SEEDS: "{{ .Values.chitchat.node.node0_svc_fixed_ip }}:{{ .Values.chitchat.node.chitchat_port }}"
+  UPDATE_INTERVAL: {{ .Values.chitchat.cluster_manager.update_interval }}

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -30,6 +30,7 @@ chitchat:
   cluster_manager:
     port: 31337
     host: "0.0.0.0"
+    update_interval: "30s"
   node:
     node_type: Ingest
     node0_svc_fixed_ip: 10.4.0.255

--- a/charts/nucliadb_search/templates/search.cm.yaml
+++ b/charts/nucliadb_search/templates/search.cm.yaml
@@ -24,3 +24,4 @@ data:
   LISTEN_PORT: {{ .Values.chitchat.node.chitchat_port | quote }}
   NODE_TYPE: {{ .Values.chitchat.node.node_type }}
   SEEDS: "{{ .Values.chitchat.node.node0_svc_fixed_ip }}:{{ .Values.chitchat.node.chitchat_port }}"
+  UPDATE_INTERVAL: {{ .Values.chitchat.cluster_manager.update_interval }}

--- a/charts/nucliadb_search/values.yaml
+++ b/charts/nucliadb_search/values.yaml
@@ -32,6 +32,7 @@ chitchat:
   cluster_manager:
     port: 31337
     host: "0.0.0.0"
+    update_interval: "30s"
   node:
     node_type: Search
     node0_svc_fixed_ip: 10.4.0.255

--- a/nucliadb_cluster/Cargo.toml
+++ b/nucliadb_cluster/Cargo.toml
@@ -31,7 +31,7 @@ bytes = "1.1.0"
 crc32fast = "1.3.2"
 rand = "0.8.5"
 strum = { version = "0.24.1", features = ["derive"] }
-structopt = "0.3.26"
+clap = { version = "4.0.29", features = ["derive", "env"] }
 parse_duration = "2.1.1"
 
 [[test]]

--- a/nucliadb_cluster/Cargo.toml
+++ b/nucliadb_cluster/Cargo.toml
@@ -32,6 +32,7 @@ crc32fast = "1.3.2"
 rand = "0.8.5"
 strum = { version = "0.24.1", features = ["derive"] }
 structopt = "0.3.26"
+parse_duration = "2.1.1"
 
 [[test]]
 name = "integration"

--- a/nucliadb_cluster/src/bin/manager.rs
+++ b/nucliadb_cluster/src/bin/manager.rs
@@ -92,20 +92,21 @@ async fn send_update(update: String, stream: &mut TcpStream) -> anyhow::Result<(
     if let Err(e) = stream.flush().await {
         error!("Error during flushing writer: {e}")
     };
-    info!("Try read the answer");
+
     let mut buf = vec![];
-    if let Ok(readed) = stream.read_buf(&mut buf).await {
-        info!("answer from server: {:#?}", buf);
-        if readed != 0 {
-            info!("valid answer receieved: {:#?}", buf);
+
+    info!("Try read the answer");
+    match stream.read_buf(&mut buf).await {
+        Ok(n) if n > 0 => {
+            info!("valid answer received: {:#?}", buf);
+
             Ok(())
-        } else {
+        }
+        _ => {
             info!("invalid ack: {:#?}", buf);
+
             Err(anyhow!("invalid ack"))
         }
-    } else {
-        info!("invalid ack: {:#?}", buf);
-        Err(anyhow!("invalid ack"))
     }
 }
 pub async fn reliable_lookup_host(host: &str) -> anyhow::Result<SocketAddr> {

--- a/nucliadb_cluster/src/cluster.rs
+++ b/nucliadb_cluster/src/cluster.rs
@@ -57,7 +57,7 @@ pub fn read_or_create_host_key(host_key_path: &Path) -> Result<Uuid, Error> {
     Ok(host_key)
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, EnumString, EnumDisplay)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, EnumString, EnumDisplay)]
 pub enum NodeType {
     Node,
     Search,
@@ -85,7 +85,7 @@ impl From<&Cluster> for Member {
         Member {
             node_id: cluster.id.id.clone(),
             listen_addr: cluster.listen_addr,
-            node_type: cluster.node_type.clone(),
+            node_type: cluster.node_type,
             is_self: true,
         }
     }
@@ -164,7 +164,8 @@ impl Cluster {
         let (self_id, mut cluster_watcher) = chitchat_handle
             .with_chitchat(|chitchat| {
                 let state = chitchat.self_node_state();
-                state.set("node_type", node_type.clone());
+
+                state.set("node_type", node_type);
                 (
                     chitchat.self_node_id().clone(),
                     chitchat.live_nodes_watcher(),


### PR DESCRIPTION
### Description
This PR is a little workaround to handle ingest restarting properly. The list of cluster members is sent to the ingest node in case of changes but now also every x times (if any changes happen during that interval).

### How was this PR tested?
We have to check it on stashify.
