### PR TITLE
more consistent script naming

### DIFF
--- a/.github/workflows/nucliadb_reader.yml
+++ b/.github/workflows/nucliadb_reader.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Extract docs
         run: |
           mkdir -p /tmp/openapi
-          extract-openapi-reader /tmp/openapi/$COMPONENT.json $API_VERSION $GITHUB_SHA
+          nucliadb-extract-openapi-reader /tmp/openapi/$COMPONENT.json $API_VERSION $GITHUB_SHA
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nucliadb_search.yml
+++ b/.github/workflows/nucliadb_search.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Extract docs
         run: |
           mkdir -p /tmp/openapi
-          extract-openapi-search /tmp/openapi/$COMPONENT.json $API_VERSION $GITHUB_SHA
+          nucliadb-extract-openapi-search /tmp/openapi/$COMPONENT.json $API_VERSION $GITHUB_SHA
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nucliadb_writer.yml
+++ b/.github/workflows/nucliadb_writer.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Extract docs
         run: |
           mkdir -p /tmp/openapi
-          extract-openapi-writer /tmp/openapi/$COMPONENT.json $API_VERSION $GITHUB_SHA
+          nucliadb-extract-openapi-writer /tmp/openapi/$COMPONENT.json $API_VERSION $GITHUB_SHA
 
       - uses: actions/upload-artifact@v2
         with:

--- a/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
@@ -59,7 +59,7 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 3
         command: [
-          "ndb_ingest_orm_grpc"
+          "nucliadb-ingest-orm-grpc"
         ]
         envFrom:
         - configMapRef:

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -71,7 +71,7 @@ spec:
           periodSeconds: 20
           timeoutSeconds: 5
           failureThreshold: 3
-        command: ["ndb_ingest"]
+        command: ["nucliadb-ingest"]
         envFrom:
         - configMapRef:
             name: nucliadb-config

--- a/charts/nucliadb_reader/templates/reader.deploy.yaml
+++ b/charts/nucliadb_reader/templates/reader.deploy.yaml
@@ -63,7 +63,7 @@ spec:
           timeoutSeconds: 10
           periodSeconds: 20
         command: [
-          "reader-metrics"
+          "nucliadb-reader"
         ]
         envFrom:
         - configMapRef:

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -63,7 +63,7 @@ spec:
           timeoutSeconds: 10
           periodSeconds: 20
         command: [
-          "search-metrics"
+          "nucliadb-search"
         ]
         envFrom:
         - configMapRef:

--- a/charts/nucliadb_train/templates/train.deploy.yaml
+++ b/charts/nucliadb_train/templates/train.deploy.yaml
@@ -61,7 +61,7 @@ spec:
           timeoutSeconds: 10
           periodSeconds: 20
         command: [
-          "ndb_train"
+          "nucliadb-train"
         ]
         envFrom:
         - configMapRef:

--- a/charts/nucliadb_writer/templates/writer.deploy.yaml
+++ b/charts/nucliadb_writer/templates/writer.deploy.yaml
@@ -63,7 +63,7 @@ spec:
           timeoutSeconds: 10
           periodSeconds: 20
         command: [
-          "writer-metrics"
+          "nucliadb-writer"
         ]
         envFrom:
         - configMapRef:

--- a/nucliadb/nucliadb/reader/app.py
+++ b/nucliadb/nucliadb/reader/app.py
@@ -30,8 +30,6 @@ from nucliadb.reader import API_PREFIX, SERVICE_NAME
 from nucliadb.reader.api.v1.router import api as api_v1
 from nucliadb.reader.lifecycle import finalize, initialize
 from nucliadb_telemetry import errors
-from nucliadb_telemetry.fastapi import instrument_app
-from nucliadb_telemetry.utils import get_telemetry
 from nucliadb_utils.authentication import STFAuthenticationBackend
 from nucliadb_utils.fastapi.openapi import extend_openapi
 from nucliadb_utils.fastapi.versioning import VersionedFastAPI
@@ -105,10 +103,3 @@ async def homepage(request: Request) -> HTMLResponse:
 
 # Use raw starlette routes to avoid unnecessary overhead
 application.add_route("/", homepage)
-
-instrument_app(
-    application,
-    tracer_provider=get_telemetry(SERVICE_NAME),
-    excluded_urls=["/"],
-    metrics=True,
-)

--- a/nucliadb/nucliadb/reader/run.py
+++ b/nucliadb/nucliadb/reader/run.py
@@ -19,7 +19,17 @@
 
 from nucliadb.reader.app import application
 from nucliadb_utils.fastapi.run import run_fastapi_with_metrics
