### PR TITLE
Ingest: handle empty vectors on field_vectors

### DIFF
--- a/nucliadb/nucliadb/ingest/fields/exceptions.py
+++ b/nucliadb/nucliadb/ingest/fields/exceptions.py
@@ -32,3 +32,7 @@ class InvalidPBClass(Exception):
             "Source and destination does not match "
             f"{self.source} - {self.destination}"
         )
+
+
+class VectorObjectNotFound(Exception):
+    pass


### PR DESCRIPTION
### Description
Processing may send some field_vectors in the protobuf messages that point to a storage file that is empty or simply does not exist.

The goal of this PR is to handle this case.

### How was this PR tested?
Describe how you tested this PR.
