### PR TITLE
Handle predict errors on search

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/search.py
+++ b/nucliadb/nucliadb/search/api/v1/search.py
@@ -373,7 +373,6 @@ async def search(
     response.status_code = 206 if incomplete_results else 200
     if check_missing_vectors(item, pb_query):
         response.status_code = 206
-        response.reason = "Vector not detected in query"
 
     if audit is not None and do_audit:
         await audit.search(

--- a/nucliadb/nucliadb/search/api/v1/search.py
+++ b/nucliadb/nucliadb/search/api/v1/search.py
@@ -294,6 +294,8 @@ async def search(
         range_modification_end=item.range_modification_end,
         fields=item.fields,
         reload=item.reload,
+        user_vector=item.vector,
+        vectorset=item.vectorset,
         with_duplicates=item.with_duplicates,
         with_status=item.with_status,
     )

--- a/nucliadb/nucliadb/search/api/v1/search.py
+++ b/nucliadb/nucliadb/search/api/v1/search.py
@@ -26,6 +26,7 @@ from fastapi import Body, Header, HTTPException, Query, Request, Response
 from fastapi_versioning import version
 from grpc import StatusCode as GrpcStatusCode
 from grpc.aio import AioRpcError  # type: ignore
+from nucliadb_protos.nodereader_pb2 import SearchRequest as PBSearchRequest
 from nucliadb_protos.nodereader_pb2 import SearchResponse
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from sentry_sdk import capture_exception
@@ -437,5 +438,5 @@ def is_valid_index_sort_field(field: SortField) -> bool:
     return SortFieldMap[field] is not None
 
 
-def check_missing_vectors(item, pb_query: SearchRequest) -> bool:
+def check_missing_vectors(item: SearchRequest, pb_query: PBSearchRequest) -> bool:
     return SearchOptions.VECTOR in item.features and len(pb_query.vector) == 0

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -30,6 +30,10 @@ class SendToPredictError(Exception):
     pass
 
 
+class PredictVectorMissing(Exception):
+    pass
+
+
 DUMMY_RELATION_NODE = [
     RelationNode(value="Ferran", ntype=RelationNode.NodeType.ENTITY, subtype="PERSON"),
     RelationNode(
@@ -103,6 +107,8 @@ class PredictEngine:
                 data = await resp.json()
             else:
                 raise SendToPredictError(f"{resp.status}: {await resp.read()}")
+        if len(data["data"]) == 0:
+            raise PredictVectorMissing()
         return data["data"]
 
     async def detect_entities(self, kbid: str, sentence: str) -> List[RelationNode]:

--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -19,7 +19,7 @@
 #
 import re
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from nucliadb_protos.nodereader_pb2 import (
     ParagraphSearchRequest,
@@ -27,10 +27,9 @@ from nucliadb_protos.nodereader_pb2 import (
     SuggestRequest,
 )
 from nucliadb_protos.noderesources_pb2 import Resource
-from nucliadb_protos.utils_pb2 import RelationNode
 
 from nucliadb.search import logger
-from nucliadb.search.predict import SendToPredictError
+from nucliadb.search.predict import PredictVectorMissing, SendToPredictError
 from nucliadb.search.utilities import get_predict
 from nucliadb_models.metadata import ResourceProcessingStatus
 from nucliadb_models.search import (
@@ -61,9 +60,11 @@ async def global_query_to_pb(
     fields: Optional[List[str]] = None,
     sort_ord: int = Sort.ASC.value,
     reload: bool = False,
+    user_vector: Optional[List[float]] = None,
+    vectorset: Optional[str] = None,
     with_duplicates: bool = False,
     with_status: Optional[ResourceProcessingStatus] = None,
-) -> SearchRequest:
+) -> Tuple[SearchRequest, bool]:
     fields = fields or []
 
     request = SearchRequest()
@@ -111,34 +112,52 @@ async def global_query_to_pb(
     request.document = SearchOptions.DOCUMENT in features
     request.paragraph = SearchOptions.PARAGRAPH in features
 
+    incomplete = False
+    if SearchOptions.VECTOR in features:
+        incomplete = await _parse_vectors(
+            request, kbid, query, user_vector=user_vector, vectorset=vectorset
+        )
+
     if SearchOptions.RELATIONS in features:
-        detected_entities = await detect_entities(kbid, query)
-        request.relations.subgraph.entry_points.extend(detected_entities)
-        request.relations.subgraph.depth = 1
+        await _parse_entities(request, kbid, query)
 
-    return request
+    return request, incomplete
 
 
-async def query_vectors_to_pb(
+async def _parse_vectors(
     request: SearchRequest,
     kbid: str,
     query: str,
-    features: List[SearchOptions],
-    user_vector: Optional[List[float]] = None,
-    vectorset: Optional[str] = None,
-):
-    if SearchOptions.VECTOR not in features:
-        return
-
+    user_vector: Optional[List[float]],
+    vectorset: Optional[str],
+) -> bool:
+    incomplete = False
     if vectorset is not None:
         request.vectorset = vectorset
-
     if user_vector is None:
         predict = get_predict()
-        predict_vector = await predict.convert_sentence_to_vector(kbid, query)
-        request.vector.extend(predict_vector)
+        try:
+            predict_vector = await predict.convert_sentence_to_vector(kbid, query)
+            request.vector.extend(predict_vector)
+        except SendToPredictError as err:
+            logger.warning(f"Errors on predict api trying to embedd query: {err}")
+            incomplete = True
+        except PredictVectorMissing:
+            logger.warning("Predict api returned an empty vector")
+            incomplete = True
     else:
         request.vector.extend(user_vector)
+    return incomplete
+
+
+async def _parse_entities(request: SearchRequest, kbid: str, query: str):
+    predict = get_predict()
+    try:
+        detected_entities = await predict.detect_entities(kbid, query)
+        request.relations.subgraph.entry_points.extend(detected_entities)
+        request.relations.subgraph.depth = 1
+    except SendToPredictError as ex:
+        logger.warning(f"Errors on predict api detecting entities: {ex}")
 
 
 async def suggest_query_to_pb(
@@ -253,12 +272,3 @@ def pre_process_query(user_query: str) -> str:
             result.append(term)
 
     return " ".join(result)
-
-
-async def detect_entities(kbid: str, query: str) -> List[RelationNode]:
-    predict = get_predict()
-    try:
-        return await predict.detect_entities(kbid, query)
-    except SendToPredictError as ex:
-        logger.warning(f"Errors on predict api detecting entities: {ex}")
-        return []

--- a/nucliadb/nucliadb/tests/fixtures.py
+++ b/nucliadb/nucliadb/tests/fixtures.py
@@ -19,6 +19,7 @@
 #
 import os
 import tempfile
+from unittest.mock import Mock
 
 import pytest
 from grpc import aio
@@ -33,7 +34,13 @@ from nucliadb.run import run_async_nucliadb
 from nucliadb.settings import Settings
 from nucliadb.tests.utils import inject_message
 from nucliadb.writer import API_PREFIX
-from nucliadb_utils.utilities import clear_global_cache
+from nucliadb_utils.utilities import (
+    Utility,
+    clean_utility,
+    clear_global_cache,
+    get_utility,
+    set_utility,
+)
 
 
 def free_port() -> int:
@@ -316,3 +323,17 @@ async def stream_audit(natsd: str):
     await audit.initialize()
     yield audit
     await audit.finalize()
+
+
+@pytest.fixture(scope="function")
+def predict_mock() -> Mock:  # type: ignore
+    predict = get_utility(Utility.PREDICT)
+    mock = Mock()
+    set_utility(Utility.PREDICT, mock)
+
+    yield mock
+
+    if predict is None:
+        clean_utility(Utility.PREDICT)
+    else:
+        set_utility(Utility.PREDICT, predict)


### PR DESCRIPTION
### Description
Will return HTTP206 partial response if semantic search is requested but no vectors can be converted due to predict api errors

### How was this PR tested?
Integration tests