### PR TITLE
Fix handling duplicates on orderer

### DIFF
--- a/nucliadb/nucliadb/search/search/find_merge.py
+++ b/nucliadb/nucliadb/search/search/find_merge.py
@@ -121,9 +121,17 @@ class Orderer:
         self.boosted_items.append(key)
 
     def sorted_by_insertion(self) -> Iterator[Any]:
+        returned = set()
         for key in self.boosted_items:
+            if key in returned:
+                continue
+            returned.add(key)
             yield key
+
         for key in self.items:
+            if key in returned:
+                continue
+            returned.add(key)
             yield key
 
 

--- a/nucliadb/nucliadb/search/tests/unit/test_find_orderer.py
+++ b/nucliadb/nucliadb/search/tests/unit/test_find_orderer.py
@@ -47,3 +47,13 @@ def test_orderer():
 
     sorted_items = list(orderer.sorted_by_insertion())
     assert sorted_items == boosted_items + regular_items
+
+
+def test_orderer_handles_duplicate_insertions():
+    orderer = Orderer()
+    orderer.add_boosted("a")
+    orderer.add_boosted("b")
+    orderer.add_boosted("a")
+    orderer.add_boosted("c")
+    orderer.add("a")
+    assert list(orderer.sorted_by_insertion()) == ["a", "b", "c"]


### PR DESCRIPTION
### Description
This made that results matching both for bm25 and vector were showing up the very end of the list.

### How was this PR tested?
Unit testing