### PR TITLE
Add ServiceMonitor chart for nucliadb_ingest

### DIFF
--- a/charts/nucliadb_ingest/templates/ingest.cm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.cm.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   GRPC_PORT: {{ .Values.serving.grpc | quote }}
   INNER_METRICS_HOST: "0.0.0.0"
-  INNER_METRICS_PORT: {{ .Values.serving.metrics | quote }}
+  INNER_METRICS_PORT: {{ .Values.serving.metricsPort | quote }}
 
   PULL_TIME: {{ .Values.config.pull_time | quote }}
   NODE_REPLICAS: {{ .Values.config.node_replicas | quote }}

--- a/charts/nucliadb_ingest/templates/ingest.sm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sm.yaml
@@ -17,7 +17,7 @@ spec:
     matchLabels:
       app: ingest
   endpoints:
-  - targetPort: {{ .Values.serving.metrics }}
+  - targetPort: {{ .Values.serving.metricsPort }}
     interval: 10s
     path: /metrics
 {{- end }}

--- a/charts/nucliadb_ingest/templates/ingest.sm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sm.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ingest-monitor
+  labels:
+    app: ingest
+    version: "{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: ingest
+  endpoints:
+  - targetPort: {{ .Values.serving.metrics }}
+    interval: 10s
+    path: /metrics
+{{- end }}

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       name: ingest
       annotations:
-        traffic.sidecar.istio.io/excludeInboundPorts: "{{.Values.serving.monitor }},{{.Values.serving.metrics }}"
+        traffic.sidecar.istio.io/excludeInboundPorts: "{{.Values.serving.monitor }},{{.Values.serving.metricsPort }}"
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
       labels:
         app: ingest
@@ -73,7 +73,7 @@ spec:
         - name: grpc-ingest
           containerPort: {{ .Values.serving.grpc }}
         - containerPort: {{ .Values.serving.monitor }}
-        - containerPort: {{ .Values.serving.metrics }}
+        - containerPort: {{ .Values.serving.metricsPort }}
         - name: cluster-monitor
           containerPort: {{ .Values.chitchat.cluster_manager.port }}
         resources:

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -26,7 +26,8 @@ serving:
   grpc: 8030
   monitor: 50101
   metricsPort: 8081
-
+serviceMonitor:
+    enabled: false
 chitchat:
   cluster_manager:
     port: 31337

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -25,7 +25,7 @@ resources: {}
 serving:
   grpc: 8030
   monitor: 50101
-  metrics: 8081
+  metricsPort: 8081
 
 chitchat:
   cluster_manager:

--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -214,7 +214,7 @@ class Node(AbstractNode):
             if replica is None:
                 raise ReplicaShardNotFound()
 
-            # Call sidecar's grpc
+            # Call sidecar's gRPC
             ssresp = await node.sidecar.CreateShadowShard(EmptyQuery())  # type: ignore
             if not ssresp.success:
                 raise SidecarCreateShadowShardError("Sidecar error")


### PR DESCRIPTION
### Description
Ingest runs with a fastapi serving prometheus metrics, but right now we are not scraping them.
This PR adds the ServiceMonitor chart that will register the component to be scraped by the prometheus exporter

### How was this PR tested?
No local tests, will check in stashify
