### PR TITLE
Add shutdown delay on I/O nodes

### DIFF
--- a/charts/nucliadb_node/templates/node.cm.yaml
+++ b/charts/nucliadb_node/templates/node.cm.yaml
@@ -36,3 +36,5 @@ data:
   INDEX_JETSTREAM_STREAM: {{ .Values.indexing.index_jetstream_stream }}
 
   JAEGER_ENABLED: {{ .Values.tracing.enabled | quote }}
+
+  SHUTDOWN_DELAY: {{ .Values.running.shutdown_delay }}

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -45,7 +45,7 @@ storage:
 
 running:
   sentry_url:
-  shutdown_delay: "15s"
+  shutdown_delay: "5s"
 
 tracing:
   enabled: false

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -45,7 +45,7 @@ storage:
 
 running:
   sentry_url:
-  shutdown_delay: "5s"
+  shutdown_delay: "15s"
 
 tracing:
   enabled: false

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -45,6 +45,7 @@ storage:
 
 running:
   sentry_url:
+  shutdown_delay: "5s"
 
 tracing:
   enabled: false

--- a/nucliadb_node/src/bin/reader.rs
+++ b/nucliadb_node/src/bin/reader.rs
@@ -21,16 +21,22 @@ use std::time::Instant;
 
 use nucliadb_core::protos::node_reader_server::NodeReaderServer;
 use nucliadb_core::tracing::*;
+use nucliadb_core::NodeResult;
 use nucliadb_node::env;
 use nucliadb_node::reader::grpc_driver::NodeReaderGRPCDriver;
 use nucliadb_node::reader::NodeReaderService;
 use nucliadb_node::telemetry::init_telemetry;
+use tokio::signal::unix::SignalKind;
+use tokio::signal::{ctrl_c, unix};
 use tonic::transport::Server;
+use tonic_health::proto::health_server::{Health, HealthServer};
+use tonic_health::server::HealthReporter;
+
+type GrpcServer = NodeReaderServer<NodeReaderGRPCDriver>;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("NucliaDB Reader Node starting...");
-
     let _guard = init_telemetry()?;
 
     let start_bootstrap = Instant::now();
@@ -42,28 +48,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         node_reader_service.load_shards()?;
     }
 
-    let node_reader_service = NodeReaderGRPCDriver::from(node_reader_service);
-    let reader_task = tokio::spawn(async move {
-        let addr = env::reader_listen_address();
-        info!("Reader listening for gRPC requests at: {:?}", addr);
-        let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
-        health_reporter
-            .set_serving::<NodeReaderServer<NodeReaderGRPCDriver>>()
-            .await;
+    let grpc_driver = NodeReaderGRPCDriver::from(node_reader_service);
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
 
-        Server::builder()
-            .add_service(health_service)
-            .add_service(NodeReaderServer::new(node_reader_service))
-            .serve(addr)
-            .await
-            .expect("Error starting gRPC writer");
-    });
+    tokio::spawn(start_grpc_service(
+        grpc_driver,
+        health_service,
+        health_reporter.clone(),
+    ));
+
     info!("Bootstrap complete in: {:?}", start_bootstrap.elapsed());
-
     eprintln!("Running");
-    tokio::try_join!(reader_task)?;
 
-    // node_reader_service.shutdown().await;
+    wait_for_sigkill().await?;
+
+    info!("Shutting down NucliaDB Reader Node...");
+    // notify that the gRPC service is not serving anymore
+    health_reporter.set_not_serving::<GrpcServer>().await;
+    // wait some time to handle latest gRPC calls
+    tokio::time::sleep(env::shutdown_delay()).await;
 
     Ok(())
