### PR TITLE
Use Rust version 1.68.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries.crates-io]
+protocol = "sparse"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.68.0"


### PR DESCRIPTION
### Description
This PR uses the latest published Rust version `1.68.0` and the cargo sparse protocol to download dependency information faster and then speed up compilation on both local machines and CI tasks.

![giphy](https://user-images.githubusercontent.com/6042495/224973251-1740125b-4e76-4c34-8f84-745f802913de.gif)

