### PR TITLE
Create new shards on least loaded nodes

### DIFF
--- a/nucliadb/nucliadb/ingest/chitchat.py
+++ b/nucliadb/nucliadb/ingest/chitchat.py
@@ -151,5 +151,6 @@ def build_member_from_json(member_serial: JsonObject):
         type=NodeType.from_str(member_serial["type"]),
         is_self=bool(member_serial["is_self"]),
         load_score=load_score,
+        shard_count=30,
         online=True,
     )

--- a/nucliadb/nucliadb/ingest/orm/__init__.py
+++ b/nucliadb/nucliadb/ingest/orm/__init__.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from nucliadb.ingest.orm.exceptions import NodeClusterNotFound, NodeClusterSmall
 from nucliadb.ingest.settings import settings
@@ -56,6 +56,14 @@ class ClusterObject:
             return nodes[: settings.node_replicas]
         else:
             raise NodeClusterNotFound()
+
+    def find_least_loaded_nodes(self) -> List[str]:
+        sorted_nodes = [
+            (nodeid, node.load_score) for nodeid, node in NODES.items()
+        ].sort(key=lambda x: x[1])
+        if len(sorted_nodes) < settings.node_replicas:
+            raise NodeClusterSmall()
+        return sorted_nodes[: settings.node_replicas]
 
     def compute(self):
         self.date = datetime.now()

--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -134,7 +134,7 @@ class Node(AbstractNode):
 
     @classmethod
     async def create_shard_by_kbid(cls, txn: Transaction, kbid: str) -> Shard:
-        nodes = NODE_CLUSTER.find_nodes(kbid)
+        nodes = NODE_CLUSTER.find_least_loaded_nodes()
         sharduuid = uuid4().hex
         shard = PBShard(shard=sharduuid)
         try:

--- a/nucliadb/nucliadb/ingest/settings.py
+++ b/nucliadb/nucliadb/ingest/settings.py
@@ -70,6 +70,8 @@ class Settings(BaseSettings):
     sidecar_port_map: Dict[int, int] = {}
     max_node_fields: int = 200000
 
+    max_node_shards: int = 200  # TODO: discuss value
+
     local_reader_threads = 5
     local_writer_threads = 5
 

