### PR TITLE
Improve knowledge graph search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,15 +68,6 @@ python-code-lint:
 	isort --profile black nucliadb_models
 	isort --profile black nucliadb
 
-	flake8  --config nucliadb_utils/setup.cfg nucliadb_utils/nucliadb_utils
-	flake8  --config nucliadb_node/setup.cfg nucliadb_node/nucliadb_node
-	flake8  --config nucliadb_telemetry/setup.cfg nucliadb_telemetry/nucliadb_telemetry
-	flake8  --config nucliadb_dataset/setup.cfg nucliadb_dataset/nucliadb_dataset
-	flake8  --config nucliadb_client/setup.cfg nucliadb_client/nucliadb_client
-	flake8  --config nucliadb_sdk/setup.cfg nucliadb_sdk/nucliadb_sdk
-	flake8  --config nucliadb_models/setup.cfg nucliadb_models/nucliadb_models
-	flake8  --config nucliadb/setup.cfg nucliadb/nucliadb
-
 	black nucliadb_utils
 	black nucliadb_node
 	black nucliadb_telemetry
@@ -85,6 +76,15 @@ python-code-lint:
 	black nucliadb_sdk
 	black nucliadb_models
 	black nucliadb
+
+	flake8  --config nucliadb_utils/setup.cfg nucliadb_utils/nucliadb_utils
+	flake8  --config nucliadb_node/setup.cfg nucliadb_node/nucliadb_node
+	flake8  --config nucliadb_telemetry/setup.cfg nucliadb_telemetry/nucliadb_telemetry
+	flake8  --config nucliadb_dataset/setup.cfg nucliadb_dataset/nucliadb_dataset
+	flake8  --config nucliadb_client/setup.cfg nucliadb_client/nucliadb_client
+	flake8  --config nucliadb_sdk/setup.cfg nucliadb_sdk/nucliadb_sdk
+	flake8  --config nucliadb_models/setup.cfg nucliadb_models/nucliadb_models
+	flake8  --config nucliadb/setup.cfg nucliadb/nucliadb
 
 	MYPYPATH=./mypy_stubs mypy nucliadb_telemetry
 	MYPYPATH=./mypy_stubs mypy nucliadb_utils

--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -49,7 +49,7 @@ from nucliadb_protos.utils_pb2 import (
 from nucliadb.ingest import logger
 from nucliadb.ingest.orm.labels import BASE_TAGS, flat_resource_tags
 from nucliadb.ingest.orm.utils import compute_paragraph_key
-from nucliadb_models.metadata import ResourceProcessingStatus
+from nucliadb_models.metadata import RelationTypePbMap, ResourceProcessingStatus
 
 if TYPE_CHECKING:
     StatusValue = Union[Metadata.Status.V, int]
@@ -374,6 +374,7 @@ class ResourceBrain:
                         relation=Relation.COLAB,
                         source=relationnodedocument,
                         to=relationnodeuser,
+                        relation_label=RelationTypePbMap[Relation.COLAB].value,
                     )
                 )
 
@@ -404,6 +405,7 @@ class ResourceBrain:
                     relation=Relation.ABOUT,
                     source=relationnodedocument,
                     to=relation_node_label,
+                    relation_label=RelationTypePbMap[Relation.ABOUT].value,
                 )
             )
 
@@ -433,6 +435,7 @@ class ResourceBrain:
                         relation=Relation.ABOUT,
                         source=relation_node_document,
                         to=relation_node_label,
+                        relation_label=RelationTypePbMap[Relation.ABOUT].value,
                     )
                 )
 
@@ -451,6 +454,7 @@ class ResourceBrain:
                 relation=Relation.ENTITY,
                 source=relation_node_document,
                 to=relation_node_entity,
+                relation_label=RelationTypePbMap[Relation.ENTITY].value,
             )
             self.brain.relations.append(rel)
 
@@ -508,6 +512,7 @@ class ResourceBrain:
                         relation=Relation.ENTITY,
                         source=relation_node_resource,
                         to=relation_node_entity,
+                        relation_label=RelationTypePbMap[Relation.ENTITY].value,
                     )
                     self.brain.relations.append(rel)
             for paragraph_annotation in basic_user_fieldmetadata.paragraphs:

