### PR TITLE
Ingest Updates

### DIFF
--- a/.github/workflows/nucliadb_dataset.yml
+++ b/.github/workflows/nucliadb_dataset.yml
@@ -26,10 +26,10 @@ jobs:
           cache: "pip"
 
       - name: Install package
-        run: make -C nucliadb_client/ install-dev
+        run: make -C nucliadb_dataset/ install-dev
 
       - name: Run pre-checks
-        run: make -C nucliadb_client/ lint
+        run: make -C nucliadb_dataset/ lint
 
   # Job to run tests
   tests:
@@ -51,7 +51,7 @@ jobs:
           cache: "pip"
 
       - name: Install the package
-        run: make -C nucliadb_client/ install-dev
+        run: make -C nucliadb_dataset/ install-dev
 
       - uses: dorny/paths-filter@v2
         id: filter
@@ -72,7 +72,7 @@ jobs:
         run: |
           docker build -t nuclia/nucliadb:latest -f Dockerfile .
       - name: Run tests
-        run: make -C nucliadb_client/ test
+        run: make -C nucliadb_dataset/ test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingest-processed-consumer
+  labels:
+    app: ingest-processed-consumer
+    version: "{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.ingest_processed_consumer_replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: ingest-processed-consumer
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
+  template:
+    metadata:
+      name: ingest-processed-consumer
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "{{.Values.serving.metricsPort }}"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
+        # do not have access to dependency chart cm this component references
+        checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+      labels:
+        app: ingest-processed-consumer
+        version: "{{ .Chart.Version | replace "+" "_" }}"
+        chart: "{{ .Chart.Name }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: ingest-processed-consumer
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.serving.grpc }}"]
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.serving.grpc }}"]
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        command: [
+          "nucliadb-ingest-processed-consumer"
+        ]
+        envFrom:
+        - configMapRef:
+            name: nucliadb-config
+        - configMapRef:
+            name: {{ .Release.Name }}-config
+        env:
+          - name: VERSION
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['version']
+        {{- range $key, $value := .Values.env }}
+          - name: "{{ $key }}"
+            value: {{ tpl $value $ | toJson }}
+        {{- end }}
+        ports:
+        - name: grpc-ingest
+          containerPort: {{ .Values.serving.grpc }}
+        - name: metrics
+          containerPort: {{ .Values.serving.metricsPort }}
+        resources:
+{{ toYaml .Values.ingest_processed_consumer_resources | indent 10 }}
+{{- if .Values.nats.secretName }}
+        volumeMounts:
+          - name: nats-creds
+            readOnly: true
+            mountPath: /appsecrets
+{{- end }}
+{{- if .Values.nats.regionalSecretName }}
+          - name: regional-nats-creds
+            readOnly: true
+            mountPath: /regioncreds
+{{- end }}
+      - name: cluster-manager
+        image: "{{ .Values.containerRegistry }}/{{ .Values.image_other }}"
+        imagePullPolicy: {{ .Values.imageOtherPullPolicy }}
+        command: ["/entrypoint.sh"]
+        args: ["/nucliadb_cluster/cluster_manager"]
+        envFrom:
+        - configMapRef:
+            name: nucliadb-config
+        - configMapRef:
+            name: {{ .Release.Name }}-config
+        ports:
+        - name: chitchat
+          containerPort: {{ .Values.chitchat.node.chitchat_port }}
+          protocol: UDP
+{{- if .Values.tracing.enabled }}
+      - name: jaeger-agent
+        image: jaegertracing/jaeger-agent:{{ .Values.tracing.jaegerAgentTag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 5775
+            name: zk-compact-trft
+            protocol: UDP
+          - containerPort: 5778
+            name: config-rest
+            protocol: TCP
+          - containerPort: 6831
+            name: jg-compact-trft
+            protocol: UDP
+          - containerPort: 6832
+            name: jg-binary-trft
+            protocol: UDP
+          - containerPort: 14271
+            name: admin-http
+            protocol: TCP
+        args:
+          - --reporter.grpc.host-port=dns:///{{ .Values.tracing.jaegerCollectorHost }}:{{ .Values.tracing.jaegerCollectorGrpcPort }}
+          - --reporter.type=grpc
+{{- end }}
+{{- if .Values.nats.secretName }}
+      volumes:
+      - name: nats-creds
+        secret:
+          secretName: {{ .Values.nats.secretName }}
+{{- end }}
+{{- if .Values.nats.regionalSecretName }}
+      - name: regional-nats-creds
+        secret:
+          secretName: {{ .Values.nats.regionalSecretName }}
+{{- end }}

--- a/charts/nucliadb_ingest/templates/ingest-processed-consumer.hpa.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-processed-consumer.hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ingest-processed-consumer
+  labels:
+    app: ingest-processed-consumer
+    version: "{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ingest-processed-consumer
+  minReplicas: {{.Values.ingest_orm_grpc_autoscaling.minReplicas}}
+  maxReplicas: {{.Values.ingest_orm_grpc_autoscaling.maxReplicas}}
+  metrics: {{- toYaml .Values.ingest_processed_consumer_autoscaling.metrics | nindent 4}}

--- a/charts/nucliadb_ingest/templates/ingest-processed-consumer.sm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-processed-consumer.sm.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ingest-processed-consumer
+  labels:
+    app: ingest-processed-consumer
+    version: "{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  namespaceSelector:
+    matchNames:
+    - "{{ .Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: ingest-processed-consumer
+  endpoints:
+  - targetPort: {{ .Values.serving.metricsPort }}
+    interval: 10s
+    path: /metrics
+{{- end }}

--- a/charts/nucliadb_ingest/templates/ingest.cm.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.cm.yaml
@@ -11,14 +11,13 @@ metadata:
 data:
   GRPC_PORT: {{ .Values.serving.grpc | quote }}
   METRICS_PORT: {{ .Values.serving.metricsPort | quote }}
-  PULL_TIME: {{ .Values.config.pull_time | quote }}
+  PULL_TIME_ERROR_BACKOFF: {{ .Values.config.pull_time_error_backoff | quote }}
   NODE_REPLICAS: {{ .Values.config.node_replicas | quote }}
 {{- if .Values.debug }}
   LOG_LEVEL: "DEBUG"
 {{- end }}
   SENTRY_URL: {{ .Values.running.sentry_url }}
 
-  INDEX_JETSTREAM_TARGET: {{ .Values.indexing.index_jetstream_target }}
   INDEX_JETSTREAM_SERVERS: {{ toJson .Values.indexing.index_jetstream_servers | quote }}
   INDEX_JETSTREAM_AUTH:  {{ .Values.indexing.index_jetstream_auth }}
 

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -22,7 +22,7 @@ env:
 
 # Kubernetes settings
 config:
-  pull_time: 100
+  pull_time_error_backoff: 100
   node_replicas: 2
 
 affinity: {}
@@ -76,7 +76,6 @@ indexing:
   index_jetstream_auth:
   index_jetstream_servers:
     - nats1
-  index_jetstream_target: "node.{node}"
 
 tracing:
   enabled: false
@@ -91,6 +90,20 @@ ingest_orm_grpc_replicaCount: 2
 ingest_orm_grpc_autoscaling:
   minReplicas: 1
   maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+
+# ingest-processed-consumer settings
+ingest_processed_consumer_resources: {}
+ingest_processed_consumer_replicaCount: 2
+ingest_processed_consumer_autoscaling:
+  minReplicas: 1
+  maxReplicas: 5
   metrics:
     - type: Resource
       resource:

--- a/charts/nucliadb_node/templates/node.cm.yaml
+++ b/charts/nucliadb_node/templates/node.cm.yaml
@@ -32,9 +32,6 @@ data:
 
   INDEX_JETSTREAM_AUTH: {{ .Values.indexing.index_jetstream_auth }}
   INDEX_JETSTREAM_SERVERS: {{ toJson .Values.indexing.index_jetstream_servers | quote }}
-  INDEX_JETSTREAM_TARGET: {{ .Values.indexing.index_jetstream_target }}
-  INDEX_JETSTREAM_GROUP: {{ .Values.indexing.index_jetstream_group }}
-  INDEX_JETSTREAM_STREAM: {{ .Values.indexing.index_jetstream_stream }}
 
   JAEGER_ENABLED: {{ .Values.tracing.enabled | quote }}
 

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -87,6 +87,3 @@ indexing:
   index_jetstream_auth:
   index_jetstream_servers:
     - nats1
-  index_jetstream_target: "node.{node}"
-  index_jetstream_group: "nucliadb-{partition}"
-  index_jetstream_stream: "nucliadb"

--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -66,9 +66,6 @@ data:
   CACHE_PUBSUB_CHANNEL: {{ .Values.cache.cache_pubsub_channel }}
   TRANSACTION_JETSTREAM_AUTH: {{ .Values.transaction.transaction_jetstream_auth }}
   TRANSACTION_JETSTREAM_SERVERS: {{ toJson .Values.transaction.transaction_jetstream_servers | quote }}
-  TRANSACTION_JETSTREAM_TARGET: {{ .Values.transaction.transaction_jetstream_target }}
-  TRANSACTION_JETSTREAM_GROUP: {{ .Values.transaction.transaction_jetstream_group }}
-  TRANSACTION_JETSTREAM_STREAM: {{ .Values.transaction.transaction_jetstream_stream }}
   DRIVER: {{ .Values.maindb.driver }}
 
 {{- if eq .Values.maindb.driver "redis" }}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -56,9 +56,6 @@ transaction:
   transaction_jetstream_auth:
   transaction_jetstream_servers:
     - nats1
-  transaction_jetstream_target: "ndb.consumer.{partition}"
-  transaction_jetstream_group: "nucliadb-{partition}"
-  transaction_jetstream_stream: "nucliadb"
 
 cache:
   cache_pubsub_nats_url:

--- a/nucliadb/nucliadb/config.py
+++ b/nucliadb/nucliadb/config.py
@@ -117,9 +117,8 @@ def config_nucliadb(nucliadb_args: Settings):
 
     if nucliadb_args.nua_api_key:
         nuclia_settings.nuclia_service_account = nucliadb_args.nua_api_key
-        ingest_settings.pull_time = 60
     else:
-        ingest_settings.pull_time = 0
+        ingest_settings.disable_pull_worker = True
         nuclia_settings.dummy_processing = True
         nuclia_settings.dummy_predict = True
 

--- a/nucliadb/nucliadb/ingest/consumer/consumer.py
+++ b/nucliadb/nucliadb/ingest/consumer/consumer.py
@@ -1,0 +1,260 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import asyncio
+import logging
+import time
+from typing import Optional
+
+import nats
+import nats.js.api
+from nats.aio.client import Msg
+from nucliadb_protos.writer_pb2 import BrokerMessage
+
+from nucliadb.ingest import logger
+from nucliadb.ingest.maindb.driver import Driver
+from nucliadb.ingest.orm.exceptions import DeadletteredError, SequenceOrderViolation
+from nucliadb.ingest.orm.processor import Processor, sequence_manager
+from nucliadb_telemetry import errors, metrics
+from nucliadb_telemetry.utils import set_info_on_span
+from nucliadb_utils import const
+from nucliadb_utils.audit.audit import AuditStorage
+from nucliadb_utils.cache import KB_COUNTER_CACHE
+from nucliadb_utils.cache.utility import Cache
+from nucliadb_utils.exceptions import ShardsNotFound
+from nucliadb_utils.nats import NatsConnectionManager
+from nucliadb_utils.storages.storage import Storage
+
+consumer_observer = metrics.Observer(
+    "message_processor",
+    labels={"source": ""},
+    buckets=[
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        30.0,
+        60.0,
+        120.0,
+        300.0,
+        float("inf"),
+    ],
+    error_mappings={"deadlettered": DeadletteredError, "shardnotfound": ShardsNotFound},
+)
+
+
+class IngestConsumer:
+    def __init__(
+        self,
+        driver: Driver,
+        partition: str,
+        storage: Storage,
+        nats_connection_manager: NatsConnectionManager,
+        audit: Optional[AuditStorage],
+        cache: Optional[Cache] = None,
+    ):
+        self.driver = driver
+        self.partition = partition
+        self.storage = storage
+        self.audit = audit
+        self.cache = cache
+        self.nats_connection_manager = nats_connection_manager
+        self.ack_wait = 10 * 60
+        self.initialized = False
+
+        self.lock = asyncio.Lock()
+        self.processor = Processor(driver, storage, audit, cache, partition)
+
+    async def initialize(self):
+        await self.setup_nats_subscription()
+        self.initialized = True
+
+    async def setup_nats_subscription(self):
+        last_seqid = await sequence_manager.get_last_seqid(self.driver, self.partition)
+        if last_seqid is None:
+            last_seqid = 1
+        subject = const.Streams.INGEST.subject.format(partition=self.partition)
+        await self.nats_connection_manager.subscribe(
+            subject=subject,
+            queue=const.Streams.INGEST.group.format(partition=self.partition),
+            stream=const.Streams.INGEST.name,
+            flow_control=True,
+            cb=self.subscription_worker,
+            subscription_lost_cb=self.setup_nats_subscription,
+            config=nats.js.api.ConsumerConfig(
+                deliver_policy=nats.js.api.DeliverPolicy.BY_START_SEQUENCE,
+                opt_start_seq=last_seqid,
+                ack_policy=nats.js.api.AckPolicy.EXPLICIT,
+                # Read about message ordering:
+                #   https://docs.nats.io/nats-concepts/subject_mapping#when-is-deterministic-partitioning-needed
+                max_ack_pending=1,  # required for strict message ordering
+                max_deliver=10000,
+                ack_wait=self.ack_wait,
+                idle_heartbeat=5.0,
+            ),
+        )
+        logger.info(
+            f"Subscribed to {subject} on stream {const.Streams.INGEST.name} from {last_seqid}"
+        )
+
+    async def _process(self, pb: BrokerMessage, seqid: int):
+        await self.processor.process(pb, seqid, self.partition)
+
+    async def subscription_worker(self, msg: Msg):
+        subject = msg.subject
+        reply = msg.reply
+        seqid = int(reply.split(".")[5])
+        logger.info(
+            f"Message received: subject:{subject}, seqid: {seqid}, reply: {reply}"
+        )
+        message_source = "<msg source not set>"
+        start = time.monotonic()
+
+        async with self.lock:
+            try:
+                pb = BrokerMessage()
+                pb.ParseFromString(msg.data)
+                if pb.source == pb.MessageSource.PROCESSOR:
+                    message_source = "processing"
+                elif pb.source == pb.MessageSource.WRITER:
+                    message_source = "writer"
+                if pb.HasField("audit"):
+                    audit_time = pb.audit.when.ToDatetime().isoformat()
+                else:
+                    audit_time = ""
+
+                logger.debug(
+                    f"Received from {message_source} on {pb.kbid}/{pb.uuid} seq {seqid} partition {self.partition} at {time}"  # noqa
+                )
+                set_info_on_span({"nuclia.kbid": pb.kbid, "nuclia.rid": pb.uuid})
+
+                try:
+                    with consumer_observer(
+                        {
+                            "source": "writer"
+                            if pb.source == pb.MessageSource.WRITER
+                            else "processor"
+                        }
+                    ):
+                        await self._process(pb, seqid)
+                except SequenceOrderViolation as err:
+                    log_func = logger.error
+                    if seqid == err.last_seqid:  # pragma: no cover
+                        # Occasional retries of the last processed message may happen
+                        log_func = logger.warning
+                    log_func(
+                        f"Old txn: DISCARD (nucliadb seqid: {seqid}, partition: {self.partition}). Current seqid: {err.last_seqid}"  # noqa
+                    )
+                else:
+                    message_type_name = pb.MessageType.Name(pb.type)
+                    time_to_process = time.monotonic() - start
+                    log_level = (
+                        logging.INFO if time_to_process < 10 else logging.WARNING
+                    )
+                    logger.log(
+                        log_level,
+                        f"Successfully processed {message_type_name} message from \
+                            {message_source}. kb: {pb.kbid}, resource: {pb.uuid}, \
+                                nucliadb seqid: {seqid}, partition: {self.partition} as {audit_time}, \
+                                    total time: {time_to_process:.2f}s",
+                    )
+                    if self.cache is not None:
+                        await self.cache.delete(
+                            KB_COUNTER_CACHE.format(kbid=pb.kbid), invalidate=True
+                        )
+            except DeadletteredError as e:
+                # Messages that have been sent to deadletter at some point
+                # We don't want to process it again so it's ack'd
+                errors.capture_exception(e)
+                logger.info(
+                    f"An error happend while processing a message from {message_source}. "
+                    f"A copy of the message has been stored on {self.processor.storage.deadletter_bucket}. "
+                    f"Check sentry for more details: {str(e)}"
+                )
+                await msg.ack()
+            except (ShardsNotFound,) as e:
+                # Any messages that for some unexpected inconsistency have failed and won't be tried again
+                # as we cannot do anything about it
+                # - ShardsNotFound: /kb/{id}/shards key or the whole /kb/{kbid} is missing
+                errors.capture_exception(e)
+                logger.info(
+                    f"An error happend while processing a message from {message_source}. "
+                    f"This message has been dropped and won't be retried again"
+                    f"Check sentry for more details: {str(e)}"
+                )
+                await msg.ack()
+            except Exception as e:
+                # Unhandled exceptions that need to be retried after a small delay
+                errors.capture_exception(e)
+                logger.info(
+                    f"An error happend while processing a message from {message_source}. "
+                    "Message has not been ACKd and will be retried. "
+                    f"Check sentry for more details: {str(e)}"
+                )
+                await asyncio.sleep(2)
+                raise e
+            else:
+                # Successful processing
+                await msg.ack()
+
+
+class IngestProcessedConsumer(IngestConsumer):
+    """
+    Consumer designed to write processed resources to the database.
+
+    This is so that we can have a single consumer for both the regular writer and writes
+    coming from processor.
+
+    This is important because writes coming from processor can be very large and slow and
+    other writes are going to be coming from user actions and we don't want to slow them down.
+    """
+
+    async def setup_nats_subscription(self):
+        subject = const.Streams.INGEST_PROCESSED.subject
+        await self.nats_connection_manager.subscribe(
+            subject=subject,
+            queue=const.Streams.INGEST_PROCESSED.group,
+            stream=const.Streams.INGEST_PROCESSED.name,
+            flow_control=True,
+            cb=self.subscription_worker,
+            subscription_lost_cb=self.setup_nats_subscription,
+            config=nats.js.api.ConsumerConfig(
+                ack_policy=nats.js.api.AckPolicy.EXPLICIT,
+                max_ack_pending=10,
+                max_deliver=10000,
+                ack_wait=self.ack_wait,
+                idle_heartbeat=5.0,
+            ),
+        )
+        logger.info(
+            f"Subscribed to {subject} on stream {const.Streams.INGEST_PROCESSED.name}"
+        )
+
+    async def _process(self, pb: BrokerMessage, seqid: int):
+        """
+        We are setting `transaction_check` to False here because we can not mix
+        transaction ids from regular ingest writes and writes coming from processor.
+        """
+        await self.processor.process(pb, seqid, self.partition, transaction_check=False)

--- a/nucliadb/nucliadb/ingest/consumer/pull.py
+++ b/nucliadb/nucliadb/ingest/consumer/pull.py
@@ -19,60 +19,35 @@
 #
 import asyncio
 import base64
-import logging
-import time
 from typing import List, Optional
 
 import aiohttp
 import nats
 from aiohttp.client_exceptions import ClientConnectorError
 from aiohttp.web import Response
-from nats.aio.client import Msg
 from nats.aio.subscription import Subscription
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
-from nucliadb.ingest import SERVICE_NAME, logger, logger_activity
+from nucliadb.ingest import logger, logger_activity
 from nucliadb.ingest.maindb.driver import Driver
-from nucliadb.ingest.orm.exceptions import (
-    DeadletteredError,
-    ReallyStopPulling,
-    SequenceOrderViolation,
-)
+from nucliadb.ingest.orm.exceptions import ReallyStopPulling
 from nucliadb.ingest.orm.processor import Processor
-from nucliadb_telemetry import errors, metrics
-from nucliadb_telemetry.utils import set_info_on_span
+from nucliadb_telemetry import errors
+from nucliadb_utils import const
 from nucliadb_utils.audit.audit import AuditStorage
-from nucliadb_utils.cache import KB_COUNTER_CACHE
 from nucliadb_utils.cache.utility import Cache
-from nucliadb_utils.exceptions import ShardsNotFound
-from nucliadb_utils.nats import get_traced_jetstream
 from nucliadb_utils.storages.storage import Storage
-from nucliadb_utils.utilities import get_transaction_utility
-
-consumer_observer = metrics.Observer(
-    "message_processor",
-    labels={"source": ""},
-    buckets=[
-        0.01,
-        0.025,
-        0.05,
-        0.1,
-        0.5,
-        1.0,
-        2.5,
-        5.0,
-        7.5,
-        10.0,
-        30.0,
-        60.0,
-        120.0,
-        float("inf"),
-    ],
-    error_mappings={"deadlettered": DeadletteredError, "shardnotfound": ShardsNotFound},
-)
+from nucliadb_utils.utilities import get_transaction_utility, has_feature
 
 
 class PullWorker:
+    """
+    The pull worker is responsible for pulling messages from the pull processing
+    http endpoint and injecting them into the processing write queue.
+
+    The processing pull endpoint is also described as the "processing proxy" at times.
+    """
+
     subscriptions: List[Subscription]
 
     def __init__(
@@ -80,257 +55,68 @@ class PullWorker:
         driver: Driver,
         partition: str,
         storage: Storage,
-        pull_time: int,
+        pull_time_error_backoff: int,
         zone: str,
         nuclia_cluster_url: str,
         nuclia_public_url: str,
         audit: Optional[AuditStorage],
-        target: str,
-        group: str,
-        stream: str,
         onprem: bool,
         cache: Optional[Cache] = None,
-        service_name: Optional[str] = None,
-        nats_creds: Optional[str] = None,
-        nats_servers: Optional[List[str]] = None,
         creds: Optional[str] = None,
         local_subscriber: bool = False,
+        pull_time_empty_backoff: float = 5.0,
     ):
         self.driver = driver
         self.partition = partition
         self.storage = storage
-        self.pull_time = pull_time
+        self.pull_time_error_backoff = pull_time_error_backoff
+        self.pull_time_empty_backoff = pull_time_empty_backoff
         self.audit = audit
         self.zone = zone
         self.nuclia_cluster_url = nuclia_cluster_url
         self.nuclia_public_url = nuclia_public_url
         self.local_subscriber = local_subscriber
-        self.nats_subscriber = not local_subscriber
         self.creds = creds
         self.cache = cache
-        self.nats_creds = nats_creds
-        self.nats_servers = nats_servers or []
-        self.target = target
-        self.group = group
-        self.stream = stream
         self.onprem = onprem
-        self.service_name = service_name
-        self.idle_heartbeat = 5 * 1_000_000_000
-        self.ack_wait = 10 * 60
         self.nc = None
-        self.js = None
-        self.initialized = False
-
-        self.subscriptions = []
 
         self.lock = asyncio.Lock()
         self.processor = Processor(driver, storage, audit, cache, partition)
 
-    async def disconnected_cb(self):
-        logger.info(
-            f"PullWorker[partition={self.partition}]: Got disconnected from NATS!"
+    async def handle_message(self, payload: bytes):
+        pb = BrokerMessage()
+        pb.ParseFromString(base64.b64decode(payload))
+
+        logger.debug(
+            f"Resource: {pb.uuid} KB: {pb.kbid} ProcessingID: {pb.processing_id}"
         )
 
-    async def reconnected_cb(self):
-        # See who we are connected to on reconnect.
-        logger.warning(
-            f"PullWorker[partition={self.partition}]: \
-                Got reconnected to NATS {self.nc.connected_url.netloc}. Attempting to re-subscribe."
-        )
-        await self.drain_subscriptions()
-        await self.setup_nats_subscription()
-
-    async def error_cb(self, e):
-        msg = f"PullWorker[partition={self.partition}]: There was an error on consumer: {e}"
-        logger.error(msg, exc_info=True)
-
-    async def closed_cb(self):
-        logger.info(
-            f"PullWorker[partition={self.partition}]: Connection is closed on NATS"
-        )
-
-    async def initialize(self):
-        await self.processor.initialize()
-
-        if self.nats_subscriber:
-            options = {
-                "error_cb": self.error_cb,
-                "closed_cb": self.closed_cb,
-                "reconnected_cb": self.reconnected_cb,
-            }
-
-            if self.nats_creds is not None:
-                options["user_credentials"] = self.nats_creds
-
-            if len(self.nats_servers) > 0:
-                options["servers"] = self.nats_servers
-
-            try:
-                self.nc = await nats.connect(**options)
-            except Exception:
-                pass
-
-            if self.nc is not None:
-                self.js = get_traced_jetstream(self.nc, SERVICE_NAME)
-                await self.setup_nats_subscription()
-
-        self.initialized = True
-
-    async def setup_nats_subscription(self):
-        last_seqid = await self.processor.driver.last_seqid(self.partition)
-        if last_seqid is None:
-            last_seqid = 1
-        self.subscriptions.append(
-            await self.js.subscribe(
-                subject=self.target.format(partition=self.partition),
-                queue=self.group.format(partition=self.partition),
-                stream=self.stream,
-                flow_control=True,
-                cb=self.subscription_worker,
-                config=nats.js.api.ConsumerConfig(
-                    deliver_policy=nats.js.api.DeliverPolicy.BY_START_SEQUENCE,
-                    opt_start_seq=last_seqid,
-                    ack_policy=nats.js.api.AckPolicy.EXPLICIT,
-                    max_ack_pending=1,
-                    max_deliver=10000,
-                    ack_wait=self.ack_wait,
-                    idle_heartbeat=5.0,
-                ),
+        if not self.local_subscriber:
+            transaction_utility = get_transaction_utility()
+            if transaction_utility is None:
+                raise Exception("No transaction utility defined")
+            subject = None
+            if has_feature(const.Features.SEPARATE_PROCESSED_MESSAGE_WRITES):
+                # send messsages to queue that is managed by separated consumer
+                subject = const.Streams.INGEST_PROCESSED.subject
+            await transaction_utility.commit(
+                writer=pb, partition=int(self.partition), target_subject=subject
             )
-        )
-        logger.info(
-            f"Subscribed to {self.target.format(partition=self.partition)} \
-                        on stream {self.stream} from {last_seqid}"
-        )
-
-    async def drain_subscriptions(self) -> None:
-        for subscription in self.subscriptions:
-            try:
-                await subscription.drain()
-            except nats.errors.ConnectionClosedError:
-                pass
-        self.subscriptions = []
-
-    async def finalize(self):
-        await self.drain_subscriptions()
-        if self.nats_subscriber and self.nc is not None:
-            try:
-                await self.nc.drain()
-            except nats.errors.ConnectionClosedError:
-                pass
-            await self.nc.close()
-
-    async def subscription_worker(self, msg: Msg):
-        subject = msg.subject
-        reply = msg.reply
-        seqid = int(reply.split(".")[5])
-        logger.info(
-            f"Message received: subject:{subject}, seqid: {seqid}, reply: {reply}"
-        )
-        message_source = "<msg source not set>"
-        start = time.monotonic()
-
-        async with self.lock:
-            try:
-                pb = BrokerMessage()
-                pb.ParseFromString(msg.data)
-                if pb.source == pb.MessageSource.PROCESSOR:
-                    message_source = "processing"
-                elif pb.source == pb.MessageSource.WRITER:
-                    message_source = "writer"
-                if pb.HasField("audit"):
-                    audit_time = pb.audit.when.ToDatetime().isoformat()
-                else:
-                    audit_time = ""
-
-                logger.debug(
-                    f"Received from {message_source} on {pb.kbid}/{pb.uuid} seq {seqid} partition {self.partition} at {time}"  # noqa
-                )
-                set_info_on_span({"nuclia.kbid": pb.kbid, "nuclia.rid": pb.uuid})
-
-                try:
-                    with consumer_observer(
-                        {
-                            "source": "writer"
-                            if pb.source == pb.MessageSource.WRITER
-                            else "processor"
-                        }
-                    ):
-                        await self.processor.process(pb, seqid, self.partition)
-                except SequenceOrderViolation as err:
-                    log_func = logger.error
-                    if seqid == err.last_seqid:  # pragma: no cover
-                        # Occasional retries of the last processed message may happen
-                        log_func = logger.warning
-                    log_func(
-                        f"Old txn: DISCARD (nucliadb seqid: {seqid}, partition: {self.partition}). Current seqid: {err.last_seqid}"  # noqa
-                    )
-                else:
-                    message_type_name = pb.MessageType.Name(pb.type)
-                    time_to_process = time.monotonic() - start
-                    log_level = (
-                        logging.INFO if time_to_process < 10 else logging.WARNING
-                    )
-                    logger.log(
-                        log_level,
-                        f"Successfully processed {message_type_name} message from \
-                            {message_source}. kb: {pb.kbid}, resource: {pb.uuid}, \
-                                nucliadb seqid: {seqid}, partition: {self.partition} as {audit_time}, \
-                                    total time: {time_to_process:.2f}s",
-                    )
-                    if self.cache is not None:
-                        await self.cache.delete(
-                            KB_COUNTER_CACHE.format(kbid=pb.kbid), invalidate=True
-                        )
-            except DeadletteredError as e:
-                # Messages that have been sent to deadletter at some point
-                # We don't want to process it again so it's ack'd
-                errors.capture_exception(e)
-                logger.info(
-                    f"An error happend while processing a message from {message_source}. "
-                    f"A copy of the message has been stored on {self.processor.storage.deadletter_bucket}. "
-                    f"Check sentry for more details: {str(e)}"
-                )
-                await msg.ack()
-            except (ShardsNotFound,) as e:
-                # Any messages that for some unexpected inconsistency have failed and won't be tried again
-                # as we cannot do anything about it
-                # - ShardsNotFound: /kb/{id}/shards key or the whole /kb/{kbid} is missing
-                errors.capture_exception(e)
-                logger.info(
-                    f"An error happend while processing a message from {message_source}. "
-                    f"This message has been dropped and won't be retried again"
-                    f"Check sentry for more details: {str(e)}"
-                )
-                await msg.ack()
-            except Exception as e:
-                # Unhandled exceptions that need to be retried after a small delay
-                errors.capture_exception(e)
-                logger.info(
-                    f"An error happend while processing a message from {message_source}. "
-                    "Message has not been ACKd and will be retried. "
-                    f"Check sentry for more details: {str(e)}"
-                )
-                await asyncio.sleep(2)
-                raise e
-            else:
-                # Successful processing
-                await msg.ack()
+        else:
+            # No nats defined == monolitic nucliadb
+            await self.processor.process(
+                pb,
+                0,  # Fake sequence id as in local mode there's no transactions
+                partition=self.partition,
+                transaction_check=False,
+            )
 
     async def loop(self):
-        while self.initialized is False:
-            try:
-                await self.initialize()
-            except Exception as e:
-                errors.capture_exception(e)
-                logger.exception("Exception on initializing worker", exc_info=e)
-                await asyncio.sleep(10)
+        """
+        Run this forever
+        """
 
-        if self.pull_time == 0:
-            logger.debug("Not pulling data from Nuclia")
-            return
-
-        # Lets do pooling from NUA
         while True:
             try:
                 await self._loop()
@@ -388,33 +174,7 @@ class PullWorker:
                             )
                             async with self.lock:
                                 try:
-                                    transaction_utility = get_transaction_utility()
-                                    if transaction_utility is None:
-                                        raise Exception(
-                                            "No transaction utility defined"
-                                        )
-
-                                    pb = BrokerMessage()
-                                    pb.ParseFromString(
-                                        base64.b64decode(data["payload"])
-                                    )
-
-                                    logger.debug(
-                                        f"Resource: {pb.uuid} KB: {pb.kbid} ProcessingID: {pb.processing_id}"
-                                    )
-
-                                    if self.nats_subscriber:
-                                        await transaction_utility.commit(
-                                            writer=pb, partition=self.partition
-                                        )
-                                    else:
-                                        # No nats defined == monolitic nucliadb
-                                        await self.processor.process(
-                                            pb,
-                                            0,  # Fake sequence id as in local mode there's no transactions
-                                            partition=self.partition,
-                                            transaction_check=False,
-                                        )
+                                    await self.handle_message(data["payload"])
                                 except Exception as e:
                                     errors.capture_exception(e)
                                     logger.exception(
@@ -425,11 +185,16 @@ class PullWorker:
                             logger_activity.debug(
                                 f"No messages waiting in partition #{self.partition}"
                             )
-                            await asyncio.sleep(self.pull_time)
+                            await asyncio.sleep(self.pull_time_empty_backoff)
                         else:
                             logger.info(f"Proxy pull answered with error: {data}")
-                            await asyncio.sleep(self.pull_time)
-                except asyncio.exceptions.CancelledError:
+                            await asyncio.sleep(self.pull_time_error_backoff)
+                except (
+                    asyncio.exceptions.CancelledError,
+                    RuntimeError,
+                    KeyboardInterrupt,
+                    SystemExit,
+                ):
                     logger.info(
                         f"Pull task for partition #{self.partition} was canceled, exiting"
                     )
@@ -439,7 +204,7 @@ class PullWorker:
                     logger.error(
                         f"Could not connect to {url}, verify your internet connection"
                     )
-                    await asyncio.sleep(self.pull_time)
+                    await asyncio.sleep(self.pull_time_error_backoff)
 
                 except nats.errors.MaxPayloadError as e:
                     if data is not None:
@@ -450,7 +215,7 @@ class PullWorker:
 
                 except Exception:
                     logger.exception("Gathering changes")
-                    await asyncio.sleep(self.pull_time)
+                    await asyncio.sleep(self.pull_time_error_backoff)
 
 
 class TelemetryHeadersMissing(Exception):

--- a/nucliadb/nucliadb/ingest/consumer/service.py
+++ b/nucliadb/nucliadb/ingest/consumer/service.py
@@ -18,162 +18,137 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
-from typing import Dict, List, Optional
+import sys
+from functools import partial
+from typing import Awaitable, Callable, Optional
 
 from nucliadb.ingest import SERVICE_NAME, logger
+from nucliadb.ingest.consumer.consumer import IngestConsumer, IngestProcessedConsumer
 from nucliadb.ingest.consumer.pull import PullWorker
-from nucliadb.ingest.maindb.driver import Driver
 from nucliadb.ingest.orm import NODES
 from nucliadb.ingest.settings import settings
 from nucliadb.ingest.utils import get_driver
+from nucliadb_utils.exceptions import ConfigurationError
 from nucliadb_utils.settings import (
     nuclia_settings,
     running_settings,
     transaction_settings,
 )
-from nucliadb_utils.storages.storage import Storage
-from nucliadb_utils.utilities import get_audit, get_cache, get_storage
+from nucliadb_utils.utilities import get_audit, get_cache, get_nats_manager, get_storage
 
 
-class ConsumerService:
-    pull_workers_task: Dict[str, asyncio.Task]
-    pull_workers: Dict[str, PullWorker]
-    driver: Driver
-    storage: Storage
+def _handle_task_result(task: asyncio.Task) -> None:
+    e = task.exception()
+    if e:
+        logger.exception(
+            "Loop stopped by exception. This should not happen. Exiting.", exc_info=e
+        )
+        sys.exit(1)
 
-    def __init__(
-        self,
-        partitions: Optional[List[str]] = None,
-        pull_time: Optional[int] = None,
-        zone: Optional[str] = None,
-        creds: Optional[str] = None,
-        nuclia_cluster_url: Optional[str] = None,
-        nuclia_public_url: Optional[str] = None,
-        nats_servers: Optional[List[str]] = None,
-        nats_auth: Optional[str] = None,
-        nats_target: Optional[str] = None,
-        nats_group: Optional[str] = None,
-        nats_stream: Optional[str] = None,
-        onprem: Optional[bool] = None,
+
+async def _exit_tasks(tasks: list[asyncio.Task]) -> None:
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def start_pull_workers(
+    service_name: Optional[str] = None,
+) -> Callable[[], Awaitable[None]]:
+    driver = await get_driver()
+    cache = await get_cache()
+    storage = await get_storage(service_name=service_name or SERVICE_NAME)
+    audit = get_audit()
+    tasks = []
+    for partition in settings.partitions:
+        worker = PullWorker(
+            driver=driver,
+            partition=partition,
+            storage=storage,
+            pull_time_error_backoff=settings.pull_time_error_backoff,
+            zone=nuclia_settings.nuclia_zone,
+            cache=cache,
+            audit=audit,
+            creds=nuclia_settings.nuclia_service_account,
+            nuclia_cluster_url=nuclia_settings.nuclia_cluster_url,
+            nuclia_public_url=nuclia_settings.nuclia_public_url,
+            onprem=nuclia_settings.onprem,
+            local_subscriber=transaction_settings.transaction_local,
+        )
+        task = asyncio.create_task(worker.loop())
+        task.add_done_callback(_handle_task_result)
+        tasks.append(task)
+
+    return partial(_exit_tasks, tasks)
+
+
+async def start_ingest_consumers(
+    service_name: Optional[str] = None,
+) -> Callable[[], Awaitable[None]]:
+    if transaction_settings.transaction_local:
+        raise ConfigurationError("Can not start ingest consumers in local mode")
+
+    while len(NODES) == 0 and running_settings.running_environment not in (
+        "local",
+        "test",
     ):
-        if partitions is not None:
-            self.partitions: List[str] = partitions
-        else:
-            self.partitions = settings.partitions
+        logger.warning("Initializion delayed 1s to receive some Nodes on the cluster")
+        await asyncio.sleep(1)
 
-        if pull_time is not None:
-            self.pull_time: int = pull_time
-        else:
-            self.pull_time = settings.pull_time
+    driver = await get_driver()
+    cache = await get_cache()
+    storage = await get_storage(service_name=service_name or SERVICE_NAME)
+    audit = get_audit()
+    nats_connection_manager = get_nats_manager()
 
-        if zone is not None:
-            self.zone: str = zone
-        else:
-            self.zone = nuclia_settings.nuclia_zone
-
-        if creds is not None:
-            self.nuclia_creds: Optional[str] = creds
-        else:
-            self.nuclia_creds = nuclia_settings.nuclia_service_account
-
-        if nuclia_cluster_url is not None:
-            self.nuclia_cluster_url: str = nuclia_cluster_url
-        else:
-            self.nuclia_cluster_url = nuclia_settings.nuclia_cluster_url
-
-        self.nuclia_public_url = (
-            nuclia_public_url
-            if nuclia_public_url
-            else nuclia_settings.nuclia_public_url
+    for partition in settings.partitions:
+        consumer = IngestConsumer(
+            driver=driver,
+            partition=partition,
+            storage=storage,
+            cache=cache,
+            audit=audit,
+            nats_connection_manager=nats_connection_manager,
         )
+        await consumer.initialize()
 
-        self.nats_auth = (
-            nats_auth if nats_auth else transaction_settings.transaction_jetstream_auth
-        )
-        self.nats_url = (
-            nats_servers
-            if nats_servers is not None and len(nats_servers) > 0
-            else transaction_settings.transaction_jetstream_servers
-        )
+    return nats_connection_manager.finalize
 
-        if nats_target is not None:
-            self.nats_target: str = nats_target
-        else:
-            self.nats_target = transaction_settings.transaction_jetstream_target
 
-        if nats_group is not None:
-            self.nats_group: str = nats_group
-        else:
-            self.nats_group = transaction_settings.transaction_jetstream_group
+async def start_ingest_processed_consumer(
+    service_name: Optional[str] = None,
+) -> Callable[[], Awaitable[None]]:
+    """
+    This is not meant to be deployed with a stateful set like the other consumers.
 
-        if nats_stream is not None:
-            self.nats_stream: str = nats_stream
-        else:
-            self.nats_stream = transaction_settings.transaction_jetstream_stream
+    We are not maintaining transactionability based on the nats sequence id from this
+    consumer and we will start off by not separating writes by partition AND
+    allowing NATS to manage the queue group for us.
+    """
+    if transaction_settings.transaction_local:
+        raise ConfigurationError("Can not start ingest consumers in local mode")
 
-        self.local_subscriber = transaction_settings.transaction_local
-        self.onprem = onprem if onprem is not None else nuclia_settings.onprem
-        self.pull_workers_task = {}
-        self.pull_workers = {}
-        self.audit = get_audit()
+    while len(NODES) == 0 and running_settings.running_environment not in (
+        "local",
+        "test",
+    ):
+        logger.warning("Initializion delayed 1s to receive some Nodes on the cluster")
+        await asyncio.sleep(1)
 
-    async def run(self, service_name: Optional[str] = None):
-        logger.info(
-            f"Ingest txn from zone '{self.zone}' & partitions: {','.join(self.partitions)}"
-        )
+    driver = await get_driver()
+    cache = await get_cache()
+    storage = await get_storage(service_name=service_name or SERVICE_NAME)
+    audit = get_audit()
+    nats_connection_manager = get_nats_manager()
 
-        while len(NODES) == 0 and running_settings.running_environment not in (
-            "local",
-            "test",
-        ):
-            logger.warning(
-                "Initializion delayed 1s to receive some Nodes on the cluster"
-            )
-            await asyncio.sleep(1)
+    consumer = IngestProcessedConsumer(
+        driver=driver,
+        partition="-1",
+        storage=storage,
+        cache=cache,
+        audit=audit,
+        nats_connection_manager=nats_connection_manager,
+    )
+    await consumer.initialize()
 
-        for partition in self.partitions:
-            self.pull_workers[partition] = PullWorker(
-                driver=self.driver,
-                partition=partition,
-                storage=self.storage,
-                pull_time=self.pull_time,
-                zone=self.zone,
-                cache=self.cache,
-                audit=self.audit,
-                creds=self.nuclia_creds,
-                nuclia_cluster_url=self.nuclia_cluster_url,
-                nuclia_public_url=self.nuclia_public_url,
-                target=self.nats_target,
-                group=self.nats_group,
-                stream=self.nats_stream,
-                onprem=self.onprem,
-                nats_creds=self.nats_auth,
-                nats_servers=self.nats_url,
-                local_subscriber=self.local_subscriber,
-                service_name=service_name,
-            )
-            self.pull_workers_task[partition] = asyncio.create_task(
-                self.pull_workers[partition].loop()
-            )
-            self.pull_workers_task[partition].add_done_callback(
-                self._handle_task_result
-            )
-
-    async def start(self, service_name: Optional[str] = None):
-        self.driver = await get_driver()
-        self.cache = await get_cache()
-        self.storage = await get_storage(service_name=SERVICE_NAME)
-
-        # Start consummer coroutine
-        await self.run(service_name)
-
-    async def stop(self):
-        for value in self.pull_workers.values():
-            await value.finalize()
-        for value in self.pull_workers_task.values():
-            value.cancel()
-
-    def _handle_task_result(self, task: asyncio.Task) -> None:
-        e = task.exception()
-        if e:
-            logger.exception("Consumer loop stopped by exception", exc_info=e)
+    return nats_connection_manager.finalize

--- a/nucliadb/nucliadb/ingest/maindb/driver.py
+++ b/nucliadb/nucliadb/ingest/maindb/driver.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, List, Optional
 
-TXNID = "/internal/worker/{worker}"
 DEFAULT_SCAN_LIMIT = 10
 DEFAULT_BATCH_SCAN_LIMIT = 100
 
@@ -34,12 +33,7 @@ class Transaction:
     async def abort(self):
         raise NotImplementedError()
 
-    async def commit(
-        self,
-        worker: Optional[str] = None,
-        tid: Optional[int] = None,
-        resource: bool = True,
-    ):
+    async def commit(self):
         raise NotImplementedError()
 
     async def batch_get(self, keys: List[str]):
@@ -62,16 +56,6 @@ class Transaction:
 
 class Driver:
     initialized = False
-
-    async def last_seqid(self, worker: str) -> Optional[int]:
-        txn = await self.begin()
-        key = TXNID.format(worker=worker)
-        last_seq = await txn.get(key)
-        await txn.abort()
-        if last_seq is None:
-            return None
-        else:
-            return int(last_seq)
 
     async def initialize(self):
         raise NotImplementedError()

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -149,7 +149,7 @@ class KnowledgeBox:
 
         when = datetime.now().isoformat()
         await subtxn.set(KB_TO_DELETE.format(kbid=kbid), when.encode())
-        await subtxn.commit(resource=False)
+        await subtxn.commit()
 
         audit_util = get_audit()
         if audit_util is not None:
@@ -413,7 +413,7 @@ class KnowledgeBox:
                         await txn.abort()
                         raise ShardNotFound(f"{exc.details()} @ {node.address}")
 
-        await txn.commit(resource=False)
+        await txn.commit()
         await cls.delete_all_kb_keys(driver, kbid)
 
     @classmethod
@@ -435,7 +435,7 @@ class KnowledgeBox:
                 txn = await driver.begin()
                 for key in chunk_of_keys:
                     await txn.delete(key)
-                await txn.commit(resource=False)
+                await txn.commit()
 
     async def get_resource_shard(self, shard_id: str, node_klass) -> Optional[Shard]:
         pb = await self.get_shards_object()

--- a/nucliadb/nucliadb/ingest/orm/processor/sequence_manager.py
+++ b/nucliadb/nucliadb/ingest/orm/processor/sequence_manager.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from typing import Optional
+
+from nucliadb.ingest.maindb.driver import Driver, Transaction
+
+TXNID = "/internal/worker/{worker}"
+
+
+async def get_last_seqid(driver: Driver, worker: str) -> Optional[int]:
+    """
+    Get last stored sequence id for a worker.
+
+    This is oriented towards the ingest consumer and processor,
+    which is the only one that should be writing to this key.
+    """
+    async with driver.transaction() as txn:
+        key = TXNID.format(worker=worker)
+        last_seq = await txn.get(key)
+        if last_seq is None:
+            return None
+        else:
+            return int(last_seq)
+
+
+async def set_last_seqid(txn: Transaction, worker: str, seqid: int) -> None:
+    """
+    Set last stored sequence id for a worker on a ingest consumer.
+    """
+    key = TXNID.format(worker=worker)
+    await txn.set(key, str(seqid).encode())

--- a/nucliadb/nucliadb/ingest/purge.py
+++ b/nucliadb/nucliadb/ingest/purge.py
@@ -77,7 +77,7 @@ async def purge_kb(driver: Driver):
             txn = await driver.begin()
             key_to_purge = KB_TO_DELETE.format(kbid=kbid)
             await txn.delete(key_to_purge)
-            await txn.commit(resource=False)
+            await txn.commit()
             logger.info(f"  √ Deleted {key_to_purge}")
         except Exception as exc:
             errors.capture_exception(exc)
@@ -126,7 +126,7 @@ async def purge_kb_storage(driver: Driver, storage: Storage):
                 logger.info(f"  X Error while deleting key {key}")
                 await txn.abort()
             else:
-                await txn.commit(resource=False)
+                await txn.commit()
 
     logger.info("FINISH PURGING KB STORAGE")
 

--- a/nucliadb/nucliadb/ingest/settings.py
+++ b/nucliadb/nucliadb/ingest/settings.py
@@ -53,7 +53,8 @@ class Settings(DriverSettings):
 
     partitions: List[str] = ["1"]
 
-    pull_time: int = 100
+    pull_time_error_backoff: int = 100
+    disable_pull_worker: bool = False
 
     replica_number: int = -1
     total_replicas: int = 1

--- a/nucliadb/nucliadb/ingest/tests/integration/consumer/__init__.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/consumer/__init__.py
@@ -16,6 +16,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-class NoWorkerCommit(Exception):
-    pass

--- a/nucliadb/nucliadb/ingest/tests/integration/consumer/test_pull.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/consumer/test_pull.py
@@ -1,0 +1,158 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import asyncio
+import base64
+import time
+import uuid
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from nucliadb_protos.writer_pb2 import BrokerMessage
+from uvicorn.config import Config  # type: ignore
+from uvicorn.server import Server  # type: ignore
+
+from nucliadb.ingest.consumer.pull import PullWorker
+from nucliadb_utils import const
+from nucliadb_utils.fastapi.run import start_server
+from nucliadb_utils.nats import NatsConnectionManager
+from nucliadb_utils.tests import free_port
+
+pytestmark = pytest.mark.asyncio
+
+
+def create_broker_message(kbid: str) -> BrokerMessage:
+    bm = BrokerMessage()
+    bm.uuid = uuid.uuid4().hex
+    bm.kbid = kbid
+    bm.texts["text1"].body = "My text1"
+    bm.basic.title = "My Title"
+    bm.source == BrokerMessage.MessageSource.PROCESSOR
+
+    return bm
+
+
+@dataclass
+class PullProcessorAPI:
+    url: str
+    messages: list[BrokerMessage]
+
+
+@pytest.fixture()
+async def pull_processor_api():
+    app = FastAPI()
+    messages: list[BrokerMessage] = []  # type: ignore
+
+    @app.get("/api/internal/processing/pull")
+    async def pull():
+        if len(messages) == 0:
+            return {"status": "empty"}
+        message = messages.pop()
+        return {
+            "status": "ok",
+            "payload": base64.b64encode(message.SerializeToString()).decode(),
+        }
+
+    port = free_port()
+    config = Config(app, host="0.0.0.0", port=port, http="auto")
+    server = Server(config=config)
+
+    await start_server(server, config)
+
+    yield PullProcessorAPI(url=f"http://127.0.0.1:{port}", messages=messages)
+
+    await server.shutdown()
+
+
+@pytest.fixture()
+async def pull_worker(redis_driver, pull_processor_api: PullProcessorAPI):
+    worker = PullWorker(
+        driver=redis_driver,
+        partition="1",
+        storage=None,  # type: ignore
+        pull_time_error_backoff=5,
+        zone="zone",
+        nuclia_cluster_url=pull_processor_api.url,
+        nuclia_public_url="nuclia_public_url",
+        audit=None,
+        onprem=False,
+        pull_time_empty_backoff=0.1,
+    )
+
+    task = asyncio.create_task(worker.loop())
+    yield worker
+    task.cancel()
+
+
+async def wait_for_messages(messages: list[BrokerMessage], max_time: int = 10) -> None:
+    start = time.monotonic()
+    while time.monotonic() - start < max_time:
+        if len(messages) == 0:
+            await asyncio.sleep(
+                0.1
+            )  # extra sleep to make sure it's flushed to consumer
+            return
+
+        await asyncio.sleep(0.1)
+
+
+async def test_pull_full_integration(
+    ingest_consumers,
+    ingest_processed_consumer,
+    pull_worker: PullWorker,
+    pull_processor_api: PullProcessorAPI,
+    knowledgebox_ingest: str,
+    nats_manager: NatsConnectionManager,
+):
+    # make sure stream is empty
+    consumer_info1 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST.name, const.Streams.INGEST.group.format(partition="1")
+    )
+    consumer_info2 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST_PROCESSED.name, const.Streams.INGEST_PROCESSED.group
+    )
+    assert consumer_info1.delivered.stream_seq == 0
+    assert consumer_info2.delivered.stream_seq == 0
+
+    # add message that should go to first consumer
+    pull_processor_api.messages.append(create_broker_message(knowledgebox_ingest))
+    await wait_for_messages(pull_processor_api.messages)
+
+    consumer_info1 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST.name, const.Streams.INGEST.group.format(partition="1")
+    )
+
+    assert consumer_info1.delivered.stream_seq == 1
+
+    # check next message goes to other consumer when ff is enabled
+    # remove this type of test when ff removed
+    with patch("nucliadb.ingest.consumer.pull.has_feature", return_value=True):
+        pull_processor_api.messages.append(create_broker_message(knowledgebox_ingest))
+        await wait_for_messages(pull_processor_api.messages)
+
+    consumer_info1 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST.name, const.Streams.INGEST.group.format(partition="1")
+    )
+    consumer_info2 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST_PROCESSED.name, const.Streams.INGEST_PROCESSED.group
+    )
+    assert consumer_info1.delivered.stream_seq == 1  # still on first
+    assert consumer_info2.delivered.stream_seq == 2

--- a/nucliadb/nucliadb/ingest/tests/integration/consumer/test_service.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/consumer/test_service.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import uuid
+
+import pytest
+from nucliadb_protos.writer_pb2 import BrokerMessage
+
+from nucliadb_utils import const
+from nucliadb_utils.nats import NatsConnectionManager
+from nucliadb_utils.transaction import TransactionUtility
+
+pytestmark = pytest.mark.asyncio
+
+
+def create_broker_message(kbid: str) -> BrokerMessage:
+    bm = BrokerMessage()
+    bm.uuid = uuid.uuid4().hex
+    bm.kbid = kbid
+    bm.texts["text1"].body = "My text1"
+    bm.basic.title = "My Title"
+
+    return bm
+
+
+async def test_separated_ingest_consumer(
+    ingest_consumers,
+    ingest_processed_consumer,
+    knowledgebox_ingest,
+    transaction_utility: TransactionUtility,
+    nats_manager: NatsConnectionManager,
+):
+    bm_normal = create_broker_message(knowledgebox_ingest)
+    bm_processed = create_broker_message(knowledgebox_ingest)
+    bm_processed.source == BrokerMessage.MessageSource.PROCESSOR
+
+    await transaction_utility.commit(bm_normal, partition=1, wait=True)
+
+    consumer_info1 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST.name, const.Streams.INGEST.group.format(partition="1")
+    )
+    consumer_info2 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST_PROCESSED.name, const.Streams.INGEST_PROCESSED.group
+    )
+
+    assert consumer_info1.delivered.stream_seq == 1
+    assert consumer_info2.delivered.stream_seq == 0
+
+    await transaction_utility.commit(
+        bm_normal,
+        partition=1,
+        wait=True,
+        target_subject=const.Streams.INGEST_PROCESSED.subject,
+    )
+
+    consumer_info1 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST.name, const.Streams.INGEST.group.format(partition="1")
+    )
+    consumer_info2 = await nats_manager.js.consumer_info(
+        const.Streams.INGEST_PROCESSED.name, const.Streams.INGEST_PROCESSED.group
+    )
+
+    assert consumer_info1.delivered.stream_seq == 1
+    assert consumer_info2.delivered.stream_seq == 2

