### PR TITLE
Fix transactional error on TiKV driver

### DIFF
--- a/nucliadb/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/nucliadb/reader/api/v1/resource.py
@@ -29,11 +29,7 @@ from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as ORMKnowledgeBox
 from nucliadb.ingest.orm.resource import KB_RESOURCE_SLUG_BASE
 from nucliadb.ingest.orm.resource import Resource as ORMResource
-from nucliadb.ingest.serialize import (
-    get_resource_uuid_by_slug,
-    serialize,
-    set_resource_field_extracted_data,
-)
+from nucliadb.ingest.serialize import serialize, set_resource_field_extracted_data
 from nucliadb.ingest.utils import get_driver
 from nucliadb.reader import SERVICE_NAME  # type: ignore
 from nucliadb.reader.api import DEFAULT_RESOURCE_LIST_PAGE_SIZE
@@ -246,7 +242,7 @@ async def get_resource_field(
     kb = ORMKnowledgeBox(txn, storage, cache, kbid)
 
     if rid is None:
-        rid = await get_resource_uuid_by_slug(kbid, rslug, service_name=SERVICE_NAME)  # type: ignore
+        rid = await kb.get_resource_uuid_by_slug(rslug)
         if rid is None:
             await txn.abort()
             raise HTTPException(status_code=404, detail="Resource does not exist")

--- a/nucliadb/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/nucliadb/reader/api/v1/resource.py
@@ -242,6 +242,7 @@ async def get_resource_field(
     kb = ORMKnowledgeBox(txn, storage, cache, kbid)
 
     if rid is None:
+        assert rslug is not None, "Either rid or rslug must be defined"
         rid = await kb.get_resource_uuid_by_slug(rslug)
         if rid is None:
             await txn.abort()

--- a/nucliadb/nucliadb/tests/test_resources.py
+++ b/nucliadb/nucliadb/tests/test_resources.py
@@ -165,9 +165,7 @@ async def test_get_resource_field(
     assert resp.status_code == 200
     body_by_slug = resp.json()
 
-    resp = await nucliadb_reader.get(
-        f"/kb/{knowledgebox}/slug/{slug}/text/{field}"
-    )
+    resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/slug/{slug}/text/{field}")
     assert resp.status_code == 200
     body_by_rid = resp.json()
 

--- a/nucliadb/nucliadb/tests/test_resources.py
+++ b/nucliadb/nucliadb/tests/test_resources.py
@@ -138,3 +138,37 @@ async def test_list_resources(
         got_rids.add(r["id"])
 
     assert got_rids == rids
+
+
+@pytest.mark.asyncio
+async def test_get_resource_field(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    knowledgebox,
+):
+    slug = "my-resource"
+    field = "text-field"
+
+    resp = await nucliadb_writer.post(
+        f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
+        headers={"X-Synchronous": "true"},
+        json={
+            "slug": slug,
+            "title": "My Resource",
+            "texts": {field: {"body": "test1", "format": "PLAIN"}},
+        },
+    )
+    assert resp.status_code == 201
+    rid = resp.json()["uuid"]
+
+    resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/resource/{rid}/text/{field}")
+    assert resp.status_code == 200
+    body_by_slug = resp.json()
+
+    resp = await nucliadb_reader.get(
+        f"/kb/{knowledgebox}/slug/{slug}/text/{field}"
+    )
+    assert resp.status_code == 200
+    body_by_rid = resp.json()
+
+    assert body_by_slug == body_by_rid


### PR DESCRIPTION
### Description
The call to `get_resource_uuid_by_slug` creates a new transaction on TiKV causing the current transaction to be dropped and raising a panic for dropping an already in use transaction. Directly using `kb.get_resource_uuid_by_slug` (the same method is called in `get_resource_uuid_by_slug`) avoids this

