### PR TITLE
Fix purge: handle shards payload not found

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -451,36 +451,37 @@ class KnowledgeBox:
         # Delete KB Shards
         shards_match = KB_SHARDS.format(kbid=kbid)
         payload = await txn.get(shards_match)
-        if payload is None:
-            await txn.abort()
-            raise ShardsNotFound(f"No shards on knowlege box {kbid}")
-        shards_obj = Shards()
-        shards_obj.ParseFromString(payload)
+        skip_cleaning_shards = payload is None
 
-        if not indexing_settings.index_local:
-            await Node.load_active_nodes()
+        if skip_cleaning_shards:
+            logger.warning(f"Shards not found for kbid={kbid}")
+        else:
+            shards_obj = Shards()
+            shards_obj.ParseFromString(payload)
 
-        for shard in shards_obj.shards:
-            # Delete the shard on nodes
-            for replica in shard.replicas:
-                node_klass = get_node_klass()
-                node: Optional[Union[LocalNode, Node]] = await node_klass.get(
-                    replica.node
-                )
-                if node is None:
-                    logger.info(f"No node {replica.node} found lets continue")
-                    continue
+            if not indexing_settings.index_local:
+                await Node.load_active_nodes()
 
-                try:
-                    await node.delete_shard(replica.shard.id)
-                    logger.debug(
-                        f"Succeded deleting shard from nodeid={replica.node} at {node.address}"
+            for shard in shards_obj.shards:
+                # Delete the shard on nodes
+                for replica in shard.replicas:
+                    node_klass = get_node_klass()
+                    node: Optional[Union[LocalNode, Node]] = await node_klass.get(
+                        replica.node
                     )
-                except AioRpcError as exc:
-                    if exc.code() == StatusCode.NOT_FOUND:
+                    if node is None:
+                        logger.info(f"No node {replica.node} found lets continue")
                         continue
-                    await txn.abort()
-                    raise ShardNotFound(f"{exc.details()} @ {node.address}")
+                    try:
+                        await node.delete_shard(replica.shard.id)
+                        logger.debug(
+                            f"Succeded deleting shard from nodeid={replica.node} at {node.address}"
+                        )
+                    except AioRpcError as exc:
+                        if exc.code() == StatusCode.NOT_FOUND:
+                            continue
+                        await txn.abort()
+                        raise ShardNotFound(f"{exc.details()} @ {node.address}")
 
         await txn.commit(resource=False)
         await cls.delete_all_kb_keys(driver, kbid)

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -451,13 +451,12 @@ class KnowledgeBox:
         # Delete KB Shards
         shards_match = KB_SHARDS.format(kbid=kbid)
         payload = await txn.get(shards_match)
-        skip_cleaning_shards = payload is None
 
-        if skip_cleaning_shards:
+        if payload is None:
             logger.warning(f"Shards not found for kbid={kbid}")
         else:
             shards_obj = Shards()
-            shards_obj.ParseFromString(payload)
+            shards_obj.ParseFromString(payload)  # type: ignore
 
             if not indexing_settings.index_local:
                 await Node.load_active_nodes()

--- a/nucliadb/nucliadb/ingest/purge.py
+++ b/nucliadb/nucliadb/ingest/purge.py
@@ -33,7 +33,6 @@ from nucliadb.ingest.orm.knowledgebox import (
 )
 from nucliadb.ingest.utils import get_driver
 from nucliadb.sentry import SENTRY, set_sentry
-from nucliadb_utils.exceptions import ShardsNotFound
 from nucliadb_utils.settings import running_settings
 from nucliadb_utils.utilities import get_storage
 

--- a/nucliadb/nucliadb/ingest/purge.py
+++ b/nucliadb/nucliadb/ingest/purge.py
@@ -60,7 +60,7 @@ async def main():
         try:
             await KnowledgeBox.purge(driver, kbid)
             logger.info(f"  √ Successfully Purged {kbid}")
-        except (ShardsNotFound, ShardNotFound) as exc:
+        except ShardNotFound as exc:
             capture_exception(exc)
             logger.info(
                 f"  X At least one shard was unavailable while purging {kbid}, skipping"

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import pytest
+
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+
+
+@pytest.mark.asyncio
+async def test_knowledgebox_purge_handles_unexisting_shard_payload(gcs_storage, redis_driver):
+    await KnowledgeBox.purge(redis_driver, "idonotexist")

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -23,5 +23,7 @@ from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 
 
 @pytest.mark.asyncio
-async def test_knowledgebox_purge_handles_unexisting_shard_payload(gcs_storage, redis_driver):
+async def test_knowledgebox_purge_handles_unexisting_shard_payload(
+    gcs_storage, redis_driver
+):
     await KnowledgeBox.purge(redis_driver, "idonotexist")


### PR DESCRIPTION
### Description
There has been a situation where the shards payload has been removed for some kbs, but we still have the kbid in the "kbs to purge list".
This PR handles this case making sure purge moves on and deletes the kb from the list instead of moving to the next kb.

### How was this PR tested?
No tests
