### PR TITLE
better grpc retries

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/node.py
+++ b/nucliadb/nucliadb/ingest/orm/node.py
@@ -229,19 +229,6 @@ class Node(AbstractNode):
             grpc_address = f"{hostname}:{port}"
         return grpc_address
 
-    def reset_connections(self) -> None:
-        if self.address in SIDECAR_CONNECTIONS:
-            del SIDECAR_CONNECTIONS[self.address]
-        self._sidecar = None
-
-        if self.address in WRITE_CONNECTIONS:
-            del WRITE_CONNECTIONS[self.address]
-        self._writer = None
-
-        if self.address in READ_CONNECTIONS:
-            del READ_CONNECTIONS[self.address]
-        self._reader = None
-
     @property
     def sidecar(self) -> NodeSidecarStub:
         if self._sidecar is None and self.address not in SIDECAR_CONNECTIONS:

--- a/nucliadb/nucliadb/ingest/orm/processor/__init__.py
+++ b/nucliadb/nucliadb/ingest/orm/processor/__init__.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import asyncio
 import logging
 from typing import Dict, List, Optional, Tuple
 
@@ -271,6 +272,13 @@ class Processor:
                     partition=partition, seqid=seqid, multi=multi, kbid=kbid, rid=uuid
                 )
                 logger.warning(f"This message did not modify the resource")
+        except (asyncio.TimeoutError, asyncio.CancelledError):  # pragma: no cover
+            # Unhandled exceptions here that should bubble and hard fail
+            # XXX We swallow too many exceptions here!
+            await self.notify_abort(
+                partition=partition, seqid=seqid, multi=multi, kbid=kbid, rid=uuid
+            )
+            raise
         except Exception as exc:
             # As we are in the middle of a transaction, we cannot let the exception raise directly
             # as we need to do some cleanup. The exception will be reraised at the end of the function

--- a/nucliadb/nucliadb/ingest/orm/processor/__init__.py
+++ b/nucliadb/nucliadb/ingest/orm/processor/__init__.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 from typing import Dict, List, Optional, Tuple
 
+import aiohttp.client_exceptions
 from nucliadb_protos.knowledgebox_pb2 import KnowledgeBox as KnowledgeBoxPB
 from nucliadb_protos.knowledgebox_pb2 import (
     KnowledgeBoxConfig,
@@ -272,7 +273,11 @@ class Processor:
                     partition=partition, seqid=seqid, multi=multi, kbid=kbid, rid=uuid
                 )
                 logger.warning(f"This message did not modify the resource")
