### PR TITLE
Add metrics notification on node writer

### DIFF
--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -33,7 +33,9 @@ use nucliadb_core::tracing::*;
 use nucliadb_node::env;
 use nucliadb_node::reader::NodeReaderService;
 use nucliadb_node::telemetry::init_telemetry;
-use nucliadb_node::writer::grpc_driver::{NodeWriterGRPCDriver, NodeWriterEvent, NodeWriterMetadata};
+use nucliadb_node::writer::grpc_driver::{
+    NodeWriterEvent, NodeWriterGRPCDriver, NodeWriterMetadata,
+};
 use nucliadb_node::writer::NodeWriterService;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio_stream::StreamExt;

--- a/nucliadb_node/src/env.rs
+++ b/nucliadb_node/src/env.rs
@@ -225,34 +225,6 @@ pub fn get_sentry_env() -> &'static str {
     }
 }
 
-/// Retuns the Promethus push timing, defaulted to 1h if not defined.
-pub fn get_metrics_update_interval() -> Duration {
-    const DEFAULT_INTERVAL_PLACEHOLDER: &str = "1h";
-    const DEFAULT_INTERVAL: Duration = Duration::from_secs(60 * 60);
-
-    match env::var("METRICS_UPDATE_INTERVAL") {
-        Ok(value) => {
-            if let Ok(duration) = parse_duration::parse(&value) {
-                duration
-            } else {
-                error!(
-                    "METRICS_UPDATE_INTERVAL defined incorrectly. Defaulting to \
-                     {DEFAULT_INTERVAL_PLACEHOLDER}"
-                );
-
-                DEFAULT_INTERVAL
-            }
-        }
-        Err(_) => {
-            warn!(
-                "METRICS_UPDATE_INTERVAL not defined. Defaulting to {DEFAULT_INTERVAL_PLACEHOLDER}"
-            );
-
-            DEFAULT_INTERVAL
-        }
-    }
-}
-
 /// Retuns the liveliness interval update used by cluster node.
 pub fn get_cluster_liveliness_interval_update() -> Duration {
     const DEFAULT_INTERVAL_UPDATE_PLACEHOLDER: &str = "500ms";

--- a/nucliadb_node/src/services/writer.rs
+++ b/nucliadb_node/src/services/writer.rs
@@ -347,6 +347,10 @@ impl ShardWriterService {
         self.text_writer.read().unwrap().count()
     }
     #[tracing::instrument(skip_all)]
+    pub fn paragraph_count(&self) -> usize {
+        self.paragraph_writer.read().unwrap().count()
+    }
+    #[tracing::instrument(skip_all)]
     pub fn gc(&self) -> NodeResult<()> {
         let vector_writer_service = self.vector_writer.clone();
         let mut writer = vector_writer_service.write().unwrap();

--- a/nucliadb_node/src/writer/grpc_driver.rs
+++ b/nucliadb_node/src/writer/grpc_driver.rs
@@ -226,7 +226,10 @@ impl NodeWriter for NodeWriterGRPCDriver {
                     shard_id: shard_id.id.clone(),
                 };
 
-                self.emit_event(NodeWriterEvent::ParagraphCount(writer.paragraph_count()));
+                self.emit_event(NodeWriterEvent::ParagraphCount(
+                    writer.paragraph_count(&shard_id).unwrap_or_default(),
+                ));
+
                 Ok(tonic::Response::new(status))
             }
             Some(Err(e)) => {
@@ -333,7 +336,9 @@ impl NodeWriter for NodeWriterGRPCDriver {
                     count: count as u64,
                     shard_id: shard_id.id.clone(),
                 };
-                self.emit_event(NodeWriterEvent::ParagraphCount(writer.paragraph_count()));
+                self.emit_event(NodeWriterEvent::ParagraphCount(
+                    writer.paragraph_count(&shard_id).unwrap_or_default(),
+                ));
 
                 Ok(tonic::Response::new(status))
             }

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -144,6 +144,10 @@ impl NodeWriterService {
 
     #[tracing::instrument(skip_all)]
     pub fn delete_shard(&mut self, shard_id: &ShardId) -> NodeResult<()> {
+        if shard_id.id.is_empty() {
+            warn!("Shard id is empty");
+            return Ok(());
+        }
         self.cache.remove(&shard_id.id);
         let shard_path = env::shards_path_id(&shard_id.id);
         if shard_path.exists() {

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -237,7 +237,6 @@ impl NodeWriterService {
         shard_id: &ShardId,
         resource: &ResourceId,
     ) -> NodeResult<Option<usize>> {
-
         let (paragraph_count, count) = {
             let Some(shard) = self.get_mut_shard(shard_id) else {
                 return Ok(None);

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -263,7 +263,8 @@ impl NodeWriterService {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn paragraph_count(&self) -> u64 {
-        self.paragraph_count()
+    pub fn paragraph_count(&self, shard_id: &ShardId) -> Option<u64> {
+        self.get_shard(shard_id)
+            .map(|shard| shard.paragraph_count() as u64)
     }
 }

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -148,13 +148,16 @@ impl NodeWriterService {
             warn!("Shard id is empty");
             return Ok(());
         }
+
         self.cache.remove(&shard_id.id);
+
         let shard_path = env::shards_path_id(&shard_id.id);
         if shard_path.exists() {
             info!("Deleting {:?}", shard_path);
             std::fs::remove_dir_all(shard_path)?;
+            self.emit_event(NodeWriterEvent::ShardDeletion);
         }
-        self.emit_event(NodeWriterEvent::ShardDeletion);
+
         Ok(())
     }
 

--- a/nucliadb_texts/src/reader.rs
+++ b/nucliadb_texts/src/reader.rs
@@ -31,13 +31,13 @@ use nucliadb_core::protos::{
 };
 use nucliadb_core::tracing::{self, *};
 use tantivy::collector::{
-    Count, DocSetCollector, FacetCollector, FacetCounts, MultiCollector, TopDocs,
+    Collector, Count, DocSetCollector, FacetCollector, FacetCounts, MultiCollector, TopDocs,
 };
 use tantivy::query::{AllQuery, Query, QueryParser, TermQuery};
 use tantivy::schema::*;
 use tantivy::{
-    collector::Collector, DocAddress, Index, IndexReader, IndexSettings, IndexSortByField,
-    LeasedItem, Order, ReloadPolicy, Result as TantivyResult, Searcher,
+    DocAddress, Index, IndexReader, IndexSettings, IndexSortByField, LeasedItem, Order,
+    ReloadPolicy, Result as TantivyResult, Searcher,
 };
 
 use super::schema::TextSchema;


### PR DESCRIPTION
# Description

This PR aims to avoid go through all the list of shards to perform node load calculation/shard counting.
To do so, the node metadata is calculated at startup then update dynamically through event-based mechanism.

**DISCLAIMER**: This PR is a duplicate of https://github.com/nuclia/nucliadb/pull/564 with merge conflicts resolved.

# How was this PR tested?

Ran locally.