+from nucliadb_telemetry.fastapi import instrument_app
+from nucliadb_telemetry.utils import get_telemetry
+from nucliadb.reader import SERVICE_NAME
 
 
-def run_with_metrics():
+def run():
+    instrument_app(
+        application,
+        tracer_provider=get_telemetry(SERVICE_NAME),
+        excluded_urls=["/"],
+        metrics=True,
+    )
+
     run_fastapi_with_metrics(application)

--- a/nucliadb/nucliadb/search/app.py
+++ b/nucliadb/nucliadb/search/app.py
@@ -29,13 +29,12 @@ from starlette.requests import ClientDisconnect, Request
 from starlette.responses import HTMLResponse
 
 from nucliadb.ingest.orm import NODES
-from nucliadb.search import API_PREFIX, SERVICE_NAME
+from nucliadb.search import API_PREFIX
 from nucliadb.search.api.v1.router import api as api_v1
 from nucliadb.search.lifecycle import finalize, initialize
 from nucliadb.search.settings import settings
 from nucliadb_telemetry import errors
-from nucliadb_telemetry.fastapi import instrument_app
-from nucliadb_telemetry.utils import get_telemetry
+
 from nucliadb_utils.authentication import STFAuthenticationBackend
 from nucliadb_utils.fastapi.openapi import extend_openapi
 from nucliadb_utils.fastapi.versioning import VersionedFastAPI
@@ -148,10 +147,3 @@ application.add_route("/", homepage)
 application.add_route("/chitchat/members", chitchat_members)
 application.add_route("/health/alive", alive)
 application.add_route("/health/ready", ready)
-
-instrument_app(
-    application,
-    tracer_provider=get_telemetry(SERVICE_NAME),
-    excluded_urls=["/"],
-    metrics=True,
-)

--- a/nucliadb/nucliadb/search/run.py
+++ b/nucliadb/nucliadb/search/run.py
@@ -20,7 +20,17 @@
 
 from nucliadb.search.app import application
 from nucliadb_utils.fastapi.run import run_fastapi_with_metrics
+from nucliadb_telemetry.fastapi import instrument_app
+from nucliadb_telemetry.utils import get_telemetry
+from nucliadb.search import SERVICE_NAME
 
 
-def run_with_metrics():
+def run():
+    instrument_app(
+        application,
+        tracer_provider=get_telemetry(SERVICE_NAME),
+        excluded_urls=["/"],
+        metrics=True,
+    )
+
     run_fastapi_with_metrics(application)

--- a/nucliadb/nucliadb/search/tests/unit/test_run.py
+++ b/nucliadb/nucliadb/search/tests/unit/test_run.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 import pytest
 
 from nucliadb.search.app import application
-from nucliadb.search.run import run_with_metrics
+from nucliadb.search.run import run
 
 
 @pytest.fixture(scope="function")
@@ -32,6 +32,6 @@ def run_fastapi_with_metrics():
 
 
 def test_run_with_metrics(run_fastapi_with_metrics):
-    run_with_metrics()
+    run()
 
     run_fastapi_with_metrics.assert_called_once_with(application)

--- a/nucliadb/nucliadb/train/app.py
+++ b/nucliadb/nucliadb/train/app.py
@@ -26,12 +26,11 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import HTMLResponse
 
-from nucliadb.train import API_PREFIX, SERVICE_NAME
+from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import api
 from nucliadb.train.lifecycle import finalize, initialize
 from nucliadb_telemetry import errors
-from nucliadb_telemetry.fastapi import instrument_app
-from nucliadb_telemetry.utils import get_telemetry
+
 from nucliadb_utils.authentication import STFAuthenticationBackend
 from nucliadb_utils.fastapi.openapi import extend_openapi
 from nucliadb_utils.fastapi.versioning import VersionedFastAPI
@@ -107,10 +106,3 @@ async def homepage(request: Request) -> HTMLResponse:
 
 # Use raw starlette routes to avoid unnecessary overhead
 application.add_route("/", homepage)
-
-instrument_app(
-    application,
-    tracer_provider=get_telemetry(SERVICE_NAME),
-    excluded_urls=["/"],
-    metrics=True,
-)

--- a/nucliadb/nucliadb/train/run.py
+++ b/nucliadb/nucliadb/train/run.py
@@ -19,7 +19,17 @@
 
 from nucliadb.train.app import application
 from nucliadb_utils.fastapi.run import run_fastapi_with_metrics
+from nucliadb_telemetry.fastapi import instrument_app
+from nucliadb_telemetry.utils import get_telemetry
+from nucliadb.train import SERVICE_NAME
 
 
-def run_with_metrics():
+def run():
+    instrument_app(
+        application,
+        tracer_provider=get_telemetry(SERVICE_NAME),
+        excluded_urls=["/"],
+        metrics=True,
+    )
+
     run_fastapi_with_metrics(application)