-        except (asyncio.TimeoutError, asyncio.CancelledError):  # pragma: no cover
+        except (
+            asyncio.TimeoutError,
+            asyncio.CancelledError,
+            aiohttp.client_exceptions.ClientError,
+        ):  # pragma: no cover
             # Unhandled exceptions here that should bubble and hard fail
             # XXX We swallow too many exceptions here!
             await self.notify_abort(

--- a/nucliadb/nucliadb/ingest/tests/unit/orm/test_node.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/orm/test_node.py
@@ -24,12 +24,7 @@ from nucliadb_protos.writer_pb2 import Member
 from nucliadb_protos.writer_pb2 import Shards as PBShards
 
 from nucliadb.ingest.orm import NODES, NodeClusterSmall
-from nucliadb.ingest.orm.node import (
-    READ_CONNECTIONS,
-    SIDECAR_CONNECTIONS,
-    WRITE_CONNECTIONS,
-    Node,
-)
+from nucliadb.ingest.orm.node import Node
 from nucliadb.ingest.settings import settings
 from nucliadb_models.cluster import MemberType
 from nucliadb_utils.keys import KB_SHARDS
@@ -130,28 +125,3 @@ async def node_errors():
 async def test_create_shard_by_kbid_rolls_back(txn, fake_node, node_errors):
     with pytest.raises(ValueError):
         await Node.create_shard_by_kbid(txn, "foo")
-
-
-def test_reset_connection():
-    READ_CONNECTIONS.clear()
-    WRITE_CONNECTIONS.clear()
-    SIDECAR_CONNECTIONS.clear()
-
-    node = Node("host:1234", MemberType.IO, 0, dummy=True)
-    assert node.reader is not None
-    assert node.writer is not None
-    assert node.sidecar is not None
-
-    assert len(READ_CONNECTIONS) == 1
-    assert len(WRITE_CONNECTIONS) == 1
-    assert len(SIDECAR_CONNECTIONS) == 1
-
-    node.reset_connections()
-
-    assert len(READ_CONNECTIONS) == 0
-    assert len(WRITE_CONNECTIONS) == 0
-    assert len(SIDECAR_CONNECTIONS) == 0
-
-    assert node._reader is None
-    assert node._writer is None
-    assert node._sidecar is None

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -21,7 +21,6 @@ import asyncio
 from enum import Enum
 from typing import Any, List, Optional, Tuple, TypeVar, Union, overload
 
-import backoff
 from fastapi import HTTPException
 from grpc import StatusCode as GrpcStatusCode
 from grpc.aio import AioRpcError  # type: ignore
@@ -37,7 +36,6 @@ from nucliadb_protos.nodereader_pb2 import (
 )
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 
-from nucliadb.ingest.orm.node import Node
 from nucliadb.ingest.txn_utils import abort_transaction
 from nucliadb.search import logger
 from nucliadb.search.search.shards import (

--- a/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
@@ -27,16 +27,16 @@ from nucliadb.search.requesters import utils
 
 
 def test_validate_node_query_results():
-    assert utils.validate_node_query_results([Mock()], []) is None
+    assert utils.validate_node_query_results([Mock()]) is None
 
 
 def test_validate_node_query_results_no_results():
-    assert isinstance(utils.validate_node_query_results([], []), HTTPException)
-    assert isinstance(utils.validate_node_query_results(None, []), HTTPException)
+    assert isinstance(utils.validate_node_query_results([]), HTTPException)
+    assert isinstance(utils.validate_node_query_results(None), HTTPException)
 
 
 def test_validate_node_query_results_unhandled_error():
-    error = utils.validate_node_query_results([Exception()], [])
+    error = utils.validate_node_query_results([Exception()])
     assert isinstance(error, HTTPException)
 
 
@@ -50,8 +50,7 @@ def test_validate_node_query_results_invalid_query():
                 details="An invalid argument was passed: 'Query is invalid. AllButQueryForbidden'",
                 debug_error_string="",
             )
-        ],
-        [],
+        ]
     )
 
     assert isinstance(result, HTTPException)

--- a/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
@@ -41,48 +41,6 @@ def test_validate_node_query_results_unhandled_error():
     assert isinstance(error, HTTPException)
 
 
