### PR TITLE
SDK v2

### DIFF
--- a/charts/nucliadb/templates/sts.yaml
+++ b/charts/nucliadb/templates/sts.yaml
@@ -69,6 +69,9 @@ spec:
           - name: "{{ $key }}"
             value: {{ tpl $value $ | toJson }}
           {{- end }}
+          {{- if .Values.envSecrets }}
+{{ toYaml .Values.envSecrets | indent 10 }}
+          {{- end }}
           - name: DATA_PATH
             value: "/data"
         ports:

--- a/charts/nucliadb/values.yaml
+++ b/charts/nucliadb/values.yaml
@@ -11,6 +11,13 @@ env:
   CORS_ORIGINS: '["http://localhost:8080"]'
   #NUA_API_KEY: "..."
 
+envSecrets:
+  - name: NUA_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: nuclia-api-key
+        key: api-key
+
 affinity: {}
 nodeSelector: {}
 tolerations: []

--- a/nucliadb_sdk/nucliadb_sdk/__init__.py
+++ b/nucliadb_sdk/nucliadb_sdk/__init__.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from nucliadb_sdk.v2 import NucliaSDK, Region, exceptions
+
+# Old SDK APIs that should eventually be removed
 from nucliadb_sdk.entities import Entity
 from nucliadb_sdk.file import File
 from nucliadb_sdk.knowledgebox import KnowledgeBox
