### PR TITLE
Process shadow shard

### DIFF
--- a/nucliadb_node/nucliadb_node/shared.py
+++ b/nucliadb_node/nucliadb_node/shared.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import asyncio
+
+sidecar_lock = asyncio.Lock()

--- a/nucliadb_protos/nodewriter.proto
+++ b/nucliadb_protos/nodewriter.proto
@@ -86,8 +86,20 @@ message ShadowShardResponse {
     noderesources.ShardId shard = 2;
 }
 
+message ProcessShadowShardRequest {
+    string shadow_shard_id = 1;
+    string dst_replica_id = 2;
+}
+
+
+message ProcessShadowShardResponse {
+    bool success = 1;
+}
+
+
 service NodeSidecar {
     rpc GetCount(noderesources.ShardId) returns (Counter) {}
     rpc CreateShadowShard(noderesources.EmptyQuery) returns (ShadowShardResponse) {}
     rpc DeleteShadowShard(noderesources.ShardId) returns (ShadowShardResponse) {}
+    rpc ProcessShadowShard(ProcessShadowShardRequest) returns (ProcessShadowShardResponse) {}
 }


### PR DESCRIPTION
### Description
This PR adds:
 - Sidecar grpc service to process the contents of a shadow shard onto a shard. This will use a lock that is shared between the servicer and the pull worker.
 - Ingest grpc service that processes a shadow shard onto another shard (calling the above sidecar service) and promotes the latter as the new replica.

The ingest service is meant to be called by the shard balancer cronjob after having copied over the shards that is rebalancing.

### How was this PR tested?
TODO
