### PR TITLE
Properly finalize Redis (maindb and pubsub)

### DIFF
--- a/nucliadb/nucliadb/ingest/maindb/redis.py
+++ b/nucliadb/nucliadb/ingest/maindb/redis.py
@@ -195,7 +195,9 @@ class RedisDriver(Driver):
         self.initialized = True
 
     async def finalize(self):
-        pass
+        if self.initialized is True:
+            await self.redis.close()
+            self.initialized = False
 
     async def begin(self) -> RedisTransaction:
         return RedisTransaction(self.redis, driver=self)

--- a/nucliadb/nucliadb/ingest/tests/fixtures.py
+++ b/nucliadb/nucliadb/ingest/tests/fixtures.py
@@ -137,6 +137,9 @@ async def grpc_servicer(redis, transaction_utility, gcs_storage, fake_node):
     cache_settings.cache_pubsub_driver = default_driver_pubsub
     driver = aioredis.from_url(f"redis://{redis[0]}:{redis[1]}")
     await driver.flushall()
+    pubsub = get_utility(Utility.PUBSUB)
+    if pubsub is not None:
+        await pubsub.finalize()
     clear_global_cache()
 
 

--- a/nucliadb_utils/nucliadb_utils/cache/redis.py
+++ b/nucliadb_utils/nucliadb_utils/cache/redis.py
@@ -71,6 +71,8 @@ class RedisPubsub(PubSubDriver):
         await self.pubsub.unsubscribe()
         if self.task:
             self.task.cancel()
+        if self.driver:
+            await self.driver.close()
         self.initialized = False
 
     async def publish(self, key: str, value: bytes):


### PR DESCRIPTION
### Description
Fix Redis finalization at maindb and pubsub and fix finalization on `grpc_servicer` ingest fixture

### How was this PR tested?
Check pytest warnings no longer appear
