### PR TITLE
File transfer protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,8 +3852,7 @@ dependencies = [
 [[package]]
 name = "tokio-tar"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50188549787c32c1c3d9c8c71ad7e003ccf2f102489c5a96e385c84760477f4"
+source = "git+https://github.com/alekece/tokio-tar#ee06e373ae4fcd7c9691fa7cf67c9494fb201362"
 dependencies = [
  "filetime",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1033,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fail"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1086,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1534,6 +1583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +1953,20 @@ dependencies = [
  "itertools",
  "nucliadb_service_interface",
  "tantivy 0.17.0",
+]
+
+[[package]]
+name = "nucliadb_ftp"
+version = "0.1.0"
+dependencies = [
+ "clap 4.0.32",
+ "color-eyre",
+ "derive_builder 0.12.0",
+ "eyre",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-tar",
 ]
 
 [[package]]
@@ -2362,6 +2431,12 @@ checksum = "e2981bd7cfb2a70e6c50083c60561275a269fc7458f151c53b126ec1b15cc040"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "page_size"
@@ -3775,6 +3850,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50188549787c32c1c3d9c8c71ad7e003ccf2f102489c5a96e385c84760477f4"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3931,6 +4021,16 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4490,6 +4590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -187,9 +187,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -300,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,7 +349,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -467,13 +473,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "aa91278560fc226a5d9d736cc21e485ff9aad47d26b8ffe1f54cba868b684b9f"
 dependencies = [
  "bitflags",
- "clap_derive 4.0.21",
- "clap_lex 0.3.0",
+ "clap_derive 4.1.0",
+ "clap_lex 0.3.1",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -495,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -517,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -698,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -710,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -725,15 +731,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -932,7 +938,7 @@ checksum = "ce5e89cd7c59faf3cf0e31369fce2382807dd794d4fcce6380adcefdf5987796"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bollard",
  "dyn-clone",
  "futures",
@@ -1097,7 +1103,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1624,19 +1630,19 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -1647,7 +1653,7 @@ dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1870,7 +1876,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1924,7 +1930,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chitchat",
- "clap 4.0.32",
+ "clap 4.1.0",
  "crc32fast",
  "derive_builder 0.12.0",
  "derive_more",
@@ -1959,7 +1965,7 @@ dependencies = [
 name = "nucliadb_ftp"
 version = "0.1.0"
 dependencies = [
- "clap 4.0.32",
+ "clap 4.1.0",
  "color-eyre",
  "derive_builder 0.12.0",
  "eyre",
@@ -2231,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
 dependencies = [
  "memchr",
 ]
@@ -2467,15 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2554,7 +2560,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2586,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
+checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2880,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2925,7 +2931,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3012,14 +3018,14 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3029,11 +3035,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3050,12 +3056,11 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3460,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "264c2549892aa83975386a924ef8d0b8e909674c837d37ea58b4bd8739495c6e"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bitpacking",
  "byteorder",
  "census",
@@ -3511,7 +3516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d1878f2daa432d6b907e1a7e16a25ba7eab6cc0da059e69943276a5165d81b"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bitpacking",
  "byteorder",
  "census",
@@ -3778,9 +3783,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3793,7 +3798,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3853,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "tokio-tar"
 version = "0.3.0"
-source = "git+https://github.com/alekece/tokio-tar#ee06e373ae4fcd7c9691fa7cf67c9494fb201362"
+source = "git+https://github.com/alekece/tokio-tar#ccef8291a10b9378901a9f67e2b6b84565676018"
 dependencies = [
  "filetime",
  "futures-core",
@@ -3900,7 +3905,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4102,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typed-builder"
@@ -4468,43 +4473,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4514,15 +4500,9 @@ checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4532,15 +4512,9 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4550,15 +4524,9 @@ checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4568,21 +4536,15 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4592,9 +4554,9 @@ checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,7 @@ dependencies = [
 name = "nucliadb_ftp"
 version = "0.1.0"
 dependencies = [
+ "backoff",
  "clap 4.1.0",
  "color-eyre",
  "derive_builder 0.12.0",
@@ -1974,6 +1975,8 @@ dependencies = [
  "tokio",
  "tokio-tar",
  "tokio-test",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tar",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3861,6 +3862,19 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xattr",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
   "nucliadb_node",
   "nucliadb_node/binding",
   "nucliadb_services",
+  "nucliadb_ftp",
   "vectors_benchmark"
 ]

--- a/nucliadb_ftp/Cargo.toml
+++ b/nucliadb_ftp/Cargo.toml
@@ -12,6 +12,9 @@ thiserror = "1.0.38"
 tokio = { version = "1.23.0", features = ["net"] }
 tokio-tar = { git = "https://github.com/alekece/tokio-tar" }
 clap = { version = "4.0.32", features = ["derive"] }
+backoff = { version = "0.4.0", features = ["tokio"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "smallvec"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/nucliadb_ftp/Cargo.toml
+++ b/nucliadb_ftp/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4.0.32", features = ["derive"] }
 [dev-dependencies]
 tempfile = "3.3.0"
 tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
+tokio-test = "0.4.2"

--- a/nucliadb_ftp/Cargo.toml
+++ b/nucliadb_ftp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nucliadb_ftp"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+
+[dependencies]
+eyre = "0.6.8"
+color-eyre = "0.6.2"
+derive_builder = "0.12.0"
+thiserror = "1.0.38"
+tokio = { version = "1.23.0", features = ["net"] }
+tokio-tar = "0.3.0"
+clap = { version = "4.0.32", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3.3.0"
+tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }

--- a/nucliadb_ftp/Cargo.toml
+++ b/nucliadb_ftp/Cargo.toml
@@ -10,7 +10,7 @@ color-eyre = "0.6.2"
 derive_builder = "0.12.0"
 thiserror = "1.0.38"
 tokio = { version = "1.23.0", features = ["net"] }
-tokio-tar = "0.3.0"
+tokio-tar = { git = "https://github.com/alekece/tokio-tar" }
 clap = { version = "4.0.32", features = ["derive"] }
 
 [dev-dependencies]

--- a/nucliadb_ftp/README.md
+++ b/nucliadb_ftp/README.md
@@ -1,0 +1,1 @@
+# nucliadb_ftp

--- a/nucliadb_ftp/README.md
+++ b/nucliadb_ftp/README.md
@@ -1,1 +1,47 @@
 # nucliadb_ftp
+
+The `nucliadb_ftp` crate aims to transfer files/directories asynchronously over the network (using a TCP/IP connection),
+based on a patched version of [`tokio-tar`](https://github.com/alekece/tokio-tar) crate.
+
+To do so, `nucliadb_ftp` provides two simple and easy-to-use types:
+- [`Publisher`] that helps appending files/directories before publishing them.
+- [`Listener`] that helps listening (once or multiple time) incoming files/directories.
+
+## Examples
+
+```rust
+# tokio_test::block_on(async {
+use nucliadb_ftp::{Listener, Publisher};
+
+let listener_task = tokio::spawn(async {
+    Listener::default()
+        .save_at("my_dir")
+        // Uncomment this line if you want to preserve metadata of receveived files/directories.
+        // .preserve_metadata()
+        .listen_once(4242)
+        // Uncomment this line if you want to keep the listener active.
+        // .listen(4242)
+        .await
+        .unwrap();
+});
+
+let publisher_task = tokio::spawn(async {
+    Publisher::default()
+        // Uncomment this line if you want to publish files/directories with their metadata
+        //.preserve_metadata()
+        // Uncomment this line if you want to follow symlinks in appended directories.
+        // .follow_symlink()
+        .append("my_dir")
+        .append("path/to/my_file")
+        .send_to_localhost(4242)
+        // Or
+        // .sent_to("x.x.x.x:4242")
+        .await
+        .unwrap();
+});
+
+publisher_task.await.unwrap();
+listener_task.await.unwrap();
+
+# });
+```

--- a/nucliadb_ftp/src/error.rs
+++ b/nucliadb_ftp/src/error.rs
@@ -25,8 +25,8 @@ use thiserror::Error;
 /// The error that may occur when publishing/receiving files/directories.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("path cannot end by '..' or be the root path '/'")]
-    InvalidPath,
+    #[error("invalid path '{0}': {1}")]
+    InvalidPath(String, String),
     #[error(transparent)]
     IoError(#[from] io::Error),
 }

--- a/nucliadb_ftp/src/error.rs
+++ b/nucliadb_ftp/src/error.rs
@@ -2,9 +2,11 @@ use std::io;
 
 use thiserror::Error;
 
+/// The error that may occur when publishing/receiving files/directories.
 #[derive(Debug, Error)]
-#[non_exhaustive]
 pub enum Error {
-   #[error(transparent)]
-   IoError(#[from] io::Error)
+    #[error("path cannot end by '..' or be the root path '/'")]
+    InvalidPath,
+    #[error(transparent)]
+    IoError(#[from] io::Error),
 }

--- a/nucliadb_ftp/src/error.rs
+++ b/nucliadb_ftp/src/error.rs
@@ -1,3 +1,23 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
 use std::io;
 
 use thiserror::Error;

--- a/nucliadb_ftp/src/error.rs
+++ b/nucliadb_ftp/src/error.rs
@@ -1,0 +1,10 @@
+use std::io;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+   #[error(transparent)]
+   IoError(#[from] io::Error)
+}

--- a/nucliadb_ftp/src/lib.rs
+++ b/nucliadb_ftp/src/lib.rs
@@ -125,7 +125,7 @@ mod tests {
                 }
 
                 Publisher::default()
-                    .retry_on_failure(RetryPolicy::MaxDuration(Duration::from_secs(1)))
+                    .retry_on_failure(RetryPolicy::MaxDuration(Duration::from_secs(30)))
                     .append(source)?
                     .send_to_localhost(port)
                     .await?;
@@ -198,7 +198,7 @@ mod tests {
             }
 
             Publisher::default()
-                .retry_on_failure(RetryPolicy::MaxDuration(Duration::from_secs(1)))
+                .retry_on_failure(RetryPolicy::MaxDuration(Duration::from_secs(30)))
                 .append(source_dir)?
                 .send_to_localhost(port)
                 .await?;

--- a/nucliadb_ftp/src/lib.rs
+++ b/nucliadb_ftp/src/lib.rs
@@ -1,3 +1,23 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
 #![warn(clippy::pedantic)]
 
 //! # `nucliadb_ftp`

--- a/nucliadb_ftp/src/lib.rs
+++ b/nucliadb_ftp/src/lib.rs
@@ -105,7 +105,7 @@ mod tests {
 
                 let destination = destination_dir.path().join(file_name);
 
-                assert_eq!(file_content, &fs::read_to_string(&destination)?);
+                assert_eq!(file_content, &fs::read_to_string(destination)?);
 
                 Ok(()) as Result<()>
             }
@@ -119,7 +119,7 @@ mod tests {
                 {
                     let mut file = File::create(&source)?;
 
-                    write!(file, "{}", file_content)?;
+                    write!(file, "{file_content}")?;
                 }
 
                 Publisher::default()
@@ -188,9 +188,9 @@ mod tests {
             {
                 for (file_name, file_content) in files {
                     let source = source_dir.join(file_name);
-                    let mut file = File::create(&source)?;
+                    let mut file = File::create(source)?;
 
-                    write!(file, "{}", file_content)?;
+                    write!(file, "{file_content}")?;
                 }
             }
 

--- a/nucliadb_ftp/src/lib.rs
+++ b/nucliadb_ftp/src/lib.rs
@@ -82,6 +82,7 @@ mod tests {
     use std::fs::{self, File};
     use std::io::Write;
 
+    use tokio::time::Duration;
     use eyre::Result;
 
     use super::*;
@@ -110,6 +111,9 @@ mod tests {
                 Ok(()) as Result<()>
             }
         });
+
+        // let enough time to the listener task to open the TCP/IP connection
+        tokio::time::sleep(Duration::from_millis(250)).await;
 
         let publisher_task = tokio::spawn({
             async move {
@@ -178,6 +182,9 @@ mod tests {
 
             Ok(()) as Result<()>
         });
+
+        // let enough time to the listener task to open the TCP/IP connection
+        tokio::time::sleep(Duration::from_millis(250)).await;
 
         let publisher_task = tokio::spawn(async move {
             let source_dir = tempfile::tempdir()?;

--- a/nucliadb_ftp/src/lib.rs
+++ b/nucliadb_ftp/src/lib.rs
@@ -1,0 +1,217 @@
+// #![warn(clippy::pedantic)]
+
+mod error;
+
+use std::path::Path;
+
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio_tar::{ArchiveBuilder, Builder, HeaderMode};
+
+pub use error::Error;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SendOptions {
+    pub follow_symlinks: bool,
+    pub append_recursively: bool,
+    pub preserve_metadata: bool,
+}
+
+impl Default for SendOptions {
+    fn default() -> Self {
+        Self {
+            follow_symlinks: false,
+            append_recursively: true,
+            preserve_metadata: true,
+        }
+    }
+}
+
+pub async fn send(address: impl ToSocketAddrs, source: impl AsRef<Path>) -> Result<(), Error> {
+    send_with_options(address, source, SendOptions::default()).await
+}
+
+pub async fn send_with_options(
+    address: impl ToSocketAddrs,
+    source: impl AsRef<Path>,
+    options: SendOptions,
+) -> Result<(), Error> {
+    let socket = TcpStream::connect(address).await?;
+    let source = source.as_ref();
+    let mut archive = Builder::new(socket);
+
+    archive.mode(if options.preserve_metadata {
+        HeaderMode::Complete
+    } else {
+        HeaderMode::Deterministic
+    });
+
+    archive.follow_symlinks(options.follow_symlinks);
+
+    if source.is_dir() {
+        let dir = source.file_name().unwrap();
+
+        if options.append_recursively {
+            archive.append_dir_all(dir, source).await?;
+        } else {
+            archive.append_dir(dir, source).await?;
+        }
+    } else {
+        archive.append_path(source).await?;
+    }
+
+    let _writer = archive.into_inner().await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ReceiveOptions {
+    pub preserve_metadata: bool,
+}
+
+impl Default for ReceiveOptions {
+    fn default() -> Self {
+        Self {
+            preserve_metadata: true,
+        }
+    }
+}
+
+pub async fn receive(
+    address: impl ToSocketAddrs,
+    destination: impl AsRef<Path>,
+) -> Result<(), Error> {
+    receive_with_options(address, destination, ReceiveOptions::default()).await
+}
+
+pub async fn receive_with_options(
+    address: impl ToSocketAddrs,
+    destination: impl AsRef<Path>,
+    options: ReceiveOptions,
+) -> Result<(), Error> {
+    let listener = TcpListener::bind(address).await?;
+    let (socket, _) = listener.accept().await?;
+
+    let mut archive = if options.preserve_metadata {
+        ArchiveBuilder::new(socket)
+            .set_preserve_mtime(true)
+            .set_preserve_permissions(true)
+            .set_unpack_xattrs(true)
+            .build()
+    } else {
+        ArchiveBuilder::new(socket).build()
+    };
+
+    Ok(archive.unpack(destination).await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    use eyre::Result;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn it_sends_file_on_localhost() -> Result<()> {
+        let address = "0.0.0.0:4242";
+        let file_name = "dummy.txt";
+        let file_content = "Time spent with cats is never wasted";
+
+        let sender = tokio::spawn({
+            let address = address;
+            let file_content = file_content;
+
+            async move {
+                let destination_dir = tempfile::tempdir()?;
+
+                // Receiver::default()
+                //     .destination(destination_dir)
+                //     .keep_metadata()
+                //     .listen(address).await?;
+
+                receive(address, &destination_dir).await?;
+
+                let destination = destination_dir.path().join(file_name);
+
+                assert_eq!(file_content, &fs::read_to_string(destination)?);
+
+                Ok(()) as Result<()>
+            }
+        });
+
+        let receiver = tokio::spawn({
+            async move {
+                let source_dir = tempfile::tempdir()?;
+                let source = source_dir.path().join(file_name);
+
+                {
+                    let mut file = File::create(&source)?;
+
+                    writeln!(file, "{}", file_content)?;
+                }
+
+                // Sender::default()
+                //     .source(file_name)
+                //     .persist_metadata()
+                //     .stream(address)
+                //     .await?;
+
+                send(address, source).await?;
+
+                Ok(()) as Result<()>
+            }
+        });
+
+        let _ = tokio::try_join!(sender, receiver)?;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn it_sends_directory_on_localhost() -> Result<()> {
+        let address = "0.0.0.0:4242";
+        let file_name = "dummy.txt";
+        let file_content = "Time spent with cats is never wasted";
+
+        let sender = tokio::spawn({
+            let address = address;
+            let file_content = file_content;
+
+            async move {
+                let destination_dir = tempfile::tempdir()?;
+
+                receive(address, &destination_dir).await?;
+
+                let destination = destination_dir.path().join(file_name);
+
+                assert_eq!(file_content, &fs::read_to_string(destination)?);
+
+                Ok(()) as Result<()>
+            }
+        });
+
+        let receiver = tokio::spawn({
+            async move {
+                let source_dir = tempfile::tempdir()?;
+                let source = source_dir.path().join(file_name);
+
+                {
+                    let mut file = File::create(&source)?;
+
+                    writeln!(file, "{}", file_content)?;
+                }
+
+                send(address, source).await?;
+
+                Ok(()) as Result<()>
+            }
+        });
+
+        let _ = tokio::try_join!(sender, receiver)?;
+
+        Ok(())
+    }
+}

--- a/nucliadb_ftp/src/lib.rs
+++ b/nucliadb_ftp/src/lib.rs
@@ -53,8 +53,8 @@
 //!         //.preserve_metadata()
 //!         // Uncomment this line if you want to follow symlinks in appended directories.
 //!         // .follow_symlink()
-//!         .append("my_dir")
-//!         .append("path/to/my_file")
+//!         .append("my_dir").unwrap()
+//!         .append("path/to/my_file").unwrap()
 //!         .retry_on_failure(RetryPolicy::Always)
 //!         .send_to_localhost(4242)
 //!         // Or
@@ -126,7 +126,7 @@ mod tests {
 
                 Publisher::default()
                     .retry_on_failure(RetryPolicy::MaxDuration(Duration::from_secs(1)))
-                    .append(source)
+                    .append(source)?
                     .send_to_localhost(port)
                     .await?;
 
@@ -199,7 +199,7 @@ mod tests {
 
             Publisher::default()
                 .retry_on_failure(RetryPolicy::MaxDuration(Duration::from_secs(1)))
-                .append(source_dir)
+                .append(source_dir)?
                 .send_to_localhost(port)
                 .await?;
 

--- a/nucliadb_ftp/src/listener.rs
+++ b/nucliadb_ftp/src/listener.rs
@@ -1,0 +1,109 @@
+use std::{num::NonZeroUsize, path::PathBuf};
+
+use tokio::net::TcpListener;
+use tokio_tar::ArchiveBuilder;
+
+use super::error::Error;
+
+/// A structure for receiving files/directories over TCP/IP connection.
+///
+/// # Examples
+/// ```no_run
+/// # tokio_test::block_on(async {
+/// use nucliadb_ftp::Listener;
+///
+/// Listener::default()
+///     .save_at("my_path")
+///     .preserve_metadata()
+///     .listen_once(4242)
+///     // Uncomment this line if you want to keep the listener active.
+///     // .listen(4242)
+///     .await
+///     .unwrap();
+/// # });
+/// ```
+#[must_use]
+pub struct Listener {
+    /// Preserves received file/directory metadata.
+    /// Defaulted to `false`.
+    preserve_metadata: bool,
+    /// Indicates the location of the received files/directories on the file system.
+    path: PathBuf,
+}
+
+impl Default for Listener {
+    fn default() -> Self {
+        Self {
+            preserve_metadata: false,
+            path: PathBuf::from("."),
+        }
+    }
+}
+
+impl Listener {
+    /// Set the location of the received files/directories on the file system.
+    ///
+    /// Note that if the given location does not exist, it will be created on the fly
+    /// on file/directory reception.
+    pub fn save_at(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = path.into();
+
+        self
+    }
+
+    /// Preserves received file/directory metadata.
+    ///
+    /// Note that [`Publisher`](crate.publisher.Publisher.struct) needs to publish file/directory with metadata preservation.
+    pub fn preserve_metadata(mut self) -> Self {
+        self.preserve_metadata = true;
+
+        self
+    }
+
+    /// Listen only once for receiving files/directories.
+    ///
+    /// # Errors
+    /// This method can fail if:
+    /// - The received files/directories are ill-formed.
+    /// - The TCP/IP connection cannot be opened (port already in use).
+    pub async fn listen_once(&self, port: u16) -> Result<(), Error> {
+        self.listen_nth(port, unsafe { Some(NonZeroUsize::new_unchecked(1)) })
+            .await
+    }
+
+    /// Listen for receiving files/directories.
+    ///
+    /// Note that this method only returns on failure.
+    ///
+    /// # Errors
+    /// This method can fail if:
+    /// - The received files/directories are ill-formed.
+    /// - The TCP/IP connection cannot be opened (port already in use).
+    pub async fn listen(&self, port: u16) -> Result<(), Error> {
+        self.listen_nth(port, None).await
+    }
+
+    async fn listen_nth(&self, port: u16, mut limit: Option<NonZeroUsize>) -> Result<(), Error> {
+        let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
+
+        loop {
+            let (socket, _) = listener.accept().await?;
+
+            let mut archive = ArchiveBuilder::new(socket)
+                .set_preserve_mtime(self.preserve_metadata)
+                .set_preserve_permissions(self.preserve_metadata)
+                .set_unpack_xattrs(self.preserve_metadata)
+                .build();
+
+            archive.unpack(&self.path).await?;
+
+            limit = match limit.map(NonZeroUsize::get) {
+                Some(1) => break,
+                Some(n) => unsafe { Some(NonZeroUsize::new_unchecked(n - 1)) },
+                None => continue,
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/nucliadb_ftp/src/listener.rs
+++ b/nucliadb_ftp/src/listener.rs
@@ -1,3 +1,23 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
 use std::{num::NonZeroUsize, path::PathBuf};
 
 use tokio::net::TcpListener;

--- a/nucliadb_ftp/src/main.rs
+++ b/nucliadb_ftp/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
                 } else {
                     RetryPolicy::Never
                 })
-                .append(path)
+                .append(path)?
                 .send_to(ip)
                 .await?
         }

--- a/nucliadb_ftp/src/main.rs
+++ b/nucliadb_ftp/src/main.rs
@@ -1,0 +1,59 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use eyre::Result;
+use nucliadb_ftp::{ReceiveOptions, SendOptions};
+
+#[derive(Parser)]
+struct Opt {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Send {
+        address: SocketAddr,
+        source: PathBuf,
+    },
+    Listen {
+        #[arg(short, long)]
+        port: u16,
+        destination: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let opt = Opt::parse();
+
+    match opt.command {
+        Command::Send { address, source } => {
+            nucliadb_ftp::send_with_options(
+                address,
+                source,
+                SendOptions {
+                    append_recursively: true,
+                    follow_symlinks: false,
+                    preserve_metadata: true,
+                },
+            )
+            .await?
+        }
+        Command::Listen { port, destination } => {
+            nucliadb_ftp::receive_with_options(
+                format!("0.0.0.0:{}", port),
+                destination,
+                ReceiveOptions {
+                    preserve_metadata: false,
+                },
+            )
+            .await?
+        }
+    }
+
+    Ok(())
+}

--- a/nucliadb_ftp/src/main.rs
+++ b/nucliadb_ftp/src/main.rs
@@ -1,3 +1,23 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
 use std::net::SocketAddr;
 use std::path::PathBuf;
 

--- a/nucliadb_ftp/src/publisher.rs
+++ b/nucliadb_ftp/src/publisher.rs
@@ -172,13 +172,14 @@ impl Publisher {
                         }
                     }
 
+                    // comment + add counter
                     let _writer = archive.into_inner().await?;
 
                     Ok(())
                 }
             },
             |e, duration| {
-                tracing::debug!("Error happened at {duration:?}: {e}");
+                tracing::warn!("Error happened at {duration:?}: {e}");
             },
         )
         .await

--- a/nucliadb_ftp/src/publisher.rs
+++ b/nucliadb_ftp/src/publisher.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio_tar::{Builder, HeaderMode};
+
+use super::error::Error;
+
+/// A structure for publishing files/directories over TCP/IP connection.
+///
+/// # Examples
+/// ```no_run
+/// # tokio_test::block_on(async {
+/// use nucliadb_ftp::Publisher;
+///
+/// Publisher::default()
+///     .follow_symlinks()
+///     .preserve_metadata()
+///     .append("my_dir")
+///     .append("path/to/my_file")
+///     .send_to("0.0.0.0:4040")
+///     .await
+///     .unwrap();
+/// # })
+/// ```
+#[must_use]
+#[derive(Default)]
+pub struct Publisher {
+    /// Indicates to follow symlinks if any directory has been appended to the current `Publisher`.
+    /// Defaulted to `false`.
+    follow_symlinks: bool,
+    /// Preserves file/directory metadata.
+    /// Defaulted to `false`.
+    preserve_metadata: bool,
+    /// The list of files/directories published on [`Publisher::send_to`] call.
+    /// Note that calling [`Publisher::send_to`] method with an empty list of paths results to a no-op.
+    paths: Vec<PathBuf>,
+}
+
+impl Publisher {
+    /// Follows symlinks on publishing.
+    pub fn follow_symlinks(mut self) -> Self {
+        self.follow_symlinks = true;
+
+        self
+    }
+
+    /// Preserves file/directory metadata on publishing.
+    pub fn preserve_metadata(mut self) -> Self {
+        self.preserve_metadata = true;
+
+        self
+    }
+
+    /// Appends the given path to the current publisher.
+    ///
+    /// Note that if the path point to a directory which result to publish the whole directory.
+    pub fn append(mut self, path: impl Into<PathBuf>) -> Self {
+        self.paths.push(path.into());
+
+        self
+    }
+
+    /// Publishs all the appended files/directories to localhost.
+    ///
+    /// # Errors
+    /// This method can fails if:
+    /// - Any of the appended paths is invalid (does not exist, permission denied, and so on).
+    /// - Can't connect to the given IP address (port already in use).
+    pub async fn send_to_localhost(&self, port: u16) -> Result<(), Error> {
+        self.send_to(format!("0.0.0.0:{port}")).await
+    }
+
+    /// Publishs all the appended files/directories to the given IP address.
+    ///
+    /// # Errors
+    /// This method can fails if:
+    /// - Any of the appended paths is invalid (does not exist, permission denied, and so on).
+    /// - Can't connect to the given IP address.
+    pub async fn send_to(&self, address: impl ToSocketAddrs) -> Result<(), Error> {
+        let socket = TcpStream::connect(address).await?;
+        let mut archive = Builder::new(socket);
+
+        archive.mode(if self.preserve_metadata {
+            HeaderMode::Complete
+        } else {
+            HeaderMode::Deterministic
+        });
+
+        archive.follow_symlinks(self.follow_symlinks);
+
+        for path in &self.paths {
+            let name = path.canonicalize()?;
+            let name = name.file_name().unwrap_or_default();
+
+            if path.is_dir() {
+                archive.append_dir_all(name, path).await?;
+            } else {
+                archive.append_path_with_name(path, name).await?;
+            }
+        }
+
+        let _writer = archive.into_inner().await?;
+
+        Ok(())
+    }
+}

--- a/nucliadb_ftp/src/publisher.rs
+++ b/nucliadb_ftp/src/publisher.rs
@@ -1,3 +1,23 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
 use std::path::PathBuf;
 
 use tokio::net::{TcpStream, ToSocketAddrs};

--- a/nucliadb_node/src/reader/mod.rs
+++ b/nucliadb_node/src/reader/mod.rs
@@ -66,7 +66,7 @@ impl NodeReaderService {
         &mut self,
     ) -> ServiceResult<impl Iterator<Item = InternalResult<ShardReaderService>>> {
         let shards_path = Configuration::shards_path();
-        Ok(std::fs::read_dir(&shards_path)?.flatten().map(|entry| {
+        Ok(std::fs::read_dir(shards_path)?.flatten().map(|entry| {
             let file_name = entry.file_name().to_str().unwrap().to_string();
             let shard_path = entry.path();
             info!("Opening {shard_path:?}");

--- a/nucliadb_node/src/services/config.rs
+++ b/nucliadb_node/src/services/config.rs
@@ -98,13 +98,13 @@ impl ShardConfig {
         let config = ShardConfig::default();
         let serialized = serde_json::to_string(&config)?;
         fs::File::create(&json_file)?;
-        fs::write(&json_file, &serialized)?;
+        fs::write(&json_file, serialized)?;
         match ShardConfig::read_config(&json_file)? {
             ConfigState::UpToDate(config) => Ok(config),
             ConfigState::Modified(config) => {
                 let serialized = serde_json::to_string(&config)?;
                 fs::File::create(&json_file)?;
-                fs::write(&json_file, &serialized)?;
+                fs::write(&json_file, serialized)?;
                 Ok(config)
             }
         }

--- a/nucliadb_paragraphs_tantivy/build.rs
+++ b/nucliadb_paragraphs_tantivy/build.rs
@@ -46,7 +46,7 @@ fn main() -> io::Result<()> {
             "pub fn is_stop_word(x:&str) -> bool {{\n {} \n}}",
             stop_words
                 .into_iter()
-                .map(|word| format!(r#"x == "{}""#, word))
+                .map(|word| format!(r#"x == "{word}""#))
                 .join("\n|| ")
         ),
     )?;

--- a/nucliadb_paragraphs_tantivy/src/writer.rs
+++ b/nucliadb_paragraphs_tantivy/src/writer.rs
@@ -228,7 +228,7 @@ impl ParagraphWriterService {
                 let chars: Vec<char> = REGEX.replace_all(&text_info.text, " ").chars().collect();
                 let start_pos = p.start as u64;
                 let end_pos = p.end as u64;
-                let index = p.index as u64;
+                let index = p.index;
                 let split = &p.split;
                 let lower_bound = std::cmp::min(start_pos as usize, chars.len());
                 let upper_bound = std::cmp::min(end_pos as usize, chars.len());

--- a/nucliadb_vectors/src/disk/directory.rs
+++ b/nucliadb_vectors/src/disk/directory.rs
@@ -52,7 +52,7 @@ where S: Serialize {
     );
     bincode::serialize_into(&mut file, state)?;
     file.flush()?;
-    std::fs::rename(&temporal_path, &state_path)?;
+    std::fs::rename(&temporal_path, state_path)?;
     Ok(())
 }
 

--- a/nucliadb_vectors/src/vectors/data_point/mod.rs
+++ b/nucliadb_vectors/src/vectors/data_point/mod.rs
@@ -328,7 +328,7 @@ impl DataPoint {
     pub fn delete(dir: &path::Path, uid: DpId) -> DPResult<()> {
         let uid = uid.to_string();
         let id = dir.join(uid);
-        fs::remove_dir_all(&id)?;
+        fs::remove_dir_all(id)?;
         Ok(())
     }
     pub fn open(dir: &path::Path, uid: DpId) -> DPResult<DataPoint> {

--- a/nucliadb_vectors/src/vectors/indexset/state.rs
+++ b/nucliadb_vectors/src/vectors/indexset/state.rs
@@ -51,7 +51,7 @@ impl State {
     pub fn remove_index(&mut self, index: &str) -> VectorR<()> {
         if self.indexes.remove(index) {
             let index_path = self.location.join(index);
-            std::fs::remove_dir_all(&index_path)?;
+            std::fs::remove_dir_all(index_path)?;
         }
         Ok(())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.1"

--- a/vectors_benchmark/src/cli.rs
+++ b/vectors_benchmark/src/cli.rs
@@ -80,7 +80,7 @@ impl Args {
             .create(true)
             .truncate(true)
             .write(true)
-            .open(&plot)?;
+            .open(plot)?;
         write!(file, "{command}")?;
 
         let path = PathBuf::from(&self.output).join(out_files::WRT);
@@ -88,7 +88,7 @@ impl Args {
             .create(true)
             .truncate(true)
             .write(true)
-            .open(&path)?;
+            .open(path)?;
         Ok(file)
     }
     pub fn reader_plot(&self) -> BenchR<File> {
@@ -101,7 +101,7 @@ impl Args {
             .create(true)
             .truncate(true)
             .write(true)
-            .open(&plot)?;
+            .open(plot)?;
         write!(file, "{command}")?;
 
         let path = PathBuf::from(&self.output).join(out_files::RDR);
@@ -109,7 +109,7 @@ impl Args {
             .create(true)
             .truncate(true)
             .write(true)
-            .open(&path)?;
+            .open(path)?;
         Ok(file)
     }
     pub fn neighbours(&self) -> usize {


### PR DESCRIPTION
### Description
This PR introduces a new workspace member, named `nucliadb_ftp`, in charge of tranfering files and directories over the network (for shard cutover).  
If you want more information about the crate usage and types, checkout this branch and run `cargo doc -p nucliadb_ftp --open` in order to access the documentation.

In addition, a small binary helper, also named `nucliadb_ftp`, has been introduced to test the internal behavior and functionality of this new workspace member.  
Run `cargo run -p nucliadb_ftp -- help` for usage.

### How was this PR tested?
Run fresh-new UTs `run test -p nucliadb_ftp` plus manual tests (sending shards over 3 machines, 2 LINUX based + 1 MacOS, using the binary helper).
