### PR TITLE
field filters will be treated with OR behaviour

### DIFF
--- a/nucliadb_paragraphs/src/reader.rs
+++ b/nucliadb_paragraphs/src/reader.rs
@@ -811,7 +811,7 @@ mod tests {
             ..Default::default()
         };
         let result = paragraph_reader_service.search(&search).unwrap();
-        assert_eq!(result.total, 0);
+        assert_eq!(result.total, 4);
 
         // Search on all paragraphs
         let search = ParagraphSearchRequest {


### PR DESCRIPTION
### Description
In `ParagraphSearchRequest` fields should be treated as a logical OR. At least one of them must be present, but not all of them.

### How was this PR tested?
Local tests
