### PR TITLE
bigger datapoints + removed redundant delete

### DIFF
--- a/nucliadb_vectors2/src/vectors/data_point_provider/mod.rs
+++ b/nucliadb_vectors2/src/vectors/data_point_provider/mod.rs
@@ -101,9 +101,9 @@ impl Index {
         let mut state = self.state.write().unwrap();
         state.remove(prefix.as_ref());
     }
-    pub fn add(&mut self, resource: String, dp: DataPoint, _lock: &ELock) {
+    pub fn add(&mut self, dp: DataPoint, _lock: &ELock) {
         let mut state = self.state.write().unwrap();
-        state.add(resource, dp);
+        state.add(dp);
     }
     pub fn get_keys(&self, _: &Lock) -> VectorR<Vec<String>> {
         self.state.read().unwrap().get_keys()

--- a/nucliadb_vectors2/src/vectors/service/writer.rs
+++ b/nucliadb_vectors2/src/vectors/service/writer.rs
@@ -113,15 +113,18 @@ impl WriterChild for VectorWriterService {
                 }
             }
         }
-        info!("New data point with {} elements", elems.len());
+
+        let new_dp = DataPoint::new(self.index.get_location(), elems)?;
+        let no_nodes = new_dp.meta().no_nodes();
+
+        info!("New data point with {} elements", no_nodes);
         let lock = self.index.get_elock()?;
         info!("Processing sentences to delete");
         for to_delete in &resource.sentences_to_delete {
             self.index.delete(to_delete, &lock)
         }
         info!("Indexing datapoints");
