### PR TITLE
Text search with count

### DIFF
--- a/nucliadb_texts/src/reader.rs
+++ b/nucliadb_texts/src/reader.rs
@@ -335,7 +335,7 @@ impl TextReaderService {
 
         let facets = produce_facets(response.facets, response.facets_count);
         DocumentSearchResponse {
-            total: total as i32,
+            total,
             results,
             facets,
             page_number: response.page_number,
@@ -360,7 +360,7 @@ impl TextReaderService {
             .into_iter()
             .take(results_per_page)
             .enumerate();
-        
+
         let mut results = Vec::with_capacity(results_per_page);
         for (id, (score, doc_address)) in result_stream {
             match searcher.doc(doc_address) {


### PR DESCRIPTION
### Description
In this PR:
- `nucliadb_paragraphs` and `nucliadb_texts` do not use [MultiCollector](https://docs.rs/tantivy/latest/tantivy/collector/struct.MultiCollector.html) anymore. Our collectors are known at compile time, therefore using tuples is possible.
-  `DocumentSearchResponse` returns in `total` the actual total number of matches, not only the ones being returned.

### How was this PR tested?
Local tests
