### PR TITLE
Fix import when nucliadb is in the cloud

### DIFF
--- a/nucliadb/nucliadb/ingest/consumer/pull.py
+++ b/nucliadb/nucliadb/ingest/consumer/pull.py
@@ -192,7 +192,7 @@ class PullWorker:
     async def subscription_worker(self, msg: Msg):
         subject = msg.subject
         reply = msg.reply
-        seqid = int(msg.reply.split(".")[5])
+        seqid = int(reply.split(".")[5])
         logger.debug(
             f"Message received: subject:{subject}, seqid: {seqid}, reply: {reply}"
         )

--- a/nucliadb/nucliadb/ingest/maindb/local.py
+++ b/nucliadb/nucliadb/ingest/maindb/local.py
@@ -106,8 +106,12 @@ class LocalTransaction(Transaction):
         if resource:
             if worker is None or tid is None:
                 raise NoWorkerCommit()
-            key = TXNID.format(worker=worker)
-            await self.save(key, f"{tid}".encode())
+            if tid != -1:
+                # If tid == -1 means we are injecting a resource via gRPC. We don't
+                # want to save the tid in this case, as it would break the next
+                # transactionability check.
+                key = TXNID.format(worker=worker)
+                await self.save(key, f"{tid}".encode())
         self.clean()
         self.open = False
 

--- a/nucliadb/nucliadb/ingest/maindb/redis.py
+++ b/nucliadb/nucliadb/ingest/maindb/redis.py
@@ -81,8 +81,12 @@ class RedisTransaction(Transaction):
             if resource:
                 if worker is None or tid is None:
                     raise NoWorkerCommit()
-                key = TXNID.format(worker=worker)
-                pipe.set(key.encode(), tid)
+                if tid != -1:
+                    # If tid == -1 means we are injecting a resource via gRPC. We don't
+                    # want to save the tid in this case, as it would break the next
+                    # transactionability check.
+                    key = TXNID.format(worker=worker)
+                    pipe.set(key.encode(), tid)
             oks = await pipe.execute()
 
         for index, ok in enumerate(oks):

--- a/nucliadb/nucliadb/ingest/maindb/tikv.py
+++ b/nucliadb/nucliadb/ingest/maindb/tikv.py
@@ -59,8 +59,12 @@ class TiKVTransaction(Transaction):
         if resource:
             if worker is None or tid is None:
                 raise NoWorkerCommit()
-            key = TXNID.format(worker=worker)
-            await self.txn.put(key.encode(), str(tid).encode())
+            if tid != -1:
+                # If tid == -1 means we are injecting a resource via gRPC. We don't
+                # want to save the tid in this case, as it would break the next
+                # transactionability check.
+                key = TXNID.format(worker=worker)
+                await self.txn.put(key.encode(), str(tid).encode())
         await self.txn.commit()
         self.open = False
 

--- a/nucliadb/nucliadb/ingest/service/writer.py
+++ b/nucliadb/nucliadb/ingest/service/writer.py
@@ -621,16 +621,6 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
             resobj.disable_vectors = not request.reindex_vectors
 
             brain = await resobj.generate_index_message()
-            n_vectors = sum(
-                [
-                    1
-                    for par in brain.brain.paragraphs.values()
-                    for pp in par.paragraphs.values()
-                    for _ in pp.sentences.values()
-                ]
-            )
-            logger.info(f"About to index {n_vectors} vectors")
-
             shard_id = await kbobj.get_resource_shard_id(request.rid)
             shard: Optional[Shard] = None
             node_klass = get_node_klass()

--- a/nucliadb_client/nucliadb_client/client.py
+++ b/nucliadb_client/nucliadb_client/client.py
@@ -161,7 +161,6 @@ class NucliaDBClient:
 
         else:
             async with aiofiles.open(location, "r") as dump_file:
-
                 b64_pb = await dump_file.readline()
                 while b64_pb:
                     await kb.import_export(b64_pb.strip())

--- a/nucliadb_client/nucliadb_client/knowledgebox.py
+++ b/nucliadb_client/nucliadb_client/knowledgebox.py
@@ -151,7 +151,6 @@ class KnowledgeBox:
                 ser_pb.group = group
                 ser_pb.entities.CopyFrom(entities)
                 await self.client.writer_stub_async.SetEntities(ser_pb)  # type:  ignore
-
         elif type_line == CODEX.LAB:
             pb_lr = GetLabelsResponse()
             pb_lr.ParseFromString(payload)


### PR DESCRIPTION
### Description

#### Problem
When importing a resource that was previously exported, we call ingest's gRPC `ProcessMessage` directly. This emulates the ingestion of a resource, but outside of a normal transaction (That is why we are setting a `tid=-1` [here](https://github.com/nuclia/nucliadb/blob/main/nucliadb/nucliadb/ingest/service/writer.py#L255)). 

This, in effect, makes that the node sidecar can't download the corresponding index message to push to the node, as it depends on a valid transaction id.

#### Solution
On the shard object, before sending the message to the node, we detect when `tid` is `-1` and will treat the operation as if it was a reindexing operation (which also doesn't rely on any transaction).

### How was this PR tested?
Local tests will test the import step.
Existing tests give us the confidence that we don't break anything.

