### PR TITLE
Add prometheus values in charts

### DIFF
--- a/charts/nucliadb_writer/templates/writer.cm.yaml
+++ b/charts/nucliadb_writer/templates/writer.cm.yaml
@@ -17,3 +17,5 @@ data:
 {{- end }}
   SERVING_PORT: {{ .Values.serving.port | quote }}
   METRICS_PORT: {{ .Values.serving.metricsPort | quote }}
+  PROMETHEUS_URL: {{ .Values.prometheus.url }}
+  PROMETHEUS_PUSH_TIMING: {{ .Values.prometheus.push_timing }}

--- a/charts/nucliadb_writer/values.yaml
+++ b/charts/nucliadb_writer/values.yaml
@@ -54,3 +54,7 @@ tracing:
   jaegerAgentTag: 1.34.1
   jaegerCollectorHost: jaeger-collector.observability.svc.cluster.local
   jaegerCollectorGrpcPort: 14250
+
+prometheus:
+  push_timing: "1h"
+  url:


### PR DESCRIPTION
### Description
This PR aims to define prometheus environment variables in order to send metrics to prometheus **AND** update the load score of the writer node.

*Note that the `prometheus.url` is not defined in charts in order to keep the repository agnostic.*

### How was this PR tested?
Not tested.
