### PR TITLE
Remove locking on new_shard operations

### DIFF
--- a/nucliadb_node/binding/src/lib.rs
+++ b/nucliadb_node/binding/src/lib.rs
@@ -297,10 +297,10 @@ impl NodeWriter {
         }
     }
 
-    pub fn new_shard<'p>(&mut self, metadata: RawProtos, py: Python<'p>) -> PyResult<&'p PyAny> {
+    pub fn new_shard<'p>(&self, metadata: RawProtos, py: Python<'p>) -> PyResult<&'p PyAny> {
         send_telemetry_event(TelemetryEvent::Create);
         let request = NewShardRequest::decode(&mut Cursor::new(metadata)).unwrap();
-        match self.writer.new_shard(&request) {
+        match RustWriterService::new_shard(&request) {
             Ok(shard) => Ok(PyList::new(py, shard.encode_to_vec())),
             Err(e) => Err(exceptions::PyTypeError::new_err(e.to_string())),
         }

--- a/nucliadb_node/src/bin/payload_test.rs
+++ b/nucliadb_node/src/bin/payload_test.rs
@@ -25,11 +25,11 @@ use nucliadb_node::writer::NodeWriterService;
 use prost::Message;
 
 fn main() -> anyhow::Result<()> {
-    let mut writer = NodeWriterService::new();
+    let writer = NodeWriterService::new();
     let reader = NodeReaderService::new();
 
     let resources_dir = std::path::Path::new("/path/to/data");
-    let new_shard = writer.new_shard(&NewShardRequest::default())?;
+    let new_shard = NodeWriterService::new_shard(&NewShardRequest::default())?;
     let shard_id = ShardId { id: new_shard.id };
     assert!(resources_dir.exists());
     for file_path in std::fs::read_dir(resources_dir).unwrap() {

--- a/nucliadb_node/src/writer/grpc_driver.rs
+++ b/nucliadb_node/src/writer/grpc_driver.rs
@@ -627,8 +627,16 @@ mod tests {
                 .await
                 .expect("Error in new_shard request");
 
-            request_ids.push(response.get_ref().id.clone());
+            let shard_id = response.into_inner().id;
+            request_ids.push(shard_id.clone());
+
+            // Get shard to ensure it is in cache
+            client
+                .get_shard(Request::new(ShardId { id: shard_id }))
+                .await
+                .expect("Error in get_shard request");
         }
+
         let response = client
             .list_shards(Request::new(EmptyQuery {}))
             .await

--- a/nucliadb_node/src/writer/grpc_driver.rs
+++ b/nucliadb_node/src/writer/grpc_driver.rs
@@ -132,11 +132,8 @@ impl NodeWriter for NodeWriterGRPCDriver {
         debug!("Creating new shard");
         let request = request.into_inner();
         send_telemetry_event(TelemetryEvent::Create).await;
-        let mut writer = self.inner.write().await;
-        let result = writer
-            .new_shard(&request)
+        let result = NodeWriterService::new_shard(&request)
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
-        std::mem::drop(writer);
         self.emit_event(NodeWriterEvent::ShardCreation);
         Ok(tonic::Response::new(result))
     }

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -109,19 +109,17 @@ impl NodeWriterService {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn new_shard(&mut self, request: &NewShardRequest) -> NodeResult<ShardCreated> {
+    pub fn new_shard(request: &NewShardRequest) -> NodeResult<ShardCreated> {
         let shard_id = Uuid::new_v4().to_string();
         let shard_path = env::shards_path_id(&shard_id);
         let new_shard = ShardWriterService::new(shard_id.clone(), &shard_path, request)?;
-        let data = ShardCreated {
-            id: new_shard.id.clone(),
+        Ok(ShardCreated {
+            id: shard_id,
             document_service: new_shard.document_version() as i32,
             paragraph_service: new_shard.paragraph_version() as i32,
             vector_service: new_shard.vector_version() as i32,
             relation_service: new_shard.relation_version() as i32,
-        };
-        self.cache.insert(shard_id, new_shard);
-        Ok(data)
+        })
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION
### Description
We want to be able to create new shards via GRPC while the node writer is indexing to other shards

### How was this PR tested?
Describe how you tested this PR.