@@ -31,6 +34,11 @@ from nucliadb_sdk.utils import (
 from nucliadb_sdk.vectors import Vector
 
 __all__ = (
+    "NucliaSDK",
+    "Region",
+    "exceptions",
+    # OLD support APIs
+    # Plan on removing these in the future
     "File",
     "KnowledgeBox",
     "Entity",

--- a/nucliadb_sdk/nucliadb_sdk/__init__.py
+++ b/nucliadb_sdk/nucliadb_sdk/__init__.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from nucliadb_sdk.v2 import NucliaSDK, Region, exceptions
-
 # Old SDK APIs that should eventually be removed
 from nucliadb_sdk.entities import Entity
 from nucliadb_sdk.file import File
@@ -31,6 +29,7 @@ from nucliadb_sdk.utils import (
     get_or_create,
     list_kbs,
 )
+from nucliadb_sdk.v2 import NucliaSDK, Region, exceptions
 from nucliadb_sdk.vectors import Vector
 
 __all__ = (

--- a/nucliadb_sdk/nucliadb_sdk/knowledgebox.py
+++ b/nucliadb_sdk/nucliadb_sdk/knowledgebox.py
@@ -365,7 +365,7 @@ class KnowledgeBox:
                 "kind": [labelset_type.value],
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
 
     def get_labels(self) -> KnowledgeBoxLabels:
         resp = self.client.get_labels()

--- a/nucliadb_sdk/nucliadb_sdk/tests/fixtures.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/fixtures.py
@@ -29,9 +29,7 @@ from pytest_docker_fixtures import images  # type: ignore
 from pytest_docker_fixtures.containers._base import BaseImage  # type: ignore
 
 from nucliadb_client.client import NucliaDBClient as GRPCNucliaDBClient
-from nucliadb_models.resource import KnowledgeBoxObj
-from nucliadb_sdk.client import Environment, NucliaDBClient
-from nucliadb_sdk.knowledgebox import KnowledgeBox
+import nucliadb_sdk
 
 images.settings["nucliadb"] = {
     "image": "nuclia/nucliadb",
@@ -64,58 +62,59 @@ class NucliaDB(BaseImage):
             return False
 
 
-@pytest.fixture(scope="session")
-def nucliadb():
-    if os.environ.get("TEST_LOCAL_NUCLIADB"):
-        yield os.environ.get("TEST_LOCAL_NUCLIADB")
-    else:
-        container = NucliaDB()
-        host, port = container.run()
-        public_api_url = f"http://{host}:{port}"
-        yield public_api_url
-        container.stop()
-
-
-@pytest.fixture(scope="function")
-def knowledgebox(nucliadb):
-    kbslug = uuid4().hex
-    api_path = f"{nucliadb}/api/v1"
-    response = requests.post(
-        f"{api_path}/kbs",
-        json={"slug": kbslug},
-        headers={"X-NUCLIADB-ROLES": "MANAGER"},
-    )
-    assert response.status_code == 201
-
-    kb = KnowledgeBoxObj.parse_raw(response.content)
-    kbid = kb.uuid
-
-    url = f"{api_path}/kb/{kbid}"
-    client = NucliaDBClient(
-        environment=Environment.OSS,
-        writer_host=url,
-        reader_host=url,
-        search_host=url,
-        train_host=url,
-    )
-    yield KnowledgeBox(client)
-
-    response = requests.delete(
-        f"{api_path}/kb/{kbid}", headers={"X-NUCLIADB-ROLES": f"MANAGER"}
-    )
-    assert response.status_code == 200
-
-
 @dataclass
-class SDKFixture:
+class NucliaFixture:
     host: str
     port: int
     grpc: int
     container: Optional[NucliaDB] = None
 
 
+@pytest.fixture(scope="session")
+def nucliadb():
+    if os.environ.get("TEST_LOCAL_NUCLIADB"):
+        yield NucliaFixture(
+            host=os.environ.get("TEST_LOCAL_NUCLIADB"),
+            port=8080,
+            grpc=8060,
+            container="local",
+        )
+    else:
+        container = NucliaDB()
+        host, port = container.run()
+        network = container.container_obj.attrs["NetworkSettings"]
+        if os.environ.get("TESTING", "") == "jenkins":
+            grpc = 8060
+        else:
+            service_port = "8060/tcp"
+            grpc = network["Ports"][service_port][0]["HostPort"]
+        yield NucliaFixture(
+            host=host, port=port, grpc=grpc, container=container.container_obj
+        )
+        container.stop()
+
+
+@pytest.fixture(scope="session")
+def sdk(nucliadb: NucliaFixture):
+    sdk = nucliadb_sdk.NucliaSDK(
+        region=nucliadb_sdk.Region.ON_PREM,
+        url=f"http://{nucliadb.host}:{nucliadb.port}/api/",
+    )
+    return sdk
+
+
+@pytest.fixture(scope="function")
+def knowledgebox(sdk: nucliadb_sdk.NucliaSDK):
+    kbslug = uuid4().hex
+    kb = sdk.create_knowledge_box(slug=kbslug)
+
+    yield kb
+
+    sdk.delete_knowledge_box(kbid=kb.uuid)
+
+
 async def init_fixture(
-    nucliadb: SDKFixture,
+    nucliadb: NucliaFixture,
     dataset_slug: str,
     dataset_location: str,
 ):
@@ -129,25 +128,6 @@ async def init_fixture(
 
 
 @pytest.fixture(scope="session")
-def nucliadb_imported():
-    ndb = NucliaDB()
-    host, port = ndb.run()
-    network = ndb.container_obj.attrs["NetworkSettings"]
-
-    if os.environ.get("TESTING", "") == "jenkins":
-        grpc = 8060
-    else:
-        service_port = "8060/tcp"
-        grpc = network["Ports"][service_port][0]["HostPort"]
-    yield SDKFixture(host=host, port=port, grpc=grpc, container=ndb.container_obj)
-    ndb.stop()
-
-
-@pytest.fixture(scope="session")
-def docs_fixture(nucliadb_imported: SDKFixture):
-    kbid = asyncio.run(init_fixture(nucliadb_imported, "docs", NUCLIA_DOCS_dataset))
-    client = NucliaDBClient(
-        environment=Environment.OSS,
-        url=f"http://{nucliadb_imported.host}:{nucliadb_imported.port}/api/v1/kb/{kbid}",
-    )
-    return KnowledgeBox(client)
+def docs_dataset(nucliadb: NucliaFixture):
+    kbid = asyncio.run(init_fixture(nucliadb, "docs", NUCLIA_DOCS_dataset))
+    yield kbid

--- a/nucliadb_sdk/nucliadb_sdk/tests/fixtures.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/fixtures.py
@@ -28,8 +28,8 @@ import requests
 from pytest_docker_fixtures import images  # type: ignore
 from pytest_docker_fixtures.containers._base import BaseImage  # type: ignore
 
-from nucliadb_client.client import NucliaDBClient as GRPCNucliaDBClient
 import nucliadb_sdk
+from nucliadb_client.client import NucliaDBClient as GRPCNucliaDBClient
 
 images.settings["nucliadb"] = {
     "image": "nuclia/nucliadb",

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
@@ -17,15 +17,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from nucliadb_sdk.knowledgebox import KnowledgeBox
+import nucliadb_sdk
 
 
-def test_chat_resource(docs_fixture: KnowledgeBox):
-    find_result, answer, relations_result, learning_id = docs_fixture.chat(
-        text="Nuclia loves Semantic Search"
-    )
-    assert learning_id == "00"
-    assert answer == b"valid answer  to"
-    assert len(find_result.resources) == 9
-    assert relations_result
-    assert len(relations_result.entities["Nuclia"].related_to) == 18
+def test_chat_resource(docs_dataset, sdk: nucliadb_sdk.NucliaSDK):
+    result = sdk.chat(kbid=docs_dataset, query="Nuclia loves Semantic Search")
+    assert result.learning_id == "00"
+    assert result.answer == "valid answer  to"
+    assert len(result.result.resources) == 9
+    assert result.relations
+    assert len(result.relations.entities["Nuclia"].related_to) == 18

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_crud.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_crud.py
@@ -17,279 +17,86 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import base64
+
 import pytest
 
-from nucliadb_models.metadata import (
-    FieldID,
-    TokenSplit,
-    UserClassification,
-    UserFieldMetadata,
-    UserMetadata,
-)
-from nucliadb_models.resource import FieldText, TextFieldData
-from nucliadb_models.text import TextFormat
-from nucliadb_sdk.entities import Entity
-from nucliadb_sdk.file import File
-from nucliadb_sdk.knowledgebox import KnowledgeBox
-from nucliadb_sdk.vectors import Vector
+import nucliadb_sdk
+from nucliadb_models.resource import KnowledgeBoxObj
+from nucliadb_models.search import ResourceProperties
 
 
-def test_create_resource(knowledgebox: KnowledgeBox):
-    assert knowledgebox.get("mykey1") is None
+def test_crud_resource(knowledgebox: KnowledgeBoxObj, sdk: nucliadb_sdk.NucliaSDK):
+    with pytest.raises(nucliadb_sdk.exceptions.NotFoundError):
+        sdk.get_resource_by_slug(kbid=knowledgebox.uuid, slug="mykey1")
 
-    resource_id = knowledgebox.create_resource(
-        key="mykey1",
-        binary=File(data=b"asd", filename="data"),
-        text="I'm Ramon",
-        labels=["labelset/positive"],
-        entities=[Entity(type="NAME", value="Ramon", positions=[(5, 9)])],
-        vectors=[Vector(value=[1.0, 0.2], vectorset="base")],
+    sdk.create_resource(
+        kbid=knowledgebox.uuid,
+        texts={"text": {"body": "I'm Ramon"}},
+        slug="mykey1",
+        files={
+            "file": {
+                "file": {
+                    "filename": "data",
+                    "payload": base64.b64encode(b"asd"),
+                }
+            }
+        },
+        usermetadata={
+            "classifications": [{"labelset": "labelset", "label": "positive"}]
+        },
+        fieldmetadata=[
+            {
+                "field": {
+                    "field": "text",
+                    "field_type": "text",
+                },
+                "token": [{"token": "Ramon", "klass": "NAME", "start": 5, "end": 9}],
+            }
+        ],
+        uservectors=[
+            {
+                "field": {
+                    "field": "text",
+                    "field_type": "text",
+                },
+                "vectors": {
+                    "base": {
+                        "vectors": {"vector": [1.0, 0.2]},
+                    }
+                },
+            }
+        ],
     )
-    resource2 = knowledgebox[resource_id]
-    assert (
-        resource2.data is not None
-        and resource2.data.texts is not None
-        and "text" in resource2.data.texts
+    resource = sdk.get_resource_by_slug(
+        kbid=knowledgebox.uuid,
+        slug="mykey1",
+        query_params={
+            "show": [ResourceProperties.BASIC.value, ResourceProperties.VALUES.value]
+        },
     )
-    assert (
-        resource2.data is not None
-        and resource2.data.files is not None
-        and "file" in resource2.data.files
-    )
+    assert resource.data is not None
+    assert resource.data.texts is not None
+    assert resource.data.texts["text"].value.body == "I'm Ramon"
+    assert resource.data.files is not None
+    assert resource.data.files["file"].value.file.filename == "data"
 
-    resource3 = knowledgebox["mykey1"]
-    assert resource3.id == resource2.id
-
-    assert len(knowledgebox) == 1
-
-    del knowledgebox["mykey1"]
-
-    assert len(knowledgebox) == 0
-
-
-def test_iter_resources(knowledgebox: KnowledgeBox):
-    assert knowledgebox.get("mykey1") is None
-
-    for i in range(50):
-        knowledgebox.create_resource(text="Test resource")
-
-    res = []
-    for resource in knowledgebox:  # type: ignore
-        res.append(resource)
-
-    assert len(res) == 50
-
-
-def test_create_resource_dict(knowledgebox: KnowledgeBox):
-    assert knowledgebox.get("mykey1") is None
-
-    resource_id = knowledgebox.create_resource(
-        key="mykey1",
-        binary=File(data=b"asd", filename="data"),
-        text="I'm Ramon",
-        labels=["labelset/positive"],
-        entities=[Entity(type="NAME", value="Ramon", positions=[(5, 9)])],
-        vectors={"base": [1.0, 2.0]},
-    )
-    resource2 = knowledgebox[resource_id]
-    assert (
-        resource2.data is not None
-        and resource2.data.texts is not None
-        and "text" in resource2.data.texts
-    )
-    assert (
-        resource2.data is not None
-        and resource2.data.files is not None
-        and "file" in resource2.data.files
+    sdk.update_resource(
+        kbid=knowledgebox.uuid,
+        rid=resource.id,
+        texts={"text": {"body": "I'm an updated Ramon"}},
     )
 
-    resource3 = knowledgebox["mykey1"]
-    assert resource3.id == resource2.id
-
-    assert len(knowledgebox) == 1
-
-    del knowledgebox["mykey1"]
-
-    assert len(knowledgebox) == 0
-
-
-@pytest.mark.asyncio
-async def test_create_resource_async(knowledgebox: KnowledgeBox):
-    assert await knowledgebox.async_get("mykey1") is None
-
-    resource_id = await knowledgebox.async_upload(
-        key="mykey1",
-        binary=File(data=b"asd", filename="data"),
-        text="asd",
-        labels=["labelset/positive"],
-        entities=[Entity(type="NAME", value="Ramon", positions=[(5, 9)])],
-        vectors=[Vector(value=[1.0, 0.2], vectorset="base")],
+    resource = sdk.get_resource_by_slug(
+        kbid=knowledgebox.uuid,
+        slug="mykey1",
+        query_params={
+            "show": [ResourceProperties.BASIC.value, ResourceProperties.VALUES.value]
+        },
     )
+    assert resource.data.texts["text"].value.body == "I'm an updated Ramon"
 
-    resource2 = await knowledgebox.async_get(resource_id)
-    assert (
-        resource2.data is not None
-        and resource2.data.texts is not None
-        and "text" in resource2.data.texts
-    )
-    assert (
-        resource2.data is not None
-        and resource2.data.files is not None
-        and "file" in resource2.data.files
-    )
+    sdk.delete_resource(kbid=knowledgebox.uuid, rid=resource.id)
 
-    resource3 = await knowledgebox.async_get("mykey1")
-    assert resource3.id == resource2.id
-
-    assert await knowledgebox.async_len() == 1
-
-    await knowledgebox.async_del("mykey1")
-
-    assert await knowledgebox.async_len() == 0
-
-
-def test_dict_resource(knowledgebox: KnowledgeBox):
-    assert knowledgebox.get("mykey1") is None
-
-    knowledgebox.new_vectorset("base", 2)
-
-    resource_id = knowledgebox.create_resource(
-        key="mykey1",
-        binary=File(data=b"asd", filename="data"),
-        text="I'm Ramon",
-        labels=["labelset/positive"],
-        entities=[Entity(type="NAME", value="Ramon", positions=[(5, 9)])],
-        vectors=[Vector(value=[1.0, 0.2], vectorset="base")],
-    )
-    resource2 = knowledgebox[resource_id]
-
-    knowledgebox["mykey2"] = resource2
-
-    assert len(knowledgebox) == 2
-
-    del knowledgebox["mykey1"]
-
-    assert len(knowledgebox) == 1
-
-    del knowledgebox["mykey2"]
-
-    assert len(knowledgebox) == 0
-
-
-def test_update_existing_resource(knowledgebox: KnowledgeBox):
-    assert knowledgebox.get("mykey1") is None
-
-    knowledgebox.new_vectorset("base", 2)
-
-    def _validate(res1, res2):
-        assert res1.id == res2.id
-        assert res1.title != res2.title
-        assert res1.summary != res2.summary
-        assert res1.data.texts["text"] != res2.data.texts["text"]
-        assert res1.usermetadata != res2.usermetadata
-        assert res1.fieldmetadata != res2.fieldmetadata
-
-        assert res2.title == "common man"
-        assert res2.summary == "I'm not Ramon"
-        assert res2.data.texts["text"] == TextFieldData(
-            value=FieldText(
-                body="Really, I'm not Ramon",
-                format=TextFormat.PLAIN,
-                md5="62ef6847d003b438c597cb82d70982d0",
-            ),
-            extracted=None,
-            error=None,
-        )
-        assert res2.usermetadata == UserMetadata(
-            classifications=[
-                UserClassification(
-                    labelset="labelset", label="negative", cancelled_by_user=False
-                )
-            ],
-            relations=[],
-        )
-        assert res2.fieldmetadata == [
-            UserFieldMetadata(
-                token=[
-                    TokenSplit(
-                        token="Ferran",
-                        klass="NAME",
-                        start=5,
-                        end=9,
-                        cancelled_by_user=False,
-                    )
-                ],
-                paragraphs=[],
-                field=FieldID(field_type=FieldID.FieldType.TEXT, field="text"),
-            )
-        ]
-
-    # Validate upload updates fields
-    resource_id = knowledgebox.create_resource(
-        key="mykey1",
-        binary=File(data=b"asd", filename="data"),
-        text="I'm Ramon",
-        labels=["labelset/positive"],
-        entities=[Entity(type="NAME", value="Ramon", positions=[(5, 9)])],
-        vectors=[Vector(value=[1.0, 0.2], vectorset="base")],
-    )
-    resource1 = knowledgebox[resource_id]
-
-    knowledgebox.update_resource(
-        resource1,
-        title="common man",
-        summary="I'm not Ramon",
-        text="Really, I'm not Ramon",
-        labels=["labelset/negative"],
-        entities=[Entity(type="NAME", value="Ferran", positions=[(5, 9)])],
-        vectors=[Vector(value=[1.0, 0.2], vectorset="base")],
-    )
-    resource2 = knowledgebox[resource_id]
-    _validate(resource1, resource2)
-
-    # Validate setattr updates fields
-    resource_id = knowledgebox.create_resource(
-        key="mykey2",
-        binary=File(data=b"asd", filename="data"),
-        text="I'm Ramon",
-        labels=["labelset/positive"],
-        entities=[Entity(type="NAME", value="Ramon", positions=[(5, 9)])],
-        vectors=[Vector(value=[1.0, 0.2], vectorset="base")],
-    )
-    resource1 = knowledgebox[resource_id]
-    resource1_updated = knowledgebox[resource_id]
-    resource1_updated.title = "common man"
-    resource1_updated.summary = "I'm not Ramon"
-    resource1_updated.data.texts["text"] = TextFieldData(  # type: ignore
-        value=FieldText(
-            body="Really, I'm not Ramon",
-            format=TextFormat.PLAIN,
-            md5="62ef6847d003b438c597cb82d70982d0",
-        ),
-        extracted=None,
-        error=None,
-    )
-    resource1_updated.usermetadata.classifications = [  # type: ignore
-        UserClassification(
-            labelset="labelset", label="negative", cancelled_by_user=False
-        )
-    ]
-    resource1_updated.fieldmetadata = [
-        UserFieldMetadata(
-            token=[
-                TokenSplit(
-                    token="Ferran",
-                    klass="NAME",
-                    start=5,
-                    end=9,
-                    cancelled_by_user=False,
-                )
-            ],
-            paragraphs=[],
-            field=FieldID(field_type=FieldID.FieldType.TEXT, field="text"),
-        )
-    ]
-    knowledgebox[resource_id] = resource1_updated
-    # pull again to validate
-    resource2 = knowledgebox[resource_id]
-    _validate(resource1, resource2)
+    with pytest.raises(nucliadb_sdk.exceptions.NotFoundError):
+        sdk.get_resource_by_slug(kbid=knowledgebox.uuid, slug="mykey1")

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_crud.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_crud.py
@@ -26,12 +26,12 @@ from nucliadb_models.resource import KnowledgeBoxObj
 from nucliadb_models.search import ResourceProperties
 
 
-def test_crud_resource(knowledgebox: KnowledgeBoxObj, sdk: nucliadb_sdk.NucliaSDK):
+def test_crud_resource(kb: KnowledgeBoxObj, sdk: nucliadb_sdk.NucliaSDK):
     with pytest.raises(nucliadb_sdk.exceptions.NotFoundError):
-        sdk.get_resource_by_slug(kbid=knowledgebox.uuid, slug="mykey1")
+        sdk.get_resource_by_slug(kbid=kb.uuid, slug="mykey1")
 
     sdk.create_resource(
-        kbid=knowledgebox.uuid,
+        kbid=kb.uuid,
         texts={"text": {"body": "I'm Ramon"}},
         slug="mykey1",
         files={
@@ -69,7 +69,7 @@ def test_crud_resource(knowledgebox: KnowledgeBoxObj, sdk: nucliadb_sdk.NucliaSD
         ],
     )
     resource = sdk.get_resource_by_slug(
-        kbid=knowledgebox.uuid,
+        kbid=kb.uuid,
         slug="mykey1",
         query_params={
             "show": [ResourceProperties.BASIC.value, ResourceProperties.VALUES.value]
@@ -82,13 +82,13 @@ def test_crud_resource(knowledgebox: KnowledgeBoxObj, sdk: nucliadb_sdk.NucliaSD
     assert resource.data.files["file"].value.file.filename == "data"
 
     sdk.update_resource(
-        kbid=knowledgebox.uuid,
+        kbid=kb.uuid,
         rid=resource.id,
         texts={"text": {"body": "I'm an updated Ramon"}},
     )
 
     resource = sdk.get_resource_by_slug(
-        kbid=knowledgebox.uuid,
+        kbid=kb.uuid,
         slug="mykey1",
         query_params={
             "show": [ResourceProperties.BASIC.value, ResourceProperties.VALUES.value]
@@ -96,7 +96,7 @@ def test_crud_resource(knowledgebox: KnowledgeBoxObj, sdk: nucliadb_sdk.NucliaSD
     )
     assert resource.data.texts["text"].value.body == "I'm an updated Ramon"
 
-    sdk.delete_resource(kbid=knowledgebox.uuid, rid=resource.id)
+    sdk.delete_resource(kbid=kb.uuid, rid=resource.id)
 
     with pytest.raises(nucliadb_sdk.exceptions.NotFoundError):
-        sdk.get_resource_by_slug(kbid=knowledgebox.uuid, slug="mykey1")
+        sdk.get_resource_by_slug(kbid=kb.uuid, slug="mykey1")

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_find.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_find.py
@@ -16,19 +16,16 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-import pytest
-
-from nucliadb_sdk.knowledgebox import KnowledgeBox
-
-
-def test_find_resource(docs_fixture: KnowledgeBox):
-    resources = docs_fixture.find(text="love")
-    assert resources.total == 10
-    assert len([x for x in resources]) == 10
+import nucliadb_sdk
+from nucliadb_models.search import KnowledgeboxFindResults
 
 
-@pytest.mark.asyncio
-async def test_find_async_resource(docs_fixture: KnowledgeBox):
-    resources = await docs_fixture.async_find(text="love")
-    assert resources.total == 10
-    assert len([x for x in resources]) == 10
+def test_find_resource(docs_dataset, sdk: nucliadb_sdk.NucliaSDK):
+    results: KnowledgeboxFindResults = sdk.find(kbid=docs_dataset, query="love")
+    assert results.total == 10
+    paragraphs = 0
+    for res in results.resources.values():
+        for field in res.fields.values():
+            paragraphs += len(field.paragraphs)
+
+    assert paragraphs == 10

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_kb.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_kb.py
@@ -18,12 +18,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+import nucliadb_sdk
+from nucliadb_models.resource import KnowledgeBoxObj
 
-from nucliadb_sdk.utils import KnowledgeBoxAlreadyExists, create_knowledge_box
 
+def test_create_kb(sdk: nucliadb_sdk.NucliaSDK):
+    kb: KnowledgeBoxObj = sdk.create_knowledge_box(slug="hola")
+    assert sdk.get_knowledge_box(kbid=kb.uuid) is not None
+    assert sdk.get_knowledge_box_by_slug(slug="hola") is not None
 
-def test_create_kb(nucliadb: str):
-    kb = create_knowledge_box(slug="hola", nucliadb_base_url=nucliadb)
-    assert kb is not None
-    with pytest.raises(KnowledgeBoxAlreadyExists):
-        create_knowledge_box(slug="hola", nucliadb_base_url=nucliadb)
+    with pytest.raises(nucliadb_sdk.exceptions.ConflictError):
+        sdk.create_knowledge_box(slug="hola")

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_kb.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_kb.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+
 import nucliadb_sdk
 from nucliadb_models.resource import KnowledgeBoxObj
 

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_vectors.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_vectors.py
@@ -16,18 +16,20 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-from nucliadb_sdk.utils import create_knowledge_box
+import nucliadb_sdk
 
 
-def test_similarity(nucliadb: str):
+def test_similarity(sdk: nucliadb_sdk.NucliaSDK):
     # Create a KB with dot similarity
-    kb = create_knowledge_box(slug="dot", similarity="dot", nucliadb_base_url=nucliadb)
+    kb = sdk.create_knowledge_box(slug="dot", similarity="dot")
     assert kb is not None
 
     # Add vectorsets with different similarities
-    kb.new_vectorset("cosine", dimension=728, similarity="cosine")
-    kb.new_vectorset("dot", dimension=728, similarity="dot")
+    sdk.create_vectorset(
+        kbid=kb.uuid, vectorset="cosine", dimension=728, similarity="cosine"
+    )
+    sdk.create_vectorset(kbid=kb.uuid, vectorset="dot", dimension=728, similarity="dot")
 
-    vectorsets = kb.list_vectorset()
+    vectorsets = sdk.list_vectorsets(kbid=kb.uuid)
     assert vectorsets.vectorsets["dot"].similarity.value == "dot"
     assert vectorsets.vectorsets["cosine"].similarity.value == "cosine"

--- a/nucliadb_sdk/nucliadb_sdk/v2/__init__.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/__init__.py
@@ -1,4 +1,21 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 from .sdk import NucliaSDK, Region
-
 
 __all__ = ("NucliaSDK", "Region")

--- a/nucliadb_sdk/nucliadb_sdk/v2/__init__.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/__init__.py
@@ -1,0 +1,4 @@
+from .sdk import NucliaSDK, Region
+
+
+__all__ = ("NucliaSDK", "Region")

--- a/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
@@ -1,3 +1,21 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 class ClientError(Exception):
     pass
 

--- a/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
@@ -1,6 +1,22 @@
-class NotFoundError(Exception):
+class ClientError(Exception):
     pass
 
 
-class UnknownError(Exception):
+class NotFoundError(ClientError):
+    pass
+
+
+class AuthError(ClientError):
+    pass
+
+
+class RateLimitError(ClientError):
+    pass
+
+
+class ConflictError(ClientError):
+    pass
+
+
+class UnknownError(ClientError):
     pass

--- a/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
@@ -1,0 +1,6 @@
+class NotFoundError(Exception):
+    pass
+
+
+class UnknownError(Exception):
+    pass

--- a/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/exceptions.py
@@ -28,6 +28,10 @@ class AuthError(ClientError):
     pass
 
 
+class AccountLimitError(ClientError):
+    pass
+
+
 class RateLimitError(ClientError):
     pass
 

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -1,0 +1,119 @@
+import enum
+from typing import Any, Optional, Type, Union
+
+import httpx
+from pydantic import BaseModel
+
+from nucliadb_models.resource import Resource, ResourceList
+from nucliadb_sdk.v2 import exceptions
+
+
+class Region(enum.Enum):
+    EUROPE1 = "europe-1"
+    ON_PREM = "on-prem"
+
+
+def _request_builder(
+    path_template: str,
+    method: str,
+    path_params: dict[str, str],
+    request_type: Optional[Type[BaseModel]],
+    response_type: Optional[Type[BaseModel]],
+):
+    def _func(self: "NucliaSDK", content: Optional[Any] = None, **kwargs):
+        path_data = {}
+        for param in path_params:
+            if param not in kwargs:
+                raise TypeError(f"Missing required parameter {param}")
+            path_data[param] = kwargs.pop(param)
+
+        path = path_template.format(**path_data)
+        if content is None and request_type is not None:
+            raise TypeError("Missing required request body")
+
+        if request_type is not None:
+            if not isinstance(content, request_type):
+                raise TypeError(f"Expected {request_type}, got {type(content)}")
+            kwargs["data"] = content.json()
+
+        resp_data = self._request(path, method, **kwargs)
+
+        if response_type is not None:
+            return response_type.parse_raw(resp_data)
+        else:
+            return resp_data
+
+    return _func
+
+
+class NucliaSDK:
+    """
+    Example usage:
+
+    from nucliadb_sdk.v2.sdk import *
+    sdk = NucliaSDK(region=Region.EUROPE1, api_key="api-key")
+    sdk.list_resources(kbid='70a2530a-5863-41ec-b42b-bfe795bef2eb')
+    """
+
+    def __init__(self, *, region: Region, api_key: str, url: Optional[str] = None):
+        self.region = region
+        self.api_key = api_key
+        if region == Region.ON_PREM:
+            if url is None:
+                raise ValueError("url must be provided for on-prem")
+            self.base_url = url
+        else:
+            self.base_url = f"https://{region.value}.nuclia.cloud/api"
+
+        self.session = httpx.Client(
+            headers={"X-STF-SERVICEACCOUNT": f"Bearer {api_key}"},
+            base_url=self.base_url,
+        )
+
+    def _request(
+        self,
+        path,
+        method: str,
+        data: Optional[Union[str, bytes]] = None,
+        query_params: Optional[dict[str, str]] = None,
+    ):
+        url = f"{self.base_url}{path}"
+        opts = {}
+        if data is not None:
+            opts["data"] = data
+        if query_params is not None:
+            opts["params"] = query_params
+        response: httpx.Response = getattr(self.session, method.lower())(url, **opts)
+
+        if response.status_code == 200:
+            return response.content
+        elif response.status_code == 404:
+            raise exceptions.NotFoundError(response.text)
+        else:
+            raise exceptions.UnknownError(
+                f"Status code {response.status_code}: {response.text}"
+            )
+
+    get_resource_by_slug = _request_builder(
+        "/v1/kb/{kbid}/slug/{rslug}",
+        "GET",
+        ("kbid", "slug"),
+        None,
+        Resource,
+    )
+
+    get_resource_by_id = _request_builder(
+        "/v1/kb/{kbid}/resource/{rid}",
+        "GET",
+        ("kbid", "rid"),
+        None,
+        Resource,
+    )
+
+    list_resources = _request_builder(
+        "/v1/kb/{kbid}/resources",
+        "GET",
+        ("kbid",),
+        None,
+        ResourceList,
+    )

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -6,6 +6,24 @@ from pydantic import BaseModel
 
 from nucliadb_models.resource import Resource, ResourceList
 from nucliadb_sdk.v2 import exceptions
+from nucliadb_models.search import (
+    FindRequest,
+    KnowledgeboxFindResults,
+    SearchRequest,
+    KnowledgeboxSearchResults,
+)
+
+from nucliadb_models.resource import (
+    KnowledgeBoxConfig,
+    KnowledgeBoxObj,
+    KnowledgeBoxList,
+)
+from nucliadb_models.writer import (
+    CreateResourcePayload,
+    ResourceCreated,
+    ResourceUpdated,
+    UpdateResourcePayload,
+)
 
 
 class Region(enum.Enum):
@@ -28,15 +46,26 @@ def _request_builder(
             path_data[param] = kwargs.pop(param)
 
         path = path_template.format(**path_data)
-        if content is None and request_type is not None:
-            raise TypeError("Missing required request body")
-
+        data = None
         if request_type is not None:
-            if not isinstance(content, request_type):
-                raise TypeError(f"Expected {request_type}, got {type(content)}")
-            kwargs["data"] = content.json()
+            if content is not None:
+                if not isinstance(content, request_type):
+                    raise TypeError(f"Expected {request_type}, got {type(content)}")
+                else:
+                    data = content.json()
+            else:
+                # pull properties out of kwargs now
+                content_data = {}
+                for key in list(kwargs.keys()):
+                    if key in request_type.__fields__:
+                        content_data[key] = kwargs.pop(key)
+                data = request_type.parse_obj(content_data).json()
 
-        resp_data = self._request(path, method, **kwargs)
+        query_params = kwargs.pop("query_params", None)
+        if len(kwargs) > 0:
+            raise TypeError(f"Invalid arguments provided: {kwargs}")
+
+        resp_data = self._request(path, method, data=data, query_params=query_params)
 
         if response_type is not None:
             return response_type.parse_raw(resp_data)
@@ -55,20 +84,32 @@ class NucliaSDK:
     sdk.list_resources(kbid='70a2530a-5863-41ec-b42b-bfe795bef2eb')
     """
 
-    def __init__(self, *, region: Region, api_key: str, url: Optional[str] = None):
+    def __init__(
+        self,
+        *,
+        region: Region = Region.EUROPE1,
+        api_key: Optional[str] = None,
+        url: Optional[str] = None,
+        headers: Optional[dict[str, str]] = None,
+    ):
         self.region = region
         self.api_key = api_key
+        headers = headers or {}
         if region == Region.ON_PREM:
             if url is None:
                 raise ValueError("url must be provided for on-prem")
-            self.base_url = url
+            self.base_url = url.rstrip("/")
+            # By default, on prem should utilize all headers available
+            # For custom auth schemes, the user will need to provide custom
+            # auth headers
+            headers["X-NUCLIADB-ROLES"] = "MANAGER;WRITER;READER"
         else:
+            if api_key is None:
+                raise ValueError("api_key must be provided for cloud sdk usage")
             self.base_url = f"https://{region.value}.nuclia.cloud/api"
+            headers["X-STF-SERVICEACCOUNT"] = f"Bearer {api_key}"
 
-        self.session = httpx.Client(
-            headers={"X-STF-SERVICEACCOUNT": f"Bearer {api_key}"},
-            base_url=self.base_url,
-        )
+        self.session = httpx.Client(headers=headers, base_url=self.base_url)
 
     def _request(
         self,
@@ -85,35 +126,87 @@ class NucliaSDK:
             opts["params"] = query_params
         response: httpx.Response = getattr(self.session, method.lower())(url, **opts)
 
-        if response.status_code == 200:
+        if response.status_code < 300:
             return response.content
+        elif response.status_code in (401, 403):
+            raise exceptions.AuthError(
+                f"Auth error {response.status_code}: {response.text}"
+            )
+        elif response.status_code == 429:
+            raise exceptions.RateLimitError(response.text)
+        elif response.status_code == 419:
+            raise exceptions.ConflictError(response.text)
         elif response.status_code == 404:
-            raise exceptions.NotFoundError(response.text)
+            raise exceptions.NotFoundError(
+                f"Resource not found at url {url}: {response.text}"
+            )
         else:
             raise exceptions.UnknownError(
-                f"Status code {response.status_code}: {response.text}"
+                f"Unknown error connecting to API: {response.status_code}: {response.text}"
             )
 
+    # Knowledge Box Endpoints
+    create_knowledge_box = _request_builder(
+        "/v1/kbs", "POST", (), KnowledgeBoxConfig, KnowledgeBoxObj
+    )
+
+    delete_knowledge_box = _request_builder(
+        "/v1/kb/{kbid}", "DELETE", ("kbid",), None, KnowledgeBoxObj
+    )
+
+    get_knowledge_box = _request_builder(
+        "/v1/kb/{kbid}", "GET", ("kbid",), None, KnowledgeBoxObj
+    )
+    get_knowledge_box_by_slug = _request_builder(
+        "/v1/kb/s/{slug}", "GET", ("slug",), None, KnowledgeBoxObj
+    )
+
+    list_knowledge_boxes = _request_builder(
+        "/v1/kbs", "GET", (), None, KnowledgeBoxList
+    )
+
+    # Resource Endpoints
+    create_resource = _request_builder(
+        "/v1/kb/{kbid}/resources",
+        "POST",
+        ("kbid",),
+        CreateResourcePayload,
+        ResourceCreated,
+    )
+
+    update_resource = _request_builder(
+        "/v1/kb/{kbid}/resource/{rid}",
+        "PATCH",
+        ("kbid", "rid"),
+        UpdateResourcePayload,
+        ResourceUpdated,
+    )
+
+    delete_resource = _request_builder(
+        "/v1/kb/{kbid}/resource/{rid}", "DELETE", ("kbid", "rid"), None, None
+    )
+
     get_resource_by_slug = _request_builder(
-        "/v1/kb/{kbid}/slug/{rslug}",
-        "GET",
-        ("kbid", "slug"),
-        None,
-        Resource,
+        "/v1/kb/{kbid}/slug/{rslug}", "GET", ("kbid", "slug"), None, Resource
     )
 
     get_resource_by_id = _request_builder(
-        "/v1/kb/{kbid}/resource/{rid}",
-        "GET",
-        ("kbid", "rid"),
-        None,
-        Resource,
+        "/v1/kb/{kbid}/resource/{rid}", "GET", ("kbid", "rid"), None, Resource
     )
 
     list_resources = _request_builder(
-        "/v1/kb/{kbid}/resources",
-        "GET",
+        "/v1/kb/{kbid}/resources", "GET", ("kbid",), None, ResourceList
+    )
+
+    # Search / Find Endpoints
+    find = _request_builder(
+        "/v1/kb/{kbid}/find", "POST", ("kbid",), FindRequest, KnowledgeboxFindResults
+    )
+
+    search = _request_builder(
+        "/v1/kb/{kbid}/search",
+        "POST",
         ("kbid",),
-        None,
-        ResourceList,
+        SearchRequest,
+        KnowledgeboxSearchResults,
     )

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -24,6 +24,12 @@ from typing import Any, Callable, Optional, Type, Union
 import httpx
 from pydantic import BaseModel
 
+from nucliadb_models.entities import (
+    CreateEntitiesGroupPayload,
+    EntitiesGroup,
+    UpdateEntitiesGroupPayload,
+)
+from nucliadb_models.labels import KnowledgeBoxLabels, LabelSet
 from nucliadb_models.resource import (
     KnowledgeBoxConfig,
     KnowledgeBoxList,
@@ -189,6 +195,10 @@ class NucliaSDK:
             raise exceptions.AuthError(
                 f"Auth error {response.status_code}: {response.text}"
             )
+        elif response.status_code == 402:
+            raise exceptions.AccountLimitError(
+                f"Account limits exceeded error {response.status_code}: {response.text}"
+            )
         elif response.status_code == 429:
             raise exceptions.RateLimitError(response.text)
         elif response.status_code == 419:
@@ -206,18 +216,15 @@ class NucliaSDK:
     create_knowledge_box = _request_builder(
         "/v1/kbs", "POST", (), KnowledgeBoxConfig, KnowledgeBoxObj
     )
-
     delete_knowledge_box = _request_builder(
         "/v1/kb/{kbid}", "DELETE", ("kbid",), None, KnowledgeBoxObj
     )
-
     get_knowledge_box = _request_builder(
         "/v1/kb/{kbid}", "GET", ("kbid",), None, KnowledgeBoxObj
     )
     get_knowledge_box_by_slug = _request_builder(
         "/v1/kb/s/{slug}", "GET", ("slug",), None, KnowledgeBoxObj
     )
-
     list_knowledge_boxes = _request_builder(
         "/v1/kbs", "GET", (), None, KnowledgeBoxList
     )
@@ -230,7 +237,6 @@ class NucliaSDK:
         CreateResourcePayload,
         ResourceCreated,
     )
-
     update_resource = _request_builder(
         "/v1/kb/{kbid}/resource/{rid}",
         "PATCH",
@@ -238,21 +244,67 @@ class NucliaSDK:
         UpdateResourcePayload,
         ResourceUpdated,
     )
-
     delete_resource = _request_builder(
         "/v1/kb/{kbid}/resource/{rid}", "DELETE", ("kbid", "rid"), None, None
     )
-
     get_resource_by_slug = _request_builder(
         "/v1/kb/{kbid}/slug/{slug}", "GET", ("kbid", "slug"), None, Resource
     )
-
     get_resource_by_id = _request_builder(
         "/v1/kb/{kbid}/resource/{rid}", "GET", ("kbid", "rid"), None, Resource
     )
-
     list_resources = _request_builder(
         "/v1/kb/{kbid}/resources", "GET", ("kbid",), None, ResourceList
+    )
+
+    # Labels
+    set_labelset = _request_builder(
+        "/v1/kb/{kbid}/labelset/{labelset}",
+        "POST",
+        ("kbid", "labelset"),
+        LabelSet,
+        None,
+    )
+    delete_labelset = _request_builder(
+        "/v1/kb/{kbid}/labelset/{labelset}", "DELETE", ("kbid", "labelset"), None, None
+    )
+    get_labelsets = _request_builder(
+        "/v1/kb/{kbid}/labelset", "GET", ("kbid", "labelset"), None, KnowledgeBoxLabels
+    )
+    get_labelset = _request_builder(
+        "/v1/kb/{kbid}/labelset/{labelset}", "GET", ("kbid", "labelset"), None, LabelSet
+    )
+
+    # Entity Groups
+    create_entitygroup = _request_builder(
+        "/v1/kb/{kbid}/entitiesgroups",
+        "POST",
+        ("kbid",),
+        CreateEntitiesGroupPayload,
+        None,
+    )
+    update_entitygroup = _request_builder(
+        "/v1/kb/{kbid}/entitiesgroup/{group}",
+        "PATCH",
+        ("kbid", "group"),
+        UpdateEntitiesGroupPayload,
+        None,
+    )
+    set_entitygroup_entities = _request_builder(
+        "/v1/kb/{kbid}/entitiesgroup/{group}",
+        "POST",
+        ("kbid", "group"),
+        EntitiesGroup,
+        None,
+    )
+    delete_entitygroup = _request_builder(
+        "/v1/kb/{kbid}/labelset/{labelset}", "DELETE", ("kbid", "labelset"), None, None
+    )
+    get_entitygroups = _request_builder(
+        "/v1/kb/{kbid}/labelset", "GET", ("kbid", "labelset"), None, KnowledgeBoxLabels
+    )
+    get_entitygroup = _request_builder(
+        "/v1/kb/{kbid}/labelset/{labelset}", "GET", ("kbid", "labelset"), None, LabelSet
     )
 
     # Vectorsets
@@ -263,11 +315,9 @@ class NucliaSDK:
         VectorSet,
         None,
     )
-
     delete_vectorset = _request_builder(
         "/v1/kb/{kbid}/vectorset/{vectorset}", "POST", ("kbid", "vectorset"), None, None
     )
-
     list_vectorsets = _request_builder(
         "/v1/kb/{kbid}/vectorsets", "GET", ("kbid",), None, VectorSets
     )
@@ -276,7 +326,6 @@ class NucliaSDK:
     find = _request_builder(
         "/v1/kb/{kbid}/find", "POST", ("kbid",), FindRequest, KnowledgeboxFindResults
     )
-
     search = _request_builder(
         "/v1/kb/{kbid}/search",
         "POST",
@@ -284,7 +333,6 @@ class NucliaSDK:
         SearchRequest,
         KnowledgeboxSearchResults,
     )
-
     chat = _request_builder(
         "/v1/kb/{kbid}/chat", "POST", ("kbid",), ChatRequest, chat_response_parser
     )

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -122,7 +122,7 @@ def _request_builder(
         resp = self._request(path, method, data=data, query_params=query_params)
 
         if response_type is not None:
-            if issubclass(response_type, BaseModel):  # type: ignore
+            if isinstance(response_type, type) and issubclass(response_type, BaseModel):
                 return response_type.parse_raw(resp.content)  # type: ignore
             else:
                 return response_type(resp)  # type: ignore


### PR DESCRIPTION
First step for v2 SDK implementation. This version focussed on HTTP API consistency and verbosity over facades over the APIs. Longer term, we can think about helpers to make some of the endpoint usage less verbose(however, helpers should be at argument level instead of sdk API level)

This implementation focuses on:
- automagical, make it easier for us to maintain, utilize our typing -- we don't want to have to deal with too much work around maintaining an SDK
- being consistent with API (if you read one, you can understand the other)
- lightly deprecates only API and updates all tests to use new API instead of old one
- DOES NOT attempt to maintain tests for both APIs
- consider this alpha version of API

What is NOT done:
- put deprecation warnings on old APIs
- type support -- this is more difficult that you would expect
- helpers to make the endpoints less verbose -- on purpose, let's wait here before we design something that we regret
- all the endpoints are NOT currently supported. If we like this approach, let's add support for everything.

Bottom line, I think this gives us a reasonable place to start. The end result is verbose but at least it is aligned with our http api. If our HTTP API is too verbose and difficult to understand, I don't think we should try and have the sdk make up for it.