--- a/nucliadb/nucliadb/ingest/tests/integration/maindb/test_drivers.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/maindb/test_drivers.py
@@ -67,7 +67,7 @@ async def driver_basic(driver):
     # Test deleting a key that doesn't exist does not raise any error
     txn = await driver.begin()
     await txn.delete("/i/do/not/exist")
-    await txn.commit(resource=False)
+    await txn.commit()
 
     txn = await driver.begin()
     await txn.set("/internal/kbs/kb1/title", b"My title")
@@ -78,7 +78,7 @@ async def driver_basic(driver):
     result = await txn.get("/kbs/kb1/r/uuid1/text")
     assert result == b"My title"
 
-    await txn.commit(resource=False)
+    await txn.commit()
 
     txn = await driver.begin()
     result = await txn.get("/kbs/kb1/r/uuid1/text")
@@ -100,7 +100,7 @@ async def driver_basic(driver):
     # Test delete one key
     txn = await driver.begin()
     result = await txn.delete("/internal/kbs/kb1/title")
-    await txn.commit(resource=False)
+    await txn.commit()
 
     current_internal_kbs_keys = set()
     async for key in driver.keys("/internal/kbs"):
@@ -112,7 +112,7 @@ async def driver_basic(driver):
 
     txn = await driver.begin()
     result = await txn.delete("/internal/kbs")
