### PR TITLE
Improve CI (Rust part)

### DIFF
--- a/.github/workflows/nucliadb_cluster.yml
+++ b/.github/workflows/nucliadb_cluster.yml
@@ -41,23 +41,6 @@ jobs:
           log-level: warn
           command: check licenses
 
-  udeps-rust:
-    name: Check unused dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-
-      - uses: aig787/cargo-udeps-action@v1
-        with:
-          version: latest
-          args: --all-targets --all-features
-
   format-rust:
     name: Code Format
     runs-on: ubuntu-latest
@@ -94,7 +77,7 @@ jobs:
   tests-rust:
     name: Tests
     runs-on: ubuntu-latest
-    needs: [clippy-rust, format-rust, licenses, udeps-rust]
+    needs: [clippy-rust, format-rust, licenses]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nucliadb_node.yml
+++ b/.github/workflows/nucliadb_node.yml
@@ -93,23 +93,6 @@ jobs:
           log-level: warn
           command: check licenses
 
-  udeps-rust:
-    name: Check unused dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-
-      - uses: aig787/cargo-udeps-action@v1
-        with:
-          version: latest
-          args: --all-targets --all-features
-
   format-rust:
     name: Code Format
     runs-on: ubuntu-latest
@@ -146,7 +129,7 @@ jobs:
   tests-rust:
     name: Tests
     runs-on: ubuntu-latest
-    needs: [clippy-rust, format-rust, licenses, udeps-rust]
+    needs: [clippy-rust, format-rust, licenses]
 
     steps:
       - uses: actions/checkout@v3

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
 ignore = [
+    "nucliadb_protos/*"
 ]
 
 comment_width = 120


### PR DESCRIPTION
### Description
This PR aims to remove a flaky job (`Check unused dependencies`) running on Rust-only codes.
Plus, the Rust formatter now ignore generated proto files.

### How was this PR tested ?
~