### PR TITLE
implement contributor app

### DIFF
--- a/nucliadb/nucliadb/one/app.py
+++ b/nucliadb/nucliadb/one/app.py
@@ -17,8 +17,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import os
+
+import nucliadb_contributor_assets
 import pkg_resources
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.cors import CORSMiddleware
@@ -96,5 +100,15 @@ async def homepage(request):
 # Use raw starlette routes to avoid unnecessary overhead
 application.add_route("/", homepage)
 application.add_route("/metrics", metrics.metrics)
+
+# mount contributor app assets
+application.mount(
+    "/contributor",
+    StaticFiles(
+        directory=os.path.dirname(nucliadb_contributor_assets.__file__), html=True
+    ),
+    name="static",
+)
+
 
 instrument_app(application, excluded_urls=["/"], metrics=True)

--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -41,6 +41,7 @@ nucliadb-telemetry>=1.8.0
 nucliadb-utils[storages,fastapi,cache]
 nucliadb-protos
 nucliadb-models
+nucliadb-contributor-assets~=1.0.0
 
 tikv-client>=0.0.3
 

--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -41,7 +41,7 @@ nucliadb-telemetry>=1.8.0
 nucliadb-utils[storages,fastapi,cache]
 nucliadb-protos
 nucliadb-models
-nucliadb-contributor-assets~=1.0.0
+nucliadb-contributor-assets^=1.0.0
 
 tikv-client>=0.0.3
 


### PR DESCRIPTION
### Description
This sets up the contributor app to be served in standalone mode.

Right now, the app is missing `app-config.json` though and will need another release.

### How was this PR tested?
Describe how you tested this PR.
