### PR TITLE
Add load score in cluster node state

### DIFF
--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -101,6 +101,7 @@ class ChitchatNucliaDB:
                                 listen_addr=x["listen_addr"],
                                 node_type=x["node_type"],
                                 is_self=x["is_self"],
+                                load_score=x["load_score"],
                                 online=True,
                             ),
                             json.loads(mgr_message.decode("utf8").replace("'", '"')),

--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -135,6 +135,7 @@ class ClusterMember:
     node_type: str
     online: bool
     is_self: bool
+    load_score: float
 
 
 class Node(AbstractNode):

--- a/nucliadb_cluster/src/cluster.rs
+++ b/nucliadb_cluster/src/cluster.rs
@@ -22,7 +22,7 @@ const NODE_TYPE_KEY: &str = "node_type";
 const LOAD_SCORE_KEY: &str = "load_score";
 
 pub trait Score {
-    fn compute_score(&self) -> f32;
+    fn score(&self) -> f32;
 }
 
 /// The ID that makes the cluster unique.
@@ -245,7 +245,7 @@ impl Cluster {
             .with_chitchat(|chitchat| {
                 let state = chitchat.self_node_state();
 
-                state.set(LOAD_SCORE_KEY, scorer.compute_score());
+                state.set(LOAD_SCORE_KEY, scorer.score());
             })
             .await;
     }

--- a/nucliadb_cluster/src/error.rs
+++ b/nucliadb_cluster/src/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     /// Incorrect node type
     #[error("Unknown node type: `{0}`")]
     UnknownNodeType(String),
+    #[error("Invalid load score '{0}")]
+    InvalidLoadScore(String),
     #[error("Cannot get state from node `{0}`")]
     MissingNodeState(String),
     #[error("Cannot start cluster: {0}")]

--- a/nucliadb_node/src/metrics/report.rs
+++ b/nucliadb_node/src/metrics/report.rs
@@ -74,7 +74,7 @@ impl Report for NodeReport {
 }
 
 impl Score for NodeReport {
-    fn compute_score(&self) -> f32 {
+    fn score(&self) -> f32 {
         self.shard_count
             .get()
             .saturating_mul(self.paragraph_count.get()) as f32

--- a/nucliadb_node/src/metrics/report.rs
+++ b/nucliadb_node/src/metrics/report.rs
@@ -20,6 +20,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
+use nucliadb_cluster::cluster::Score;
 use prometheus::proto::MetricFamily;
 use prometheus::{labels, opts, IntGauge, Registry};
 
@@ -69,5 +70,14 @@ impl Report for NodeReport {
 
     fn labels(&self) -> HashMap<String, String> {
         labels! { "node_id".to_string() => self.id.to_string() }
+    }
+}
+
+impl Score for NodeReport {
+    fn compute_score(&self) -> f32 {
+        self.shard_count
+            .get()
+            .saturating_mul(self.paragraph_count.get()) as f32
+            / 100.0
     }
 }


### PR DESCRIPTION
### Description
This PR aims to add load score in cluster node state in order to the future load balancer to perform shard cutover with fresh data.

### How was this PR tested?
We have to check on stashify.
