### PR TITLE
Convert load score to float

### DIFF
--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import binascii
 import json
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from nucliadb.ingest import logger
 from nucliadb.ingest.orm.node import ClusterMember, chitchat_update_node
@@ -130,7 +130,7 @@ class ChitchatNucliaDB:
         self.task.cancel()
 
 
-def build_member_from_json(member_serial):
+def build_member_from_json(member_serial: dict[str, Any]):
     try:
         load_score = float(member_serial.get("load_score"))
     except TypeError:

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import binascii
 import json
-from typing import List, Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from nucliadb.ingest import logger
 from nucliadb.ingest.orm.node import ClusterMember, chitchat_update_node

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -112,7 +112,7 @@ class ChitchatNucliaDB:
                                 listen_addr=x["address"],
                                 node_type=x["type"],
                                 is_self=x["is_self"],
-                                load_score=x.get("load_score", 0.0),
+                                load_score=float(x.get("load_score", "0")),
                                 online=True,
                             ),
                             json.loads(mgr_message.decode("utf8").replace("'", '"')),

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -107,14 +107,7 @@ class ChitchatNucliaDB:
                     logger.debug("update message received: {!r}".format(mgr_message))
                     members: List[ClusterMember] = list(
                         map(
-                            lambda x: ClusterMember(
-                                node_id=x["id"],
-                                listen_addr=x["address"],
-                                node_type=x["type"],
-                                is_self=x["is_self"],
-                                load_score=float(x.get("load_score", "0")),
-                                online=True,
-                            ),
+                            lambda x: build_member_from_json(x),
                             json.loads(mgr_message.decode("utf8").replace("'", '"')),
                         )
                     )
@@ -135,3 +128,20 @@ class ChitchatNucliaDB:
     async def close(self):
         self.chitchat_update_srv.close()
         self.task.cancel()
+
+
+def build_member_from_json(x):
+    try:
+        load_score = float(x.get("load_score"))
+    except:
+        logger.warn("Cannot convert load score. Defaulted to 0")
+        load_score = 0.0
+
+    return ClusterMember(
+        node_id=x["id"],
+        listen_addr=x["address"],
+        node_type=x["type"],
+        is_self=x["is_self"],
+        load_score=load_score,
+        online=True,
+    )

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -137,7 +137,7 @@ JsonObject = Dict[str, JsonValue]
 
 def build_member_from_json(member_serial: JsonObject):
     try:
-        load_score = float(member_serial.get("load_score"))
+        load_score = float(member_serial.get("load_score"))  # type: ignore
     except TypeError:
         # load score is set only on `Io` node so this log will be redundant if set to
         # an higher log level.
@@ -148,10 +148,10 @@ def build_member_from_json(member_serial: JsonObject):
         load_score = 0.0
 
     return ClusterMember(
-        node_id=member_serial["id"],
-        listen_addr=member_serial["address"],
-        node_type=member_serial["type"],
-        is_self=member_serial["is_self"],
+        node_id=str(member_serial["id"]),
+        listen_addr=str(member_serial["address"]),
+        node_type=str(member_serial["type"]),
+        is_self=bool(member_serial["is_self"]),
         load_score=load_score,
         online=True,
     )

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -130,18 +130,18 @@ class ChitchatNucliaDB:
         self.task.cancel()
 
 
-def build_member_from_json(x):
+def build_member_from_json(json):
     try:
-        load_score = float(x.get("load_score"))
+        load_score = float(json.get("load_score"))
     except:
         logger.warn("Cannot convert load score. Defaulted to 0")
         load_score = 0.0
 
     return ClusterMember(
-        node_id=x["id"],
-        listen_addr=x["address"],
-        node_type=x["type"],
-        is_self=x["is_self"],
+        node_id=json["id"],
+        listen_addr=json["address"],
+        node_type=json["type"],
+        is_self=json["is_self"],
         load_score=load_score,
         online=True,
     )

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -130,9 +130,9 @@ class ChitchatNucliaDB:
         self.task.cancel()
 
 
-def build_member_from_json(json):
+def build_member_from_json(member_serial):
     try:
-        load_score = float(json.get("load_score"))
+        load_score = float(member_serial.get("load_score"))
     except TypeError:
         logger.warn("Missing load score: Defaulted to 0")
         load_score = 0.0
@@ -141,10 +141,10 @@ def build_member_from_json(json):
         load_score = 0.0
 
     return ClusterMember(
-        node_id=json["id"],
-        listen_addr=json["address"],
-        node_type=json["type"],
-        is_self=json["is_self"],
+        node_id=member_serial["id"],
+        listen_addr=member_serial["address"],
+        node_type=member_serial["type"],
+        is_self=member_serial["is_self"],
         load_score=load_score,
         online=True,
     )

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -133,7 +133,10 @@ class ChitchatNucliaDB:
 def build_member_from_json(json):
     try:
         load_score = float(json.get("load_score"))
-    except:
+    except TypeError:
+        logger.warn("Missing load score: Defaulted to 0")
+        load_score = 0.0
+    except ValueError:
         logger.warn("Cannot convert load score. Defaulted to 0")
         load_score = 0.0
 

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import asyncio
 import binascii
 import json
-from typing import Any, List, Optional
+from typing import List, Dict, Optional, Union
 
 from nucliadb.ingest import logger
 from nucliadb.ingest.orm.node import ClusterMember, chitchat_update_node
@@ -130,7 +130,12 @@ class ChitchatNucliaDB:
         self.task.cancel()
 
 
-def build_member_from_json(member_serial: dict[str, Any]):
+JsonValue = Union["JsonObject", list["JsonValue"], str, bool, int, float, None]
+JsonArray = List[JsonValue]
+JsonObject = Dict[str, JsonValue]
+
+
+def build_member_from_json(member_serial: JsonObject):
     try:
         load_score = float(member_serial.get("load_score"))
     except TypeError:

--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -134,7 +134,9 @@ def build_member_from_json(member_serial):
     try:
         load_score = float(member_serial.get("load_score"))
     except TypeError:
-        logger.warn("Missing load score: Defaulted to 0")
+        # load score is set only on `Io` node so this log will be redundant if set to
+        # an higher log level.
+        logger.debug("Missing load score: Defaulted to 0")
         load_score = 0.0
     except ValueError:
         logger.warn("Cannot convert load score. Defaulted to 0")


### PR DESCRIPTION
### Description
This PR fixes the issue that the load score in propagated as a string (due to chitchat internal node state management).

### How was this PR tested?
Run ingest node, node writer and cluster manager with debug logs enabled and check that `ClusterMember::load_score` attribute contains a float and not a string anymore.
