### PR TITLE
Delete KB keys in batches while purging

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from datetime import datetime
-from typing import AsyncGenerator, AsyncIterator, Optional, Tuple, Union
+from typing import AsyncGenerator, AsyncIterator, Optional, Tuple, Union, Any, List
 from uuid import uuid4
 
 from grpc import StatusCode
@@ -620,8 +620,10 @@ class KnowledgeBox:
                 )
 
 
-async def iter_in_chunks(gen: AsyncGenerator, chunk_size=100):
-    chunk = []
+async def iter_in_chunks(
+    gen: AsyncGenerator[Any, None], chunk_size: int = 100
+) -> AsyncIterator[List[Any]]:
+    chunk: List[Any] = []
 
     async for item in gen:
         if len(chunk) == chunk_size:
@@ -629,5 +631,5 @@ async def iter_in_chunks(gen: AsyncGenerator, chunk_size=100):
             chunk = []
         chunk.append(item)
 
-    if len(chunk):
+    if len(chunk) > 0:
         yield chunk

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -496,8 +496,8 @@ class KnowledgeBox:
             async for chunk_of_keys in iter_in_chunks(
                 txn.keys(match=prefix, count=-1), chunk_size=chunk_size
             ):
-                done = False
                 for key in chunk_of_keys:
+                    done = False
                     await txn.delete(key)
                 await txn.commit(resource=False)
             if done:

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from datetime import datetime
-from typing import AsyncGenerator, AsyncIterator, Optional, Tuple, Union, Any, List
+from typing import Any, AsyncGenerator, AsyncIterator, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from grpc import StatusCode

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -486,7 +486,7 @@ class KnowledgeBox:
         await cls.delete_all_kb_keys(driver, kbid)
 
     @classmethod
-    async def delete_all_kb_keys(cls, driver: Driver, kbid: str, chunk_size=1_000):
+    async def delete_all_kb_keys(cls, driver: Driver, kbid: str):
         # Delete KB Keys
         prefix = KB_KEYS.format(kbid=kbid)
         done = False
