### PR TITLE
fixing directly accessing indexes

### DIFF
--- a/nucliadb_vectors/src/memory_system/elements/definitions.rs
+++ b/nucliadb_vectors/src/memory_system/elements/definitions.rs
@@ -179,7 +179,10 @@ impl GraphLayer {
         self.decrease_policy();
     }
     pub fn get_edges(&self, from: Node) -> HashMap<Node, Edge> {
-        self.cnx[&from].clone().into_iter().collect()
+        self.cnx
+            .get(&from)
+            .map(|list| list.clone().into_iter().collect())
+            .unwrap_or_default()
     }
     #[allow(unused)]
     #[cfg(test)]


### PR DESCRIPTION
### Description
Avoiding directly accessing connexions lists on `nucliadb_vectors/`

### How was this PR tested?
Local tests