--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -49,7 +49,7 @@ from nucliadb_protos.utils_pb2 import (
 from nucliadb.ingest import logger
 from nucliadb.ingest.orm.labels import BASE_TAGS, flat_resource_tags
 from nucliadb.ingest.orm.utils import compute_paragraph_key
-from nucliadb_models.metadata import RelationTypePbMap, ResourceProcessingStatus
+from nucliadb_models.metadata import ResourceProcessingStatus
 
 if TYPE_CHECKING:
     StatusValue = Union[Metadata.Status.V, int]
@@ -374,7 +374,6 @@ class ResourceBrain:
                         relation=Relation.COLAB,
                         source=relationnodedocument,
                         to=relationnodeuser,
-                        relation_label=RelationTypePbMap[Relation.COLAB].value,
                     )
                 )
 
@@ -405,7 +404,6 @@ class ResourceBrain:
                     relation=Relation.ABOUT,
                     source=relationnodedocument,
                     to=relation_node_label,
-                    relation_label=RelationTypePbMap[Relation.ABOUT].value,
                 )
             )
 
@@ -435,7 +433,6 @@ class ResourceBrain:
                         relation=Relation.ABOUT,
                         source=relation_node_document,
                         to=relation_node_label,
-                        relation_label=RelationTypePbMap[Relation.ABOUT].value,
                     )
                 )
 
@@ -454,7 +451,6 @@ class ResourceBrain:
                 relation=Relation.ENTITY,
                 source=relation_node_document,
                 to=relation_node_entity,
-                relation_label=RelationTypePbMap[Relation.ENTITY].value,
             )
             self.brain.relations.append(rel)
 
@@ -512,7 +508,6 @@ class ResourceBrain:
                         relation=Relation.ENTITY,
                         source=relation_node_resource,
                         to=relation_node_entity,
