### PR TITLE
Fix load score issue

### DIFF
--- a/nucliadb_cluster/src/bin/manager.rs
+++ b/nucliadb_cluster/src/bin/manager.rs
@@ -191,6 +191,8 @@ async fn main() -> anyhow::Result<()> {
                 let live_nodes = node.live_nodes().await;
                 let cluster_snapshot = node::cluster_snapshot(live_nodes).await;
 
+                debug!("Cluster snapshot {cluster_snapshot:?}");
+
                 if let Err(e) = send_update(cluster_snapshot, &mut writer, &arg).await {
                     error!("Send cluster cluster_snapshot failed: {e}");
                 } else {
@@ -201,6 +203,8 @@ async fn main() -> anyhow::Result<()> {
                 debug!("Something changed in cluster");
 
                 let cluster_snapshot = node::cluster_snapshot(live_nodes).await;
+
+                debug!("Cluster snapshot {cluster_snapshot:?}");
 
                 if let Err(e) = send_update(cluster_snapshot, &mut writer, &arg).await {
                     error!("Send cluster cluster_snapshot failed: {e}");

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -38,7 +38,7 @@ use tonic::transport::Server;
 use tracing::*;
 use uuid::Uuid;
 
-const LOAD_SCORE_KEY: Key<f32> = Key::new("load-score");
+const LOAD_SCORE_KEY: Key<f32> = Key::new("load_score");
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
### Description
This PR aims to fix the recurrent problem about the load score which is not updated on python side.

### How was this PR tested?
Run locally a node writer, a cluster manager and a ingest node with debug log enabled and watch if each part receives and propagate the correct load score.
