### PR TITLE
Fix ranged stream downloads downloads

### DIFF
--- a/nucliadb/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/nucliadb/reader/api/v1/download.py
@@ -189,7 +189,6 @@ async def download_api(sf: StorageField, headers: Headers):
         "Content-Disposition": '{}; filename="{}"'.format("attachment", filename),
     }
     download_headers = {}
-
     if "range" in headers and file_size > -1:
         range_request = headers["range"]
         try:
@@ -234,7 +233,7 @@ async def download_api(sf: StorageField, headers: Headers):
         status_code = 206
         logger.debug(f"Range request: {range_request}")
         extra_headers["Content-Length"] = f"{range_size}"
-        extra_headers["Content-Range"] = f"bytes {start}-{end - 1}/{file_size}"
+        extra_headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
         download_headers["Range"] = range_request
 
     return StreamingResponse(
@@ -271,7 +270,7 @@ def parse_media_range(range_request: str, file_size: int) -> Tuple[int, int, int
     if len(end_str) == 0:
         # bytes=0- is valid
         end = max_range_size
-        range_size = file_size
+        range_size = file_size - start
     else:
         end = int(end_str)
         end = min(end, max_range_size)

--- a/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
+++ b/nucliadb/nucliadb/reader/tests/test_reader_file_download.py
@@ -214,24 +214,25 @@ async def _get_message_with_file(test_resource):
     return msg_id, file_num
 
 
-FILE_SIZE = 10
-
-
 @pytest.mark.parametrize(
     "range_request,filesize,start,end,range_size,exception",
     [
         # No end range specified
-        ("bytes=0-", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
+        ("bytes=0-", 10, 0, 9, 10, None),
         # End range == file size
-        (f"bytes=0-{FILE_SIZE}", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
+        (f"bytes=0-10", 10, 0, 9, 10, None),
         # End range < file size
-        (f"bytes=0-5", FILE_SIZE, 0, 5, 6, None),
+        (f"bytes=0-5", 10, 0, 5, 6, None),
         # End range > file size
-        (f"bytes=0-{FILE_SIZE + 1}", FILE_SIZE, 0, FILE_SIZE - 1, FILE_SIZE, None),
+        (f"bytes=0-11", 10, 0, 9, 10, None),
+        # Starting at a middle point until the end
+        (f"bytes=2-", 10, 2, 9, 8, None),
+        # A slice of bytes in the middle of the file
+        (f"bytes=2-8", 10, 2, 8, 7, None),
         # Invalid range
-        ("bytes=something", FILE_SIZE, None, None, None, ValueError),
+        ("bytes=something", 10, None, None, None, ValueError),
         # Multi-part ranges not supported yet
-        ("bytes=0-50, 100-150", FILE_SIZE, None, None, None, NotImplementedError),
+        ("bytes=0-50, 100-150", 10, None, None, None, NotImplementedError),
     ],
 )
 def test_parse_media_range(range_request, filesize, start, end, range_size, exception):


### PR DESCRIPTION
### Description
There was a case where we would set incorrect response headers, triggering some errors on downloads

### How was this PR tested?
Unit tests and local tests (starting the reader locally and trying out all different range combinations)