-    await txn.commit(resource=False)
+    await txn.commit()
 
     current_internal_kbs_keys = set()
     async for key in driver.keys("/internal/kbs"):
@@ -124,7 +124,7 @@ async def driver_basic(driver):
 
     txn = await driver.begin()
     await txn.set("/internal/kbs", b"I am the father")
-    await txn.commit(resource=False)
+    await txn.commit()
 
     # It works without trailing slash ...
     txn = await driver.begin()
@@ -158,7 +158,7 @@ async def _test_keys_async_generator(driver):
     txn = await driver.begin()
     for i in range(10):
         await txn.set(f"/keys/{i}", str(i).encode())
-    await txn.commit(resource=False)
+    await txn.commit()
 
     txn = await driver.begin()
     async_generator = txn.keys("/keys/", count=10)
@@ -179,7 +179,7 @@ async def _test_transaction_context_manager(driver):
     async with driver.transaction() as txn:
         assert await txn.get("/some/key") is None
         await txn.set("/some/key", b"some value")
-        await txn.commit(resource=False)
+        await txn.commit()
 
     async with driver.transaction() as txn:
         assert await txn.get("/some/key") == b"some value"

--- a/nucliadb/nucliadb/ingest/tests/integration/orm/test_nodes_manager.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/orm/test_nodes_manager.py
@@ -118,13 +118,13 @@ async def shards(fake_nodes, fake_kbid: str, redis_driver: Driver):
 
     async with driver.transaction() as txn:
         await txn.set(key, shards.SerializeToString())
