### PR TITLE
Various chitchat monitor error fixes

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -506,6 +506,15 @@ async def chitchat_update_node(members: List[ClusterMember]) -> None:
                 destroyed_node_ids.append(key)
                 logger.info(f"{key}/{node.type} remove {node.address}")
                 await Node.destroy(key)
+    try:
+        if len(destroyed_node_ids) > 1:
+            raise Exception(
+                f"{len(destroyed_node_ids)} nodes are down simultaneously. This should never happen!"
+            )
+    except Exception as e:
+        logger.error(str(e))
+        errors.capture_exception(e)
+
     update_node_metrics(NODES, destroyed_node_ids)
 
 

--- a/nucliadb_utils/nucliadb_utils/fastapi/run.py
+++ b/nucliadb_utils/nucliadb_utils/fastapi/run.py
@@ -43,7 +43,7 @@ def metrics_app() -> tuple[Server, Config]:
         application_metrics,
         host=running_settings.metrics_host,
         port=running_settings.metrics_port,
-        debug=running_settings.debug,
+        debug=False,
         loop=loop_setup,
         http="auto",
         reload=False,
@@ -54,6 +54,7 @@ def metrics_app() -> tuple[Server, Config]:
         backlog=2047,
         limit_max_requests=None,
         timeout_keep_alive=5,
+        access_log=False,
     )
     metrics_server = Server(config=metrics_config)
     return metrics_server, metrics_config


### PR DESCRIPTION
### Description
- Handles BrokenPipeError exceptions
- Properly closes connections on disconnects
- Improved logging

Additionally:
- Disable access logs for nucliadb_utils's metrics server

### How was this PR tested?
Existing integration tests cover this
