### PR TITLE
Refactor ingest processing txn logic

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/exceptions.py
+++ b/nucliadb/nucliadb/ingest/orm/exceptions.py
@@ -66,3 +66,11 @@ class SequenceOrderViolation(Exception):
 
 class EntitiesGroupNotFound(NotFound):
     pass
+
+
+class ApplyMessageError(Exception):
+    pass
+
+
+class NoResourceError(Exception):
+    pass

--- a/nucliadb/nucliadb/ingest/orm/processor.py
+++ b/nucliadb/nucliadb/ingest/orm/processor.py
@@ -382,7 +382,8 @@ class Processor:
                     created = created or _created
                 except ApplyMessageError as exc:
                     logger.warning(str(exc))
-                    pass
+                    continue
+
             if resource is None:
                 raise NoResourceError()
 

--- a/nucliadb/nucliadb/ingest/orm/processor.py
+++ b/nucliadb/nucliadb/ingest/orm/processor.py
@@ -482,14 +482,12 @@ class Processor:
         counter = await shard.add_resource(
             resource.indexer.brain, seqid, partition=partition, kb=kb.kbid
         )
-        if counter and counter.fields > settings.max_shard_fields:
+        if counter is not None and counter.fields > settings.max_shard_fields:
             # The current shard is full, create a new one so next resource
             # is placed on a new shard
             similarity = await kb.get_similarity()
-            shard = await node_klass.create_shard_by_kbid(
-                txn, kb.kbid, similarity=similarity
-            )
-        return counter, shard
+            await node_klass.create_shard_by_kbid(txn, kb.kbid, similarity=similarity)
+        return counter, shard  # type: ignore
 
     async def _mark_resource_error(
         self,

--- a/nucliadb/nucliadb/ingest/orm/processor.py
+++ b/nucliadb/nucliadb/ingest/orm/processor.py
@@ -396,7 +396,7 @@ class Processor:
 
             if resource.modified or reindex:
                 # TODO: Shouldn't we index the resource after it has been commited?
-                counter = await self.index_resource(
+                counter, shard = await self.index_resource(
                     resource, txn, kb, uuid, seqid, partition
                 )
 
@@ -456,9 +456,10 @@ class Processor:
         uuid: str,
         seqid: int,
         partition: str,
-    ) -> Optional[ShardCounter]:
+    ) -> Tuple[Optional[ShardCounter], Shard]:
         shard_id = await kb.get_resource_shard_id(uuid)
         node_klass = get_node_klass()
+        shard: Optional[Shard] = None
 
         if shard_id is not None:
             shard = await kb.get_resource_shard(shard_id, node_klass)
@@ -488,7 +489,7 @@ class Processor:
             shard = await node_klass.create_shard_by_kbid(
                 txn, kb.kbid, similarity=similarity
             )
-        return counter
+        return counter, shard
 
     async def _mark_resource_error(
         self,


### PR DESCRIPTION
### Description
- Fixed reindex logic (it was checking only the last message)
- Fixed code smell where `apply_resource` was optionally returning a tuple or None. Better handled via raising an exception.
- Encapsulate index resource logic in its own method (for better readability)

### How was this PR tested?
Existing tests should cover it
