### PR TITLE
Prevent processed resources from disappearing from resources list page

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -63,6 +63,8 @@ METADATA_STATUS_PB_TYPE_TO_NAME_MAP = {
     Metadata.Status.ERROR: ResourceProcessingStatus.ERROR.name,
     Metadata.Status.PROCESSED: ResourceProcessingStatus.PROCESSED.name,
     Metadata.Status.PENDING: ResourceProcessingStatus.PENDING.name,
+    Metadata.Status.BLOCKED: ResourceProcessingStatus.BLOCKED.name,
+    Metadata.Status.EXPIRED: ResourceProcessingStatus.EXPIRED.name,
 }
 
 

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -533,7 +533,7 @@ async def test_processing_status_doesnt_change_on_search_after_processed(
                 "title": "My new title",
             },
             headers={"X-SYNCHRONOUS": "True"},
-            timeout=None
+            timeout=None,
         )
     ).status_code == 200
 

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -322,17 +322,29 @@ async def test_search_can_filter_by_processing_status(
     assert resp.status_code == 200
     assert len(resp.json()["resources"]) == created
 
-    for status in valid_status:
-        resp = await nucliadb_reader.post(
-            f"/kb/{knowledgebox}/search",
-            json={
-                "features": ["document"],
-                "fields": ["a/title"],
-                "with_status": status,
-            },
-        )
-        assert resp.status_code == 200
-        assert len(resp.json()["resources"]) == 1
+    # Two should be PROCESSED (the ERROR is counted as processed)
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "features": ["document"],
+            "fields": ["a/title"],
+            "with_status": "PROCESSED",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["resources"]) == 2
+
+    # One should be PENDING
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "features": ["document"],
+            "fields": ["a/title"],
+            "with_status": "PENDING",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["resources"]) == 1
 
     # Check facets by processing status
     resp = await nucliadb_reader.post(

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, Mock
 
@@ -497,3 +498,73 @@ async def test_search_relations(
 
         for expected_relation in expected[entity]["related_to"]:
             assert expected_relation in entities[entity]["related_to"]
+
+
+@pytest.mark.asyncio
+async def test_processing_status_doesnt_change_on_search_after_processed(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    nucliadb_grpc: WriterStub,
+    knowledgebox,
+):
+    # Inject a resource with status=PROCESSED
+    bm = broker_resource(knowledgebox)
+    bm.basic.metadata.status = rpb.Metadata.Status.PROCESSED
+    await inject_message(nucliadb_grpc, bm)
+
+    # Check that search for resource list shows it
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "features": ["document"],
+            "fields": ["a/title"],
+            "query": "",
+            "with_status": "PROCESSED",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["resources"]) == 1
+
+    # Edit the resource so that status=PENDING
+    assert (
+        await nucliadb_writer.patch(
+            f"/kb/{knowledgebox}/resource/{bm.uuid}",
+            json={
+                "title": "My new title",
+            },
+            headers={"X-SYNCHRONOUS": "True"},
+            timeout=None
+        )
+    ).status_code == 200
+
+    # Wait a bit until for the node to index it
+    await asyncio.sleep(1)
+
+    # Check that search for resource list still shows it
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "features": ["document"],
+            "fields": ["a/title"],
+            "query": "",
+            "with_status": "PROCESSED",
+        },
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["resources"]) == 1
+
+    # Check that facets count it as PENDING though
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "features": ["document"],
+            "fields": ["a/title"],
+            "faceted": ["/n/s"],
+            "query": "",
+            "page_size": 0,
+        },
+    )
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    facets = resp_json["fulltext"]["facets"]
+    assert facets["/n/s"] == {"/n/s/PENDING": 1}

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -276,8 +276,9 @@ async def modify_resource(
 
     writer.source = BrokerMessage.MessageSource.WRITER
     set_processing_info(writer, processing_info)
-    await transaction.commit(writer, partition, wait=x_synchronous)
 
+    await transaction.commit(writer, partition, wait=x_synchronous)
+    
     return ResourceUpdated(seqid=processing_info.seqid)
 
 

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -278,7 +278,7 @@ async def modify_resource(
     set_processing_info(writer, processing_info)
 
     await transaction.commit(writer, partition, wait=x_synchronous)
-    
+
     return ResourceUpdated(seqid=processing_info.seqid)
 
 

--- a/nucliadb_models/nucliadb_models/metadata.py
+++ b/nucliadb_models/nucliadb_models/metadata.py
@@ -145,6 +145,8 @@ class ResourceProcessingStatus(Enum):
     PROCESSED = "PROCESSED"
     ERROR = "ERROR"
     EMPTY = "EMPTY"
+    BLOCKED = "BLOCKED"
+    EXPIRED = "EXPIRED"
 
 
 class Metadata(InputMetadata):


### PR DESCRIPTION
### Description
This PR tweaks the way we are indexing the processing status:
 - Facets: the current processing status is always set there
 - Status document tantivy field:
   - Once it becomes PROCESSED it stays like that forever.
   - Once it becomes ERROR, it can only go to PROCESSED.
   
### How was this PR tested?
Integration tests
