### PR TITLE
fix release check names to include matrix

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -41,42 +41,42 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: main
-          check-name: NucliaDBUtilsTests
+          check-name: NucliaDBUtilsTests (3.9)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Wait for models
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: main
-          check-name: NucliaDBModelsTests
+          check-name: NucliaDBModelsTests (3.9)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Wait for client tests
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: main
-          check-name: NucliaDBClientTests
+          check-name: NucliaDBClientTests (3.9)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Wait for sdk tests
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: main
-          check-name: NucliaDBSDKTests
+          check-name: NucliaDBSDKTests (3.9)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Wait for dataset tests
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: main
-          check-name: NucliaDBDatasetTests
+          check-name: NucliaDBDatasetTests (3.9)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
       - name: Wait for nucliadb tests
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: main
-          check-name: NucliaDBTests
+          check-name: NucliaDBTests (3.9)
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 


### PR DESCRIPTION
### Description
Turns out matrix is part of the name implicitly

https://github.com/nuclia/nucliadb/actions/runs/4292847904/jobs/7479790474#step:30:173
```
Checks completed: clippy, Code Format, Clippy lint, pre-checks-python (3.9), pre-checks (3.9), pre-checks (3.9), pre-checks (3.9), pre-checks (3.9), pre-checks (3.9), tests (3.9), pre-checks (3.9), NucliaDBModelsTests (3.9), pre-checks (3.9), Build wheels, Validate docker build, pre-checks (3.9), pre-checks (3.9), pre-checks (3.9), pre-checks (3.9), pre-checks (3.9)
Checks in_progress: tests-python (3.9), NucliaDBTests (3.9), NucliaDBSDKTests (3.9), tests (3.9), tests (3.9), tests (3.9), tests (3.9), NucliaDBClientTests (3.9), NucliaDBDatasetTests (3.9), tests (3.9), Check Licenses, NucliaDBUtilsTests (3.9), Build wheels, tests (3.9)
Checks after check_name filter:
Checks after Regexp filter:
The requested check was never run against this ref, exiting...
Error: Process completed with exit code 1.

```

### How was this PR tested?
Describe how you tested this PR.
