### PR TITLE
Handle limits exceeded error responses for proxy and predict apis

### DIFF
--- a/nucliadb/nucliadb/ingest/tests/integration/ingest/test_processing_engine.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/ingest/test_processing_engine.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+
 from uuid import uuid4
 
 import pytest

--- a/nucliadb/nucliadb/ingest/tests/unit/test_processing.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/test_processing.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from nucliadb.ingest.processing import ProcessingEngine, PushPayload
+from nucliadb_utils.exceptions import LimitsExceededError
+
+
+@pytest.fixture(scope="function")
+def proxy_session_402_error():
+    session = AsyncMock()
+    resp = Mock(status=402)
+    resp.json = AsyncMock(return_value={"detail": "limits exceeded"})
+    session.post.return_value = resp
+    return session
+
+
+@pytest.fixture(scope="function")
+def proxy_session_413_error():
+    session = AsyncMock()
+    resp = Mock(status=413)
+    resp.json = AsyncMock(return_value={"detail": "limits exceeded"})
+    session.post.return_value = resp
+    return session
+
+
+@pytest.mark.asyncio
+async def test_send_to_process_handles_proxy_limits_exceeded_error_responses(
+    proxy_session_402_error, proxy_session_413_error
+):
+    pe = ProcessingEngine(
+        onprem=True,
+        nuclia_cluster_url="foo",
+        nuclia_public_url="bar",
+    )
+    payload = PushPayload(uuid="uuid", kbid="kbid", userid="userid", partition=0)
+
+    pe.session = proxy_session_402_error
+    with pytest.raises(LimitsExceededError) as exc:
+        await pe.send_to_process(payload, partition=0)
+    assert exc.value.status_code == 402
+
+    pe.session = proxy_session_413_error
+    with pytest.raises(LimitsExceededError) as exc:
+        await pe.send_to_process(payload, partition=0)
+    assert exc.value.status_code == 413

--- a/nucliadb/nucliadb/models/responses.py
+++ b/nucliadb/nucliadb/models/responses.py
@@ -24,18 +24,23 @@ class Response(JSONResponse):
     pass
 
 
-class HTTPNotFound(Response):
+class HTTPClientError(Response):
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(status_code=status_code, content=detail)
+
+
+class HTTPNotFound(HTTPClientError):
     status_code = 404
 
     def __init__(self, detail: str):
-        super().__init__(content=detail, status_code=self.status_code)
+        super().__init__(status_code=self.status_code, detail=detail)
 
 
-class HTTPConflict(Response):
+class HTTPConflict(HTTPClientError):
     status_code = 409
 
     def __init__(self, detail: str):
-        super().__init__(content=detail, status_code=self.status_code)
+        super().__init__(status_code=self.status_code, detail=detail)
 
 
 class HTTPInternalServerError(Response):

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -54,7 +54,7 @@ FEEDBACK = "/feedback"
 
 
 predict_observer = metrics.Observer(
-    "predict_api",
+    "predict_engine",
     labels={"type": ""},
     error_mappings={
         "over_limits": LimitsExceededError,

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -25,6 +25,7 @@ from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb.ingest.tests.vectors import Q
 from nucliadb.search import logger
 from nucliadb_models.search import ChatModel, FeedbackRequest
+from nucliadb_utils.exceptions import LimitsExceededError
 
 
 class SendToPredictError(Exception):
@@ -70,8 +71,8 @@ class PredictEngine:
         self.zone = zone
         self.onprem = onprem
         self.dummy = dummy
-        # TODO: Should we accumulate sentences requested,
-        # or is this only for testing purposes?
+        # TODO: self.calls is only for testing purposes.
+        # It should be removed
         self.calls: List[str] = []
 
     async def initialize(self):
@@ -79,6 +80,15 @@ class PredictEngine:
 
     async def finalize(self):
         await self.session.close()
+
+    async def check_response(self, resp, expected: int = 200) -> None:
+        if resp.status == expected:
+            return
+        if resp.status == 402:
+            data = await resp.json()
+            raise LimitsExceededError(402, data["detail"])
+        else:
+            raise SendToPredictError(f"{resp.status}: {await resp.read()}")
 
     async def send_feedback(
         self,
@@ -100,8 +110,6 @@ class PredictEngine:
                 json=data,
                 headers={"X-STF-KBID": kbid},
             )
-            if resp.status != 204:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
         else:
             if self.nuclia_service_account is None:
                 logger.warning(
@@ -115,14 +123,11 @@ class PredictEngine:
                 json=data,
                 headers=headers,
             )
-            if resp.status != 204:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
+        await self.check_response(resp, expected=204)
 
     async def chat_query(
         self, kbid: str, item: ChatModel
     ) -> Tuple[str, AsyncIterator[bytes]]:
-        # If token is offered
-
         if self.onprem is False:
             # Upload the payload
             resp = await self.session.post(
@@ -130,8 +135,6 @@ class PredictEngine:
                 json=item.dict(),
                 headers={"X-STF-KBID": kbid},
             )
-            if resp.status != 200:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
         else:
             if self.nuclia_service_account is None:
                 error = "Nuclia Service account is not defined so could not retrieve vectors for the query"
@@ -144,13 +147,11 @@ class PredictEngine:
                 json=item.dict(),
                 headers=headers,
             )
-            if resp.status != 200:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
+        await self.check_response(resp, expected=200)
         ident = resp.headers.get("NUCLIA-LEARNING-ID")
         return ident, resp.content.iter_any()
 
     async def convert_sentence_to_vector(self, kbid: str, sentence: str) -> List[float]:
-        # If token is offered
         if self.dummy:
             self.calls.append(sentence)
             return Q
@@ -161,10 +162,6 @@ class PredictEngine:
                 url=f"{self.cluster_url}{PRIVATE_PREDICT}{SENTENCE}?text={sentence}",
                 headers={"X-STF-KBID": kbid},
             )