@@ -494,7 +494,7 @@ class KnowledgeBox:
             txn = await driver.begin()
             done = True
             async for chunk_of_keys in iter_in_chunks(
-                txn.keys(match=prefix, count=-1), chunk_size=chunk_size
+                txn.keys(match=prefix, count=-1), chunk_size=1_000
             ):
                 for key in chunk_of_keys:
                     done = False

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -76,11 +76,18 @@ async def test_knowledgebox_delete_all_kb_keys(
         bm = broker_resource(kbid)
         r = await kb_obj.add_resource(uuid=bm.uuid, slug=bm.uuid, basic=bm.basic)
         assert r is not None
+        await r.set_slug()
         uuids.add(bm.uuid)
     await txn.commit(resource=False)
 
+    # Check that all of them are there
+    for uuid in uuids:
+        assert await kb_obj.get_resource_uuid_by_slug(uuid) == uuid
+
     # Now delete all kb keys
     await KnowledgeBox.delete_all_kb_keys(redis_driver, kbid)
+    # This is needed to clean the in-memory cache of the transaction of visited_keys
+    txn.clean()
 
     # Check that all of them were deleted
     for uuid in uuids:

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -29,7 +29,6 @@ async def test_knowledgebox_purge_handles_unexisting_shard_payload(
     redis_driver,
     txn,
     cache,
-    knowledgebox_ingest: str,
 ):
     await KnowledgeBox.purge(redis_driver, "idonotexist")
 

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -29,7 +29,7 @@ async def test_knowledgebox_purge_handles_unexisting_shard_payload(
     redis_driver,
     txn,
     cache,
-    knowledgebox: str,
+    knowledgebox_ingest: str,
 ):
     await KnowledgeBox.purge(redis_driver, "idonotexist")
 
@@ -60,21 +60,22 @@ async def test_knowledgebox_delete_all_kb_keys(
     txn,
     cache,
     fake_node,
-    knowledgebox: str,
+    knowledgebox_ingest: str,
 ):
-    kb_obj = KnowledgeBox(txn, gcs_storage, cache, kbid=knowledgebox)
+    kbid = knowledgebox_ingest
+    kb_obj = KnowledgeBox(txn, gcs_storage, cache, kbid=kbid)
 
     # Create some resources in the KB
     for i in range(10):
         uuid = f"myresource{i}"
-        bm = broker_resource(knowledgebox, uuid)
+        bm = broker_resource(kbid, uuid)
         r = await kb_obj.add_resource(uuid=uuid, slug=uuid, basic=bm.basic)
         assert r is not None
 
     await txn.commit(resource=False)
 
     # Now delete all kb keys
-    await KnowledgeBox.delete_all_kb_keys(redis_driver, knowledgebox, chunk_size=3)
+    await KnowledgeBox.delete_all_kb_keys(redis_driver, kbid, chunk_size=3)
 
     # Check that all of them were deleted
     for i in range(10):

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -63,7 +63,7 @@ async def test_iter_in_chunks():
 @pytest.mark.asyncio
 async def test_knowledgebox_delete_all_kb_keys(
     gcs_storage,
-    tikv_driver,
+    redis_driver,
     txn,
     cache,
     fake_node,
@@ -85,7 +85,7 @@ async def test_knowledgebox_delete_all_kb_keys(
     await txn.commit(resource=False)
 
     # Now delete all kb keys
-    await KnowledgeBox.delete_all_kb_keys(tikv_driver, kbid, chunk_size=chunk_size)
+    await KnowledgeBox.delete_all_kb_keys(redis_driver, kbid, chunk_size=chunk_size)
 
     # Check that all of them were deleted
     for uuid in uuids:

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -19,11 +19,64 @@
 #
 import pytest
 
-from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox, iter_in_chunks
+from nucliadb.ingest.tests.fixtures import broker_resource
 
 
 @pytest.mark.asyncio
 async def test_knowledgebox_purge_handles_unexisting_shard_payload(
-    gcs_storage, redis_driver
+    gcs_storage,
+    redis_driver,
+    txn,
+    cache,
+    knowledgebox: str,
 ):
     await KnowledgeBox.purge(redis_driver, "idonotexist")
+
+
+@pytest.mark.asyncio
+async def test_iter_in_chunks():
+    async def thegenerator(n):
+        for i in range(n):
+            yield i
+
+    total_items = 100
+    chunk_size = 10
+    iterations = 0
+    async for chunk in iter_in_chunks(thegenerator(total_items), chunk_size=chunk_size):
+        assert len(chunk) == 10
+        assert chunk == list(
+            range(iterations * chunk_size, (iterations * chunk_size) + chunk_size)
+        )
+        iterations += 1
+
+    assert iterations == 10
+
+
+@pytest.mark.asyncio
+async def test_knowledgebox_delete_all_kb_keys(
+    gcs_storage,
+    redis_driver,
+    txn,
+    cache,
+    fake_node,
+    knowledgebox: str,
+):
+    kb_obj = KnowledgeBox(txn, gcs_storage, cache, kbid=knowledgebox)
+
+    # Create some resources in the KB
+    for i in range(10):
+        uuid = f"myresource{i}"
+        bm = broker_resource(knowledgebox, uuid)
+        r = await kb_obj.add_resource(uuid=uuid, slug=uuid, basic=bm.basic)
+        assert r is not None
+
+    await txn.commit(resource=False)
+
+    # Now delete all kb keys
+    await KnowledgeBox.delete_all_kb_keys(redis_driver, knowledgebox, chunk_size=3)
+
+    # Check that all of them were deleted
+    for i in range(10):
+        uuid = f"myresource{i}"
+        assert await kb_obj.get_resource_uuid_by_slug(uuid) is None

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -69,10 +69,8 @@ async def test_knowledgebox_delete_all_kb_keys(
     kbid = knowledgebox_ingest
     kb_obj = KnowledgeBox(txn, gcs_storage, cache, kbid=kbid)
 
-    n_resources = 200
-    chunk_size = 33
-
     # Create some resources in the KB
+    n_resources = 200
     uuids = set()
     for _ in range(n_resources):
         bm = broker_resource(kbid)
@@ -82,7 +80,7 @@ async def test_knowledgebox_delete_all_kb_keys(
     await txn.commit(resource=False)
 
     # Now delete all kb keys
-    await KnowledgeBox.delete_all_kb_keys(redis_driver, kbid, chunk_size=chunk_size)
+    await KnowledgeBox.delete_all_kb_keys(redis_driver, kbid)
 
     # Check that all of them were deleted
     for uuid in uuids:

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -25,10 +25,7 @@ from nucliadb.ingest.tests.fixtures import broker_resource
 
 @pytest.mark.asyncio
 async def test_knowledgebox_purge_handles_unexisting_shard_payload(
-    gcs_storage,
-    redis_driver,
-    txn,
-    cache,
+    gcs_storage, redis_driver
 ):
     await KnowledgeBox.purge(redis_driver, "idonotexist")
 

--- a/nucliadb/nucliadb/search/tests/test_basic_search.py
+++ b/nucliadb/nucliadb/search/tests/test_basic_search.py
@@ -78,7 +78,7 @@ async def test_multiple_fuzzy_search_resource_all(
         )
 
 
-# @pytest.mark.xfail(RUNNING_IN_GH_ACTIONS, reason="Somethimes this fails in GH actions")
+@pytest.mark.xfail(RUNNING_IN_GH_ACTIONS, reason="Somethimes this fails in GH actions")
 @pytest.mark.asyncio
 async def test_multiple_search_resource_all(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str

--- a/nucliadb/nucliadb/search/tests/test_basic_search.py
+++ b/nucliadb/nucliadb/search/tests/test_basic_search.py
@@ -51,7 +51,7 @@ async def test_search_kb_not_found(search_api: Callable[..., AsyncClient]) -> No
         assert resp.status_code == 404
 
 
-# @pytest.mark.xfail(RUNNING_IN_GH_ACTIONS, reason="Somethimes this fails in GH actions")
+@pytest.mark.xfail(RUNNING_IN_GH_ACTIONS, reason="Somethimes this fails in GH actions")
 @pytest.mark.asyncio
 async def test_multiple_fuzzy_search_resource_all(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str


### PR DESCRIPTION
### Description
This PR changes the way we delete the KB keys from the main database. Before we were deleting them all at once, while now we will delete them in batches of 1000.

### How was this PR tested?
Added integration and unit tests.
I tested against a local tikv server and a batch size of 1000 keys isn't causing any trouble