### PR TITLE
fix prefix deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "nucliadb_node_binding"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bincode",
  "log",

--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.9
+
+- Fix vector deletion 
 ## 0.5.8
 
 - Store node metadata 

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucliadb_node_binding"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nucliadb_vectors/src/data_types/mod.rs
+++ b/nucliadb_vectors/src/data_types/mod.rs
@@ -43,7 +43,7 @@ impl<'a, D: DeleteLog> DeleteLog for &'a D {
     }
 }
 
-impl<Prop: std::marker::Sync> DeleteLog for dtrie_ram::DTrie<Prop> {
+impl DeleteLog for dtrie_ram::DTrie {
     fn is_deleted(&self, key: &[u8]) -> bool {
         self.get(key).is_some()
     }


### PR DESCRIPTION
### Description
When several prefixes are added to the deleted trie and some are prefixes between them, the time order is lost. In these cases the index may return vectors that are deleted.
The current fix does not require reindexing since the order is still there, it just needs to be interpreted correctly. This will start to happen as soon as this PR is merge. 
### How was this PR tested?
Local tests
