### PR TITLE
Update node state from chitchat cluster

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -273,10 +273,7 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
     valid_ids = []
     for member in members:
         valid_ids.append(member.node_id)
-        if (
-            member.is_self is False
-            and member.node_type == "Io"
-        ):
+        if member.is_self is False and member.node_type == "Io":
             if member.node_id not in NODES:
                 logger.debug(
                     f"{member.node_id}/{member.node_type} add {member.listen_addr}"
@@ -289,9 +286,7 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
                 )
                 logger.debug("Node added")
             else:
-                logger.debug(
-                    f"{member.node_id}/{member.node_type} update"
-                )
+                logger.debug(f"{member.node_id}/{member.node_type} update")
                 node = NODES.get(member.node_id)
                 node.load_score = member.load_score
                 logger.debug("Node updated")

--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -276,21 +276,27 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
         if (
             member.is_self is False
             and member.node_type == "Io"
-            and member.node_id not in NODES
         ):
-            print(
-                f"logger debug: {member.node_id}/{member.node_type} add {member.listen_addr}"
-            )
-            logger.debug(
-                f"{member.node_id}/{member.node_type} add {member.listen_addr}"
-            )
-            await Node.set(
-                member.node_id,
-                address=member.listen_addr,
-                label=member.node_type,
-                load_score=member.load_score,
-            )
-            print("Node added")
+            if member.node_id not in NODES:
+                print(
+                    f"logger debug: {member.node_id}/{member.node_type} add {member.listen_addr}"
+                )
+                logger.debug(
+                    f"{member.node_id}/{member.node_type} add {member.listen_addr}"
+                )
+                await Node.set(
+                    member.node_id,
+                    address=member.listen_addr,
+                    label=member.node_type,
+                    load_score=member.load_score,
+                )
+                print("Node added")
+            else:
+                logger.debug(
+                    f"{member.node_id}/{member.node_type} update"
+                )
+                node = NODES.get(member.node_id)
+                node.load_score = member.load_score
     node_ids = [x for x in NODES.keys()]
     for key in node_ids:
         if key not in valid_ids:

--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -274,7 +274,8 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
     for member in members:
         valid_ids.append(member.node_id)
         if member.is_self is False and member.node_type == "Io":
-            if member.node_id not in NODES:
+            node = NODES.get(member.node_id)
+            if node is None:
                 logger.debug(
                     f"{member.node_id}/{member.node_type} add {member.listen_addr}"
                 )
@@ -287,7 +288,6 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
                 logger.debug("Node added")
             else:
                 logger.debug(f"{member.node_id}/{member.node_type} update")
-                node = NODES.get(member.node_id)
                 node.load_score = member.load_score
                 logger.debug("Node updated")
     node_ids = [x for x in NODES.keys()]

--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -278,9 +278,6 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
             and member.node_type == "Io"
         ):
             if member.node_id not in NODES:
-                print(
-                    f"logger debug: {member.node_id}/{member.node_type} add {member.listen_addr}"
-                )
                 logger.debug(
                     f"{member.node_id}/{member.node_type} add {member.listen_addr}"
                 )
@@ -290,13 +287,14 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
                     label=member.node_type,
                     load_score=member.load_score,
                 )
-                print("Node added")
+                logger.debug("Node added")
             else:
                 logger.debug(
                     f"{member.node_id}/{member.node_type} update"
                 )
                 node = NODES.get(member.node_id)
                 node.load_score = member.load_score
+                logger.debug("Node updated")
     node_ids = [x for x in NODES.keys()]
     for key in node_ids:
         if key not in valid_ids:

--- a/nucliadb/nucliadb/ingest/tests/orm/test_node.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_node.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import pytest
+from nucliadb.ingest.orm.node import chitchat_update_node, ClusterMember
+from nucliadb.ingest.orm import NODES
+
+
+def get_cluster_member(
+    node_id="foo",
+    listen_addr="192.1.1.1:8080",
+    node_type="Io",
+    online=True,
+    is_self=False,
+    load_score=0,
+) -> ClusterMember:
+    return ClusterMember(
+        node_id=node_id,
+        listen_addr=listen_addr,
+        node_type=node_type,
+        online=online,
+        is_self=is_self,
+        load_score=load_score,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chitchat_update_node():
+    assert NODES == {}
+    await chitchat_update_node([])
+    assert len(NODES) == 0
+
+    # Check that it ignores itself
+    member = get_cluster_member(is_self=True)
+    await chitchat_update_node([member])
+    assert len(NODES) == 0
+
+    # Check that it ignores types other than node_type="Io"
+    member = get_cluster_member(node_type="anythingelse")
+    await chitchat_update_node([member])
+    assert len(NODES) == 0
+
+    # Check it registers new members
+    member = get_cluster_member(node_id="node1")
+    await chitchat_update_node([member])
+    assert len(NODES) == 1
+    node = NODES["node1"]
+    assert node.address == member.listen_addr
+    assert node.load_score == member.load_score
+
+    # Check that it updates loads score for registered members
+    member.load_score = 30
+    await chitchat_update_node([member])
+    assert len(NODES) == 1
+    node = NODES["node1"]
+    assert node.load_score == 30
+
+    # Check that it removes members that are no longer reported
+    await chitchat_update_node([])
+    assert len(NODES) == 0

--- a/nucliadb/nucliadb/ingest/tests/orm/test_node.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_node.py
@@ -18,8 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import pytest
-from nucliadb.ingest.orm.node import chitchat_update_node, ClusterMember
+
 from nucliadb.ingest.orm import NODES
+from nucliadb.ingest.orm.node import ClusterMember, chitchat_update_node
 
 
 def get_cluster_member(


### PR DESCRIPTION
### Description
This PR fixes a bug in node state update on python side (already known node were skipped on update).

### How was this PR tested?
Run new UT that test node state update (`load_score` only for the moment).
