### PR TITLE
Fix streaming downloads

### DIFF
--- a/nucliadb/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/nucliadb/reader/api/v1/download.py
@@ -198,7 +198,7 @@ async def download_api(sf: StorageField, headers: Headers):
         range_request = headers["range"]
         try:
             start, end, range_size = parse_media_range(range_request, file_size)
-        except NotImplementedError as err:
+        except NotImplementedError:
             raise HTTPException(
                 detail={
                     "reason": "rangeNotSupported",

--- a/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
+++ b/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
@@ -218,6 +218,8 @@ FILE_SIZE = 10
         (f"bytes=0-{FILE_SIZE}", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
         # End range < file size
         (f"bytes=0-5", FILE_SIZE, 0, 5, 6, None),
+        # End range > file size
+        (f"bytes=0-{FILE_SIZE + 1}", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
         # Invalid range
         ("bytes=something", FILE_SIZE, None, None, None, ValueError),
     ],

--- a/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
+++ b/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
@@ -84,6 +84,14 @@ async def test_resource_download_field_file(
         assert resp.status_code == 416
         assert resp.json()["detail"]["reason"] == "rangeNotParsable"
 
+        # Check that multipart ranges not implemented is handled
+        resp = await client.get(
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/file/{field_id}/download/field",
+            headers={"range": "bytes=0-50, 100-150"},
+        )
+        assert resp.status_code == 416
+        assert resp.json()["detail"]["reason"] == "rangeNotSupported"
+
         resp = await client.get(
             f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/file/{field_id}/download/field",
             headers={"range": "bytes=0-"},
@@ -222,6 +230,8 @@ FILE_SIZE = 10
         (f"bytes=0-{FILE_SIZE + 1}", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
         # Invalid range
         ("bytes=something", FILE_SIZE, None, None, None, ValueError),
+        # Multi-part ranges not supported yet
+        ("bytes=0-50, 100-150", FILE_SIZE, None, None, None, NotImplementedError),
     ],
 )
 def test_parse_media_range(range_request, filesize, start, end, range_size, exception):

--- a/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
+++ b/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
@@ -206,17 +206,26 @@ async def _get_message_with_file(test_resource):
     return msg_id, file_num
 
 
+FILE_SIZE = 10
+
+
 @pytest.mark.parametrize(
-    "range_request,filesize,start,end,exception",
+    "range_request,filesize,start,end,range_size,exception",
     [
-        ("bytes=0-", 7489387, 0, 7489387 - 1, None),
-        ("bytes=0-10", 7489387, 0, 10 + 1, None),
-        ("bytes=something", 10, None, None, ValueError),
+        # No end range specified
+        ("bytes=0-", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
+        # End range == file size
+        (f"bytes=0-{FILE_SIZE}", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
+        # End range < file size
+        (f"bytes=0-5", FILE_SIZE, 0, 5, 6, None),
+        # Invalid range
+        ("bytes=something", FILE_SIZE, None, None, None, ValueError),
     ],
 )
-def test_parse_media_range(range_request, filesize, start, end, exception):
+def test_parse_media_range(range_request, filesize, start, end, range_size, exception):
     if not exception:
-        assert parse_media_range(range_request, filesize) == (start, end)
+        result = parse_media_range(range_request, filesize)
+        assert result == (start, end, range_size)
     else:
         with pytest.raises(exception):
             parse_media_range(range_request, filesize)


### PR DESCRIPTION
### Description
`Content-Lenght` and `Content-Range` response headers were not properly set in all cases.

I fixed it by following these docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests

### How was this PR tested?
Unit test
Local tests: I started the reader locally and checked that all the download combinations worked.
