### PR TITLE
Allow easy switch between maindb drivers

### DIFF
--- a/nucliadb/nucliadb/ingest/tests/fixtures.py
+++ b/nucliadb/nucliadb/ingest/tests/fixtures.py
@@ -150,6 +150,7 @@ async def grpc_servicer(redis, transaction_utility, gcs_storage, fake_node):
 @pytest.fixture(scope="function")
 async def local_driver() -> AsyncIterator[Driver]:
     path = mkdtemp()
+    settings.driver = DriverConfig.local
     settings.driver_local_url = path
     driver: Driver = LocalDriver(url=path)
     await driver.initialize()
@@ -166,7 +167,7 @@ async def tikv_driver(tikvd: List[str]) -> AsyncIterator[Driver]:
         url = "localhost:2379"
     else:
         url = f"{tikvd[0]}:{tikvd[2]}"
-    settings.driver = "tikv"
+    settings.driver = DriverConfig.tikv
     settings.driver_tikv_url = [url]
 
     driver: Driver = TiKVDriver(url=[url])

--- a/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_knowledgebox.py
@@ -49,35 +49,11 @@ def test_chunker():
     assert iterations == 0
 
 
-@pytest.fixture(scope="function")
-def tikv_driver_configured(tikv_driver):
-    from nucliadb.ingest.settings import settings
-    from nucliadb_utils.store import MAIN
-
-    prev_driver = settings.driver
-    settings.driver = "tikv"
-    settings.driver_tikv_url = tikv_driver.url
-    MAIN["driver"] = tikv_driver_configured
-
-    yield
-
-    settings.driver = prev_driver
-    MAIN.pop("driver", None)
-
-
-@pytest.fixture(scope="function")
-async def tikv_txn(tikv_driver):
-    txn = await tikv_driver.begin()
-    yield txn
-    await txn.abort()
-
-
 @pytest.mark.asyncio
 async def test_knowledgebox_delete_all_kb_keys(
     gcs_storage,
     cache,
     fake_node,
-    tikv_driver_configured,
     tikv_driver,
     knowledgebox_ingest: str,
 ):

--- a/nucliadb/nucliadb/reader/tests/fixtures.py
+++ b/nucliadb/nucliadb/reader/tests/fixtures.py
@@ -33,11 +33,11 @@ from nucliadb_utils.utilities import Utility, clear_global_cache, set_utility
 
 
 @pytest.fixture(scope="function")
-def test_settings_reader(cache, gcs, fake_node, redis_driver):  # type: ignore
+def test_settings_reader(cache, gcs, fake_node, maindb_driver):  # type: ignore
     from nucliadb_utils.settings import running_settings, storage_settings
 
     running_settings.debug = False
-    print(f"Redis ready at {redis_driver.url}")
+    print(f"Driver ready at {maindb_driver.url}")
 
     storage_settings.gcs_endpoint_url = gcs
     storage_settings.file_backend = "gcs"

--- a/nucliadb/nucliadb/search/tests/fixtures.py
+++ b/nucliadb/nucliadb/search/tests/fixtures.py
@@ -48,7 +48,7 @@ def free_port() -> int:
 
 
 @pytest.fixture(scope="function")
-def test_settings_search(gcs, redis, node):  # type: ignore
+def test_settings_search(gcs, redis, node, maindb_driver):  # type: ignore
     from nucliadb.ingest.settings import settings as ingest_settings
     from nucliadb_utils.cache.settings import settings as cache_settings
     from nucliadb_utils.settings import (
@@ -74,8 +74,7 @@ def test_settings_search(gcs, redis, node):  # type: ignore
     running_settings.debug = False
 
     ingest_settings.pull_time = 0
-    ingest_settings.driver = "redis"
-    ingest_settings.driver_redis_url = url
+
     ingest_settings.nuclia_partitions = 1
 
     nuclia_settings.dummy_processing = True

--- a/nucliadb/nucliadb/train/tests/fixtures.py
+++ b/nucliadb/nucliadb/train/tests/fixtures.py
@@ -242,12 +242,12 @@ def free_port() -> int:
 
 
 @pytest.fixture(scope="function")
-def test_settings_train(cache, gcs, fake_node, redis_driver):  # type: ignore
+def test_settings_train(cache, gcs, fake_node, maindb_driver):  # type: ignore
     from nucliadb.train.settings import settings
     from nucliadb_utils.settings import running_settings, storage_settings
 
     running_settings.debug = False
-    print(f"Redis ready at {redis_driver.url}")
+    print(f"Redis ready at {maindb_driver.url}")
 
     old_file_backend = storage_settings.file_backend
     old_gcs_endpoint_url = storage_settings.gcs_endpoint_url


### PR DESCRIPTION
### Description
Improve maindb fixtures and create a generic `maindb_driver` fixture using `redis_driver` as default. To change driver in a single file, simply override `maindb_driver` fixture:
```python
@pytest.fixture()
async def maindb_fixture(tikv_driver):
    yield tikv_driver
```
and every test using maindb will use TiKV

### How was this PR tested?
Validating all tests keep running correctly with the same driver
