### PR TITLE
add processor error type metric labels

### DIFF
--- a/nucliadb/nucliadb/ingest/consumer/pull.py
+++ b/nucliadb/nucliadb/ingest/consumer/pull.py
@@ -64,6 +64,7 @@ consumer_observer = metrics.Observer(
         120.0,
         float("inf"),
     ],
+    error_mappings={"deadlettered": DeadletteredError, "shardnotfound": ShardsNotFound},
 )
 
 


### PR DESCRIPTION
### Description
We want to know when a deadletter or shard not found error happens and not just have it bucketed as a single error type.