+}
+
+async fn wait_for_sigkill() -> NodeResult<()> {
+    let mut sigterm = unix::signal(SignalKind::terminate())?;
+    let mut sigquit = unix::signal(SignalKind::quit())?;
+
+    tokio::select! {
+        _ = sigterm.recv() => println!("Terminating on SIGTERM"),
+        _ = sigquit.recv() => println!("Terminating on SIGQUIT"),
+        _ = ctrl_c() => println!("Terminating on ctrl-c"),
+    }
+
+    Ok(())
+}
+
+pub async fn start_grpc_service(
+    grpc_driver: NodeReaderGRPCDriver,
+    health_service: HealthServer<impl Health>,
+    mut health_reporter: HealthReporter,
+) {
+    let addr = env::reader_listen_address();
+
+    info!("Reader listening for gRPC requests at: {:?}", addr);
+
+    health_reporter.set_serving::<GrpcServer>().await;
+
+    Server::builder()
+        .add_service(health_service)
+        .add_service(GrpcServer::new(grpc_driver))
+        .serve(addr)
+        .await
+        .expect("Error starting gRPC reader");
 }

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -143,9 +143,9 @@ pub async fn monitor_cluster(cluster_watcher: impl Stream<Item = Vec<NodeHandle>
 
             if let Ok(snapshot) = serde_json::to_string(&cluster_snapshot) {
                 info!("Cluster update: {snapshot}");
-            };
-        } else {
-            error!("Cluster snapshot cannot be serialized");
+            } else {
+                error!("Cluster snapshot cannot be serialized");
+            }
         }
     }
 }

--- a/nucliadb_node/src/env.rs
+++ b/nucliadb_node/src/env.rs
@@ -258,3 +258,29 @@ pub fn get_cluster_liveliness_interval_update() -> Duration {
         }
     }
 }
+
+pub fn shutdown_delay() -> Duration {
+    const SHUTDOWN_DELAY_KEY: &str = "SHUTDOWN_DELAY";
+    const SHUTDOWN_DELAY_PLACEHOLDER: &str = "5s";
+    const DEFAULT_SHUTDOWN_DELAY: Duration = Duration::from_secs(5);
+
+    match env::var(SHUTDOWN_DELAY_KEY) {
+        Ok(value) => {
+            if let Ok(duration) = parse_duration::parse(&value) {
+                duration
+            } else {
+                error!(
+                    "{SHUTDOWN_DELAY_KEY} defined incorrectly. Defaulting to \
+                     {SHUTDOWN_DELAY_PLACEHOLDER}"
+                );
+
+                DEFAULT_SHUTDOWN_DELAY
+            }
+        }
+        Err(_) => {
+            warn!("{SHUTDOWN_DELAY_KEY} not defined. Defaulting to {SHUTDOWN_DELAY_PLACEHOLDER}");
+
+            DEFAULT_SHUTDOWN_DELAY
+        }
+    }
+}

--- a/nucliadb_node/src/env.rs
+++ b/nucliadb_node/src/env.rs
@@ -264,23 +264,18 @@ pub fn shutdown_delay() -> Duration {
     const SHUTDOWN_DELAY_PLACEHOLDER: &str = "5s";
     const DEFAULT_SHUTDOWN_DELAY: Duration = Duration::from_secs(5);
 
-    match env::var(SHUTDOWN_DELAY_KEY) {
-        Ok(value) => {
-            if let Ok(duration) = parse_duration::parse(&value) {
-                duration
-            } else {
-                error!(
-                    "{SHUTDOWN_DELAY_KEY} defined incorrectly. Defaulting to \
-                     {SHUTDOWN_DELAY_PLACEHOLDER}"
-                );
+    let Ok(value) = env::var(SHUTDOWN_DELAY_KEY) else {
+        warn!("{SHUTDOWN_DELAY_KEY} not defined. Defaulting to {SHUTDOWN_DELAY_PLACEHOLDER}");
+        return DEFAULT_SHUTDOWN_DELAY
+    };
 
-                DEFAULT_SHUTDOWN_DELAY
-            }
-        }
-        Err(_) => {
-            warn!("{SHUTDOWN_DELAY_KEY} not defined. Defaulting to {SHUTDOWN_DELAY_PLACEHOLDER}");
+    let Ok(duration) = parse_duration::parse(&value) else {
+        error!(
+            "{SHUTDOWN_DELAY_KEY} defined incorrectly. Defaulting to \
+             {SHUTDOWN_DELAY_PLACEHOLDER}"
+        );
+        return DEFAULT_SHUTDOWN_DELAY
+    };
 
-            DEFAULT_SHUTDOWN_DELAY
-        }
-    }
+    duration
 }


### PR DESCRIPTION
### Description
This PR adds a shutdown delay on I/O nodes (a.k.a node reader and node writer) to fix 5xx errors during node restart.
When an I/O node receive termination signal, it will notify that the gRPC server will not serve anymore then sleep the main process for a period of time and then really shutdown.
For the node writer, it will also close the chitchat TCP/IP connection after receiving the termination signal and before sleeping in order to propagate the information over the network.

### How was this PR tested?
Ran I/O nodes locally, sent termination signals and performed some gRPC calls.
