### PR TITLE
Parse `cancelled_by_user` field on fieldmetadata classifications

### DIFF
--- a/nucliadb/nucliadb/one/tests/test_fieldmetadata.py
+++ b/nucliadb/nucliadb/one/tests/test_fieldmetadata.py
@@ -47,7 +47,11 @@ async def test_fieldmetadata_crud(
             {
                 "key": "paragraph0",
                 "classifications": [
-                    {"labelset": "My Labels", "label": "Label 0"},
+                    {
+                        "labelset": "My Labels",
+                        "label": "Label 0",
+                        "cancelled_by_user": False,
+                    },
                 ],
             },
         ],
@@ -66,7 +70,13 @@ async def test_fieldmetadata_crud(
         "paragraphs": [
             {
                 "key": "paragraph2",
-                "classifications": [{"labelset": "My Labels", "label": "Label 2"}],
+                "classifications": [
+                    {
+                        "labelset": "My Labels",
+                        "label": "Label 2",
+                        "cancelled_by_user": False,
+                    }
+                ],
             }
         ],
     }
@@ -75,7 +85,13 @@ async def test_fieldmetadata_crud(
         "paragraphs": [
             {
                 "key": "paragraph1",
-                "classifications": [{"labelset": "My Labels", "label": "Label 1"}],
+                "classifications": [
+                    {
+                        "labelset": "My Labels",
+                        "label": "Label 1",
+                        "cancelled_by_user": True,
+                    }
+                ],
             }
         ],
         "token": [

--- a/nucliadb/nucliadb/tests/test_labels.py
+++ b/nucliadb/nucliadb/tests/test_labels.py
@@ -345,7 +345,7 @@ async def test_fieldmetadata_classification_labels(
     )
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        data=payload.json(),
+        data=payload.json(),  # type: ignore
         headers={"X-SYNCHRONOUS": "True"},
     )
     assert resp.status_code == 201
@@ -355,4 +355,4 @@ async def test_fieldmetadata_classification_labels(
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/resource/{rid}?show=basic")
     assert resp.status_code == 200
     resource = Resource.parse_raw(resp.content)
-    assert resource.fieldmetadata[0] == fieldmetadata
+    assert resource.fieldmetadata[0] == fieldmetadata  # type: ignore

--- a/nucliadb/nucliadb/writer/resource/basic.py
+++ b/nucliadb/nucliadb/writer/resource/basic.py
@@ -104,6 +104,7 @@ def parse_basic_modify(
                         Classification(
                             labelset=classification.labelset,
                             label=classification.label,
+                            cancelled_by_user=classification.cancelled_by_user,
                         )
                     )
                 userfieldmetadata.paragraphs.append(paragraphpb)

--- a/nucliadb_models/nucliadb_models/metadata.py
+++ b/nucliadb_models/nucliadb_models/metadata.py
@@ -271,7 +271,7 @@ class TokenSplit(BaseModel):
 
 
 class ParagraphAnnotation(BaseModel):
-    classifications: List[Classification] = []
+    classifications: List[UserClassification] = []
     key: str
 
 


### PR DESCRIPTION
### Description
Enable the `cancelled_by_user` property on classifications for paragraphs in `fieldmetadata`.

### How was this PR tested?
Integration tests
