### PR TITLE
Add more performance tests for read operations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @nuclia/nuclia-db

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -179,17 +179,11 @@ class KnowledgeBox:
             return None
 
     @classmethod
-    async def iterate_kb_slugs(
-        cls, txn: Transaction, slug: str, count: int = -1
-    ) -> AsyncIterator[str]:
-        async for key in txn.keys(KB_SLUGS.format(slug=slug), count=count):
-            yield key.replace(KB_SLUGS_BASE, "")
-
-    @classmethod
     async def get_kbs(
         cls, txn: Transaction, slug: str, count: int = -1
     ) -> AsyncIterator[Tuple[str, str]]:
-        async for slug in cls.iterate_kb_slugs(txn, slug, count):
+        async for key in txn.keys(KB_SLUGS.format(slug=slug), count=count):
+            slug = key.replace(KB_SLUGS_BASE, "")
             uuid = await cls.get_kb_uuid(txn, slug)
             if uuid is None:
                 logger.error(f"KB with slug ({slug}) but without uuid?")

--- a/nucliadb/nucliadb/ingest/orm/processor.py
+++ b/nucliadb/nucliadb/ingest/orm/processor.py
@@ -667,7 +667,7 @@ class Processor:
 
     async def list_kb(self, prefix: str):
         txn = await self.driver.begin()
-        async for slug in KnowledgeBox.get_kbs(txn, prefix):
+        async for kbid, slug in KnowledgeBox.get_kbs(txn, prefix):
             yield slug
         await txn.abort()
 

--- a/nucliadb/nucliadb/ingest/service/writer.py
+++ b/nucliadb/nucliadb/ingest/service/writer.py
@@ -531,8 +531,8 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
         logger.info("Status Call")
         response = WriterStatusResponse()
         txn = await self.proc.driver.begin()
-        async for key in KnowledgeBoxObj.get_kbs(txn, slug="", count=-1):
-            response.knowledgeboxes.append(key)
+        async for (kbid, slug) in KnowledgeBoxObj.get_kbs(txn, slug="", count=-1):
+            response.knowledgeboxes.append(slug)
 
         for partition in settings.partitions:
             msgid = await self.proc.driver.last_seqid(partition)

--- a/nucliadb/nucliadb/reader/api/v1/knowledgebox.py
+++ b/nucliadb/nucliadb/reader/api/v1/knowledgebox.py
@@ -48,10 +48,8 @@ async def get_kbs(request: Request, prefix: str = "") -> KnowledgeBoxList:
     driver = await get_driver()
     txn = await driver.begin()
     response = KnowledgeBoxList()
-    async for slug in KnowledgeBox.get_kbs(txn, prefix):
-        uuid = await KnowledgeBox.get_kb_uuid(txn, slug)
-        slug = slug or None  # type: ignore
-        response.kbs.append(KnowledgeBoxObjSummary(slug=slug, uuid=uuid))
+    async for kbid, slug in KnowledgeBox.get_kbs(txn, prefix):
+        response.kbs.append(KnowledgeBoxObjSummary(slug=slug or None, uuid=kbid))
     return response
 
 

--- a/nucliadb/nucliadb/reader/api/v1/router.py
+++ b/nucliadb/nucliadb/reader/api/v1/router.py
@@ -24,4 +24,5 @@ api = APIRouter()
 KB_PREFIX = "kb"
 KBS_PREFIX = "kbs"
 RESOURCE_PREFIX = "resource"
+RESOURCES_PREFIX = "resources"
 RSLUG_PREFIX = "slug"