-            if resp.status == 200:
-                data = await resp.json()
-            else:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
         else:
             if self.nuclia_service_account is None:
                 logger.warning(
@@ -177,10 +174,8 @@ class PredictEngine:
                 url=f"{self.public_url}{PUBLIC_PREDICT}{SENTENCE}?text={sentence}",
                 headers=headers,
             )
-            if resp.status == 200:
-                data = await resp.json()
-            else:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
+        await self.check_response(resp, expected=200)
+        data = await resp.json()
         if len(data["data"]) == 0:
             raise PredictVectorMissing()
         return data["data"]
@@ -197,10 +192,6 @@ class PredictEngine:
                 url=f"{self.cluster_url}{PRIVATE_PREDICT}{TOKENS}?text={sentence}",
                 headers={"X-STF-KBID": kbid},
             )
-            if resp.status == 200:
-                data = await resp.json()
-            else:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
         else:
             if self.nuclia_service_account is None:
                 logger.warning(
@@ -213,10 +204,8 @@ class PredictEngine:
                 url=f"{self.public_url}{PUBLIC_PREDICT}{TOKENS}?text={sentence}",
                 headers=headers,
             )
-            if resp.status == 200:
-                data = await resp.json()
-            else:
-                raise SendToPredictError(f"{resp.status}: {await resp.read()}")
+        await self.check_response(resp, expected=200)
+        data = await resp.json()
 
         result = []
         for token in data["tokens"]:

--- a/nucliadb/nucliadb/search/tests/integration/api/v1/test_chat.py
+++ b/nucliadb/nucliadb/search/tests/integration/api/v1/test_chat.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from unittest import mock
+
+import pytest
+
+from nucliadb.search.api.v1.router import KB_PREFIX
+from nucliadb_models.resource import NucliaDBRoles
+from nucliadb_utils.exceptions import LimitsExceededError
+
+
+@pytest.fixture(scope="function")
+def chat_with_limits_exceeded_error():
+    with mock.patch(
+        "nucliadb.search.api.v1.chat.chat",
+        side_effect=LimitsExceededError(402, "over the quota"),
+    ):
+        yield
+
+
+@pytest.mark.asyncio()
+async def test_chat_handles_limits_exceeded_error(
+    search_api, knowledgebox_ingest, chat_with_limits_exceeded_error
+):
+    async with search_api(roles=[NucliaDBRoles.READER]) as client:
+        kb = knowledgebox_ingest
+        resp = await client.post(f"/{KB_PREFIX}/{kb}/chat", json={})
+        assert resp.status_code == 402
+        assert resp.json() == "over the quota"