-def test_validate_node_query_results_unavailable_reset_conns():
-    # if result len match used nodes len, just reset the connection
-    # from the used node
-    node = MagicMock()
-    with pytest.raises(utils.RetriableNodeQueryException):
-        utils.validate_node_query_results(
-            [
-                AioRpcError(
-                    code=StatusCode.UNAVAILABLE,
-                    initial_metadata=Mock(),
-                    trailing_metadata=Mock(),
-                    details="",
-                    debug_error_string="",
-                )
-            ],
-            [node],
-        )
-
-    node.reset_connections.assert_called_once()
-
-
-def test_validate_node_query_results_unavailable_reset_all_node_conns():
-    node1 = MagicMock()
-    node2 = MagicMock()
-    with pytest.raises(utils.RetriableNodeQueryException):
-        utils.validate_node_query_results(
-            [
-                AioRpcError(
-                    code=StatusCode.UNAVAILABLE,
-                    initial_metadata=Mock(),
-                    trailing_metadata=Mock(),
-                    details="",
-                    debug_error_string="",
-                )
-            ],
-            [node1, node2],
-        )
-
-    node1.reset_connections.assert_called_once()
-    node2.reset_connections.assert_called_once()
-
-
 def test_validate_node_query_results_invalid_query():
     result = utils.validate_node_query_results(
         [

--- a/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
@@ -17,9 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
-import pytest
 from fastapi import HTTPException
 from grpc import StatusCode
 from grpc.aio import AioRpcError  # type: ignore

--- a/nucliadb_node/nucliadb_node/reader.py
+++ b/nucliadb_node/nucliadb_node/reader.py
@@ -33,7 +33,6 @@ CACHE = LRU(128)
 
 
 class Reader:
-    _stub: Optional[NodeReaderStub] = None
     lock: asyncio.Lock
 
     def __init__(self, grpc_reader_address: str):

--- a/nucliadb_protos/rust/src/resources.rs
+++ b/nucliadb_protos/rust/src/resources.rs
@@ -179,10 +179,13 @@ pub struct Conversation {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldConversation {
+    /// Total number of pages
     #[prost(int32, tag="1")]
     pub pages: i32,
+    /// Max page size
     #[prost(int32, tag="2")]
     pub size: i32,
+    /// Total number of messages
     #[prost(int32, tag="3")]
     pub total: i32,
 }

--- a/nucliadb_utils/nucliadb_utils/grpc.py
+++ b/nucliadb_utils/nucliadb_utils/grpc.py
@@ -19,7 +19,7 @@
 
 import json
 import logging
-from typing import Optional, TypeVar
+from typing import Optional
 
 from grpc import aio  # type: ignore
 from grpc import ChannelCredentials

--- a/nucliadb_utils/nucliadb_utils/grpc.py
+++ b/nucliadb_utils/nucliadb_utils/grpc.py
@@ -69,6 +69,7 @@ def get_traced_grpc_server(service_name: str, max_receive_message: int = 100):
                                 "UNAVAILABLE",
                                 "DEADLINE_EXCEEDED",
                                 "ABORTED",
+                                "CANCELLED",
                             ],
                         },
                         "waitForReady": True,

--- a/nucliadb_utils/nucliadb_utils/grpc.py
+++ b/nucliadb_utils/nucliadb_utils/grpc.py
@@ -17,8 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import logging
-from typing import Optional
+from typing import Optional, TypeVar
 
 from grpc import aio  # type: ignore
 from grpc import ChannelCredentials
@@ -54,6 +55,26 @@ def get_traced_grpc_server(service_name: str, max_receive_message: int = 100):
     else:
         options = [
             ("grpc.max_receive_message_length", max_receive_message * 1024 * 1024),
+            (
+                "grpc.service_config",
+                json.dumps(
+                    {
+                        "name": [{}],  # require to enable retrying all methods
+                        "retryPolicy": {
+                            "maxAttempts": 4,
+                            "initialBackoff": "0.02s",
+                            "maxBackoff": "2s",
+                            "backoffMultiplier": 2,
+                            "retryableStatusCodes": [
+                                "UNAVAILABLE",
+                                "DEADLINE_EXCEEDED",
+                                "ABORTED",
+                            ],
+                        },
+                        "waitForReady": True,
+                    }
+                ),
+            ),
         ]
         server = aio.server(options=options)
     return server

--- a/nucliadb_utils/nucliadb_utils/storages/gcs.py
+++ b/nucliadb_utils/nucliadb_utils/storages/gcs.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import socket
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import datetime
@@ -29,6 +30,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 from urllib.parse import quote_plus
 
 import aiohttp
+import aiohttp.client_exceptions
 import backoff  # type: ignore
 import google.auth.transport.requests  # type: ignore
 import yarl
@@ -81,9 +83,12 @@ RETRIABLE_EXCEPTIONS = (
     GoogleCloudException,
     aiohttp.client_exceptions.ClientPayloadError,
     aiohttp.client_exceptions.ClientConnectorError,
+    aiohttp.client_exceptions.ClientConnectionError,
     aiohttp.client_exceptions.ClientOSError,
     aiohttp.client_exceptions.ServerConnectionError,
+    aiohttp.client_exceptions.ServerDisconnectedError,
     CouldNotCreateBucket,
+    socket.gaierror,
 )
 
 
@@ -469,7 +474,9 @@ class GCSStorage(Storage):
         loop = asyncio.get_event_loop()
 
         await setup_telemetry(service_name or "GCS_SERVICE")
-        self.session = aiohttp.ClientSession(loop=loop)
+        self.session = aiohttp.ClientSession(
+            loop=loop, connector=aiohttp.TCPConnector(ttl_dns_cache=60 * 5)
+        )
 
         try:
             if self.deadletter_bucket is not None and self.deadletter_bucket != "":


### PR DESCRIPTION
### Description
It turns out the grpc client already has a less advertised feature of implementing retry logic for errors: https://github.com/grpc/proposal/blob/master/A6-client-retries.md

other things:
- increase dns cache for gcs connector
- more exceptions to retry on for gcs errors

[sc-5463]

