### PR TITLE
Remove usage of deprecated set-output GH action commands

### DIFF
--- a/.github/workflows/nucliadb.yml
+++ b/.github/workflows/nucliadb.yml
@@ -164,7 +164,7 @@ jobs:
         run: |-
           python bump.py --build=${{github.run_number}}
           VERSION=`cat VERSION`
-          echo "::set-output name=version_number::$VERSION"
+          echo "version_number=$VERSION" >> $GITHUB_OUTPUT
 
       # We need to setup buildx to be able to cache with gha
       - name: Set up Docker Buildx
@@ -196,7 +196,7 @@ jobs:
         id: branch_name
         run: |-
           BRANCH_NAME=`echo $GITHUB_HEAD_REF | sed 's$/$-$g'`
-          echo "::set-output name=branch_name::$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0

--- a/.github/workflows/nucliadb_cluster.yml
+++ b/.github/workflows/nucliadb_cluster.yml
@@ -105,8 +105,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       # As base image is on a private registry, we need to authenticate 1st to be able to download that image
       - name: Setup gcloud CLI

--- a/.github/workflows/nucliadb_ingest.yml
+++ b/.github/workflows/nucliadb_ingest.yml
@@ -91,8 +91,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0
@@ -135,7 +135,7 @@ jobs:
         id: env-vars
         run: |-
           HASH=`git rev-parse --short HEAD`
-          echo "::set-output name=short_sha::$HASH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
 
       - name: Set helm package image
         id: version_step
@@ -145,7 +145,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+${{ steps.env-vars.outputs.short_sha }}
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_ingest/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nucliadb_node.yml
+++ b/.github/workflows/nucliadb_node.yml
@@ -298,8 +298,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       # As base image is on a private registry, we need to authenticate 1st to
       # be able to download that image
@@ -345,8 +345,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0
@@ -389,7 +389,7 @@ jobs:
         id: env-vars
         run: |-
           HASH=`git rev-parse --short HEAD`
-          echo "::set-output name=short_sha::$HASH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
 
       - name: Set helm package image
         id: version_step
@@ -400,7 +400,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+${{ steps.env-vars.outputs.short_sha }}
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_node/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nucliadb_reader.yml
+++ b/.github/workflows/nucliadb_reader.yml
@@ -96,8 +96,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0
@@ -140,7 +140,7 @@ jobs:
         id: env-vars
         run: |-
           HASH=`git rev-parse --short HEAD`
-          echo "::set-output name=short_sha::$HASH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
 
       - name: Set helm package image
         id: version_step
@@ -150,7 +150,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+${{ steps.env-vars.outputs.short_sha }}
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_reader/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nucliadb_search.yml
+++ b/.github/workflows/nucliadb_search.yml
@@ -205,8 +205,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0
@@ -249,7 +249,7 @@ jobs:
         id: env-vars
         run: |-
           HASH=`git rev-parse --short HEAD`
-          echo "::set-output name=short_sha::$HASH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
 
       - name: Set helm package image
         id: version_step
@@ -259,7 +259,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+${{ steps.env-vars.outputs.short_sha }}
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_search/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nucliadb_shared.yml
+++ b/.github/workflows/nucliadb_shared.yml
@@ -28,7 +28,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+$(echo $GITHUB_SHA | cut -c1-6)
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_shared/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nucliadb_train.yml
+++ b/.github/workflows/nucliadb_train.yml
@@ -108,8 +108,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0
@@ -152,7 +152,7 @@ jobs:
         id: env-vars
         run: |-
           HASH=`git rev-parse --short HEAD`
-          echo "::set-output name=short_sha::$HASH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
 
       - name: Set helm package image
         id: version_step
@@ -162,7 +162,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+${{ steps.env-vars.outputs.short_sha }}
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_train/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |

--- a/.github/workflows/nucliadb_writer.yml
+++ b/.github/workflows/nucliadb_writer.yml
@@ -93,8 +93,8 @@ jobs:
         run: |-
           HASH=`git rev-parse --short HEAD`
           BRANCH=${GITHUB_REF##*/}
-          echo "::set-output name=short_sha::$HASH"
-          echo "::set-output name=branch::$BRANCH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
       - name: Setup gcloud CLI
         uses: google-github-actions/auth@v0
@@ -137,7 +137,7 @@ jobs:
         id: env-vars
         run: |-
           HASH=`git rev-parse --short HEAD`
-          echo "::set-output name=short_sha::$HASH"
+          echo "short_sha=$HASH" >> $GITHUB_OUTPUT
 
       - name: Set helm package image
         id: version_step
@@ -147,7 +147,7 @@ jobs:
           VERSION=`cat VERSION`
           VERSION_SHA=$VERSION+${{ steps.env-vars.outputs.short_sha }}
           sed -i.bak "s#99999.99999.99999#$VERSION_SHA#" ./charts/nucliadb_writer/Chart.yaml
-          echo "::set-output name=version_number::$VERSION_SHA"
+          echo "version_number=$VERSION_SHA" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
### Description
This PR is doing the [github actions docs recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples)

### How was this PR tested?
Describe how you tested this PR.
