### PR TITLE
using temp-then-rename strategy for updating states

### DIFF
--- a/nucliadb_vectors2/src/disk/directory.rs
+++ b/nucliadb_vectors2/src/disk/directory.rs
@@ -32,6 +32,7 @@ use super::DiskR;
 mod names {
     pub const LOCK: &str = "lk.lock";
     pub const STATE: &str = "state.bincode";
+    pub const TEMP: &str = "temp_state.bincode";
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -39,12 +40,15 @@ pub struct Version(SystemTime);
 
 fn write_state<S>(path: &Path, state: &S) -> DiskR<()>
 where S: Serialize {
+    let temporal_path = path.join(names::TEMP);
+    let state_path = path.join(names::STATE);
     let mut file = OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
-        .open(path.join(names::STATE))?;
+        .open(&temporal_path)?;
     bincode::serialize_into(&mut file, state)?;
+    std::fs::rename(&temporal_path, &state_path)?;
     Ok(())
 }
 


### PR DESCRIPTION
### Description
The directory functionality in `nucliadb_vectors2/src/disk/directory.rs` now uses the `temp-then-rename` stategy for updating the directories state. This will prevent the state from getting corrupted if the writing operation fails. 

### How was this PR tested?
Local tests
