### PR TITLE
Hermegarcia/sc 4646

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "nucliadb_node_binding"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "bincode",
  "log",

--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.7.5
+
+- Fully remove stop-words from paragraphs
 ## 0.7.4
 
 - Vectors returns the labels of the nearest neighbors 

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucliadb_node_binding"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
### Description
In this PR `nucliadb_paragraphs` removes stop-words from the regular query and from the fuzzy query.
A bug was also found in the stop-words removal procedure.

### How was this PR tested?
Local tests