--- a/nucliadb/nucliadb/ingest/tests/fixtures.py
+++ b/nucliadb/nucliadb/ingest/tests/fixtures.py
@@ -723,3 +723,14 @@ async def create_resource(storage, driver: Driver, cache, knowledgebox_ingest: s
 
     await txn.commit(resource=False)
     return test_resource
+
+
+@pytest.fixture(scope="function")
+def metrics_registry():
+    import prometheus_client.registry  # type: ignore
+
+    for collector in prometheus_client.registry.REGISTRY._names_to_collectors.values():
+        if not hasattr(collector, "_metrics"):
+            continue
+        collector._metrics.clear()
+    yield prometheus_client.registry.REGISTRY

--- a/nucliadb/nucliadb/ingest/tests/orm/test_node.py
+++ b/nucliadb/nucliadb/ingest/tests/orm/test_node.py
@@ -31,6 +31,7 @@ def get_cluster_member(
     online=True,
     is_self=False,
     load_score=0,
+    shard_count=0,
 ) -> ClusterMember:
     return ClusterMember(
         node_id=node_id,
@@ -39,6 +40,7 @@ def get_cluster_member(
         online=online,
         is_self=is_self,
         load_score=load_score,
+        shard_count=shard_count,
     )
 
 
@@ -100,3 +102,48 @@ def test_node_type_pb_conversion():
     ]:
         assert node_type.to_pb() == member_type
         assert NodeType.from_pb(member_type) == node_type
+
+
+@pytest.mark.asyncio
+async def test_update_node_metrics(metrics_registry):
+    node1 = "node-1"
+    member1 = get_cluster_member(
+        node_id=node1, type=NodeType.IO, load_score=10, shard_count=2
+    )
+    await chitchat_update_node([member1])
+
+    assert metrics_registry.get_sample_value("nucliadb_nodes_available", {}) == 1
+    assert (
+        metrics_registry.get_sample_value("nucliadb_node_shard_count", {"node": node1})
+        == 2
+    )
+    assert (
+        metrics_registry.get_sample_value("nucliadb_node_load_score", {"node": node1})
+        == 10
+    )
+
+    node2 = "node-2"
+    member2 = get_cluster_member(
+        node_id=node2, type=NodeType.IO, load_score=40, shard_count=1
+    )
+    await chitchat_update_node([member2])
+
+    assert metrics_registry.get_sample_value("nucliadb_nodes_available", {}) == 1
+    assert (
+        metrics_registry.get_sample_value("nucliadb_node_shard_count", {"node": node2})
+        == 1
+    )
+    assert (
+        metrics_registry.get_sample_value("nucliadb_node_load_score", {"node": node2})
+        == 40
+    )
+
+    # Check that samples of destroyed node have been removed
+    assert (
+        metrics_registry.get_sample_value("nucliadb_node_shard_count", {"node": node1})
+        is None
+    )
+    assert (
+        metrics_registry.get_sample_value("nucliadb_node_load_score", {"node": node1})
+        is None
+    )

--- a/nucliadb/nucliadb/ingest/tests/test_cluster_object.py
+++ b/nucliadb/nucliadb/ingest/tests/test_cluster_object.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from unittest import mock
+
+import pytest
+
+from nucliadb.ingest import orm
+from nucliadb.ingest.orm.exceptions import NodeClusterSmall
+from nucliadb.ingest.orm.node import Node
+from nucliadb.ingest.settings import settings
+
+
+@pytest.fixture(scope="function")
+def nodes():
+    nodes = {}
+    for index, load_score in enumerate(range(10)):
+        node_id = f"node-{index}"
+        nodes[node_id] = Node(node_id, "local", load_score, dummy=True)
+
+    with mock.patch.object(orm, "NODES", new=nodes):
+        yield
+
+
+def test_find_nodes(nodes):
+    cluster = orm.ClusterObject()
+    assert cluster.find_nodes() == ["node-0", "node-1"]
+
+
+def test_find_nodes_raises_error_if_not_enough_nodes(nodes):
+    cluster = orm.ClusterObject()
+
+    prev = settings.node_replicas
+    settings.node_replicas = 200
+
+    with pytest.raises(NodeClusterSmall):
+        cluster.find_nodes()
+
+    settings.node_replicas = prev

--- a/nucliadb/nucliadb/ingest/tests/test_cluster_object.py
+++ b/nucliadb/nucliadb/ingest/tests/test_cluster_object.py
@@ -24,7 +24,7 @@ import pytest
 
 from nucliadb.ingest import orm
 from nucliadb.ingest.orm.exceptions import NodeClusterSmall
-from nucliadb.ingest.orm.node import Node
+from nucliadb.ingest.orm.node import Node, NodeType
 from nucliadb.ingest.settings import settings
 
 
@@ -33,7 +33,7 @@ def nodes():
     nodes = {}
     for index, load_score in enumerate(range(10)):
         node_id = f"node-{index}"
-        nodes[node_id] = Node(node_id, "local", load_score, dummy=True)
+        nodes[node_id] = Node(node_id, NodeType.IO, load_score, dummy=True)
 
     with mock.patch.object(orm, "NODES", new=nodes):
         yield


### PR DESCRIPTION
### Description
This PR changes the way we choose the nodes when it comes to create a new shard.
We leverage the new `load_score` metric added by the nodes to simply find the least loaded ones.

We no longer need to use the rendervouz algorithm, which it doesn't make sense since the number of nodes changes over time (and the number of shards in the nodes too, due to deletions)

### How was this PR tested?
Unit test + existing tests should cover integration tests