-        if !elems.is_empty() {
-            let new_dp = DataPoint::new(self.index.get_location(), elems)?;
+        if no_nodes > 0 {
             self.index.add(new_dp, &lock);
             self.index.commit(lock)?;
         }

--- a/nucliadb_vectors2/src/vectors/service/writer.rs
+++ b/nucliadb_vectors2/src/vectors/service/writer.rs
@@ -98,37 +98,33 @@ impl WriterChild for VectorWriterService {
         use data_point::{DataPoint, Elem, LabelDictionary};
         info!("Updating main index");
         info!("creating datapoints");
-        let mut data_points = Vec::new();
+        let mut elems = Vec::new();
         if resource.status != ResourceStatus::Delete as i32 {
             for paragraph in resource.paragraphs.values() {
-                for (key, index) in paragraph.paragraphs.iter() {
-                    let index_key = key.clone();
+                for index in paragraph.paragraphs.values() {
                     let labels = resource.labels.iter().chain(index.labels.iter()).cloned();
                     let labels = LabelDictionary::new(labels.collect());
-                    let elems = index
+                    index
                         .sentences
                         .iter()
                         .map(|(key, sentence)| (key.clone(), sentence.vector.clone()))
                         .map(|(key, sentence)| Elem::new(key, sentence, labels.clone()))
-                        .collect::<Vec<_>>();
-                    if !elems.is_empty() {
-                        let new_dp = DataPoint::new(self.index.get_location(), elems)?;
-                        data_points.push((index_key, new_dp));
-                    }
+                        .for_each(|e| elems.push(e));
                 }
             }
         }
-        info!("{} datapoints where created", data_points.len());
+        info!("New data point with {} elements", elems.len());
         let lock = self.index.get_elock()?;
         info!("Processing sentences to delete");
         for to_delete in &resource.sentences_to_delete {
             self.index.delete(to_delete, &lock)
         }
         info!("Indexing datapoints");
-        for (key, data_point) in data_points {
-            self.index.add(key, data_point, &lock);
+        if !elems.is_empty() {
+            let new_dp = DataPoint::new(self.index.get_location(), elems)?;
+            self.index.add(new_dp, &lock);
+            self.index.commit(lock)?;
         }
-        self.index.commit(lock)?;
 
         info!("Updating vectorset indexes");
         // Updating existing indexes
@@ -174,9 +170,8 @@ impl WriterChild for VectorWriterService {
                 elems.push(Elem::new(key, vector, labels));
             }
             let new_dp = DataPoint::new(index.get_location(), elems)?;
-            let key = uuid::Uuid::new_v4().to_string();
             let lock = index.get_elock()?;
-            index.add(key, new_dp, &lock);
+            index.add(new_dp, &lock);
             index.commit(lock)?;
         }
         info!("Create and update operations where applied to the indexes in the set");

--- a/nucliadb_vectors2/src/vectors/service/writer.rs
+++ b/nucliadb_vectors2/src/vectors/service/writer.rs
@@ -126,8 +126,8 @@ impl WriterChild for VectorWriterService {
         info!("Indexing datapoints");
         if no_nodes > 0 {
             self.index.add(new_dp, &lock);
-            self.index.commit(lock)?;
         }
+        self.index.commit(lock)?;
 
         info!("Updating vectorset indexes");
         // Updating existing indexes

--- a/vectors_benchmark/src/binaries/1m_stats.rs
+++ b/vectors_benchmark/src/binaries/1m_stats.rs
@@ -39,12 +39,7 @@ fn label_set(batch_id: usize) -> Vec<String> {
         .collect()
 }
 
-fn add_batch(
-    writer: &mut Index,
-    _batch_id: String,
-    elems: Vec<(String, Vec<f32>)>,
-    labels: Vec<String>,
-) {
+fn add_batch(writer: &mut Index, elems: Vec<(String, Vec<f32>)>, labels: Vec<String>) {
     let labels = LabelDictionary::new(labels);
     let elems = elems
         .into_iter()
@@ -67,7 +62,6 @@ fn main() {
     let mut possible_tag = vec![];
     let mut writer = Index::new(at.path(), IndexCheck::None).unwrap();
     for i in 0..(INDEX_SIZE / BATCH_SIZE) {
-        let batch_id = format!("Batch_{i}");
         let labels = label_set(i);
         let elems = RandomVectors::new(VECTOR_DIM)
             .take(BATCH_SIZE)
@@ -76,7 +70,7 @@ fn main() {
             .collect();
         possible_tag.push(labels[0].clone());
         let now = SystemTime::now();
-        add_batch(&mut writer, batch_id, elems, labels);
+        add_batch(&mut writer, elems, labels);
         stats.writing_time += now.elapsed().unwrap().as_millis();
         println!("{} vectors included", BATCH_SIZE * i);
     }

--- a/vectors_benchmark/src/binaries/1m_stats.rs
+++ b/vectors_benchmark/src/binaries/1m_stats.rs
@@ -41,7 +41,7 @@ fn label_set(batch_id: usize) -> Vec<String> {
 
 fn add_batch(
     writer: &mut Index,
-    batch_id: String,
+    _batch_id: String,
     elems: Vec<(String, Vec<f32>)>,
     labels: Vec<String>,
 ) {
@@ -52,7 +52,7 @@ fn add_batch(
         .collect();
     let new_dp = DataPoint::new(writer.get_location(), elems).unwrap();
     let lock = writer.get_elock().unwrap();
-    writer.add(batch_id, new_dp, &lock);
+    writer.add(new_dp, &lock);
     writer.commit(lock).unwrap();
 }
 fn main() {

--- a/vectors_benchmark/src/engines/vectors2.rs
+++ b/vectors_benchmark/src/engines/vectors2.rs
@@ -49,7 +49,8 @@ impl VectorEngine for Index {
         }
         let new_dp = DataPoint::new(self.get_location(), elems).unwrap();
         let lock = self.get_elock().unwrap();
-        self.add(batch_id, new_dp, &lock);
+        self.add(new_dp, &lock);
+        self.delete(&batch_id, &lock);
         self.commit(lock).unwrap();
     }
 


### PR DESCRIPTION
### Description
`nucliadb_vectors2` state needs to grow at a slower pace, in order to achieve this the following PR includes:
- Bigger datapoints, one resource will produce exactly one datapoint.
- Removing redundant delete logs. The index should rely on the `sentence_to_delete` and `vectors_to_delete`.

### How was this PR tested?
Local tests.
