### PR TITLE
add helm chart linting and config map checksums

### DIFF
--- a/.github/workflows/lint_helm.yml
+++ b/.github/workflows/lint_helm.yml
@@ -1,0 +1,25 @@
+name: Lint Helm Charts
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint all helm charts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Helm
+        uses: azure/setup-helm@v2.0
+        with:
+          version: v3.4.0
+
+      - name: Lint helm packages
+        run: |-
+          helm lint charts/*
+          helm package charts/*

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -39,6 +39,8 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
     spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -34,6 +34,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         version: "{{ .Chart.Version | replace "+" "_" }}"
         chart: "{{ .Chart.Name }}"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/node.cm.yaml") . | sha256sum }}
     spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/nucliadb_reader/templates/reader.deploy.yaml
+++ b/charts/nucliadb_reader/templates/reader.deploy.yaml
@@ -28,6 +28,8 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/reader.cm.yaml") . | sha256sum }}
     spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -28,6 +28,8 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/search.cm.yaml") . | sha256sum }}
     spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/nucliadb_train/templates/train.deploy.yaml
+++ b/charts/nucliadb_train/templates/train.deploy.yaml
@@ -28,6 +28,8 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/train.cm.yaml") . | sha256sum }}
     spec:
       topologySpreadConstraints:
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}

--- a/charts/nucliadb_writer/templates/writer.deploy.yaml
+++ b/charts/nucliadb_writer/templates/writer.deploy.yaml
@@ -25,6 +25,8 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/writer.cm.yaml") . | sha256sum }}
       annotations:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.config.dm_redis_port }},{{.Values.services.maindb }},{{.Values.services.nats }}"
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.serving.metricsPort }}"


### PR DESCRIPTION
### Description
Right now, if there was an error in our helm charts, we would not know until after PR was merged.

Additionally, when using config maps, we should have checksums on changes to them to a change to a config map env var will trigger deploys to cycle.

### How was this PR tested?
Manually running helm lint locally against changes.
