### PR TITLE
Configurable cluster liveliness update

### DIFF
--- a/charts/nucliadb_ingest/templates/ingest.cm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.cm.yaml
@@ -43,3 +43,4 @@ data:
   NODE_TYPE: {{ .Values.chitchat.node.node_type }}
   SEEDS: "{{ .Values.chitchat.node.node0_svc_fixed_ip }}:{{ .Values.chitchat.node.chitchat_port }}"
   UPDATE_INTERVAL: {{ .Values.chitchat.cluster_manager.update_interval }}
+  LIVELINESS_UPDATE: {{ .Values.chitchat.cluster_manager.liveliness_interval }}

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -31,6 +31,7 @@ chitchat:
     port: 31337
     host: "0.0.0.0"
     update_interval: "30s"
+    liveliness_update: "2s"
   node:
     node_type: Ingest
     node0_svc_fixed_ip: 10.4.0.255

--- a/charts/nucliadb_search/templates/search.cm.yaml
+++ b/charts/nucliadb_search/templates/search.cm.yaml
@@ -25,3 +25,4 @@ data:
   NODE_TYPE: {{ .Values.chitchat.node.node_type }}
   SEEDS: "{{ .Values.chitchat.node.node0_svc_fixed_ip }}:{{ .Values.chitchat.node.chitchat_port }}"
   UPDATE_INTERVAL: {{ .Values.chitchat.cluster_manager.update_interval }}
+  LIVELINESS_UPDATE: {{ .Values.chitchat.cluster_manager.liveliness_interval }}

--- a/charts/nucliadb_search/values.yaml
+++ b/charts/nucliadb_search/values.yaml
@@ -33,6 +33,7 @@ chitchat:
     port: 31337
     host: "0.0.0.0"
     update_interval: "30s"
+    liveliness_update: "2s"
   node:
     node_type: Search
     node0_svc_fixed_ip: 10.4.0.255

--- a/nucliadb_cluster/src/cluster.rs
+++ b/nucliadb_cluster/src/cluster.rs
@@ -144,6 +144,7 @@ impl Cluster {
         listen_addr: SocketAddr,
         node_type: NodeType,
         seed_node: Vec<String>,
+        liveliness_update: Duration,
     ) -> Result<Self, Error> {
         info!( node_id=?node_id, listen_addr=?listen_addr, "Create new cluster.");
         let chitchat_node_id = NodeId::new(node_id, listen_addr);
@@ -217,7 +218,7 @@ impl Cluster {
         let chitchat_clone = Arc::clone(&chitchat);
         let interval_task_stop = cluster.stop.clone();
         tokio::task::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_millis(500));
+            let mut interval = tokio::time::interval(liveliness_update);
             while !interval_task_stop.load(Ordering::Relaxed) {
                 interval.tick().await;
                 let mut chitchat_guard = chitchat_clone.lock().await;

--- a/nucliadb_cluster/tests/integration.rs
+++ b/nucliadb_cluster/tests/integration.rs
@@ -1,6 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use std::{env, io};
 
 use bytes::BytesMut;
@@ -12,6 +13,7 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 const SEED_NODE: &str = "0.0.0.0:40400";
+const LIVELINESS_UPDATE: Duration = Duration::from_secs(2);
 
 pub async fn create_seed_node() -> anyhow::Result<Cluster> {
     // create seed node
@@ -21,6 +23,7 @@ pub async fn create_seed_node() -> anyhow::Result<Cluster> {
         peer_addr,
         NodeType::Node,
         vec![SEED_NODE.to_string()],
+        LIVELINESS_UPDATE,
     )
     .await?)
 }
@@ -39,7 +42,14 @@ pub async fn create_cluster_for_test_with_id(
     let port = find_available_port()?;
     eprintln!("port: {port}");
     let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-    let cluster = Cluster::new(peer_uuid, peer_addr, NodeType::Node, vec![seed_node]).await?;
+    let cluster = Cluster::new(
+        peer_uuid,
+        peer_addr,
+        NodeType::Node,
+        vec![seed_node],
+        LIVELINESS_UPDATE,
+    )
+    .await?;
     Ok(cluster)
 }
 

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -65,6 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         chitchat_addr,
         NodeType::Node,
         seed_nodes,
+        Configuration::get_cluster_liveliness_interval_update(),
     )
     .await?;
 

--- a/nucliadb_node/src/config.rs
+++ b/nucliadb_node/src/config.rs
@@ -312,4 +312,33 @@ impl Configuration {
             }
         }
     }
+
+    /// Retuns the liveliness interval update used by cluster node.
+    pub fn get_cluster_liveliness_interval_update() -> Duration {
+        const DEFAULT_INTERVAL_UPDATE_PLACEHOLDER: &str = "2s";
+        const DEFAULT_INTERVAL_UPDATE: Duration = Duration::from_secs(2);
+
+        match env::var("CLUSTER_LIVELINESS_UPDATE") {
+            Ok(value) => {
+                if let Ok(duration) = parse_duration::parse(&value) {
+                    duration
+                } else {
+                    error!(
+                        "CLUSTER_LIVELINESS_UPDATE defined incorrectly. Defaulting to \
+                         {DEFAULT_INTERVAL_UPDATE_PLACEHOLDER}"
+                    );
+
+                    DEFAULT_INTERVAL_UPDATE
+                }
+            }
+            Err(_) => {
+                warn!(
+                    "CLUSTER_LIVELINESS_UPDATE not defined. Defaulting to \
+                     {DEFAULT_INTERVAL_UPDATE_PLACEHOLDER}"
+                );
+
+                DEFAULT_INTERVAL_UPDATE
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Description
This PR aims to make the cluster liveliness update configurable in order to test the cluster behaviour and hopefully fix the inconsistent list of alive cluster nodes. 

### How was this PR tested?
No tests.