-        await txn.commit(resource=False)
+        await txn.commit()
 
     yield shards
 
     async with driver.transaction() as txn:
         await txn.delete(key)
-        await txn.commit(resource=False)
+        await txn.commit()
 
 
 @pytest.mark.parametrize(

--- a/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_knowledgebox.py
@@ -70,7 +70,7 @@ async def test_knowledgebox_delete_all_kb_keys(
         assert r is not None
         await r.set_slug()
         uuids.add(bm.uuid)
-    await txn.commit(resource=False)
+    await txn.commit()
 
     # Check that all of them are there
     txn = await tikv_driver.begin()

--- a/nucliadb/nucliadb/ingest/tests/unit/consumer/__init__.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/consumer/__init__.py
@@ -16,4 +16,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-#

--- a/nucliadb/nucliadb/ingest/tests/unit/consumer/test_pull.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/consumer/test_pull.py
@@ -68,32 +68,10 @@ class TestPullWorker:
             driver=AsyncMock(),
             partition="1",
             storage=AsyncMock(),
-            pull_time=100,
+            pull_time_error_backoff=100,
             zone="zone",
             nuclia_cluster_url="nuclia_cluster_url",
             nuclia_public_url="nuclia_public_url",
             audit=None,
-            target="target",
-            group="group",
-            stream="stream",
             onprem=False,
         )
-
-    async def test_lifecycle(self, worker: PullWorker, processor, nats_conn):
-        await worker.initialize()
-
-        assert worker.processor == processor
-        assert worker.nc == nats_conn
-
-        nats_conn.jetstream.assert_called_once()
-        nats_conn.jetstream().subscribe.assert_called_once()
-
-        await worker.finalize()
-
-        nats_conn.jetstream().subscribe.return_value.drain.assert_called_once()
-
-    async def test_reconnect(self, worker: PullWorker, processor, nats_conn):
-        await worker.initialize()
-        await worker.reconnected_cb()
-
-        assert nats_conn.jetstream().subscribe.call_count == 2

--- a/nucliadb/nucliadb/ingest/tests/unit/maindb/test_driver.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/maindb/test_driver.py
@@ -45,7 +45,7 @@ def driver() -> Driver:  # type: ignore
 @pytest.mark.asyncio
 async def test_transaction_does_not_abotr_if_commited(driver):
     async with driver.transaction() as txn:
-        await txn.commit(resource=False)
+        await txn.commit()
     txn.abort.assert_not_awaited()
 
 

--- a/nucliadb/nucliadb/one/lifecycle.py
+++ b/nucliadb/nucliadb/one/lifecycle.py
@@ -19,7 +19,9 @@
 #
 import asyncio
 
-from nucliadb.ingest.app import initialize_consumer_and_grpc as initialize_ingest
+from nucliadb.ingest.app import initialize_grpc as initialize_ingest_grpc
+from nucliadb.ingest.app import initialize_pull_workers
+from nucliadb.ingest.settings import settings as ingest_settings
 from nucliadb.reader.lifecycle import finalize as finalize_reader
 from nucliadb.reader.lifecycle import initialize as initialize_reader
 from nucliadb.search.lifecycle import finalize as finalize_search
@@ -34,7 +36,10 @@ SYNC_FINALIZERS = []
 
 
 async def initialize():
-    finalizers = await initialize_ingest()
+    if ingest_settings.disable_pull_worker:
+        finalizers = await initialize_ingest_grpc()
+    else:
+        finalizers = await initialize_pull_workers()
     SYNC_FINALIZERS.extend(finalizers)
     await initialize_writer()
     await initialize_reader()

--- a/nucliadb/nucliadb/search/tests/fixtures.py
+++ b/nucliadb/nucliadb/search/tests/fixtures.py
@@ -35,15 +35,8 @@ from nucliadb.ingest.orm.node import Node
 from nucliadb.ingest.tests.fixtures import broker_resource
 from nucliadb.ingest.utils import get_driver
 from nucliadb.search import API_PREFIX
+from nucliadb_utils.tests import free_port
 from nucliadb_utils.utilities import clear_global_cache
-
-
-def free_port() -> int:
-    import socket
-
-    sock = socket.socket()
-    sock.bind(("", 0))
-    return sock.getsockname()[1]
 
 
 @pytest.fixture(scope="function")
@@ -73,7 +66,7 @@ def test_settings_search(gcs, redis, node, maindb_driver):  # type: ignore
 
     running_settings.debug = False
 
-    ingest_settings.pull_time = 0
+    ingest_settings.disable_pull_worker = True
 
     ingest_settings.nuclia_partitions = 1
 
@@ -89,13 +82,7 @@ def test_settings_search(gcs, redis, node, maindb_driver):  # type: ignore
 
 @pytest.mark.asyncio
 @pytest.fixture(scope="function")
-async def search_api(
-    redis,
-    transaction_utility,
-    indexing_utility_registered,
-    test_settings_search,
-    event_loop,
-):  # type: ignore
+async def search_api(test_settings_search, transaction_utility, redis):  # type: ignore
     from nucliadb.ingest.orm import NODES
     from nucliadb.search.app import application
 

--- a/nucliadb/nucliadb/search/tests/integration/api/v1/test_search.py
+++ b/nucliadb/nucliadb/search/tests/integration/api/v1/test_search.py
@@ -135,9 +135,9 @@ async def test_multiple_search_resource_all(
             else:
                 break
         assert len(resp.json()["paragraphs"]["results"]) == 20
-        assert resp.json()["paragraphs"]["total"] == 20
+        assert resp.json()["paragraphs"]["total"] == 100
         assert len(resp.json()["fulltext"]["results"]) == 20
-        assert resp.json()["fulltext"]["total"] == 20
+        assert resp.json()["fulltext"]["total"] == 100
 
         assert resp.json()["paragraphs"]["next_page"] is False
         assert resp.json()["fulltext"]["next_page"] is False

--- a/nucliadb/nucliadb/search/tests/node.py
+++ b/nucliadb/nucliadb/search/tests/node.py
@@ -32,6 +32,7 @@ from pytest_docker_fixtures import images  # type: ignore
 from pytest_docker_fixtures.containers._base import BaseImage  # type: ignore
 
 from nucliadb.ingest.settings import settings
+from nucliadb_utils.tests import free_port
 
 logger = logging.getLogger(__name__)
 
@@ -86,9 +87,6 @@ images.settings["nucliadb_node_sidecar"] = {
     "image": "eu.gcr.io/stashify-218417/node_sidecar",
     "version": "main",
     "env": {
-        "INDEX_JETSTREAM_TARGET": "node.{node}",
-        "INDEX_JETSTREAM_GROUP": "node-{node}",
-        "INDEX_JETSTREAM_STREAM": "node",
         "INDEX_JETSTREAM_SERVERS": "[]",
         "CACHE_PUBSUB_NATS_URL": "",
         "HOST_KEY_PATH": "/data/node.key",
@@ -96,6 +94,8 @@ images.settings["nucliadb_node_sidecar"] = {
         "SIDECAR_LISTEN_ADDRESS": "0.0.0.0:4447",
         "READER_LISTEN_ADDRESS": "0.0.0.0:4445",
         "WRITER_LISTEN_ADDRESS": "0.0.0.0:4446",
+        "PYTHONUNBUFFERED": "1",
+        "LOG_LEVEL": "DEBUG",
     },
     "options": {
         "command": [
@@ -123,14 +123,6 @@ images.settings["nucliadb_cluster_manager"] = {
         ],
     },
 }
-
-
-def free_port() -> int:
-    import socket
-
-    sock = socket.socket()
-    sock.bind(("", 0))
-    return sock.getsockname()[1]
 
 
 def get_chitchat_port(container_obj, port):
@@ -211,14 +203,6 @@ class nucliadbChitchatNode(BaseImage):
 
     def check(self):
         return True
-        # channel = insecure_channel(f"{self.host}:{self.get_port()}")
-        # stub = health_pb2_grpc.HealthStub(channel)
-        # pb = HealthCheckRequest(service="Chitchat")
-        # try:
-        #    result = stub.Check(pb)
-        #    return result.status == 1
-        # except:  # noqa
-        #    return False
 
 
 class nucliadbNodeSidecar(BaseImage):

--- a/nucliadb/nucliadb/tests/fixtures.py
+++ b/nucliadb/nucliadb/tests/fixtures.py
@@ -34,6 +34,7 @@ from nucliadb.run import run_async_nucliadb
 from nucliadb.settings import Settings
 from nucliadb.tests.utils import inject_message
 from nucliadb.writer import API_PREFIX
+from nucliadb_utils.tests import free_port
 from nucliadb_utils.utilities import (
     Utility,
     clean_utility,
@@ -41,16 +42,6 @@ from nucliadb_utils.utilities import (
     get_utility,
     set_utility,
 )
-
-
-def free_port() -> int:
-    import socket
-
-    sock = socket.socket()
-    sock.bind(("", 0))
-    port = sock.getsockname()[1]
-    sock.close()
-    return port
 
 
 @pytest.fixture(scope="function")

--- a/nucliadb/nucliadb/train/tests/fixtures.py
+++ b/nucliadb/nucliadb/train/tests/fixtures.py
@@ -42,6 +42,7 @@ from nucliadb.ingest.orm.processor import Processor
 from nucliadb.ingest.orm.resource import KB_RESOURCE_SLUG_BASE
 from nucliadb.settings import Settings
 from nucliadb.train.utils import start_nodes_manager, stop_nodes_manager
+from nucliadb_utils.tests import free_port
 from nucliadb_utils.utilities import (
     Utility,
     clear_global_cache,
@@ -228,17 +229,9 @@ async def test_pagination_resources(
     label.title = label_title
     labelset.labels.append(label)
     await kb.set_labelset(label_title, labelset)
-    await txn.commit(resource=False)
+    await txn.commit()
 
     yield knowledgebox_ingest
-
-
-def free_port() -> int:
-    import socket
-
-    sock = socket.socket()
-    sock.bind(("", 0))
-    return sock.getsockname()[1]
 
 
 @pytest.fixture(scope="function")

--- a/nucliadb/nucliadb/train/uploader.py
+++ b/nucliadb/nucliadb/train/uploader.py
@@ -51,10 +51,9 @@ class UploadServicer:
         driver = await get_driver()
         cache = await get_cache()
         self.proc = Processor(driver=driver, storage=storage, audit=audit, cache=cache)
-        await self.proc.initialize()
 
     async def finalize(self):
-        await self.proc.finalize()
+        ...
 
     async def GetSentences(self, request: GetSentencesRequest, context=None):
         async for sentence in self.proc.kb_sentences(request):

--- a/nucliadb/nucliadb/writer/lifecycle.py
+++ b/nucliadb/nucliadb/writer/lifecycle.py
@@ -28,10 +28,10 @@ from nucliadb_utils.partition import PartitionUtility
 from nucliadb_utils.settings import nuclia_settings, storage_settings
 from nucliadb_utils.utilities import (
     Utility,
+    finalize_utilities,
     set_utility,
     start_transaction_utility,
     stop_transaction_utility,
-    finalize_utilities,
 )
 
 

--- a/nucliadb/nucliadb/writer/lifecycle.py
+++ b/nucliadb/nucliadb/writer/lifecycle.py
@@ -25,7 +25,7 @@ from nucliadb.writer.tus import initialize as storage_initialize
 from nucliadb.writer.utilities import get_processing
 from nucliadb_telemetry.utils import clean_telemetry, setup_telemetry
 from nucliadb_utils.partition import PartitionUtility
-from nucliadb_utils.settings import nuclia_settings, storage_settings
+from nucliadb_utils.settings import nuclia_settings
 from nucliadb_utils.utilities import (
     Utility,
     finalize_utilities,

--- a/nucliadb/nucliadb/writer/tests/fixtures.py
+++ b/nucliadb/nucliadb/writer/tests/fixtures.py
@@ -41,11 +41,11 @@ from nucliadb_utils.settings import (
 @pytest.fixture(scope="function")
 async def writer_api(
     redis,
+    grpc_servicer: IngestFixture,
     gcs_storage_writer,
     transaction_utility,
     processing_utility,
     tus_manager,
-    grpc_servicer: IngestFixture,
     event_loop,
 ) -> AsyncIterator[Callable[[List[Enum], str, str], AsyncClient]]:
     nucliadb_settings.nucliadb_ingest = grpc_servicer.host

--- a/nucliadb/nucliadb/writer/tests/test_files.py
+++ b/nucliadb/nucliadb/writer/tests/test_files.py
@@ -31,6 +31,7 @@ from nucliadb.writer.api.v1.router import KB_PREFIX, RSLUG_PREFIX
 from nucliadb.writer.api.v1.upload import maybe_b64decode
 from nucliadb.writer.tus import TUSUPLOAD, UPLOAD
 from nucliadb_models.resource import NucliaDBRoles
+from nucliadb_utils import const
 from nucliadb_utils.utilities import get_ingest, get_storage, get_transaction_utility
 
 ASSETS_PATH = os.path.dirname(__file__) + "/assets"
@@ -121,7 +122,9 @@ async def test_knowledgebox_file_tus_upload_root(writer_api, knowledgebox_writer
 
     transaction = get_transaction_utility()
 
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(1)
 
     writer = BrokerMessage()
@@ -179,7 +182,9 @@ async def test_knowledgebox_file_upload_root(
     transaction = get_transaction_utility()
 
     assert transaction.js is not None
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(1)
     writer = BrokerMessage()
     writer.ParseFromString(msgs[0].data)
@@ -235,7 +240,9 @@ async def test_knowledgebox_file_upload_root_headers(
     transaction = get_transaction_utility()
 
     assert transaction.js is not None
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(1)
     writer = BrokerMessage()
     writer.ParseFromString(msgs[0].data)
@@ -322,7 +329,9 @@ async def test_knowledgebox_file_tus_upload_field(
 
     transaction = get_transaction_utility()
 
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(2)
 
     writer = BrokerMessage()
@@ -370,7 +379,9 @@ async def test_knowledgebox_file_upload_field_headers(
 
     transaction = get_transaction_utility()
 
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(2)
     writer = BrokerMessage()
     writer.ParseFromString(msgs[1].data)
@@ -488,7 +499,9 @@ async def test_file_tus_upload_field_by_slug(writer_api, knowledgebox_writer, re
 
     transaction = get_transaction_utility()
 
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(2)
 
     writer = BrokerMessage()
@@ -606,7 +619,9 @@ async def test_file_upload_by_slug(writer_api, knowledgebox_writer):
 
     transaction = get_transaction_utility()
 
-    sub = await transaction.js.pull_subscribe("nucliadb.1", "auto")
+    sub = await transaction.js.pull_subscribe(
+        const.Streams.INGEST.subject.format(partition="1"), "auto"
+    )
     msgs = await sub.fetch(2)
 
     writer = BrokerMessage()

--- a/nucliadb/setup.py
+++ b/nucliadb/setup.py
@@ -57,7 +57,11 @@ setup(
             # Standalone
             "nucliadb = nucliadb.run:run",
             # Ingest
+            #   - This command runs pull workers + ingest write consumer
             "nucliadb-ingest = nucliadb.ingest.app:run_consumer",
+            #   - Only runs processed resources write consumer
+            "nucliadb-ingest-processed-consumer = nucliadb.ingest.app:run_processed_consumer",
+            #   - Only runs GRPC Service
             "nucliadb-ingest-orm-grpc = nucliadb.ingest.app:run_orm_grpc",
             # Reader
             "nucliadb-reader = nucliadb.reader.run:run",

--- a/nucliadb_dataset/Makefile
+++ b/nucliadb_dataset/Makefile
@@ -6,7 +6,7 @@ install-dev:
 	pip install -r ../code-requirements.txt
 	cd .. && pip install -r nucliadb_dataset/requirements-sources.txt
 	pip install -r requirements.txt
-	pip install -r requirements-test.txt
+	cd .. && pip install -r nucliadb_dataset/requirements-test.txt
 	pip install -e .
 
 .PHONY: format

--- a/nucliadb_node/nucliadb_node/tests/integration/test_indexing.py
+++ b/nucliadb_node/nucliadb_node/tests/integration/test_indexing.py
@@ -32,7 +32,7 @@ from nucliadb_utils.utilities import get_pubsub, get_storage
 
 from nucliadb_node import SERVICE_NAME
 from nucliadb_node.pull import Worker
-from nucliadb_node.settings import indexing_settings, settings
+from nucliadb_node.settings import settings
 
 TEST_PARTITION = "111"
 
@@ -157,9 +157,8 @@ async def create_indexing_message(
 
 async def send_indexing_message(worker: Worker, index: IndexMessage, node: str):
     # Push on stream
-    assert indexing_settings.index_jetstream_target is not None
     await worker.js.publish(
-        indexing_settings.index_jetstream_target.format(node=node),
+        const.Streams.INDEX.subject.format(node=node),
         index.SerializeToString(),
     )
 

--- a/nucliadb_utils/nucliadb_utils/const.py
+++ b/nucliadb_utils/nucliadb_utils/const.py
@@ -21,6 +21,37 @@ class PubSubChannels:
     RESOURCE_NOTIFY = "notify.{kbid}"
 
 
+class Streams:
+    class INGEST:
+        """
+        Writing resource changes go to this steam/consumer group.
+        """
+
+        name = "nucliadb"
+        subject = "ndb.consumer.{partition}"
+        group = "nucliadb-{partition}"
+
+    class INGEST_PROCESSED:
+        """
+        Resources that have been processed by learning need to be
+        written to the database and then Indexed.
+        """
+
+        name = "nucliadb"
+        subject = "ndb.consumer.processed"
+        group = "nucliadb-processed"
+
+    class INDEX:
+        """
+        Indexing resources on the IndexNode
+        """
+
+        name = "node"
+        subject = "node.{node}"
+        group = "node-{node}"
+
+
 class Features:
     WAIT_FOR_INDEX = "nucliadb_wait_for_resource_index"
     SEEK_TO_PARAGRAPH = "nucliadb_seek_to_paragraph"
+    SEPARATE_PROCESSED_MESSAGE_WRITES = "nucliadb_separate_processed_message_writes"

--- a/nucliadb_utils/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/nucliadb_utils/featureflagging.py
@@ -43,6 +43,10 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["none"]},
     },
+    const.Features.SEPARATE_PROCESSED_MESSAGE_WRITES: {
+        "rollout": 0,
+        "variants": {"environment": ["none"]},
+    },
 }
 
 

--- a/nucliadb_utils/nucliadb_utils/indexing.py
+++ b/nucliadb_utils/nucliadb_utils/indexing.py
@@ -25,7 +25,7 @@ from nats.js.client import JetStreamContext
 from nucliadb_protos.nodewriter_pb2 import IndexMessage  # type: ignore
 from nucliadb_telemetry.jetstream import JetStreamContextTelemetry
 
-from nucliadb_utils import logger
+from nucliadb_utils import const, logger
 from nucliadb_utils.nats import get_traced_jetstream
 
 
@@ -36,13 +36,11 @@ class IndexingUtility:
     def __init__(
         self,
         nats_servers: List[str],
-        nats_target: str,
         nats_creds: Optional[str] = None,
         dummy: bool = False,
     ):
         self.nats_creds = nats_creds
         self.nats_servers = nats_servers
-        self.nats_target = nats_target
         self.dummy = dummy
         self._calls: List[Tuple[str, IndexMessage]] = []
 
@@ -92,13 +90,12 @@ class IndexingUtility:
             self._calls.append((node, writer))
             return 0
 
-        if self.js is None or self.nats_target is None:
+        if self.js is None:
             raise AttributeError()
 
-        res = await self.js.publish(
-            self.nats_target.format(node=node), writer.SerializeToString()
-        )
+        subject = const.Streams.INDEX.subject.format(node=node)
+        res = await self.js.publish(subject, writer.SerializeToString())
         logger.info(
-            f" - Pushed message to index {self.nats_target.format(node=node)}.  shard: {writer.shard}, txid: {writer.txid}  seqid: {res.seq}"  # noqa
+            f" - Pushed message to index {subject}.  shard: {writer.shard}, txid: {writer.txid}  seqid: {res.seq}"  # noqa
         )
         return res.seq

--- a/nucliadb_utils/nucliadb_utils/nats.py
+++ b/nucliadb_utils/nucliadb_utils/nats.py
@@ -17,9 +17,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import logging
+import time
+from functools import cached_property
+from typing import Any, Awaitable, Callable, Optional
 
-from nats.aio.client import Client as NATS
+import nats
+import nats.errors
+import nats.js.api
+from nats.aio.client import Client as NATSClient
+from nats.aio.client import Msg
+from nats.aio.subscription import Subscription
 from nats.js.client import JetStreamContext
 from nucliadb_telemetry.jetstream import JetStreamContextTelemetry
 from nucliadb_telemetry.utils import get_telemetry
@@ -27,7 +36,7 @@ from nucliadb_telemetry.utils import get_telemetry
 logger = logging.getLogger(__name__)
 
 
-def get_traced_jetstream(nc: NATS, service_name: str) -> JetStreamContext:
+def get_traced_jetstream(nc: NATSClient, service_name: str) -> JetStreamContext:
     jetstream = nc.jetstream()
     tracer_provider = get_telemetry(service_name)
 
@@ -35,3 +44,136 @@ def get_traced_jetstream(nc: NATS, service_name: str) -> JetStreamContext:
         logger.info(f"Configuring {service_name} jetstream with telemetry")
         jetstream = JetStreamContextTelemetry(jetstream, service_name, tracer_provider)
     return jetstream
+
+
+class NatsConnectionManager:
+    _nc: NATSClient
+    _subscriptions: list[tuple[Subscription, Callable[[], Awaitable[None]]]]
+    _unhealthy_timeout = (
+        10  # needs to be unhealth for 10 seconds to be unhealthy and force exit
+    )
+
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        nats_servers: list[str],
+        nats_creds: Optional[str] = None,
+    ):
+        self._service_name = service_name
+        self._nats_servers = nats_servers
+        self._nats_creds = nats_creds
+        self._subscriptions = []
+        self._lock = asyncio.Lock()
+        self._healthy = True
+        self._last_unhealthy: Optional[float] = None
+
+    def healthy(self) -> bool:
+        if not self._healthy:
+            return False
+
+        if (
+            self._last_unhealthy is not None
+            and time.monotonic() - self._last_unhealthy > self._unhealthy_timeout
+        ):
+            return False
+
+        if not self._nc.is_connected:
+            self._last_unhealthy = time.monotonic()
+
+        return True
+
+    async def initialize(self) -> None:
+        options: dict[str, Any] = {
+            "error_cb": self.error_cb,
+            "closed_cb": self.closed_cb,
+            "reconnected_cb": self.reconnected_cb,
+            "disconnected_cb": self.disconnected_cb,
+        }
+
+        if self._nats_creds is not None:
+            options["user_credentials"] = self._nats_creds
+
+        if len(self._nats_servers) > 0:
+            options["servers"] = self._nats_servers
+
+        async with self._lock:
+            self._nc = await nats.connect(**options)
+
+    async def finalize(self):
+        async with self._lock:
+            for sub, _ in self._subscriptions:
+                try:
+                    await sub.drain()
+                except nats.errors.ConnectionClosedError:  # pragma: no cover
+                    pass
+            try:
+                await self.nc.drain()
+            except nats.errors.ConnectionClosedError:  # pragma: no cover
+                pass
+            await self.nc.close()
+            self._subscriptions = []
+
+    async def disconnected_cb(self) -> None:
+        logger.info("Disconnected from NATS!")
+        self._last_unhealthy = time.monotonic()
+
+    async def reconnected_cb(self):
+        # See who we are connected to on reconnect.
+        logger.warning(
+            f"Reconnected to NATS {self._nc.connected_url.netloc}. Attempting to re-subscribe."
+        )
+        async with self._lock:
+            existing_subs = self._subscriptions
+            self._subscriptions = []
+            for sub, recon_callback in existing_subs:
+                try:
+                    await sub.drain()
+                    await recon_callback()
+                except Exception:
+                    logger.exception(
+                        f"Error resubscribing to {sub.subject} on {self._nc.connected_url.netloc}"
+                    )
+                    # should force exit here to restart the service
+                    self._healthy = False
+                    raise
+        self._healthy = True
+        self._last_unhealthy = None  # reset the last unhealthy time
+
+    async def error_cb(self, e):  # pragma: no cover
+        logger.error(f"There was an error on consumer: {e}", exc_info=e)
+
+    async def closed_cb(self):  # pragma: no cover
+        logger.info("Connection is closed on NATS")
+
+    @property
+    def nc(self) -> NATSClient:
+        return self._nc
+
+    @cached_property
+    def js(self) -> JetStreamContext:
+        return get_traced_jetstream(self._nc, self._service_name)
+
+    async def subscribe(
+        self,
+        *,
+        subject: str,
+        queue: str,
+        stream: str,
+        cb: Callable[[Msg], Awaitable[None]],
+        subscription_lost_cb: Callable[[], Awaitable[None]],
+        flow_control: bool = False,
+        config: Optional[nats.js.api.ConsumerConfig] = None,
+    ) -> Subscription:
+        sub = await self.js.subscribe(
+            subject=subject,
+            queue=queue,
+            stream=stream,
+            cb=cb,
+            flow_control=flow_control,
+            config=config,
+        )
+
+        self._subscriptions.append((sub, subscription_lost_cb))
+
+        return sub

--- a/nucliadb_utils/nucliadb_utils/settings.py
+++ b/nucliadb_utils/nucliadb_utils/settings.py
@@ -132,9 +132,6 @@ nucliadb_settings = NucliaDBSettings()
 class TransactionSettings(BaseSettings):
     transaction_jetstream_auth: Optional[str] = None
     transaction_jetstream_servers: List[str] = ["nats://localhost:4222"]
-    transaction_jetstream_target: str = "ndb.consumer.{partition}"
-    transaction_jetstream_group: str = "nucliadb-{partition}"
-    transaction_jetstream_stream: str = "nucliadb"
     transaction_local: bool = False
 
 
@@ -142,9 +139,6 @@ transaction_settings = TransactionSettings()
 
 
 class IndexingSettings(BaseSettings):
-    index_jetstream_target: Optional[str] = "node.{node}"
-    index_jetstream_group: Optional[str] = "node-{node}"
-    index_jetstream_stream: Optional[str] = "node"
     index_jetstream_servers: List[str] = []
     index_jetstream_auth: Optional[str] = None
     index_local: bool = False

--- a/nucliadb_utils/nucliadb_utils/tests/__init__.py
+++ b/nucliadb_utils/nucliadb_utils/tests/__init__.py
@@ -16,3 +16,13 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+def free_port() -> int:
+    import socket
+
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port

--- a/nucliadb_utils/nucliadb_utils/tests/unit/test_nats.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/test_nats.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nucliadb_utils import nats
+
+pytestmark = pytest.mark.unit
+
+
+class TestNatsConnectionManager:
+    @pytest.fixture()
+    def nats_conn(self):
+        conn = MagicMock()
+        conn.drain = AsyncMock()
+        conn.close = AsyncMock()
+        with patch("nucliadb_utils.nats.nats.connect", return_value=conn):
+            yield conn
+
+    @pytest.fixture()
+    def js(self):
+        conn = AsyncMock()
+        with patch("nucliadb_utils.nats.get_traced_jetstream", return_value=conn):
+            yield conn
+
+    @pytest.fixture()
+    def manager(self, nats_conn, js):
+        yield nats.NatsConnectionManager(service_name="test", nats_servers=["test"])
+
+    async def test_initialize(self, manager: nats.NatsConnectionManager, nats_conn):
+        await manager.initialize()
+
+        assert manager.nc == nats_conn
+
+    async def test_lifecycle_finalize(
+        self, manager: nats.NatsConnectionManager, nats_conn, js
+    ):
+        await manager.initialize()
+
+        cb = AsyncMock()
+        lost_cb = AsyncMock()
+        await manager.subscribe(
+            subject="subject",
+            queue="queue",
+            stream="stream",
+            cb=cb,
+            subscription_lost_cb=lost_cb,
+            flow_control=True,
+        )
+
+        js.subscribe.assert_called_once_with(
+            subject="subject",
+            queue="queue",
+            stream="stream",
+            cb=cb,
+            flow_control=True,
+            config=None,
+        )
+
+        await manager.reconnected_cb()
+        lost_cb.assert_called_once()
+
+        await manager.finalize()
+
+        nats_conn.drain.assert_called_once()
+        nats_conn.close.assert_called_once()
+
+    async def test_healthy(self, manager: nats.NatsConnectionManager):
+        await manager.initialize()
+
+        assert manager.healthy()
+
+        manager._healthy = False
+        assert not manager.healthy()
+
+        manager._healthy = True
+        manager._last_unhealthy = time.monotonic() - 100
+        assert not manager.healthy()
+
+        manager._last_unhealthy = None
+        manager._nc.is_connected = False
+        assert manager.healthy()
+        assert manager._last_unhealthy is not None

--- a/nucliadb_utils/nucliadb_utils/tests/unit/test_transaction.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/test_transaction.py
@@ -37,7 +37,7 @@ def pubsub():
 async def txn(pubsub):
     nats_conn = mock.AsyncMock()
     with mock.patch("nucliadb_utils.transaction.nats.connect", return_value=nats_conn):
-        txn = TransactionUtility(nats_servers=["foobar"], nats_target="node.{node}")
+        txn = TransactionUtility(nats_servers=["foobar"])
         await txn.initialize()
         yield txn
         await txn.finalize()

--- a/nucliadb_utils/requirements.txt
+++ b/nucliadb_utils/requirements.txt
@@ -9,3 +9,4 @@ memorylru>=1.1.2
 nucliadb-protos
 nucliadb-telemetry>=1.9.2
 mrflagly
+urllib3<1.27,>=1.21.1


### PR DESCRIPTION
### Description

- Decouple pull workers from ingest consumers
- Move to constants for stream configuration
- Reuse nats connections between consumers instead of having a unique connection for every one
- Be able to split out processed messages writes from regular transaction writes
- Decouple ingest write seq id tracking from the db transaction handling

### How was this PR tested?
Unit, integration and pain
