### PR TITLE
Always calculate load score in node writer

### DIFF
--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -108,47 +108,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    if let Some(prometheus_url) = Configuration::get_prometheus_url() {
+    let report = NodeReport::new(host_key.to_string())?;
+    let mut node_reader = NodeReaderService::new();
+
+    node_reader.load_shards()?;
+
+    tokio::spawn(async move {
         info!("Start metrics task");
 
-        let report = NodeReport::new(host_key.to_string())?;
-        let mut metrics_publisher = Publisher::new("node_metrics", prometheus_url);
+        let metrics_publisher = Configuration::get_prometheus_url().map(|url| {
+            let mut metrics_publisher = Publisher::new("node_metrics", url);
 
-        if let Some((username, password)) =
-            Configuration::get_prometheus_username().zip(Configuration::get_prometheus_password())
-        {
-            metrics_publisher = metrics_publisher.with_credentials(username, password);
-        }
+            if let Some((username, password)) = Configuration::get_prometheus_username()
+                .zip(Configuration::get_prometheus_password())
+            {
+                metrics_publisher = metrics_publisher.with_credentials(username, password);
+            }
 
-        let mut node_reader = NodeReaderService::new();
-        node_reader.load_shards()?;
+            metrics_publisher
+        });
 
-        let push_timing = Configuration::get_prometheus_push_timing();
+        let mut interval = tokio::time::interval(Configuration::get_prometheus_push_timing());
 
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(push_timing);
+        loop {
+            interval.tick().await;
 
-            loop {
-                interval.tick().await;
+            let mut shard_count = 0;
+            let mut paragraph_count = 0;
 
-                let mut shard_count = 0;
-                let mut paragraph_count = 0;
-
-                node_reader.cache.values().for_each(|shard| {
-                    match shard.get_info(&GetShardRequest::default()) {
-                        Err(e) => error!("Cannot get for {} metrics: {e:?}", shard.id),
-                        Ok(count) => {
-                            shard_count += 1;
-                            paragraph_count += count.paragraphs;
-                        }
+            node_reader.cache.values().for_each(|shard| {
+                match shard.get_info(&GetShardRequest::default()) {
+                    Err(e) => error!("Cannot get for {} metrics: {e:?}", shard.id),
+                    Ok(count) => {
+                        shard_count += 1;
+                        paragraph_count += count.paragraphs;
                     }
-                });
+                }
+            });
 
-                report.shard_count.set(shard_count);
-                report.paragraph_count.set(paragraph_count as i64);
+            report.shard_count.set(shard_count);
+            report.paragraph_count.set(paragraph_count as i64);
 
-                node.update_state(LOAD_SCORE_KEY, report.score()).await;
+            let load_score = report.score();
+            info!("Update node state: load_score = {load_score}");
+            node.update_state(LOAD_SCORE_KEY, load_score).await;
 
+            if let Some(ref metrics_publisher) = metrics_publisher {
                 if let Err(e) = metrics_publisher.publish(&report).await {
                     error!("Cannot publish Node metrics: {e}");
                 } else {
@@ -158,8 +163,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                 }
             }
-        });
-    }
+        }
+    });
 
     info!("Bootstrap complete in: {:?}", start_bootstrap.elapsed());
     eprintln!("Running");


### PR DESCRIPTION
### Description
This PR aims to change the way we're calculating the load score:
- Current behaviour: If `PROMETHEUS_URL` is defined, a metrics task is started and the load score is calculated before sending the metrics to prometheus.
- New behaviour: The metrics task is always started calculating the load score every X times, and if the `PROMETHEUS_URL` is set, send the metrics at the same time.

### How was this PR tested?
Tested locally
