### PR TITLE
Raise 419 conflict error on  duplicate resource slugs

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -565,6 +565,13 @@ class KnowledgeBox:
                 key_ok = True
         return slug
 
+    @classmethod
+    async def resource_slug_exists(
+        self, txn: Transaction, kbid: str, slug: str
+    ) -> bool:
+        key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug)
+        return await txn.get(key) is not None
+
     async def add_resource(
         self, uuid: str, slug: str, basic: Optional[Basic] = None
     ) -> Resource:

--- a/nucliadb/nucliadb/tests/test_resources.py
+++ b/nucliadb/nucliadb/tests/test_resources.py
@@ -170,3 +170,34 @@ async def test_get_resource_field(
     body_by_rid = resp.json()
 
     assert body_by_slug == body_by_rid
+
+
+@pytest.mark.asyncio
+async def test_resource_creation_slug_conflicts(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    knowledgebox,
+):
+    """
+    Test that creating two resources with the same slug raises a conflict error
+    """
+    slug = "myresource"
+    resources_path = f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}"
+
+    resp = await nucliadb_writer.post(
+        resources_path,
+        headers={"X-Synchronous": "true"},
+        json={
+            "slug": slug,
+        },
+    )
+    assert resp.status_code == 201
+
+    resp = await nucliadb_writer.post(
+        resources_path,
+        headers={"X-Synchronous": "true"},
+        json={
+            "slug": slug,
+        },
+    )
+    assert resp.status_code == 419

--- a/nucliadb/nucliadb/writer/api/v1/knowledgebox.py
+++ b/nucliadb/nucliadb/writer/api/v1/knowledgebox.py
@@ -117,7 +117,7 @@ async def update_kb(request: Request, kbid: str, item: KnowledgeBoxConfig):
     if kbobj.status == KnowledgeBoxResponseStatus.OK:
         return KnowledgeBoxObjID(uuid=kbobj.uuid)
     elif kbobj.status == KnowledgeBoxResponseStatus.NOTFOUND:
-        raise HTTPException(status_code=419, detail="Knowledge box does not exist")
+        raise HTTPException(status_code=404, detail="Knowledge box does not exist")
     elif kbobj.status == KnowledgeBoxResponseStatus.ERROR:
         raise HTTPException(status_code=500, detail="Error on creating knowledge box")
 

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -59,6 +59,7 @@ from nucliadb.writer.resource.basic import (
 )
 from nucliadb.writer.resource.field import extract_fields, parse_fields
 from nucliadb.writer.resource.origin import parse_origin
+from nucliadb.writer.resource.slug import resource_slug_exists
 from nucliadb.writer.resource.vectors import (
     create_vectorset,
     get_vectorsets,
@@ -133,6 +134,8 @@ async def create_resource(
     toprocess.source = Source.HTTP
 
     if item.slug:
+        if await resource_slug_exists(kbid, item.slug):
+            raise HTTPException(status_code=419, detail="Resource slug already exists")
         writer.slug = item.slug
         toprocess.slug = item.slug
 

--- a/nucliadb/nucliadb/writer/resource/slug.py
+++ b/nucliadb/nucliadb/writer/resource/slug.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.utils import get_driver
+
+
+async def resource_slug_exists(kbid: str, slug: str) -> bool:
+    driver = await get_driver()
+    async with driver.transaction() as txn:
+        return await KnowledgeBox.resource_slug_exists(txn, kbid, slug)


### PR DESCRIPTION
### Description
When creating resources, make sure writer API returns HTTP419 Conflict error response if attempting to create two resources in the same KB with the same slug.

### How was this PR tested?
Integration tests