-                        relation_label=RelationTypePbMap[Relation.ENTITY].value,
                     )
                     self.brain.relations.append(rel)
             for paragraph_annotation in basic_user_fieldmetadata.paragraphs:

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -57,6 +57,7 @@ from nucliadb_models.search import (
     Paragraphs,
     RelatedEntities,
     RelationDirection,
+    RelationNodeTypeMap,
     Relations,
     ResourceProperties,
     ResourceResult,
@@ -404,22 +405,24 @@ async def merge_relations_results(
 
     for relation_response in relations_responses:
         for relation in relation_response.subgraph.relations:
-            origin = relation.source.value
-            destination = relation.to.value
+            origin = relation.source
+            destination = relation.to
             relation_label = relation.relation_label
 
-            if origin in relations.entities:
-                relations.entities[origin].related_to.append(
+            if origin.value in relations.entities:
+                relations.entities[origin.value].related_to.append(
                     DirectionalRelation(
-                        entity=destination,
+                        entity=destination.value,
+                        entity_type=RelationNodeTypeMap[destination.ntype],
                         relation=relation_label,
                         direction=RelationDirection.OUT,
                     )
                 )
-            elif destination in relations.entities:
-                relations.entities[destination].related_to.append(
+            elif destination.value in relations.entities:
+                relations.entities[destination.value].related_to.append(
                     DirectionalRelation(
-                        entity=origin,
+                        entity=origin.value,
+                        entity_type=RelationNodeTypeMap[origin.ntype],
                         relation=relation_label,
                         direction=RelationDirection.IN,
                     )

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -47,6 +47,7 @@ from nucliadb.search.search.fetch import (
     get_text_sentence,
 )
 from nucliadb_models.common import FieldTypeName
+from nucliadb_models.metadata import RelationTypePbMap
 from nucliadb_models.resource import ExtractedDataTypeName
 from nucliadb_models.search import (
     DirectionalRelation,
@@ -407,6 +408,7 @@ async def merge_relations_results(
         for relation in relation_response.subgraph.relations:
             origin = relation.source
             destination = relation.to
+            relation_type = RelationTypePbMap[relation.relation]
             relation_label = relation.relation_label
 
             if origin.value in relations.entities:
@@ -414,7 +416,8 @@ async def merge_relations_results(
                     DirectionalRelation(
                         entity=destination.value,
                         entity_type=RelationNodeTypeMap[destination.ntype],
-                        relation=relation_label,
+                        relation=relation_type,
+                        relation_label=relation_label,
                         direction=RelationDirection.OUT,
                     )
                 )
@@ -423,7 +426,8 @@ async def merge_relations_results(
                     DirectionalRelation(
                         entity=origin.value,
                         entity_type=RelationNodeTypeMap[origin.ntype],
-                        relation=relation_label,
+                        relation=relation_type,
+                        relation_label=relation_label,
                         direction=RelationDirection.IN,
                     )
                 )

--- a/nucliadb/nucliadb/tests/knowledgeboxes/philosophy_books.py
+++ b/nucliadb/nucliadb/tests/knowledgeboxes/philosophy_books.py
@@ -39,9 +39,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Marcus Aurelius",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Marcus Aurelius",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -57,9 +58,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Aristotle",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Aristotle",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -76,9 +78,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Friedrich Nietzsche",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Friedrich Nietzsche",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -95,9 +98,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "René Descartes",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "René Descartes",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -113,9 +117,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Anne Conway",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Anne Conway",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -132,9 +137,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Baruch Spinoza",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Baruch Spinoza",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -148,9 +154,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Immanuel Kant",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Immanuel Kant",
+                            "group": "PERSON",
                         },
                     }
                 ]
@@ -167,9 +174,10 @@ async def philosophy_books_kb(
                 "relations": [
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "Hannah Arendt",
-                            "entity_type": "PERSON",
+                        "to": {
+                            "type": "entity",
+                            "value": "Hannah Arendt",
+                            "group": "PERSON",
                         },
                     }
                 ]

--- a/nucliadb/nucliadb/tests/test_relations.py
+++ b/nucliadb/nucliadb/tests/test_relations.py
@@ -25,7 +25,7 @@ from nucliadb_protos.writer_pb2_grpc import WriterStub
 
 
 @pytest.mark.asyncio
-async def test_relations(
+async def test_broker_message_relations(
     nucliadb_grpc: WriterStub,
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -84,7 +84,7 @@ async def test_relations(
 
 
 @pytest.mark.asyncio
-async def test_relations_extracted(
+async def test_extracted_relations(
     nucliadb_grpc: WriterStub,
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -113,26 +113,30 @@ async def test_relations_extracted(
                 "relations": [
                     {
                         "relation": "CHILD",
-                        "resource": "document",
+                        "to": {"type": "resource", "value": "document-uuid"},
                     },
-                    {
-                        "relation": "ABOUT",
-                        "label": "label",
-                    },
+                    {"relation": "ABOUT", "to": {"type": "label", "value": "label"}},
                     {
                         "relation": "ENTITY",
-                        "entity": {
-                            "entity": "entity-1",
-                            "entity_type": "entity-type-1",
+                        "to": {
+                            "type": "entity",
+                            "value": "entity-1",
+                            "group": "entity-type-1",
                         },
                     },
                     {
                         "relation": "COLAB",
-                        "user": "user",
+                        "to": {
+                            "type": "user",
+                            "value": "user",
+                        },
                     },
                     {
                         "relation": "OTHER",
-                        "other": "other",
+                        "to": {
+                            "type": "label",
+                            "value": "other",
+                        },
                     },
                 ],
             },

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -464,19 +464,22 @@ async def test_search_relations(
                 {
                     "entity": "Poetry",
                     "entity_type": "entity",
-                    "relation": "write",
+                    "relation": "ENTITY",
+                    "relation_label": "write",
                     "direction": "out",
                 },
                 {
                     "entity": "Poetry",
                     "entity_type": "entity",
-                    "relation": "like",
+                    "relation": "ENTITY",
+                    "relation_label": "like",
                     "direction": "out",
                 },
                 {
                     "entity": "Joan Antoni",
                     "entity_type": "entity",
-                    "relation": "read",
+                    "relation": "ENTITY",
+                    "relation_label": "read",
                     "direction": "in",
                 },
             ]
@@ -486,13 +489,15 @@ async def test_search_relations(
                 {
                     "entity": "Gravity",
                     "entity_type": "entity",
-                    "relation": "formulate",
+                    "relation": "ENTITY",
+                    "relation_label": "formulate",
                     "direction": "out",
                 },
                 {
                     "entity": "Physics",
                     "entity_type": "entity",
-                    "relation": "study",
+                    "relation": "ENTITY",
+                    "relation_label": "study",
                     "direction": "out",
                 },
             ]
@@ -526,13 +531,15 @@ async def test_search_relations(
                 {
                     "entity": "Cat",
                     "entity_type": "entity",
-                    "relation": "species",
+                    "relation": "ENTITY",
+                    "relation_label": "species",
                     "direction": "in",
                 },
                 {
                     "entity": "Swallow",
                     "entity_type": "entity",
-                    "relation": "species",
+                    "relation": "ENTITY",
+                    "relation_label": "species",
                     "direction": "in",
                 },
             ]
@@ -1092,54 +1099,63 @@ async def test_search_automatic_relations(
                     "entity": "Pepita",
                     "entity_type": "user",
                     "relation": "COLAB",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "Anne",
                     "entity_type": "user",
                     "relation": "COLAB",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "John",
                     "entity_type": "user",
                     "relation": "COLAB",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "cat",
                     "entity_type": "entity",
                     "relation": "ENTITY",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "label",
                     "entity_type": "label",
                     "relation": "ABOUT",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "animals/cat",
                     "entity_type": "label",
                     "relation": "ABOUT",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "food/cookie",
                     "entity_type": "label",
                     "relation": "ABOUT",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "sub-document",
                     "entity_type": "resource",
                     "relation": "CHILD",
+                    "relation_label": "",
                     "direction": "out",
                 },
                 {
                     "entity": "other",
                     "entity_type": "entity",
                     "relation": "OTHER",
+                    "relation_label": "",
                     "direction": "out",
                 },
             ]
@@ -1180,6 +1196,7 @@ async def test_search_automatic_relations(
                     "entity": rid,
                     "entity_type": "resource",
                     "relation": "COLAB",
+                    "relation_label": "",
                     "direction": "in",
                 }
             ]

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -1006,9 +1006,7 @@ async def test_search_ordering_with_no_query(
 
 @pytest.mark.asyncio
 async def test_search_automatic_relations(
-    nucliadb_reader: AsyncClient,
-    nucliadb_writer: AsyncClient,
-    knowledgebox
+    nucliadb_reader: AsyncClient, nucliadb_writer: AsyncClient, knowledgebox
 ):
     predict_mock = Mock()
     set_utility(Utility.PREDICT, predict_mock)
@@ -1148,17 +1146,15 @@ async def test_search_automatic_relations(
         }
     }
 
-    sort_key = lambda x: x["entity"]
-
     for entity in expected:
         assert entity in entities
         assert len(entities[entity]["related_to"]) == len(
             expected[entity]["related_to"]
         )
 
-        assert sorted(expected[entity]["related_to"], key=sort_key) == sorted(
-            entities[entity]["related_to"], key=sort_key
-        )
+        assert sorted(
+            expected[entity]["related_to"], key=lambda x: x["entity"]
+        ) == sorted(entities[entity]["related_to"], key=lambda x: x["entity"])
 
     # Search a colaborator
     rn = RelationNode(
@@ -1196,6 +1192,6 @@ async def test_search_automatic_relations(
             expected[entity]["related_to"]
         )
 
-        assert sorted(expected[entity]["related_to"], key=sort_key) == sorted(
-            entities[entity]["related_to"], key=sort_key
-        )
+        assert sorted(
+            expected[entity]["related_to"], key=lambda x: x["entity"]
+        ) == sorted(entities[entity]["related_to"], key=lambda x: x["entity"])

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -1031,26 +1031,37 @@ async def test_search_automatic_relations(
                 "relations": [
                     {
                         "relation": "CHILD",
-                        "resource": "sub-document",
-                    },
-                    {
-                        "relation": "ABOUT",
-                        "label": "label",
-                    },
-                    {
-                        "relation": "ENTITY",
-                        "entity": {
-                            "entity": "cat",
-                            "entity_type": "animal",
+                        "to": {
+                            "type": "resource",
+                            "value": "sub-document",
                         },
                     },
                     {
+                        "relation": "ABOUT",
+                        "to": {
+                            "type": "label",
+                            "value": "label",
+                        },
+                    },
+                    {
+                        "relation": "ENTITY",
+                        "to": {"type": "entity", "value": "cat", "group": "ANIMAL"},
+                    },
+                    {
                         "relation": "COLAB",
-                        "user": "Pepita",
+                        "to": {
+                            "type": "user",
+                            "value": "Pepita",
+                            "group": "PERSON",
+                        },
                     },
                     {
                         "relation": "OTHER",
-                        "other": "other",
+                        "to": {
+                            "type": "entity",
+                            "value": "other",
+                            "group": "things",
+                        },
                     },
                 ],
             },
@@ -1129,7 +1140,7 @@ async def test_search_automatic_relations(
                 },
                 {
                     "entity": "other",
-                    "entity_type": "resource",
+                    "entity_type": "entity",
                     "relation": "",
                     "direction": "out",
                 },

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -1093,60 +1093,62 @@ async def test_search_automatic_relations(
                 {
                     "entity": "Pepita",
                     "entity_type": "user",
-                    "relation": "",
+                    "relation": "COLAB",
                     "direction": "out",
                 },
                 {
                     "entity": "Anne",
                     "entity_type": "user",
-                    "relation": "",
+                    "relation": "COLAB",
                     "direction": "out",
                 },
                 {
                     "entity": "John",
                     "entity_type": "user",
-                    "relation": "",
+                    "relation": "COLAB",
                     "direction": "out",
                 },
                 {
                     "entity": "cat",
                     "entity_type": "entity",
-                    "relation": "",
+                    "relation": "ENTITY",
                     "direction": "out",
                 },
                 {
                     "entity": "label",
                     "entity_type": "label",
-                    "relation": "",
+                    "relation": "ABOUT",
                     "direction": "out",
                 },
                 {
                     "entity": "animals/cat",
                     "entity_type": "label",
-                    "relation": "",
+                    "relation": "ABOUT",
                     "direction": "out",
                 },
                 {
                     "entity": "food/cookie",
                     "entity_type": "label",
-                    "relation": "",
+                    "relation": "ABOUT",
                     "direction": "out",
                 },
                 {
                     "entity": "sub-document",
                     "entity_type": "resource",
-                    "relation": "",
+                    "relation": "CHILD",
                     "direction": "out",
                 },
                 {
                     "entity": "other",
                     "entity_type": "entity",
-                    "relation": "",
+                    "relation": "OTHER",
                     "direction": "out",
                 },
             ]
         }
     }
+
+    sort_key = lambda x: x["entity"]
 
     for entity in expected:
         assert entity in entities
@@ -1154,8 +1156,9 @@ async def test_search_automatic_relations(
             expected[entity]["related_to"]
         )
 
-        for expected_relation in expected[entity]["related_to"]:
-            assert expected_relation in entities[entity]["related_to"]
+        assert sorted(expected[entity]["related_to"], key=sort_key) == sorted(
+            entities[entity]["related_to"], key=sort_key
+        )
 
     # Search a colaborator
     rn = RelationNode(
@@ -1180,7 +1183,7 @@ async def test_search_automatic_relations(
                 {
                     "entity": rid,
                     "entity_type": "resource",
-                    "relation": "",
+                    "relation": "COLAB",
                     "direction": "in",
                 }
             ]
@@ -1193,5 +1196,6 @@ async def test_search_automatic_relations(
             expected[entity]["related_to"]
         )
 
-        for expected_relation in expected[entity]["related_to"]:
-            assert expected_relation in entities[entity]["related_to"]
+        assert sorted(expected[entity]["related_to"], key=sort_key) == sorted(
+            entities[entity]["related_to"], key=sort_key
+        )

--- a/nucliadb/nucliadb/tests/test_suggest.py
+++ b/nucliadb/nucliadb/tests/test_suggest.py
@@ -175,7 +175,14 @@ async def test_suggest_related_entities(
         ("Solomon Islands", "country"),
     ]
     relations = [
-        {"relation": "ENTITY", "entity": {"entity": entity, "entity_type": type}}
+        {
+            "relation": "ENTITY",
+            "to": {
+                "type": "entity",
+                "value": entity,
+                "group": type,
+            },
+        }
         for entity, type in entities
     ]
     resp = await nucliadb_writer.post(

--- a/nucliadb/nucliadb/writer/resource/basic.py
+++ b/nucliadb/nucliadb/writer/resource/basic.py
@@ -148,6 +148,7 @@ def parse_basic_modify(
                     relation=RelationTypeMap[relation.relation],
                     source=relation_node_from,
                     to=relation_node_to,
+                    relation_label=relation.label,
                 )
             )
 

--- a/nucliadb/nucliadb/writer/resource/basic.py
+++ b/nucliadb/nucliadb/writer/resource/basic.py
@@ -148,7 +148,7 @@ def parse_basic_modify(
                     relation=RelationTypeMap[relation.relation],
                     source=relation_node_from,
                     to=relation_node_to,
-                    relation_label=relation.label,
+                    relation_label=relation.label or "",
                 )
             )
 

--- a/nucliadb/nucliadb/writer/tests/test_resources.py
+++ b/nucliadb/nucliadb/writer/tests/test_resources.py
@@ -149,10 +149,10 @@ async def test_resource_crud(
                     "relations": [
                         {
                             "relation": "CHILD",
-                            "properties": {
-                                "prop1": "value",
+                            "to": {
+                                "type": "resource",
+                                "value": "resource_uuid",
                             },
-                            "resource": "resource_uuid",
                         }
                     ],
                 },
@@ -245,10 +245,10 @@ async def test_resource_crud_sync(
                     "relations": [
                         {
                             "relation": "CHILD",
-                            "properties": {
-                                "prop1": "value",
+                            "to": {
+                                "type": "resource",
+                                "value": "resource_uuid",
                             },
-                            "resource": "resource_uuid",
                         }
                     ],
                 },

--- a/nucliadb_models/nucliadb_models/metadata.py
+++ b/nucliadb_models/nucliadb_models/metadata.py
@@ -108,14 +108,22 @@ class RelationEntity(BaseModel):
 
 
 class Relation(BaseModel):
+    relation: RelationType
+    label: Optional[str] = None
+
     from_: Optional[RelationEntity]
     to: RelationEntity
-    relation: RelationType
 
     class Config:
         fields = {"from_": "from"}
 
-    @root_validator(pre=False)
+    @root_validator
+    def default_label_is_relation_type(cls, values):
+        if values.get("label") is None:
+            values["label"] = values["relation"].value
+        return values
+
+    @root_validator
     def check_relation_is_valid(cls, values):
         if values["relation"] == RelationType.CHILD.value:
             if values["to"].get("type") != RelationNodeType.RESOURCE.value:

--- a/nucliadb_models/nucliadb_models/metadata.py
+++ b/nucliadb_models/nucliadb_models/metadata.py
@@ -118,12 +118,6 @@ class Relation(BaseModel):
         fields = {"from_": "from"}
 
     @root_validator
-    def default_label_is_relation_type(cls, values):
-        if values.get("label") is None:
-            values["label"] = values["relation"].value
-        return values
-
-    @root_validator
     def check_relation_is_valid(cls, values):
         if values["relation"] == RelationType.CHILD.value:
             if values["to"].get("type") != RelationNodeType.RESOURCE.value:

--- a/nucliadb_models/nucliadb_models/metadata.py
+++ b/nucliadb_models/nucliadb_models/metadata.py
@@ -39,97 +39,106 @@ class EntityRelation(BaseModel):
 
 
 class RelationType(Enum):
-    CHILD = "CHILD"
     ABOUT = "ABOUT"
-    ENTITY = "ENTITY"
+    CHILD = "CHILD"
     COLAB = "COLAB"
+    ENTITY = "ENTITY"
     OTHER = "OTHER"
+    SYNONYM = "SYNONYM"
 
 
-class Relation(BaseModel):
-    relation: RelationType
-    properties: Dict[str, str] = {}
+RelationTypePbMap: Dict[utils_pb2.Relation.RelationType.ValueType, RelationType] = {
+    utils_pb2.Relation.RelationType.ABOUT: RelationType.ABOUT,
+    utils_pb2.Relation.RelationType.CHILD: RelationType.CHILD,
+    utils_pb2.Relation.RelationType.COLAB: RelationType.COLAB,
+    utils_pb2.Relation.RelationType.ENTITY: RelationType.ENTITY,
+    utils_pb2.Relation.RelationType.OTHER: RelationType.OTHER,
+    utils_pb2.Relation.RelationType.SYNONYM: RelationType.SYNONYM,
+}
 
-    resource: Optional[str] = None
-    label: Optional[str] = None
-    user: Optional[str] = None
-    other: Optional[str] = None
-    entity: Optional[EntityRelation] = None
+RelationTypeMap: Dict[RelationType, utils_pb2.Relation.RelationType.ValueType] = {
+    RelationType.ABOUT: utils_pb2.Relation.RelationType.ABOUT,
+    RelationType.CHILD: utils_pb2.Relation.RelationType.CHILD,
+    RelationType.COLAB: utils_pb2.Relation.RelationType.COLAB,
+    RelationType.ENTITY: utils_pb2.Relation.RelationType.ENTITY,
+    RelationType.OTHER: utils_pb2.Relation.RelationType.OTHER,
+    RelationType.SYNONYM: utils_pb2.Relation.RelationType.SYNONYM,
+}
+
+
+class RelationNodeType(str, Enum):
+    ENTITY = "entity"
+    LABEL = "label"
+    RESOURCE = "resource"
+    USER = "user"
+
+
+RelationNodeTypeMap: Dict[
+    RelationNodeType, utils_pb2.RelationNode.NodeType.ValueType
+] = {
+    RelationNodeType.ENTITY: utils_pb2.RelationNode.NodeType.ENTITY,
+    RelationNodeType.LABEL: utils_pb2.RelationNode.NodeType.LABEL,
+    RelationNodeType.RESOURCE: utils_pb2.RelationNode.NodeType.RESOURCE,
+    RelationNodeType.USER: utils_pb2.RelationNode.NodeType.USER,
+}
+
+RelationNodeTypePbMap: Dict[
+    utils_pb2.RelationNode.NodeType.ValueType, RelationNodeType
+] = {
+    utils_pb2.RelationNode.NodeType.ENTITY: RelationNodeType.ENTITY,
+    utils_pb2.RelationNode.NodeType.LABEL: RelationNodeType.LABEL,
+    utils_pb2.RelationNode.NodeType.RESOURCE: RelationNodeType.RESOURCE,
+    utils_pb2.RelationNode.NodeType.USER: RelationNodeType.USER,
+}
+
+
+class RelationEntity(BaseModel):
+    value: str
+    type: RelationNodeType
+    group: Optional[str] = None
 
     @root_validator(pre=True)
     def check_relation_is_valid(cls, values):
+        if values["type"] == RelationNodeType.ENTITY.value:
+            if "group" not in values:
+                raise ValueError(
+                    f"All {RelationNodeType.ENTITY.value} values must define a 'group'"
+                )
+        return values
+
+
+class Relation(BaseModel):
+    from_: Optional[RelationEntity]
+    to: RelationEntity
+    relation: RelationType
+
+    class Config:
+        fields = {"from_": "from"}
+
+    @root_validator(pre=False)
+    def check_relation_is_valid(cls, values):
         if values["relation"] == RelationType.CHILD.value:
-            if "resource" not in values:
+            if values["to"].get("type") != RelationNodeType.RESOURCE.value:
                 raise ValueError(
-                    "Missing 'resource' field containg the uuid of a resource"
+                    f"When using {RelationType.CHILD.value} relation, only "
+                    f"{RelationNodeType.RESOURCE.value} entities can be used"
                 )
-            if (
-                "label" in values
-                or "user" in values
-                or "other" in values
-                or "entity" in values
-            ):
+        elif values["relation"] == RelationType.COLAB.value:
+            if values["to"].get("type") != RelationNodeType.USER.value:
                 raise ValueError(
-                    "When using CHILD relation, only 'resource' field can be used"
+                    f"When using {RelationType.COLAB.value} relation, only "
+                    f"{RelationNodeType.USER.value} can be used"
                 )
-
-        if values["relation"] == RelationType.ABOUT.value:
-            if "label" not in values:
-                raise ValueError("Missing 'label' field containing a label")
-            if (
-                "resource" in values
-                or "user" in values
-                or "other" in values
-                or "entity" in values
-            ):
+        elif values["relation"] == RelationType.ENTITY.value:
+            if values["to"].get("type") != RelationNodeType.ENTITY.value:
                 raise ValueError(
-                    "When using CHILD relation, only 'label' field can be used"
-                )
-
-        if values["relation"] == RelationType.ENTITY.value:
-            if "entity" not in values:
-                raise ValueError(
-                    "Missing 'entity' field containing a valid entity of this resource"
-                )
-            if (
-                "resource" in values
-                or "user" in values
-                or "other" in values
-                or "label" in values
-            ):
-                raise ValueError(
-                    "When using ENTITY relation, only 'entity' field can be used"
-                )
-
-        if values["relation"] == RelationType.COLAB.value:
-            if "user" not in values:
-                raise ValueError("Missing 'user' field containing a user reference")
-            if (
-                "label" in values
-                or "resource" in values
-                or "other" in values
-                or "entity" in values
-            ):
-                raise ValueError(
-                    "When using COLAB relation, only 'user' field can be used"
-                )
-
-        if values["relation"] == RelationType.OTHER.value:
-            if "other" not in values:
-                raise ValueError("Missing 'other' field")
-            if (
-                "label" in values
-                or "resource" in values
-                or "user" in values
-                or "entity" in values
-            ):
-                raise ValueError(
-                    "When using OTHER relation, only 'other' field can be used"
+                    f"When using {RelationType.ENTITY.value} relation, only "
+                    f"{RelationNodeType.ENTITY.value} can be used"
                 )
         return values
 
     @classmethod
-    def from_message(cls: Type[_T], message: resources_pb2.Relation) -> _T:
+    def from_message(cls: Type[_T], message: utils_pb2.Relation) -> _T:
         value = convert_pb_relation_to_api(message)
         return cls(**value)
 
@@ -163,26 +172,22 @@ class Metadata(InputMetadata):
         )
 
 
-def convert_pb_relation_to_api(relation: utils_pb2.Relation):
-    result: Dict[str, Any] = {}
-    if relation.relation == utils_pb2.Relation.RelationType.OTHER:
-        result["relation"] = RelationType.OTHER.value
-        result["other"] = relation.to.value
-    elif relation.relation == utils_pb2.Relation.RelationType.CHILD:
-        result["relation"] = RelationType.CHILD.value
-        result["resource"] = relation.to.value
-    elif relation.relation == utils_pb2.Relation.RelationType.ABOUT:
-        result["relation"] = RelationType.ABOUT.value
-        result["label"] = relation.to.value
-    elif relation.relation == utils_pb2.Relation.RelationType.COLAB:
-        result["relation"] = RelationType.COLAB.value
-        result["user"] = relation.to.value
-    elif relation.relation == utils_pb2.Relation.RelationType.ENTITY:
-        result["relation"] = RelationType.ENTITY.value
-        result["entity"] = EntityRelation(
-            entity=relation.to.value, entity_type=relation.to.subtype
-        )
-    return result
+def convert_pb_relation_node_to_api(
+    relation_node: utils_pb2.RelationNode,
+) -> Dict[str, Any]:
+    return {
+        "type": RelationNodeTypePbMap[relation_node.ntype],
+        "value": relation_node.value,
+        "group": relation_node.subtype,
+    }
+
+
+def convert_pb_relation_to_api(relation: utils_pb2.Relation) -> Dict[str, Any]:
+    return {
+        "relation": RelationTypePbMap[relation.relation],
+        "from": convert_pb_relation_node_to_api(relation.source),
+        "to": convert_pb_relation_node_to_api(relation.to),
+    }
 
 
 class FieldClassification(BaseModel):

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, TypeVa
 
 from google.protobuf.json_format import MessageToDict
 from nucliadb_protos.nodereader_pb2 import OrderBy
+from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from pydantic import BaseModel
 
@@ -148,12 +149,28 @@ class Resources(BaseModel):
 
 
 class RelationDirection(str, Enum):
-    IN = "IN"
-    OUT = "OUT"
+    IN = "in"
+    OUT = "out"
+
+
+class EntityType(str, Enum):
+    ENTITY = "entity"
+    LABEL = "label"
+    RESOURCE = "resource"
+    USER = "user"
+
+
+RelationNodeTypeMap = {
+    RelationNode.NodeType.ENTITY: EntityType.ENTITY,
+    RelationNode.NodeType.LABEL: EntityType.LABEL,
+    RelationNode.NodeType.RESOURCE: EntityType.RESOURCE,
+    RelationNode.NodeType.USER: EntityType.USER,
+}
 
 
 class DirectionalRelation(BaseModel):
     entity: str
+    entity_type: str
     relation: str
     direction: RelationDirection
 

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -28,7 +28,7 @@ from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from pydantic import BaseModel
 
 from nucliadb_models.common import FieldTypeName
-from nucliadb_models.metadata import ResourceProcessingStatus
+from nucliadb_models.metadata import RelationType, ResourceProcessingStatus
 from nucliadb_models.resource import ExtractedDataTypeName, Resource
 
 if TYPE_CHECKING:
@@ -170,8 +170,9 @@ RelationNodeTypeMap = {
 
 class DirectionalRelation(BaseModel):
     entity: str
-    entity_type: str
-    relation: str
+    entity_type: EntityType
+    relation: RelationType
+    relation_label: str
     direction: RelationDirection
 
 


### PR DESCRIPTION
- Added label to relations
- Added entity type to serialized relations
- Breaking changes on relations API: relations are now closer to protobuffers. A relation is defined by a relation type, a label and two entities (from and to). If not defined, from is the resource


[sc-3672] https://app.shortcut.com/flaps/story/3672/knowledge-graph-return-empty-relations
[sc-3673] https://app.shortcut.com/flaps/story/3673/serialize-entity-type