### PR TITLE
Node metadata ref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,9 @@ name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "async-channel"

--- a/charts/nucliadb_node/templates/node.cm.yaml
+++ b/charts/nucliadb_node/templates/node.cm.yaml
@@ -16,6 +16,7 @@ data:
 {{- else }}
   RUST_LOG: "nucliadb_node=WARN,nucliadb_cluster=WARN,nucliadb_cluster=WARN"
 {{- end }}
+  RUST_LIB_BACKTRACE: "1"
   HOST_KEY_PATH: "{{ .Values.config.data_path }}/node.key"
   SENTRY_URL: {{ .Values.running.sentry_url }}
   READER_LISTEN_ADDRESS: 0.0.0.0:{{ .Values.serving.grpc_reader }}

--- a/nucliadb_core/Cargo.toml
+++ b/nucliadb_core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
+anyhow = { version = "1", features = ["backtrace"] }
 tracing = "0.1.29"
 prost-types = "0.10"
 prost = "0.10"

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -61,7 +61,7 @@ async fn main() -> NodeResult<()> {
     let start_bootstrap = Instant::now();
 
     let metadata_path = env::metadata_path();
-    let node_metadata = NodeMetadata::load_or_create(&metadata_path).await?;
+    let node_metadata = NodeMetadata::load_or_create(&metadata_path)?;
     let mut node_writer_service = NodeWriterService::new();
 
     std::fs::create_dir_all(env::shards_path())?;

--- a/nucliadb_node/src/node_metadata.rs
+++ b/nucliadb_node/src/node_metadata.rs
@@ -54,9 +54,7 @@ pub struct NodeMetadata {
 
 impl Serialize for NodeMetadata {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    where S: Serializer {
         let mut s = serializer.serialize_struct("NodeMetadata", 3)?;
         s.serialize_field("load_score", &self.load_score())?;
         s.serialize_field("shard_count", &self.shard_count())?;

--- a/nucliadb_node/src/node_metadata.rs
+++ b/nucliadb_node/src/node_metadata.rs
@@ -146,7 +146,7 @@ impl NodeMetadata {
 
     pub fn create(path: &Path) -> NodeResult<Self> {
         info!("Creating node metadata file '{}'", path.display());
-        let mut reader = NodeReaderService::new();
+        let reader = NodeReaderService::new();
         let mut node_metadata = NodeMetadata::default();
         for shard in reader.iter_shards()?.flatten() {
             let shard_id = shard.id.clone();

--- a/nucliadb_node/src/node_metadata.rs
+++ b/nucliadb_node/src/node_metadata.rs
@@ -53,9 +53,7 @@ pub struct NodeMetadata {
 
 impl Serialize for NodeMetadata {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    where S: Serializer {
         let mut s = serializer.serialize_struct("NodeMetadata", 3)?;
         s.serialize_field("load_score", &self.load_score())?;
         s.serialize_field("shard_count", &self.shard_count())?;

--- a/nucliadb_node/src/node_metadata.rs
+++ b/nucliadb_node/src/node_metadata.rs
@@ -115,7 +115,7 @@ impl NodeMetadata {
         }
     }
 
-    pub async fn load_or_create(path: &Path) -> NodeResult<Self> {
+    pub fn load_or_create(path: &Path) -> NodeResult<Self> {
         if !path.exists() {
             info!("Node metadata file does not exist.");
 

--- a/nucliadb_node/src/reader/mod.rs
+++ b/nucliadb_node/src/reader/mod.rs
@@ -64,9 +64,7 @@ impl NodeReaderService {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn iter_shards(
-        &mut self,
-    ) -> NodeResult<impl Iterator<Item = NodeResult<ShardReaderService>>> {
+    pub fn iter_shards(&self) -> NodeResult<impl Iterator<Item = NodeResult<ShardReaderService>>> {
         let shards_path = env::shards_path();
         Ok(std::fs::read_dir(shards_path)?.flatten().map(|entry| {
             let file_name = entry.file_name().to_str().unwrap().to_string();

--- a/nucliadb_node/src/services/reader.rs
+++ b/nucliadb_node/src/services/reader.rs
@@ -541,6 +541,21 @@ impl ShardReaderService {
         })
     }
 
+    #[tracing::instrument(skip_all)]
+    pub fn paragraph_count(&self) -> NodeResult<usize> {
+        self.paragraph_reader.count()
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn vector_count(&self, vector_set: &str) -> NodeResult<usize> {
+        self.vector_reader.count(vector_set)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn text_count(&self) -> NodeResult<usize> {
+        self.text_reader.count()
+    }
+
     fn reload_policy(&self, trigger: bool) {
         let elapsed = self
             .creation_time


### PR DESCRIPTION
### Description
A small refactor in `node_metadata`. 
Also, anyhow uses the `backtrace` feature, so we are capable of mapping runtime errors to code locations. 

### How was this PR tested?
Local tests
