### PR TITLE
temporal marks added to transactions

### DIFF
--- a/nucliadb_vectors2/src/vectors/data_point/mod.rs
+++ b/nucliadb_vectors2/src/vectors/data_point/mod.rs
@@ -64,7 +64,7 @@ impl DeleteLog for NoDLog {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
 pub struct Journal {
     uid: DpId,
     nodes: usize,
@@ -340,7 +340,11 @@ impl DataPoint {
             index,
         })
     }
-    pub fn new(dir: &path::Path, mut elems: Vec<Elem>) -> DPResult<DataPoint> {
+    pub fn new(
+        dir: &path::Path,
+        mut elems: Vec<Elem>,
+        with_time: Option<SystemTime>,
+    ) -> DPResult<DataPoint> {
         use io::Write;
 
         let uid = DpId::new_v4().to_string();
@@ -378,7 +382,7 @@ impl DataPoint {
         let journal = Journal {
             nodes: key_value::get_no_elems(&nodes),
             uid: DpId::parse_str(&uid).unwrap(),
-            ctime: SystemTime::now(),
+            ctime: with_time.unwrap_or_else(SystemTime::now),
         };
         (0..journal.nodes)
             .into_iter()

--- a/nucliadb_vectors2/src/vectors/data_point/tests.rs
+++ b/nucliadb_vectors2/src/vectors/data_point/tests.rs
@@ -52,7 +52,7 @@ fn simple_flow() {
         elems.push(Elem::new(key.clone(), vector, labels));
         expected_keys.push(key);
     }
-    let reader = DataPoint::new(temp_dir.path(), elems).unwrap();
+    let reader = DataPoint::new(temp_dir.path(), elems, None).unwrap();
     let id = reader.get_id();
     let reader = DataPoint::open(temp_dir.path(), id).unwrap();
     let query = vec![rand::random::<f32>(); 8];
@@ -79,7 +79,7 @@ fn accuracy_test() {
         let labels = labels_dictionary.clone();
         elems.push(Elem::new(key, vector, labels));
     }
-    let reader = DataPoint::new(temp_dir.path(), elems).unwrap();
+    let reader = DataPoint::new(temp_dir.path(), elems, None).unwrap();
     let query = create_query();
     println!("QUERY 0: {:?}", query);
     let no_results = 10;
@@ -113,7 +113,7 @@ fn single_graph() {
         vector.clone(),
         LabelDictionary::default(),
     )];
-    let reader = DataPoint::new(temp_dir.path(), elems.clone()).unwrap();
+    let reader = DataPoint::new(temp_dir.path(), elems.clone(), None).unwrap();
     let result = reader.search(
         &HashSet::from([key.clone()]),
         &vector,
@@ -123,7 +123,7 @@ fn single_graph() {
     );
     assert_eq!(result.len(), 0);
 
-    let reader = DataPoint::new(temp_dir.path(), elems).unwrap();
+    let reader = DataPoint::new(temp_dir.path(), elems, None).unwrap();
     let result = reader.search(&HashSet::new(), &vector, &[] as &[String], true, 5);
     assert_eq!(result.len(), 1);
     assert!(result[0].1 >= 0.9);
@@ -148,8 +148,8 @@ fn data_merge() {
         vector1.clone(),
         LabelDictionary::default(),
     )];
-    let dp_0 = DataPoint::new(temp_dir.path(), elems0).unwrap();
-    let dp_1 = DataPoint::new(temp_dir.path(), elems1).unwrap();
+    let dp_0 = DataPoint::new(temp_dir.path(), elems0, None).unwrap();
+    let dp_1 = DataPoint::new(temp_dir.path(), elems1, None).unwrap();
     let dp = DataPoint::merge(
         temp_dir.path(),
         &[

--- a/nucliadb_vectors2/src/vectors/data_point_provider/merge_worker.rs
+++ b/nucliadb_vectors2/src/vectors/data_point_provider/merge_worker.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use std::path::PathBuf;
-use std::time::SystemTime;
 
 use tracing::*;
 
@@ -52,13 +51,12 @@ impl Worker {
         let subscriber = self.0.as_path();
         let lock = directory::shared_lock(subscriber)?;
         let state: State = directory::load_state(&lock)?;
-        let time = SystemTime::now();
         std::mem::drop(lock);
-        if let Some(work) = state.get_work() {
+        if let Some(work) = state.current_work_unit() {
             let work: Vec<_> = work
                 .iter()
                 .rev()
-                .map(|j| (state.create_dlog(*j), j.id()))
+                .map(|j| (state.delete_log(*j), j.id()))
                 .collect();
             let new_dp = DataPoint::merge(subscriber, &work)?;
             let ids: Vec<_> = work.into_iter().map(|(_, v)| v).collect();
@@ -67,7 +65,7 @@ impl Worker {
             let report = self.merge_report(ids.iter().copied(), new_dp.meta().id());
             let lock = directory::exclusive_lock(subscriber)?;
             let mut state: State = directory::load_state(&lock)?;
-            state.replace_work_unit(new_dp, time);
+            state.replace_work_unit(new_dp);
             directory::persist_state(&lock, &state)?;
             std::mem::drop(lock);
             info!("Merge on {subscriber:?}:\n{report}");

--- a/vectors_benchmark/src/binaries/1m_stats.rs
+++ b/vectors_benchmark/src/binaries/1m_stats.rs
@@ -40,12 +40,13 @@ fn label_set(batch_id: usize) -> Vec<String> {
 }
 
 fn add_batch(writer: &mut Index, elems: Vec<(String, Vec<f32>)>, labels: Vec<String>) {
+    let temporal_mark = TemporalMark::now();
     let labels = LabelDictionary::new(labels);
     let elems = elems
         .into_iter()
         .map(|(key, vector)| Elem::new(key, vector, labels.clone()))
         .collect();
-    let new_dp = DataPoint::new(writer.get_location(), elems).unwrap();
+    let new_dp = DataPoint::new(writer.get_location(), elems, Some(temporal_mark)).unwrap();
     let lock = writer.get_elock().unwrap();
     writer.add(new_dp, &lock);
     writer.commit(lock).unwrap();


### PR DESCRIPTION
### Description
This PR uses temporal marks to unify deletes and inserts during a `set_resource`. Thanks to this technique the state size  is considerably smaller.

### How was this PR tested?
Local tests
