### PR TITLE
Fix loading shard issue on node writer

### DIFF
--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -109,12 +109,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let report = NodeReport::new(host_key.to_string())?;
-    let mut node_reader = NodeReaderService::new();
 
-    node_reader.load_shards()?;
-
-    tokio::spawn(async move {
+    let metrics_task = tokio::spawn(async move {
         info!("Start metrics task");
+
+        let mut node_reader = NodeReaderService::new();
+
+        if let Err(e) = node_reader.load_shards() {
+            warn!("Not all the shards have been loaded: {e}");
+        };
 
         let metrics_publisher = Configuration::get_prometheus_url().map(|url| {
             let mut metrics_publisher = Publisher::new("node_metrics", url);
@@ -169,7 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Bootstrap complete in: {:?}", start_bootstrap.elapsed());
     eprintln!("Running");
 
-    tokio::try_join!(writer_task, monitor_task)?;
+    tokio::try_join!(writer_task, monitor_task, metrics_task)?;
     telemetry_handle.terminate_telemetry().await;
     // node_writer_service.shutdown().await;
 


### PR DESCRIPTION
### Description
This PR fix an issue on the writer node when there is a problem loading shards:
- Current behaviour: `text` fold is missing for some reason in shard then the writer stops.
- New behaviour: If the loading shards fails, a warning is log and the writer continue to work.

### How was this PR tested?
Tested locally