--- a/nucliadb/nucliadb/reader/tests/benchmarks/test_fields.py
+++ b/nucliadb/nucliadb/reader/tests/benchmarks/test_fields.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import time
+from typing import Callable
+
+import pytest
+from httpx import AsyncClient
+
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb.reader.api.v1.router import KB_PREFIX, RESOURCE_PREFIX
+from nucliadb_models.resource import NucliaDBRoles
+from nucliadb_utils.tests.asyncbenchmark import AsyncBenchmarkFixture
+
+
+@pytest.mark.parametrize(
+    ["field_type", "field_id"],
+    [
+        ("text", "text1"),
+        ("link", "link1"),
+        ("file", "file1"),
+        ("layout", "layout1"),
+        ("keywordset", "keywordset1"),
+        ("datetime", "datetime1"),
+        # BUG: sc-4346 - uncomment this when bug is solved
+        # ("conversation", "conversation1"),
+    ],
+)
+@pytest.mark.benchmark(
+    group="resource",
+    min_time=0.1,
+    max_time=0.5,
+    min_rounds=5,
+    timer=time.time,
+    disable_gc=True,
+    warmup=False,
+)
+@pytest.mark.asyncio
+async def test_get_field_all(
+    reader_api: Callable[..., AsyncClient],
+    test_resource: Resource,
+    asyncbenchmark: AsyncBenchmarkFixture,
+    field_type: str,
+    field_id: str,
+) -> None:
+    rsc = test_resource
+    kbid = rsc.kb.kbid
+    rid = rsc.uuid
+
+    async with reader_api(roles=[NucliaDBRoles.READER]) as client:
+        resp = await asyncbenchmark(
+            client.get,
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/{field_type}/{field_id}",
+            params={
+                "show": ["value", "extracted", "error"],
+                "field_type": [field_type],
+                "extracted": [
+                    "metadata",
+                    "vectors",
+                    "uservectors",
+                    "large_metadata",
+                    "text",
+                    "link",
+                    "file",
+                ],
+            },
+        )
+        assert resp.status_code == 200

--- a/nucliadb/nucliadb/reader/tests/benchmarks/test_knowledgebox.py
+++ b/nucliadb/nucliadb/reader/tests/benchmarks/test_knowledgebox.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import time
+from typing import Callable
+
+import pytest
+from httpx import AsyncClient
+
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb.reader.api.v1.router import KB_PREFIX, KBS_PREFIX
+from nucliadb_models.resource import NucliaDBRoles
+from nucliadb_utils.tests.asyncbenchmark import AsyncBenchmarkFixture
+
+
+@pytest.mark.benchmark(
+    group="resource",
+    min_time=0.1,
+    max_time=0.5,
+    min_rounds=5,
+    timer=time.time,
+    disable_gc=True,
+    warmup=False,
+)
+@pytest.mark.asyncio
+async def test_get_knowledgeboxes(
+    reader_api: Callable[..., AsyncClient],
+    test_resource: Resource,
+    asyncbenchmark: AsyncBenchmarkFixture,
+) -> None:
+    async with reader_api(roles=[NucliaDBRoles.MANAGER]) as client:
+        resp = await asyncbenchmark(
+            client.get,
+            f"/{KBS_PREFIX}",
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_knowledgebox(
+    reader_api: Callable[..., AsyncClient],
+    test_resource: Resource,
+    asyncbenchmark: AsyncBenchmarkFixture,
+) -> None:
+    kbid = test_resource.kb.kbid
+
+    async with reader_api(roles=[NucliaDBRoles.READER]) as client:
+        resp = await asyncbenchmark(
+            client.get,
+            f"/{KB_PREFIX}/{kbid}",
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_knowledgebox_by_slug(
+    reader_api: Callable[..., AsyncClient],
+    test_resource: Resource,
+    asyncbenchmark: AsyncBenchmarkFixture,
+) -> None:
+    slug = test_resource.kb.kbid
+
+    async with reader_api(roles=[NucliaDBRoles.READER]) as client:
+        resp = await asyncbenchmark(
+            client.get,
+            f"/{KB_PREFIX}/{slug}",
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
### Description
- Add performance tests for KB and fields read operations
- KB read endpoints use ingest ORM instead of gRPC API
