### PR TITLE
Set PENDING status after reprocess

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -168,10 +168,7 @@ class Resource:
         if self.basic is not None and self.basic != payload:
             self.basic.MergeFrom(payload)
 
-            if (
-                payload.HasField("metadata")
-                and payload.metadata.status != self.basic.metadata.status
-            ):
+            if payload.HasField("metadata") and payload.metadata.useful:
                 self.basic.metadata.status = payload.metadata.status
 
             # We force the usermetadata classification to be the one defined

--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -168,6 +168,12 @@ class Resource:
         if self.basic is not None and self.basic != payload:
             self.basic.MergeFrom(payload)
 
+            if (
+                payload.HasField("metadata")
+                and payload.metadata.status != self.basic.metadata.status
+            ):
+                self.basic.metadata.status = payload.metadata.status
+
             # We force the usermetadata classification to be the one defined
             if payload.HasField("usermetadata"):
                 self.basic.usermetadata.CopyFrom(payload.usermetadata)

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -327,6 +327,7 @@ async def reprocess_resource(
     writer.kbid = kbid
     writer.uuid = rid
     writer.source = BrokerMessage.MessageSource.WRITER
+    writer.basic.metadata.useful = True
     writer.basic.metadata.status = Metadata.Status.PENDING
     set_processing_info(writer, processing_info)
     await transaction.commit(writer, partition, wait=False)

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -26,6 +26,7 @@ from fastapi.params import Header
 from fastapi_versioning import version  # type: ignore
 from grpc import StatusCode as GrpcStatusCode
 from grpc.aio import AioRpcError  # type: ignore
+from nucliadb_protos.resources_pb2 import Metadata
 from nucliadb_protos.writer_pb2 import (
     BrokerMessage,
     IndexResource,
@@ -326,6 +327,7 @@ async def reprocess_resource(
     writer.kbid = kbid
     writer.uuid = rid
     writer.source = BrokerMessage.MessageSource.WRITER
+    writer.basic.metadata.status = Metadata.Status.PENDING
     set_processing_info(writer, processing_info)
     await transaction.commit(writer, partition, wait=False)
 


### PR DESCRIPTION
### Description
When calling `/reprocess` on a resource, its status is now set to `PENDING`.

### How was this PR tested?
Integration test added at nucliadb