### PR TITLE
More ingest refactor improvements

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/processor.py
+++ b/nucliadb/nucliadb/ingest/orm/processor.py
@@ -463,7 +463,7 @@ class Processor:
         uuid: str,
         seqid: int,
         partition: str,
-    ) -> ShardCounter:
+    ) -> Tuple[Optional[ShardCounter], Shard]:
         shard_id = await kb.get_resource_shard_id(uuid)
         node_klass = get_node_klass()
         shard: Optional[Shard] = None
@@ -489,6 +489,7 @@ class Processor:
         counter = await shard.add_resource(
             resource.indexer.brain, seqid, partition=partition, kb=kb.kbid
         )
+        # TODO: Move this out of the transaction processing
         if counter is not None and counter.fields > settings.max_shard_fields:
             # The current shard is full, create a new one so next resource
             # is placed on a new shard

--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -119,6 +119,7 @@ class Resource:
         self.all_fields_keys: List[Tuple[int, str]] = []
         self.origin: Optional[PBOrigin] = None
         self.modified: bool = False
+        self.slug_modified: bool = False
         self._indexer: Optional[ResourceBrain] = None
         self._modified_extracted_text: List[FieldID] = []
 
@@ -242,6 +243,7 @@ class Resource:
         if slug is not None and slug != "":
             slug = await self.kb.get_unique_slug(self.uuid, slug)
             self.basic.slug = slug
+            self.slug_modified = True
         if deleted_fields is not None and len(deleted_fields) > 0:
             remove_field_classifications(self.basic, deleted_fields=deleted_fields)
         await set_basic(self.txn, self.kb.kbid, self.uuid, self.basic)

--- a/nucliadb/nucliadb/ingest/tests/integration/servicer/test_export.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/servicer/test_export.py
@@ -113,7 +113,8 @@ async def test_export_resources(grpc_servicer: IngestFixture):
     fed.field = "file1"
     bm.file_extracted_data.append(fed)
 
-    await stub.ProcessMessage([bm])  # type: ignore
+    resp = await stub.ProcessMessage([bm])  # type: ignore
+    assert resp.status == resp.Status.OK
 
     req = ExportRequest()
     req.kbid = result.uuid

--- a/nucliadb/nucliadb/ingest/tests/unit/orm/test_resource.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/orm/test_resource.py
@@ -33,9 +33,8 @@ from nucliadb.ingest.orm.resource import (
     maybe_update_basic_thumbnail,
 )
 
-pytestmark = pytest.mark.asyncio
 