--- a/nucliadb/nucliadb/search/tests/integration/api/v1/test_find.py
+++ b/nucliadb/nucliadb/search/tests/integration/api/v1/test_find.py
@@ -18,12 +18,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from typing import Callable
+from unittest import mock
 
 import pytest
 from httpx import AsyncClient
 
 from nucliadb.search.api.v1.router import KB_PREFIX
 from nucliadb_models.resource import NucliaDBRoles
+from nucliadb_utils.exceptions import LimitsExceededError
 
 
 @pytest.mark.asyncio
@@ -80,3 +82,27 @@ async def test_find_order(
                 orders.update({paragraph["order"] for paragraph in paragraphs.values()})
                 paragraph_count += len(paragraphs)
         assert orders == set(range(paragraph_count))
+
+
+@pytest.fixture(scope="function")
+def find_with_limits_exceeded_error():
+    with mock.patch(
+        "nucliadb.search.api.v1.find.find",
+        side_effect=LimitsExceededError(402, "over the quota"),
+    ):
+        yield
+
+
+@pytest.mark.asyncio()
+async def test_find_handles_limits_exceeded_error(
+    search_api, knowledgebox_ingest, find_with_limits_exceeded_error
+):
+    async with search_api(roles=[NucliaDBRoles.READER]) as client:
+        kb = knowledgebox_ingest
+        resp = await client.get(f"/{KB_PREFIX}/{kb}/find")
+        assert resp.status_code == 402
+        assert resp.json() == "over the quota"
+
+        resp = await client.post(f"/{KB_PREFIX}/{kb}/find", json={})
+        assert resp.status_code == 402
+        assert resp.json() == "over the quota"

--- a/nucliadb/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/nucliadb/writer/api/v1/field.py
@@ -161,7 +161,7 @@ async def add_resource_field_text(
     try:
         seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -200,7 +200,7 @@ async def add_resource_field_link(
     try:
         seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -239,7 +239,7 @@ async def add_resource_field_keywordset(
     try:
         seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -278,7 +278,7 @@ async def add_resource_field_datetime(
     try:
         seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -317,7 +317,7 @@ async def add_resource_field_layout(
     try:
         seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -358,7 +358,7 @@ async def add_resource_field_conversation(
     try:
         seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -403,7 +403,7 @@ async def add_resource_field_file(
             writer, toprocess, partition, wait_on_commit=x_synchronous
         )
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -469,7 +469,7 @@ async def append_messages_to_conversation_field(
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -538,7 +538,7 @@ async def append_blocks_to_layout_field(
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -655,11 +655,10 @@ async def reprocess_file_field(
             raise HTTPException(status_code=404, detail="Field does not exist")
 
     # Send current resource to reprocess.
-
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -188,7 +188,7 @@ async def create_resource(
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -281,7 +281,7 @@ async def modify_resource(
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 
@@ -358,7 +358,7 @@ async def reprocess_resource(
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 

--- a/nucliadb/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/nucliadb/writer/api/v1/upload.py
@@ -448,7 +448,7 @@ async def patch(
                 wait_on_commit=x_synchronous,
             )
         except LimitsExceededError as exc:
-            raise HTTPException(status_code=402, detail=str(exc))
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail)
 
         headers["NDB-Seq"] = f"{seqid}"
     else:
@@ -587,7 +587,7 @@ async def upload(
             wait_on_commit=x_synchronous,
         )
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
 
     return ResourceFileUploaded(seqid=seqid, uuid=rid, field_id=valid_field)
 
@@ -737,7 +737,7 @@ async def store_file_on_nuclia_db(
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
-        raise HTTPException(status_code=402, detail=str(exc))
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
         raise HTTPException(status_code=500, detail="Error while sending to process")
 

--- a/nucliadb_utils/nucliadb_utils/exceptions.py
+++ b/nucliadb_utils/nucliadb_utils/exceptions.py
@@ -24,7 +24,9 @@ class SendToProcessError(Exception):
 
 
 class LimitsExceededError(Exception):
-    pass
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
 
 
 class ShardsNotFound(Exception):


### PR DESCRIPTION
### Description
Both predict and proxy apis will return a 402 response when a particular account has exceeded the quota (aka is over the limits).

This PR makes sure that the response status is handled.

Missing TODO:
 - [x] Add metrics to predict and proxy api

### How was this PR tested?
- [x] Unit tests
- [x] Integration tests