### PR TITLE
Add entity positions in train get paragraphs

### DIFF
--- a/nucliadb/nucliadb/train/tests/fixtures.py
+++ b/nucliadb/nucliadb/train/tests/fixtures.py
@@ -157,11 +157,11 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
 
     p2 = Paragraph()
     p2.start = 84
-    p2.end = 112
+    p2.end = 114
 
     s1 = Sentence()
     s1.start = 84
-    s1.end = 112
+    s1.end = 114
     p2.sentences.append(s1)
 
     fcmw.metadata.metadata.paragraphs.append(p1)
@@ -171,7 +171,7 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
     fcmw.metadata.metadata.ner.update(
         {
             "Barcelona": "CITY",
-            "Manresa": "CITY",  # This one will have no positions
+            "Manresa": "CITY",
             "Sofia": "CITY",  # This entity should not appear, as it is not in the text
         }
     )

--- a/nucliadb/nucliadb/train/tests/fixtures.py
+++ b/nucliadb/nucliadb/train/tests/fixtures.py
@@ -138,7 +138,7 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
 
     etw = ExtractedTextWrapper()
     etw.field.CopyFrom(field1_if)
-    etw.body.text = "My lovely field with some information from Barcelona. This will be the good field. \n\n And then we will go Manresa."  # noqa
+    etw.body.text = "My lovely field with some information from Barcelona. This will be the good field. \n\n And then we will go Manresa. I miss Manresa!"  # noqa
     message2.extracted_text.append(etw)
 
     fcmw = FieldComputedMetadataWrapper()
@@ -157,11 +157,11 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
 
     p2 = Paragraph()
     p2.start = 84
-    p2.end = 114
+    p2.end = 130
 
     s1 = Sentence()
     s1.start = 84
-    s1.end = 114
+    s1.end = 130
     p2.sentences.append(s1)
 
     fcmw.metadata.metadata.paragraphs.append(p1)
@@ -172,7 +172,6 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
         {
             "Barcelona": "CITY",
             "Manresa": "CITY",
-            "Sofia": "CITY",  # This entity should not appear, as it is not in the text
         }
     )
     fcmw.metadata.metadata.positions["CITY/Barcelona"].entity = "Barcelona"

--- a/nucliadb/nucliadb/train/tests/test_list_paragraphs.py
+++ b/nucliadb/nucliadb/train/tests/test_list_paragraphs.py
@@ -55,27 +55,19 @@ async def test_list_paragraphs_shows_ners_with_positions(
         if "Barcelona" in paragraph.metadata.text:
             found_barcelona = True
             assert paragraph.metadata.entities == {"Barcelona": "CITY"}
-            assert (
-                paragraph.metadata.entity_positions["CITY/Barcelona"].entity
-                == "Barcelona"
-            )
-            assert (
-                paragraph.metadata.entity_positions["CITY/Barcelona"].positions[0].start
-                == 43
-            )
-            assert (
-                paragraph.metadata.entity_positions["CITY/Barcelona"].positions[0].end
-                == 52
-            )
+            positions = paragraph.metadata.entity_positions["CITY/Barcelona"]
+            assert positions.entity == "Barcelona"
+            assert len(positions.positions) == 1
+            assert positions.positions[0].start == 43
+            assert positions.positions[0].end == 52
         elif "Manresa" in paragraph.metadata.text:
             found_manresa = True
             assert paragraph.metadata.entities == {"Manresa": "CITY"}
-            assert (
-                paragraph.metadata.entity_positions["CITY/Manresa"].positions[0].start
-                == 22
-            )
-            assert (
-                paragraph.metadata.entity_positions["CITY/Manresa"].positions[0].end
-                == 29
-            )
+            positions = paragraph.metadata.entity_positions["CITY/Manresa"]
+            assert positions.entity == "Manresa"
+            assert len(positions.positions) == 2
+            assert positions.positions[0].start == 22
+            assert positions.positions[0].end == 29
+            assert positions.positions[1].start == 38
+            assert positions.positions[1].end == 45
     assert found_manresa and found_barcelona

--- a/nucliadb/nucliadb/train/tests/test_list_sentences.py
+++ b/nucliadb/nucliadb/train/tests/test_list_sentences.py
@@ -64,9 +64,15 @@ async def test_list_sentences_shows_ners_with_positions(
                 == 52
             )
         elif "Manresa" in sentence.metadata.text:
-            # Entity found in text but without positions
             assert sentence.metadata.entities == {"Manresa": "CITY"}
-            assert "CITY/Manresa" not in sentence.metadata.entity_positions
+            assert (
+                sentence.metadata.entity_positions["CITY/Manresa"].positions[0].start
+                == 22
+            )
+            assert (
+                sentence.metadata.entity_positions["CITY/Manresa"].positions[0].end
+                == 29
+            )
         else:
             # Other sentences should not have entities nor positions
             assert sentence.metadata.entities == {}

--- a/nucliadb/nucliadb/train/tests/test_list_sentences.py
+++ b/nucliadb/nucliadb/train/tests/test_list_sentences.py
@@ -49,30 +49,21 @@ async def test_list_sentences_shows_ners_with_positions(
     req.metadata.entities = True
     async for sentence in train_client.GetSentences(req):  # type: ignore
         if "Barcelona" in sentence.metadata.text:
-            # Entity in text with positions
             assert sentence.metadata.entities == {"Barcelona": "CITY"}
-            assert (
-                sentence.metadata.entity_positions["CITY/Barcelona"].entity
-                == "Barcelona"
-            )
-            assert (
-                sentence.metadata.entity_positions["CITY/Barcelona"].positions[0].start
-                == 43
-            )
-            assert (
-                sentence.metadata.entity_positions["CITY/Barcelona"].positions[0].end
-                == 52
-            )
+            positions = sentence.metadata.entity_positions["CITY/Barcelona"]
+            assert positions.entity == "Barcelona"
+            assert len(positions.positions) == 1
+            assert positions.positions[0].start == 43
+            assert positions.positions[0].end == 52
         elif "Manresa" in sentence.metadata.text:
             assert sentence.metadata.entities == {"Manresa": "CITY"}
-            assert (
-                sentence.metadata.entity_positions["CITY/Manresa"].positions[0].start
-                == 22
-            )
-            assert (
-                sentence.metadata.entity_positions["CITY/Manresa"].positions[0].end
-                == 29
-            )
+            positions = sentence.metadata.entity_positions["CITY/Manresa"]
+            assert positions.entity == "Manresa"
+            assert len(positions.positions) == 2
+            assert positions.positions[0].start == 22
+            assert positions.positions[0].end == 29
+            assert positions.positions[1].start == 38
+            assert positions.positions[1].end == 45
         else:
             # Other sentences should not have entities nor positions
             assert sentence.metadata.entities == {}


### PR DESCRIPTION
### Description
This PR extends the response of nucliadb_dataset.api.iterate_paragraphs so that it returns positions of entities found in the texts

### How was this PR tested?
Added integration tests
