### PR TITLE
Move values for push gateway to the node chart

### DIFF
--- a/charts/nucliadb_node/templates/node.cm.yaml
+++ b/charts/nucliadb_node/templates/node.cm.yaml
@@ -25,6 +25,8 @@ data:
   NODE_TYPE: "{{ .Values.serving.node_type }}"
   DATA_PATH: "{{.Values.config.data_path}}"
   SEED_NODES: "{{.Values.serving.node0_svc_fixed_ip}}:{{ .Values.serving.chitchat_port }}"
+  PROMETHEUS_URL: {{ .Values.prometheus.url }}
+  PROMETHEUS_PUSH_TIMING: {{ .Values.prometheus.push_timing }}
 {{- if .Values.config.lazyloading }}
   LAZY_LOADING: "true"
 {{- end }}

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -52,6 +52,10 @@ tracing:
   jaegerCollectorHost: jaeger-collector.observability.svc.cluster.local
   jaegerCollectorGrpcPort: 14250
 
+prometheus:
+  push_timing: "1h"
+  url:
+
 # secret containing NATS user credentials
 ## credential names inside the secret should be consistent with
 ## what's configured on nucliadb_shared

--- a/charts/nucliadb_writer/templates/writer.cm.yaml
+++ b/charts/nucliadb_writer/templates/writer.cm.yaml
@@ -17,5 +17,3 @@ data:
 {{- end }}
   SERVING_PORT: {{ .Values.serving.port | quote }}
   METRICS_PORT: {{ .Values.serving.metricsPort | quote }}
-  PROMETHEUS_URL: {{ .Values.prometheus.url }}
-  PROMETHEUS_PUSH_TIMING: {{ .Values.prometheus.push_timing }}

--- a/charts/nucliadb_writer/values.yaml
+++ b/charts/nucliadb_writer/values.yaml
@@ -54,7 +54,3 @@ tracing:
   jaegerAgentTag: 1.34.1
   jaegerCollectorHost: jaeger-collector.observability.svc.cluster.local
   jaegerCollectorGrpcPort: 14250
-
-prometheus:
-  push_timing: "1h"
-  url:


### PR DESCRIPTION
### Description
These values need to be in the node so that the node writer picks them up to export the load score to prometheus.

### How was this PR tested?
No tests needed
