### PR TITLE
Always calculate load score

### DIFF
--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -108,47 +108,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    if let Some(prometheus_url) = Configuration::get_prometheus_url() {
+    let report = NodeReport::new(host_key.to_string())?;
+
+    let metrics_task = tokio::spawn(async move {
         info!("Start metrics task");
 
-        let report = NodeReport::new(host_key.to_string())?;
-        let mut metrics_publisher = Publisher::new("node_metrics", prometheus_url);
-
-        if let Some((username, password)) =
-            Configuration::get_prometheus_username().zip(Configuration::get_prometheus_password())
-        {
-            metrics_publisher = metrics_publisher.with_credentials(username, password);
-        }
-
         let mut node_reader = NodeReaderService::new();
-        node_reader.load_shards()?;
 
-        let push_timing = Configuration::get_prometheus_push_timing();
+        if let Err(e) = node_reader.load_shards() {
+            warn!("Not all the shards have been loaded: {e}");
+        };
 
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(push_timing);
+        let metrics_publisher = Configuration::get_prometheus_url().map(|url| {
+            let mut metrics_publisher = Publisher::new("node_metrics", url);
 
-            loop {
-                interval.tick().await;
+            if let Some((username, password)) = Configuration::get_prometheus_username()
+                .zip(Configuration::get_prometheus_password())
+            {
+                metrics_publisher = metrics_publisher.with_credentials(username, password);
+            }
 
-                let mut shard_count = 0;
-                let mut paragraph_count = 0;
+            metrics_publisher
+        });
 
-                node_reader.cache.values().for_each(|shard| {
-                    match shard.get_info(&GetShardRequest::default()) {
-                        Err(e) => error!("Cannot get for {} metrics: {e:?}", shard.id),
-                        Ok(count) => {
-                            shard_count += 1;
-                            paragraph_count += count.paragraphs;
-                        }
+        let mut interval = tokio::time::interval(Configuration::get_prometheus_push_timing());
+
+        loop {
+            interval.tick().await;
+
+            let mut shard_count = 0;
+            let mut paragraph_count = 0;
+
+            node_reader.cache.values().for_each(|shard| {
+                match shard.get_info(&GetShardRequest::default()) {
+                    Err(e) => error!("Cannot get for {} metrics: {e:?}", shard.id),
+                    Ok(count) => {
+                        shard_count += 1;
+                        paragraph_count += count.paragraphs;
                     }
-                });
+                }
+            });
 
-                report.shard_count.set(shard_count);
-                report.paragraph_count.set(paragraph_count as i64);
+            report.shard_count.set(shard_count);
+            report.paragraph_count.set(paragraph_count as i64);
 
-                node.update_state(LOAD_SCORE_KEY, report.score()).await;
+            let load_score = report.score();
+            info!("Update node state: load_score = {load_score}");
+            node.update_state(LOAD_SCORE_KEY, load_score).await;
 
+            if let Some(ref metrics_publisher) = metrics_publisher {
                 if let Err(e) = metrics_publisher.publish(&report).await {
                     error!("Cannot publish Node metrics: {e}");
                 } else {
@@ -158,13 +166,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                 }
             }
-        });
-    }
+        }
+    });
 
     info!("Bootstrap complete in: {:?}", start_bootstrap.elapsed());
     eprintln!("Running");
 
-    tokio::try_join!(writer_task, monitor_task)?;
+    tokio::try_join!(writer_task, monitor_task, metrics_task)?;
     telemetry_handle.terminate_telemetry().await;
     // node_writer_service.shutdown().await;
 


### PR DESCRIPTION
### Description
This PR re-introduces the commits about always calculating the load score even if the prometheus environment variables are not set.

### How was this PR tested?
Copy (partially) shards folder from `node-1` and run locally the node writer.
