### PR TITLE
Fix purge: use different transactions for reading keys and for deletion

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -498,6 +498,8 @@ class KnowledgeBox:
             if len(all_keys) == 0:
                 break
 
+            # We commit deletions in chunks because otherwise
+            # tikv complains if there is too much data to commit
             for chunk_of_keys in chunker(all_keys, chunk_size):
                 txn = await driver.begin()
                 for key in chunk_of_keys:

--- a/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_orm_knowledgebox.py
@@ -44,7 +44,7 @@ def test_chunker():
     assert iterations == total_items / chunk_size
 
     iterations = 0
-    for chunk in chunker([]):
+    for chunk in chunker([], 2):
         iterations += 1
     assert iterations == 0
 

--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -28,7 +28,7 @@ gcloud
 oauth2client
 
 fastapi-versioning>=0.10.0
-fastapi>=0.75.0
+fastapi>=0.75.0,<0.89.0
 sentry-sdk>=1.5.12
 pyjwt>=2.4.0
 mmh3>=3.0.0

--- a/nucliadb_utils/requirements-fastapi.txt
+++ b/nucliadb_utils/requirements-fastapi.txt
@@ -1,3 +1,3 @@
-fastapi>=0.75.0
+fastapi>=0.75.0,<0.89.0
 uvicorn>=0.16.0,<0.19.0
 starlette>=0.21.0


### PR DESCRIPTION
### Description
We introduced a bug in the purge command where we were using the same tikv transaction for reading all kb keys and for deleting them. This is not possible with tikv.
We were not catching the bug in tests because they were running with the redis driver instead.

### How was this PR tested?
Added a tikv driver integration test