-
+@pytest.mark.asyncio
 async def test_get_file_page_positions():
     extracted_data = FileExtractedData()
     extracted_data.file_pages_previews.positions.extend(

--- a/nucliadb/nucliadb/ingest/tests/unit/service/test_writer.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/service/test_writer.py
@@ -31,8 +31,6 @@ from nucliadb.ingest.service.writer import (
 )
 from nucliadb_protos import writer_pb2
 
-pytestmark = pytest.mark.asyncio
-
 
 def test_update_shards_pb_replica():
     shard1_rep1 = writer_pb2.ShardReplica(
@@ -163,6 +161,7 @@ class TestWriterServicer:
         with patch("nucliadb.ingest.service.writer.ResourceORM", return_value=mock):
             yield mock
 
+    @pytest.mark.asyncio
     async def test_GetKnowledgeBox(self, writer):
         value = Mock()
         writer.proc.get_kb.return_value = value
@@ -170,6 +169,7 @@ class TestWriterServicer:
 
         assert await writer.GetKnowledgeBox(req, None) is value
 
+    @pytest.mark.asyncio
     async def test_SetVectors(self, writer: WriterServicer, resource):
         request = writer_pb2.SetVectorsRequest(
             kbid="kbid",
@@ -182,6 +182,7 @@ class TestWriterServicer:
 
         assert resp.found
 
+    @pytest.mark.asyncio
     async def test_SetVectors_not_found(self, writer: WriterServicer, resource):
         request = writer_pb2.SetVectorsRequest(
             kbid="kbid",
@@ -194,6 +195,7 @@ class TestWriterServicer:
 
         assert not resp.found
 
+    @pytest.mark.asyncio
     async def test_SetVectors_error(self, writer: WriterServicer, resource, field):
         request = writer_pb2.SetVectorsRequest(
             kbid="kbid",
@@ -207,6 +209,7 @@ class TestWriterServicer:
         assert resp.found
         writer.proc.driver.begin.return_value.abort.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_NewKnowledgeBox(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxNew(slug="slug")
         writer.proc.create_kb.return_value = "kbid"
@@ -221,6 +224,7 @@ class TestWriterServicer:
         )
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.OK
 
+    @pytest.mark.asyncio
     async def test_NewKnowledgeBox_handle_error(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxNew(slug="slug")
         writer.proc.create_kb.side_effect = Exception("error")
@@ -229,6 +233,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.ERROR
 
+    @pytest.mark.asyncio
     async def test_UpdateKnowledgeBox(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxUpdate(slug="slug", uuid="uuid")
         writer.proc.update_kb.return_value = "kbid"
@@ -240,6 +245,7 @@ class TestWriterServicer:
         )
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.OK
 
+    @pytest.mark.asyncio
     async def test_UpdateKnowledgeBox_not_found(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxUpdate(slug="slug", uuid="uuid")
         writer.proc.update_kb.side_effect = KnowledgeBoxNotFound()
@@ -248,6 +254,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_UpdateKnowledgeBox_error(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxUpdate(slug="slug")
         writer.proc.update_kb.side_effect = Exception()
@@ -256,6 +263,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.ERROR
 
+    @pytest.mark.asyncio
     async def test_DeleteKnowledgeBox(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
 
@@ -264,6 +272,7 @@ class TestWriterServicer:
         writer.proc.delete_kb.assert_called_once_with(request.uuid, request.slug)
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.OK
 
+    @pytest.mark.asyncio
     async def test_DeleteKnowledgeBox_handle_error(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
         writer.proc.delete_kb.side_effect = Exception("error")
@@ -272,6 +281,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.ERROR
 
+    @pytest.mark.asyncio
     async def test_GCKnowledgeBox(self, writer: WriterServicer):
         request = writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
 
@@ -279,6 +289,7 @@ class TestWriterServicer:
 
         assert isinstance(resp, writer_pb2.GCKnowledgeBoxResponse)
 
+    @pytest.mark.asyncio
     async def test_SetLabels(self, writer: WriterServicer):
         request = writer_pb2.SetLabelsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), id="id"
@@ -289,6 +300,7 @@ class TestWriterServicer:
         assert resp.status == writer_pb2.OpStatusWriter.Status.OK
         writer.proc.driver.begin.return_value.commit.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_SetLabels_missing(self, writer: WriterServicer):
         request = writer_pb2.SetLabelsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), id="id"
@@ -299,6 +311,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.OpStatusWriter.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_SetLabels_handle_error(self, writer: WriterServicer):
         request = writer_pb2.SetLabelsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), id="id"
@@ -312,6 +325,7 @@ class TestWriterServicer:
         assert resp.status == writer_pb2.OpStatusWriter.Status.ERROR
         writer.proc.driver.begin.return_value.abort.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_DelLabels(self, writer: WriterServicer):
         request = writer_pb2.DelLabelsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), id="id"
@@ -322,6 +336,7 @@ class TestWriterServicer:
         assert resp.status == writer_pb2.OpStatusWriter.Status.OK
         writer.proc.driver.begin.return_value.commit.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_DelLabels_missing(self, writer: WriterServicer):
         request = writer_pb2.DelLabelsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), id="id"
@@ -332,6 +347,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.OpStatusWriter.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_DelLabels_handle_error(self, writer: WriterServicer):
         request = writer_pb2.DelLabelsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), id="id"
@@ -345,6 +361,7 @@ class TestWriterServicer:
         assert resp.status == writer_pb2.OpStatusWriter.Status.ERROR
         writer.proc.driver.begin.return_value.abort.assert_called_once()
 
+    @pytest.mark.asyncio
     async def test_GetLabelSet(self, writer: WriterServicer):
         request = writer_pb2.GetLabelSetRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), labelset="labelset"
@@ -355,6 +372,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetLabelSetResponse.Status.OK
 
+    @pytest.mark.asyncio
     async def test_GetLabelSet_kb_missing(self, writer: WriterServicer):
         request = writer_pb2.GetLabelSetRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), labelset="labelset"
@@ -365,6 +383,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetLabelSetResponse.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_GetEntities(self, writer: WriterServicer):
         request = writer_pb2.GetEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
@@ -382,6 +401,7 @@ class TestWriterServicer:
         entities_manager.get_entities.assert_called_once_with(resp)
         assert resp.status == writer_pb2.GetEntitiesResponse.Status.OK
 
+    @pytest.mark.asyncio
     async def test_GetEntities_missing(self, writer: WriterServicer):
         request = writer_pb2.GetEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
@@ -392,6 +412,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetEntitiesResponse.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_GetEntities_handle_error(self, writer: WriterServicer):
         request = writer_pb2.GetEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
@@ -409,6 +430,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetEntitiesResponse.Status.ERROR
 
+    @pytest.mark.asyncio
     async def test_ListEntitiesGroups(self, writer: WriterServicer):
         request = writer_pb2.ListEntitiesGroupsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
@@ -429,6 +451,7 @@ class TestWriterServicer:
         entities_manager.list_entities_groups.assert_called_once()
         assert resp.status == writer_pb2.GetEntitiesResponse.Status.OK
 
+    @pytest.mark.asyncio
     async def test_ListEntitiesGroups_missing(self, writer: WriterServicer):
         request = writer_pb2.ListEntitiesGroupsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
@@ -439,6 +462,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetEntitiesResponse.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_ListEntitiesGroups_handle_error(self, writer: WriterServicer):
         request = writer_pb2.ListEntitiesGroupsRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid")
@@ -456,6 +480,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetEntitiesResponse.Status.ERROR
 
+    @pytest.mark.asyncio
     async def test_GetEntitiesGroup(self, writer: WriterServicer):
         request = writer_pb2.GetEntitiesGroupRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -476,6 +501,7 @@ class TestWriterServicer:
         entities_manager.get_entities_group.assert_called_once_with("group")
         assert resp.status == writer_pb2.GetEntitiesGroupResponse.Status.OK
 
+    @pytest.mark.asyncio
     async def test_GetEntitiesGroup_missing(self, writer: WriterServicer):
         request = writer_pb2.GetEntitiesGroupRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -486,6 +512,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetEntitiesGroupResponse.Status.KB_NOT_FOUND
 
+    @pytest.mark.asyncio
     async def test_GetEntitiesGroup_handle_error(self, writer: WriterServicer):
         request = writer_pb2.GetEntitiesGroupRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -503,6 +530,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.GetEntitiesGroupResponse.Status.ERROR
 
+    @pytest.mark.asyncio
     async def test_SetEntities(self, writer: WriterServicer):
         request = writer_pb2.SetEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -522,6 +550,7 @@ class TestWriterServicer:
         )
         assert resp.status == writer_pb2.OpStatusWriter.Status.OK
 
+    @pytest.mark.asyncio
     async def test_SetEntities_missing(self, writer: WriterServicer):
         request = writer_pb2.SetEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -532,6 +561,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.OpStatusWriter.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_SetEntities_handle_error(self, writer: WriterServicer):
         request = writer_pb2.SetEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -549,6 +579,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.OpStatusWriter.Status.ERROR
 
+    @pytest.mark.asyncio
     async def test_DelEntities(self, writer: WriterServicer):
         request = writer_pb2.DelEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -566,6 +597,7 @@ class TestWriterServicer:
         entities_manager.delete_entities_group.assert_called_once_with(request.group)
         assert resp.status == writer_pb2.OpStatusWriter.Status.OK
 
+    @pytest.mark.asyncio
     async def test_DelEntities_missing(self, writer: WriterServicer):
         request = writer_pb2.DelEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -576,6 +608,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.OpStatusWriter.Status.NOTFOUND
 
+    @pytest.mark.asyncio
     async def test_DelEntities_handle_error(self, writer: WriterServicer):
         request = writer_pb2.DelEntitiesRequest(
             kb=writer_pb2.KnowledgeBoxID(slug="slug", uuid="uuid"), group="group"
@@ -593,6 +626,7 @@ class TestWriterServicer:
 
         assert resp.status == writer_pb2.OpStatusWriter.Status.ERROR
 
+    @pytest.mark.asyncio
     async def test_Index(self, writer: WriterServicer):
         request = writer_pb2.IndexResource(kbid="kbid", rid="rid")
 


### PR DESCRIPTION
### Description
- Don't compute global text and global tags twice if we are reindexing
- Set slug only when it changed
- Index resource after the maindb transaction has been committed
- Use driver's context manager for main transaction: this way for sure we are not leaking any open transaction

### How was this PR tested?
Existing integration tests should cover it