### PR TITLE
fix redis connection leak 2

### DIFF
--- a/nucliadb/nucliadb/writer/tests/test_files.py
+++ b/nucliadb/nucliadb/writer/tests/test_files.py
@@ -546,6 +546,66 @@ async def test_file_tus_upload_field_by_slug(writer_api, knowledgebox_writer, re
 
 
 @pytest.mark.asyncio
+async def test_multiple_tus_file_upload_tries(
+    writer_api, knowledgebox_writer, resource
+):
+    kb = knowledgebox_writer
+    rslug = "resource1"
+
+    async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
+        headers = {
+            "tus-resumable": "1.0.0",
+            "content-type": "image/jpg",
+            "upload-defer-length": "1",
+        }
+
+        resp = await client.post(
+            f"/{KB_PREFIX}/{kb}/slug/{rslug}/file/field1/{TUSUPLOAD}",
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        url = resp.headers["location"]
+
+        # Check that we are using the slug for the whole file upload
+        assert f"{RSLUG_PREFIX}/{rslug}" in url
+        resp = await client.patch(
+            url,
+            data=b"x" * 10000,
+            headers={
+                "upload-offset": "0",
+                "content-length": "10000",
+                "upload-length": "10000",
+            },
+        )
+        assert resp.status_code == 200
+
+        assert resp.headers["Tus-Upload-Finished"] == "1"
+
+        # next one should work as well
+        resp = await client.post(
+            f"/{KB_PREFIX}/{kb}/slug/{rslug}/file/field1/{TUSUPLOAD}",
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        url = resp.headers["location"]
+
+        # Check that we are using the slug for the whole file upload
+        assert f"{RSLUG_PREFIX}/{rslug}" in url
+        resp = await client.patch(
+            url,
+            data=b"x" * 10000,
+            headers={
+                "upload-offset": "0",
+                "content-length": "10000",
+                "upload-length": "10000",
+            },
+        )
+        assert resp.status_code == 200
+
+        assert resp.headers["Tus-Upload-Finished"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_file_upload_by_slug(writer_api, knowledgebox_writer):
     kb = knowledgebox_writer
     rslug = "myslug"

--- a/nucliadb/nucliadb/writer/tests/unit/tus/test_dm.py
+++ b/nucliadb/nucliadb/writer/tests/unit/tus/test_dm.py
@@ -1,0 +1,41 @@
+from unittest.mock import AsyncMock, patch
+import pytest
+from nucliadb.writer.tus.dm import (
+    RedisFileDataManagerFactory,
+    RedisFileDataManager,
+    FileDataMangaer,
+)
+from nucliadb.writer import tus
+
+
+@pytest.fixture()
+def redis():
+    mock = AsyncMock()
+    with patch("nucliadb.writer.tus.dm.aioredis.from_url", return_value=mock):
+        yield mock
+
+
+async def test_file_data_manager_factory(redis):
+    factory = RedisFileDataManagerFactory("redis://localhost:6379")
+    inst = factory()
+
+    assert isinstance(inst, RedisFileDataManager)
+    assert inst.redis == redis
+
+    await factory.finalize()
+
+    redis.close.assert_called_once_with(close_connection_pool=True)
+
+
+async def test_get_file_data_manager():
+    await tus.finalize()  # make sure to clear
+
+    with patch.object(tus.writer_settings, "dm_enabled", False):
+        assert isinstance(tus.get_dm(), FileDataMangaer)
+
+
+async def test_get_file_data_manager_redis(redis):
+    await tus.finalize()  # make sure to clear
+
+    with patch.object(tus.writer_settings, "dm_enabled", True):
+        assert isinstance(tus.get_dm(), RedisFileDataManager)

--- a/nucliadb/nucliadb/writer/tests/unit/tus/test_dm.py
+++ b/nucliadb/nucliadb/writer/tests/unit/tus/test_dm.py
@@ -1,11 +1,13 @@
 from unittest.mock import AsyncMock, patch
+
 import pytest
-from nucliadb.writer.tus.dm import (
-    RedisFileDataManagerFactory,
-    RedisFileDataManager,
-    FileDataMangaer,
-)
+
 from nucliadb.writer import tus
+from nucliadb.writer.tus.dm import (
+    FileDataMangaer,
+    RedisFileDataManager,
+    RedisFileDataManagerFactory,
+)
 
 
 @pytest.fixture()

--- a/nucliadb/nucliadb/writer/tests/unit/tus/test_dm.py
+++ b/nucliadb/nucliadb/writer/tests/unit/tus/test_dm.py
@@ -1,3 +1,22 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/nucliadb/nucliadb/writer/tus/__init__.py
+++ b/nucliadb/nucliadb/writer/tus/__init__.py
@@ -23,8 +23,8 @@ from typing import Optional
 from nucliadb.writer.settings import settings as writer_settings
 from nucliadb.writer.tus.dm import (
     FileDataMangaer,
-    RedisFileDataManagerFactory,
     RedisFileDataManager,
+    RedisFileDataManagerFactory,
 )
 from nucliadb.writer.tus.exceptions import ManagerNotAvailable
 from nucliadb.writer.tus.gcs import GCloudBlobStore, GCloudFileStorageManager

--- a/nucliadb/nucliadb/writer/tus/__init__.py
+++ b/nucliadb/nucliadb/writer/tus/__init__.py
@@ -21,11 +21,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from nucliadb.writer.settings import settings as writer_settings
-from nucliadb.writer.tus.dm import (
-    FileDataMangaer,
-    RedisFileDataManager,
-    RedisFileDataManagerFactory,
-)
+from nucliadb.writer.tus.dm import FileDataMangaer, RedisFileDataManagerFactory
 from nucliadb.writer.tus.exceptions import ManagerNotAvailable
 from nucliadb.writer.tus.gcs import GCloudBlobStore, GCloudFileStorageManager
 from nucliadb.writer.tus.local import LocalBlobStore, LocalFileStorageManager

--- a/nucliadb/nucliadb/writer/tus/dm.py
+++ b/nucliadb/nucliadb/writer/tus/dm.py
@@ -115,9 +115,24 @@ class FileDataMangaer:
         return self._data.get(name, default)
 
 
-class RedisFileDataManager(FileDataMangaer):
+class RedisFileDataManagerFactory:
+    """
+    Allow sharing a single redis pool between multiple data managers.
+    """
+
     def __init__(self, redis_url: str):
         self.redis = aioredis.from_url(redis_url)
+
+    def __call__(self):
+        return RedisFileDataManager(self.redis)
+
+    async def finalize(self):
+        await self.redis.close(close_connection_pool=True)
+
+
+class RedisFileDataManager(FileDataMangaer):
+    def __init__(self, redis: aioredis.Redis):
+        self.redis = redis
 
     async def load(self, key):
         # preload data


### PR DESCRIPTION
### Description
The previous fix did not work because file data manager instances could not be shared(duh)

### How was this PR tested?
Integration and unit.
