### PR TITLE
remove prefix harcoded limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "nucliadb_node_binding"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bincode",
  "log",

--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.2
+
+- Unbounded prefix search on relations
 ## 0.7.1
 
 - load shard on join graph.

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucliadb_node_binding"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nucliadb_relations/src/index.rs
+++ b/nucliadb_relations/src/index.rs
@@ -116,13 +116,8 @@ impl Index {
     fn get_nodeid(&self, txn: &RoToken, x: &str) -> RResult<Option<Entity>> {
         self.graphdb.get_nodeid(txn, x)
     }
-    fn prefix_search(
-        &self,
-        dict_reader: &DReader,
-        results: usize,
-        prefix: &str,
-    ) -> RResult<Vec<String>> {
-        self.dictionary.search(dict_reader, results, prefix)
+    fn prefix_search(&self, dict_reader: &DReader, prefix: &str) -> RResult<Vec<String>> {
+        self.dictionary.search(dict_reader, prefix)
     }
     fn get_inedges<'a>(
         &self,
@@ -214,13 +209,8 @@ impl<'a> GraphReader<'a> {
     pub fn get_node_id(&self, x: &str) -> RResult<Option<Entity>> {
         self.index.get_nodeid(&self.graph_txn, x)
     }
-    pub fn prefix_search(
-        &self,
-        RMode(reader): &RMode,
-        results: usize,
-        prefix: &str,
-    ) -> RResult<Vec<String>> {
-        self.index.prefix_search(reader, results, prefix)
+    pub fn prefix_search(&self, RMode(reader): &RMode, prefix: &str) -> RResult<Vec<String>> {
+        self.index.prefix_search(reader, prefix)
     }
     pub fn search<G: BfsGuide>(
         &self,

--- a/nucliadb_relations/src/service/reader.rs
+++ b/nucliadb_relations/src/service/reader.rs
@@ -42,7 +42,6 @@ impl Debug for RelationsReaderService {
 }
 
 impl RelationsReaderService {
-    const NO_RESULTS: usize = 10;
     #[tracing::instrument(skip_all)]
     fn graph_search(
         &self,
@@ -166,7 +165,7 @@ impl RelationsReaderService {
             info!("{id:?} - running prefix search: starts {v} ms");
         }
         let prefixes = reader
-            .prefix_search(&self.rmode, Self::NO_RESULTS, prefix)?
+            .prefix_search(&self.rmode, prefix)?
             .into_iter()
             .flat_map(|key| reader.get_node_id(&key).ok().flatten());
         if let Ok(v) = time.elapsed().map(|s| s.as_millis()) {


### PR DESCRIPTION
### Description
Prefix search had a hardcoded limit, this pr removes it.
Additionally we now use [`DocSetCollector`](https://docs.rs/tantivy/latest/tantivy/collector/struct.DocSetCollector.html#impl-Collector-for-DocSetCollector) for the prefix search instead of [`TopDocs`](https://docs.rs/tantivy/latest/tantivy/collector/struct.TopDocs.html).

### How was this PR tested?
Local tests
