### PR TITLE
remove telemetry from client tests

### DIFF
--- a/nucliadb/nucliadb/tests/fixtures.py
+++ b/nucliadb/nucliadb/tests/fixtures.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import os
 import tempfile
 
 import pytest
@@ -51,7 +52,14 @@ async def dummy_processing():
 
 
 @pytest.fixture(scope="function")
-async def nucliadb(dummy_processing):
+def telemetry_disabled():
+    os.environ["NUCLIADB_DISABLE_TELEMETRY"] = "True"
+    yield
+    os.environ.pop("NUCLIADB_DISABLE_TELEMETRY")
+
+
+@pytest.fixture(scope="function")
+async def nucliadb(dummy_processing, telemetry_disabled):
     with tempfile.TemporaryDirectory() as tmpdir:
         settings = Settings(
             blob=f"{tmpdir}/blob",

--- a/nucliadb/nucliadb/tests/test_search.py
+++ b/nucliadb/nucliadb/tests/test_search.py
@@ -43,7 +43,6 @@ async def test_search_sc_2062(
     # PUBLIC API
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}")
     assert resp.status_code == 200
-
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
         json={

--- a/nucliadb_client/nucliadb_client/tests/fixtures.py
+++ b/nucliadb_client/nucliadb_client/tests/fixtures.py
@@ -33,6 +33,7 @@ images.settings["nucliadb"] = {
     "image": "nuclia/nucliadb",
     "version": "latest",
     "env": {
+        "NUCLIADB_DISABLE_TELEMETRY": "True",
         "NUCLIADB_ENV": "True",
         "DRIVER": "LOCAL",
         "LOG": "DEBUG",

--- a/nucliadb_sdk/nucliadb_sdk/tests/fixtures.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/fixtures.py
@@ -33,6 +33,7 @@ images.settings["nucliadb"] = {
     "image": "nuclia/nucliadb",
     "version": "latest",
     "env": {
+        "NUCLIADB_DISABLE_TELEMETRY": "True",
         "max_receive_message_length": "40",
     },
 }


### PR DESCRIPTION
### Description
Set env var to disable telemetry from client tests

### How was this PR tested?
Local tests
