### PR TITLE
add get_entities method to nucliadb_dataset

### DIFF
--- a/nucliadb_dataset/nucliadb_dataset/api.py
+++ b/nucliadb_dataset/nucliadb_dataset/api.py
@@ -26,7 +26,7 @@ from nucliadb_protos.train_pb2 import (
     TrainResource,
     TrainSentence,
 )
-from nucliadb_protos.writer_pb2 import GetLabelsResponse
+from nucliadb_protos.writer_pb2 import GetLabelsResponse, GetEntitiesResponse
 
 from nucliadb_dataset import CLIENT_ID, NUCLIA_GLOBAL
 from nucliadb_dataset.nuclia import NucliaDriver
@@ -77,6 +77,10 @@ def get_labels(kbid: str) -> GetLabelsResponse:
     labels = client.get_labels(kbid)
     return labels
 
+def get_entities(kbid: str) -> GetEntitiesResponse:
+    client = get_nuclia_client()
+    entities = client.get_entities(kbid)
+    return entities
 
 def get_info(kbid: str) -> TrainInfo:
     client = get_nuclia_client()

--- a/nucliadb_dataset/nucliadb_dataset/nuclia.py
+++ b/nucliadb_dataset/nucliadb_dataset/nuclia.py
@@ -35,7 +35,7 @@ from nucliadb_protos.train_pb2 import (
     TrainSentence,
 )
 from nucliadb_protos.train_pb2_grpc import TrainStub
-from nucliadb_protos.writer_pb2 import GetLabelsRequest, GetLabelsResponse
+from nucliadb_protos.writer_pb2 import GetLabelsRequest, GetLabelsResponse, GetEntitiesRequest
 
 
 class NucliaDriver:
@@ -93,6 +93,11 @@ class NucliaDriver:
         request = GetLabelsRequest()
         request.kb.uuid = kbid
         return self.stub.GetOntology(request)
+
+    def get_entities(self, kbid: str) -> GetLabelsResponse:
+        request = GetEntitiesRequest()
+        request.kb.uuid = kbid
+        return self.stub.GetEntities(request)
 
     def get_info(self, kbid: str) -> TrainInfo:
         request = GetInfoRequest()


### PR DESCRIPTION
### Description
Implement method to retrieve entities from KB into the nucliadb_dataset API

### How was this PR tested?
Using the following snippet:

```
from nucliadb_dataset.api import get_entities

kb_ner_testing = 'fdfcc171-a941-43b3-81a3-1a6b3deac41e'

r = get_entities(kb_ner_testing)
entity_groups = r.groups.keys()
```
