### PR TITLE
Fix fields query param on paragraph search

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/resource.py
+++ b/nucliadb/nucliadb/search/api/v1/resource.py
@@ -99,7 +99,7 @@ async def search(
     extracted: List[ExtractedDataTypeName] = Query(list(ExtractedDataTypeName)),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     debug: bool = Query(False),
-    shards: Optional[List[str]] = None,
+    shards: List[str] = Query(default=[]),
 ) -> ResourceSearchResults:
     if not rid:
         rid = await get_resource_uuid_by_slug(kbid, rslug, service_name=SERVICE_NAME)  # type: ignore

--- a/nucliadb/nucliadb/search/api/v1/resource.py
+++ b/nucliadb/nucliadb/search/api/v1/resource.py
@@ -74,9 +74,9 @@ async def search(
     query: str,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
-    fields: Optional[List[str]] = None,
-    filters: Optional[List[str]] = None,
-    faceted: Optional[List[str]] = None,
+    fields: List[str] = Query(default=[]),
+    filters: List[str] = Query(default=[]),
+    faceted: List[str] = Query(default=[]),
     sort: Optional[SortField] = None,
     page_number: int = 0,
     page_size: int = 20,
@@ -106,9 +106,6 @@ async def search(
         if rid is None:
             raise HTTPException(status_code=404, detail="Resource does not exist")
 
-    filters = filters or []
-    faceted = faceted or []
-
     # We need the nodes/shards that are connected to the KB
     nodemanager = get_nodes()
 
@@ -125,6 +122,7 @@ async def search(
         features,
         rid,
         query,
+        fields,
         filters,
         faceted,
         page_number,
@@ -133,7 +131,6 @@ async def search(
         range_creation_end,
         range_modification_start,
         range_modification_end,
-        fields=fields,
         reload=reload,
         sort=sort.value if sort else None,
     )

--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -161,6 +161,7 @@ async def paragraph_query_to_pb(
     features: List[SearchOptions],
     rid: str,
     query: str,
+    fields: List[str],
     filters: List[str],
     faceted: List[str],
     page_number: int,
@@ -169,14 +170,11 @@ async def paragraph_query_to_pb(
     range_creation_end: Optional[datetime] = None,
     range_modification_start: Optional[datetime] = None,
     range_modification_end: Optional[datetime] = None,
-    fields: Optional[List[str]] = None,
     sort: Optional[str] = None,
     sort_ord: int = Sort.ASC.value,
     reload: bool = False,
     with_duplicates: bool = False,
 ) -> ParagraphSearchRequest:
-    fields = fields or []
-
     request = ParagraphSearchRequest()
     request.reload = reload
     request.with_duplicates = with_duplicates


### PR DESCRIPTION
### Description
There's an open bug with optional lists that are query params in fastapi.
The workaround is to use the `Query` object.

https://github.com/tiangolo/fastapi/issues/1403

### How was this PR tested?
Integration tests