### PR TITLE
Fix chat again

### DIFF
--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -183,7 +183,7 @@ class PredictEngine:
                 headers=headers,
             )
         await self.check_response(resp, expected=200)
-        return await resp.read()
+        return await resp.text()
 
     @predict_observer.wrap({"type": "chat"})
     async def chat_query(


### PR DESCRIPTION
### Description
resp.read() is returning bytes, making find fail with the following traceback:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 92, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/cors.py", line 147, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/authentication.py", line 48, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 235, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 161, in run_endpoint_function
    return await dependant.call(**values)
  File "/usr/src/app/nucliadb_utils/nucliadb_utils/authentication.py", line 142, in async_wrapper
    return await func(*args, **kwargs)
  File "/usr/src/app/nucliadb/nucliadb/search/api/v1/chat.py", line 82, in chat_post_knowledgebox
    return await chat(
  File "/usr/src/app/nucliadb/nucliadb/search/api/v1/chat.py", line 131, in chat
    results = await find(
  File "/usr/src/app/nucliadb/nucliadb/search/api/v1/find.py", line 211, in find
    processed_query = pre_process_query(item.query)
  File "/usr/src/app/nucliadb/nucliadb/search/search/query.py", line 277, in pre_process_query
    if term.startswith('"'):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

### How was this PR tested?
Describe how you tested this PR.