--- a/nucliadb/nucliadb/writer/app.py
+++ b/nucliadb/nucliadb/writer/app.py
@@ -26,12 +26,10 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import ClientDisconnect, Request
 from starlette.responses import HTMLResponse
 
-from nucliadb.writer import API_PREFIX, SERVICE_NAME
+from nucliadb.writer import API_PREFIX
 from nucliadb.writer.api.v1.router import api as api_v1
 from nucliadb.writer.lifecycle import finalize, initialize
 from nucliadb_telemetry import errors
-from nucliadb_telemetry.fastapi import instrument_app
-from nucliadb_telemetry.utils import get_telemetry
 from nucliadb_utils.authentication import STFAuthenticationBackend
 from nucliadb_utils.fastapi.openapi import extend_openapi
 from nucliadb_utils.fastapi.versioning import VersionedFastAPI
@@ -105,10 +103,3 @@ async def homepage(request):
 
 # Use raw starlette routes to avoid unnecessary overhead
 application.add_route("/", homepage)
-
-instrument_app(
-    application,
-    tracer_provider=get_telemetry(SERVICE_NAME),
-    excluded_urls=["/"],
-    metrics=True,
-)

--- a/nucliadb/nucliadb/writer/run.py
+++ b/nucliadb/nucliadb/writer/run.py
@@ -20,7 +20,18 @@
 
 from nucliadb.writer.app import application
 from nucliadb_utils.fastapi.run import run_fastapi_with_metrics
+from nucliadb_telemetry.fastapi import instrument_app
+from nucliadb_telemetry.utils import get_telemetry
+
+from nucliadb.writer import SERVICE_NAME
 
 
-def run_with_metrics():
+def run():
+    instrument_app(
+        application,
+        tracer_provider=get_telemetry(SERVICE_NAME),
+        excluded_urls=["/"],
+        metrics=True,
+    )
+
     run_fastapi_with_metrics(application)

--- a/nucliadb/setup.py
+++ b/nucliadb/setup.py
@@ -53,20 +53,27 @@ setup(
     install_requires=requirements,
     entry_points={
         "console_scripts": [
+            # Service commands
+            # Standalone
             "nucliadb = nucliadb.run:run",
-            "nucliadb_purge = nucliadb.purge:purge",
-            "ndb_ingest = nucliadb.ingest.app:run_consumer",
-            "ndb_ingest_orm_grpc = nucliadb.ingest.app:run_orm_grpc",
-            "ndb_purge = nucliadb.ingest.purge:run",
-            "nucliadb_one = nucliadb.one:run",
-            "extract-openapi-reader = nucliadb.reader.openapi:command_extract_openapi",
-            "reader-metrics = nucliadb.reader.run:run_with_metrics",
-            "extract-openapi-search = nucliadb.search.openapi:command_extract_openapi",
-            "search-metrics = nucliadb.search.run:run_with_metrics",
-            "extract-openapi-writer = nucliadb.writer.openapi:command_extract_openapi",
-            "writer-metrics = nucliadb.writer.run:run_with_metrics",
-            "ndb_train = nucliadb.train.run:run_with_metrics",
-            "nuclia_dataset_upload = nucliadb.train.upload:run",
+            # Ingest
+            "nucliadb-ingest = nucliadb.ingest.app:run_consumer",
+            "nucliadb-ingest-orm-grpc = nucliadb.ingest.app:run_orm_grpc",
+            # Reader
+            "nucliadb-reader = nucliadb.reader.run:run",
+            # Writer
+            "nucliadb-writer = nucliadb.writer.run:run",
+            # Search
+            "nucliadb-search = nucliadb.search.run:run",
+            # Train
+            "nucliadb-train = nucliadb.train.run:run",
+            # utilities
+            "nucliadb-purge = nucliadb.purge:purge",
+            "nucliadb-ingest-purge = nucliadb.ingest.purge:run",
+            "nucliadb-extract-openapi-reader = nucliadb.reader.openapi:command_extract_openapi",
+            "nucliadb-extract-openapi-search = nucliadb.search.openapi:command_extract_openapi",
+            "nucliadb-extract-openapi-writer = nucliadb.writer.openapi:command_extract_openapi",
+            "nucliadb-dataset-upload = nucliadb.train.upload:run",
         ]
     },
     project_urls={


### PR DESCRIPTION
### Description
For me, it doesn't make sense to have scripts that are named with "-metrics".

Let's just have 1 entrypoint and 1 way to deploy ndb.

Additionally, some cleanup to not do telemetry setup at module/global scope.

### How was this PR tested?
Describe how you tested this PR.
