### PR TITLE
fix relations start without relations folder

### DIFF
--- a/nucliadb_vectors2/src/relations/service/writer.rs
+++ b/nucliadb_vectors2/src/relations/service/writer.rs
@@ -149,9 +149,7 @@ impl WriterChild for RelationsWriterService {
 
 impl RelationsWriterService {
     pub fn start(config: &RelationConfig) -> InternalResult<Self> {
-        let path = std::path::Path::new(&config.path);
-        let (index, wmode) = Index::new_writer(path)?;
-        Ok(RelationsWriterService { index, wmode })
+        Self::open(config).or_else(|_| Self::new(config))
     }
     pub fn new(config: &RelationConfig) -> InternalResult<Self> {
         let path = std::path::Path::new(&config.path);


### PR DESCRIPTION
### Description
The relations index was not taking into account during "start" that some shards may not have the "relations" folder.
Now this is fixed

### How was this PR tested?
Local tests
