### PR TITLE
Fix constant rebuild issue (Rust part)

### DIFF
--- a/nucliadb_protos/rust/build.rs
+++ b/nucliadb_protos/rust/build.rs
@@ -18,14 +18,14 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=nucliadb_protos/knowledgebox.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/resources.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/noderesources.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/utils.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/writer.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/nodesidecar.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/nodewriter.proto");
-    println!("cargo:rerun-if-changed=nucliadb_protos/nodereader.proto");
+    println!("cargo:rerun-if-changed=../knowledgebox.proto");
+    println!("cargo:rerun-if-changed=../resources.proto");
+    println!("cargo:rerun-if-changed=../noderesources.proto");
+    println!("cargo:rerun-if-changed=../utils.proto");
+    println!("cargo:rerun-if-changed=../writer.proto");
+    println!("cargo:rerun-if-changed=../nodesidecar.proto");
+    println!("cargo:rerun-if-changed=../nodewriter.proto");
+    println!("cargo:rerun-if-changed=../nodereader.proto");
 
     let mut prost_config = prost_build::Config::default();
 

--- a/nucliadb_protos/rust/build.rs
+++ b/nucliadb_protos/rust/build.rs
@@ -17,7 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+
+use std::io::Result;
+
+fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=../knowledgebox.proto");
     println!("cargo:rerun-if-changed=../resources.proto");
     println!("cargo:rerun-if-changed=../noderesources.proto");
@@ -30,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut prost_config = prost_build::Config::default();
 
     prost_config
-        .out_dir("src/")
+        .out_dir("src")
         .compile_protos(
             &[
                 "nucliadb_protos/utils.proto",
@@ -42,20 +45,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "nucliadb_protos/nodereader.proto",
             ],
             &["../../"],
-        )
-        .unwrap();
+        )?;
 
     tonic_build::configure()
         .build_server(true)
-        .out_dir("src") // you can change the generated code's location
+        .out_dir("src")
         .compile(
             &[
                 "nucliadb_protos/nodewriter.proto",
                 "nucliadb_protos/nodereader.proto",
             ],
             &["../../"],
-        )
-        .unwrap();
+        )?;
 
     Ok(())
 }


### PR DESCRIPTION
### Description
This PR aims to fix a problem we face for ages:
Any time we run a `cargo build` , `cargo test` or `cargo run --bin` at the root project, some workspace members are recompiled no matter what.
The problem is due to an invalid path in the build script in `nucliadb_protos/rust`.