### PR TITLE
Implement telemetry context variables

### DIFF
--- a/nucliadb_telemetry/nucliadb_telemetry/context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/context.py
@@ -26,8 +26,9 @@
 # This allows us to leverage context data for both tracing and logs.
 #
 import contextvars
+from typing import Optional
 
-context_data = contextvars.ContextVar("data", default=None)
+context_data = contextvars.ContextVar[Optional[dict[str, str]]]("data", default=None)
 
 
 def add_context(new_data: dict[str, str]):

--- a/nucliadb_telemetry/nucliadb_telemetry/context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/context.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# ABOUT
+# The module is meant to manage telemetry oriented context data.
+# This is a little different than the span context because we do
+# not necessarily want to inject all context data into every span,
+# only particular ones like the request handler root span.
+#
+# This allows us to leverage context data for both tracing and logs.
+#
+import contextvars
+
+context_data = contextvars.ContextVar("data", default=None)
+
+
+def add_context(new_data: dict[str, str]):
+    """
+    This implementation always merges and sets the context, even if is was already set.
+
+    This is so data is propated forward but not backward.
+    """
+    data = context_data.get()
+    if data is None:
+        data = {}
+    else:
+        data = data.copy()
+    data.update(new_data)
+    context_data.set(data)  # always set the context
+
+
+def get_context() -> dict[str, str]:
+    return context_data.get() or {}

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/__init__.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/__init__.py
@@ -25,12 +25,14 @@ from fastapi import FastAPI
 from opentelemetry.instrumentation.fastapi import _get_route_details  # type: ignore
 from prometheus_client import CONTENT_TYPE_LATEST
 from starlette.responses import PlainTextResponse
-from .context import ContextInjectorMiddleware
+
 from nucliadb_telemetry.fastapi.metrics import PrometheusMiddleware
 from nucliadb_telemetry.fastapi.tracing import (
     OpenTelemetryMiddleware,
     ServerRequestHookT,
 )
+
+from .context import ContextInjectorMiddleware
 
 try:
     from sentry_sdk.integrations.asgi import SentryAsgiMiddleware

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/__init__.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/__init__.py
@@ -75,6 +75,7 @@ def instrument_app(
 
     excluded_urls_obj = ExcludeList(excluded_urls)
 
+    app.add_middleware(ContextInjectorMiddleware)
     app.add_middleware(
         OpenTelemetryMiddleware,
         excluded_urls=excluded_urls_obj,
@@ -82,7 +83,6 @@ def instrument_app(
         server_request_hook=server_request_hook,
         tracer_provider=tracer_provider,
     )
-    app.add_middleware(ContextInjectorMiddleware)
 
     if SentryAsgiMiddleware is not None:
         # add last to catch all exceptions

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
@@ -1,3 +1,21 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
@@ -1,0 +1,23 @@
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+from .utils import get_path_template
+from nucliadb_telemetry import context
+
+
+class ContextInjectorMiddleware(BaseHTTPMiddleware):
+    """
+    Automatically inject context values for the current request's path parameters
+
+    For example:
+        - `/api/v1/kb/{kbid}` would inject a context value for `kbid`
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        found_path_template = get_path_template(request.scope)
+        if found_path_template.match:
+            context.add_context(found_path_template.scope.get("path_params", {}))
+
+        return await call_next(request)

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
@@ -1,8 +1,10 @@
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
-from .utils import get_path_template
+
 from nucliadb_telemetry import context
+
+from .utils import get_path_template
 
 
 class ContextInjectorMiddleware(BaseHTTPMiddleware):

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/context.py
@@ -38,6 +38,6 @@ class ContextInjectorMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         found_path_template = get_path_template(request.scope)
         if found_path_template.match:
-            context.add_context(found_path_template.scope.get("path_params", {}))
+            context.add_context(found_path_template.scope.get("path_params", {}))  # type: ignore
 
         return await call_next(request)

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/metrics.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/metrics.py
@@ -24,6 +24,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
+
 from .utils import get_path_template
 
 try:

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/metrics.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/metrics.py
@@ -18,15 +18,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import time
-from typing import Optional, Tuple
 
 from prometheus_client import Counter, Gauge, Histogram
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import Match, Mount, Route
 from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
-from starlette.types import ASGIApp, Scope
+from .utils import get_path_template
 
 try:
     from starlette_prometheus.middleware import (
@@ -67,18 +65,16 @@ except ImportError:  # pragma: no cover
 
 
 class PrometheusMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: ASGIApp, filter_unhandled_paths: bool = False) -> None:
-        super().__init__(app)
-        self.filter_unhandled_paths = filter_unhandled_paths
-
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         method = request.method
-        path_template, is_handled_path = self.get_path_template(request)
+        found_path_template = get_path_template(request.scope)
 
-        if self._is_path_filtered(is_handled_path):
+        if not found_path_template.match:
             return await call_next(request)
+
+        path_template = found_path_template.path
 
         REQUESTS_IN_PROGRESS.labels(method=method, path_template=path_template).inc()
         REQUESTS.labels(method=method, path_template=path_template).inc()
@@ -108,33 +104,3 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
             ).dec()
 
         return response
-
-    @staticmethod
-    def get_path_template(request: Request) -> Tuple[str, bool]:
-        path, found = PrometheusMiddleware._find_route(
-            request.scope, request.app.routes
-        )
-        return path or request.url.path, found
-
-    @staticmethod
-    def _find_route(scope: Scope, routes: list[Route]) -> Tuple[Optional[str], bool]:
-        # we mutate scope, so we need a copy
-        scope = scope.copy()  # type:ignore
-        for route in routes:
-            if isinstance(route, Mount):
-                mount_match, child_scope = route.matches(scope)
-                if mount_match == Match.FULL:
-                    scope.update(child_scope)
-                    sub_path, sub_match = PrometheusMiddleware._find_route(
-                        scope, route.routes
-                    )
-                    if sub_match:
-                        return route.path + sub_path, sub_match
-            elif isinstance(route, Route):
-                match, child_scope = route.matches(scope)
-                if match == Match.FULL:
-                    return route.path, True
-        return None, False
-
-    def _is_path_filtered(self, is_handled_path: bool) -> bool:
-        return self.filter_unhandled_paths and not is_handled_path

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/tracing.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/tracing.py
@@ -42,6 +42,7 @@ from opentelemetry.util.http import (
     normalise_response_header_name,
     remove_url_credentials,
 )
+
 from nucliadb_telemetry.context import get_context as get_nuclia_context
 
 ServerRequestHookT = Optional[Callable[[Span, dict], None]]

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/tracing.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/tracing.py
@@ -43,8 +43,6 @@ from opentelemetry.util.http import (
     remove_url_credentials,
 )
 
-from nucliadb_telemetry.context import get_context as get_nuclia_context
-
 ServerRequestHookT = Optional[Callable[[Span, dict], None]]
 
 
@@ -311,14 +309,7 @@ class OpenTelemetryMiddleware:
                     send,
                 )
 
-                try:
-                    await self.app(scope, receive, otel_send)
-                finally:
-                    # set custom context on the span
-                    if current_span.is_recording():
-                        current_span.set_attributes(
-                            {f"nuclia.{k}": v for k, v in get_nuclia_context().items()}
-                        )
+                await self.app(scope, receive, otel_send)
 
         finally:
             if token:

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/utils.py
@@ -34,7 +34,7 @@ def get_path_template(scope: Scope) -> FoundPathTemplate:
     if "found_path_template" in scope:
         return scope["found_path_template"]
     app: Starlette = scope["app"]
-    path, sub_scope = find_route(scope, app.routes)
+    path, sub_scope = find_route(scope, app.routes)  # type:ignore
     if path is None:
         path = URL(scope=scope).path
     path_template = FoundPathTemplate(path, sub_scope, sub_scope is not None)
@@ -53,7 +53,7 @@ def find_route(
             if mount_match == Match.FULL:
                 scope.update(child_scope)
                 sub_path, sub_match = find_route(scope, route.routes)
-                if sub_match:
+                if sub_match and sub_path is not None:
                     return route.path + sub_path, sub_match
         elif isinstance(route, Route):
             match, child_scope = route.matches(scope)

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/utils.py
@@ -1,8 +1,27 @@
-from starlette.routing import Match, Mount, Route
-from starlette.types import Scope
-from typing import Optional, NamedTuple
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from typing import NamedTuple, Optional
+
 from starlette.applications import Starlette
 from starlette.datastructures import URL
+from starlette.routing import Match, Mount, Route
+from starlette.types import Scope
 
 
 class FoundPathTemplate(NamedTuple):

--- a/nucliadb_telemetry/nucliadb_telemetry/fastapi/utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/fastapi/utils.py
@@ -1,0 +1,43 @@
+from starlette.routing import Match, Mount, Route
+from starlette.types import Scope
+from typing import Optional, NamedTuple
+from starlette.applications import Starlette
+from starlette.datastructures import URL
+
+
+class FoundPathTemplate(NamedTuple):
+    path: str
+    scope: Optional[Scope]
+    match: bool
+
+
+def get_path_template(scope: Scope) -> FoundPathTemplate:
+    if "found_path_template" in scope:
+        return scope["found_path_template"]
+    app: Starlette = scope["app"]
+    path, sub_scope = find_route(scope, app.routes)
+    if path is None:
+        path = URL(scope=scope).path
+    path_template = FoundPathTemplate(path, sub_scope, sub_scope is not None)
+    scope["found_path_template"] = path_template
+    return path_template
+
+
+def find_route(
+    scope: Scope, routes: list[Route]
+) -> tuple[Optional[str], Optional[Scope]]:
+    # we mutate scope, so we need a copy
+    scope = scope.copy()  # type:ignore
+    for route in routes:
+        if isinstance(route, Mount):
+            mount_match, child_scope = route.matches(scope)
+            if mount_match == Match.FULL:
+                scope.update(child_scope)
+                sub_path, sub_match = find_route(scope, route.routes)
+                if sub_match:
+                    return route.path + sub_path, sub_match
+        elif isinstance(route, Route):
+            match, child_scope = route.matches(scope)
+            if match == Match.FULL:
+                return route.path, child_scope
+    return None, None

--- a/nucliadb_telemetry/nucliadb_telemetry/logs.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/logs.py
@@ -27,6 +27,7 @@ import orjson
 import pydantic
 from opentelemetry import trace
 from opentelemetry.trace.span import INVALID_SPAN
+from . import context
 
 from nucliadb_telemetry.settings import LogLevel, LogSettings
 
@@ -99,6 +100,10 @@ class JSONFormatter(logging.Formatter):
             "line": record.lineno,
             "function": record.funcName,
         }
+
+        current_ctx = context.get_context()
+        if len(current_ctx) > 0:
+            data["context"] = current_ctx
 
         current_span = trace.get_current_span()
         if current_span not in (INVALID_SPAN, None):

--- a/nucliadb_telemetry/nucliadb_telemetry/logs.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/logs.py
@@ -27,9 +27,10 @@ import orjson
 import pydantic
 from opentelemetry import trace
 from opentelemetry.trace.span import INVALID_SPAN
-from . import context
 
 from nucliadb_telemetry.settings import LogLevel, LogSettings
+
+from . import context
 
 try:
     from uvicorn.logging import AccessFormatter  # type: ignore

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/integration/test_fastapi.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/integration/test_fastapi.py
@@ -210,7 +210,7 @@ class TestCasePrometheusMiddlewareFilterUnhandledPaths:
     @pytest.fixture(scope="class")
     def app(self):
         app_ = Starlette()
-        app_.add_middleware(PrometheusMiddleware, filter_unhandled_paths=True)
+        app_.add_middleware(PrometheusMiddleware)
         app_.add_route("/metrics/", metrics_endpoint)
 
         return app_

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/integration/test_fastapi.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/integration/test_fastapi.py
@@ -161,36 +161,6 @@ class TestCasePrometheusMiddleware:
             in metrics_text
         )
 
-    def test_unhandled_paths(self, client):
-        # Do a request
-        client.get("/any/unhandled/path")
-
-        # Get metrics
-        response = client.get("/metrics/")
-        metrics_text = response.content.decode()
-
-        # Asserts: Requests
-        assert (
-            'starlette_requests_total{method="GET",path_template="/any/unhandled/path"} 1.0'
-            in metrics_text
-        )
-
-        # Asserts: Responses
-        assert (
-            'starlette_responses_total{method="GET",path_template="/any/unhandled/path",status_code="404"} 1.0'
-            in metrics_text
-        )
-
-        # Asserts: Requests in progress
-        assert (
-            'starlette_requests_in_progress{method="GET",path_template="/any/unhandled/path"} 0.0'
-            in metrics_text
-        )
-        assert (
-            'starlette_requests_in_progress{method="GET",path_template="/metrics/"} 1.0'
-            in metrics_text
-        )
-
     def test_sub_path_match(self, client):
         # Do a request
         client.get("/sub/foobar/")

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
@@ -33,7 +33,6 @@ from opentelemetry.propagators.b3 import B3MultiFormat
 from pytest_docker_fixtures import images  # type: ignore
 from pytest_docker_fixtures.containers._base import BaseImage  # type: ignore
 
-from nucliadb_telemetry import context
 from nucliadb_telemetry.fastapi import instrument_app
 from nucliadb_telemetry.grpc import GRPCTelemetry
 from nucliadb_telemetry.jetstream import JetStreamContextTelemetry, NatsClientTelemetry
@@ -44,7 +43,12 @@ from nucliadb_telemetry.tests.grpc import (
     helloworld_pb2,
     helloworld_pb2_grpc,
 )
-from nucliadb_telemetry.utils import clean_telemetry, get_telemetry, init_telemetry
+from nucliadb_telemetry.utils import (
+    clean_telemetry,
+    get_telemetry,
+    init_telemetry,
+    set_info_on_span,
+)
 
 images.settings["jaeger"] = {
     "image": "jaegertracing/all-in-one",
@@ -317,7 +321,7 @@ async def http_service(
 
     @app.get("/")
     async def simple_api():
-        context.add_context({"my.data": "is this"})
+        set_info_on_span({"my.data": "is this"})
         tracer = tracer_provider.get_tracer(__name__)
         with tracer.start_as_current_span("simple_api_work") as _:
             channel = telemetry_grpc.init_client(f"localhost:{grpc_service}")

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
@@ -33,6 +33,7 @@ from opentelemetry.propagators.b3 import B3MultiFormat
 from pytest_docker_fixtures import images  # type: ignore
 from pytest_docker_fixtures.containers._base import BaseImage  # type: ignore
 
+from nucliadb_telemetry import context
 from nucliadb_telemetry.fastapi import instrument_app
 from nucliadb_telemetry.grpc import GRPCTelemetry
 from nucliadb_telemetry.jetstream import JetStreamContextTelemetry, NatsClientTelemetry
@@ -44,7 +45,6 @@ from nucliadb_telemetry.tests.grpc import (
     helloworld_pb2_grpc,
 )
 from nucliadb_telemetry.utils import clean_telemetry, get_telemetry, init_telemetry
-from nucliadb_telemetry import context
 
 images.settings["jaeger"] = {
     "image": "jaegertracing/all-in-one",

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
@@ -43,12 +43,8 @@ from nucliadb_telemetry.tests.grpc import (
     helloworld_pb2,
     helloworld_pb2_grpc,
 )
-from nucliadb_telemetry.utils import (
-    clean_telemetry,
-    get_telemetry,
-    init_telemetry,
-    set_info_on_span,
-)
+from nucliadb_telemetry.utils import clean_telemetry, get_telemetry, init_telemetry
+from nucliadb_telemetry import context
 
 images.settings["jaeger"] = {
     "image": "jaegertracing/all-in-one",
@@ -321,7 +317,7 @@ async def http_service(
 
     @app.get("/")
     async def simple_api():
-        set_info_on_span({"my.data": "is this"})
+        context.add_context({"my.data": "is this"})
         tracer = tracer_provider.get_tracer(__name__)
         with tracer.start_as_current_span("simple_api_work") as _:
             channel = telemetry_grpc.init_client(f"localhost:{grpc_service}")

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/__init__.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_context.py
@@ -1,9 +1,28 @@
-from nucliadb_telemetry.fastapi.context import ContextInjectorMiddleware
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 from unittest.mock import AsyncMock
-from nucliadb_telemetry import context
-from fastapi import FastAPI
+
 import pytest
-from starlette.requests import Request
+from fastapi import FastAPI
+
+from nucliadb_telemetry import context
+from nucliadb_telemetry.fastapi.context import ContextInjectorMiddleware
 
 app = FastAPI()
 

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_context.py
@@ -1,0 +1,37 @@
+from nucliadb_telemetry.fastapi.context import ContextInjectorMiddleware
+from unittest.mock import AsyncMock
+from nucliadb_telemetry import context
+from fastapi import FastAPI
+import pytest
+from starlette.requests import Request
+
+app = FastAPI()
+
+
+@app.get("/api/v1/kb/{kbid}")
+def get_kb(kbid: str):
+    return {"kbid": kbid}
+
+
+@pytest.mark.asyncio
+async def test_context_injected():
+    scope = {
+        "app": app,
+        "path": "/api/v1/kb/123",
+        "method": "GET",
+        "type": "http",
+    }
+
+    mdlw = ContextInjectorMiddleware(app)
+
+    found_ctx = {}
+
+    async def receive(*args, **kwargs):
+        found_ctx.update(context.get_context())
+        return {
+            "type": "http.disconnect",
+        }
+
+    await mdlw(scope, receive, AsyncMock())
+
+    assert found_ctx == {"kbid": "123"}

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_utils.py
@@ -1,5 +1,24 @@
-from nucliadb_telemetry.fastapi import utils
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 from fastapi import FastAPI
+
+from nucliadb_telemetry.fastapi import utils
 
 app = FastAPI()
 

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/fastapi/test_utils.py
@@ -1,0 +1,23 @@
+from nucliadb_telemetry.fastapi import utils
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/api/v1/kb/{kbid}")
+def get_kb(kbid: str):
+    return {"kbid": kbid}
+
+
+def test_get_path_template():
+    scope = {
+        "app": app,
+        "path": "/api/v1/kb/123",
+        "method": "GET",
+        "type": "http",
+    }
+
+    path_template = utils.get_path_template(scope)
+    assert path_template.path == "/api/v1/kb/{kbid}"
+    assert path_template.match is True
+    assert path_template.scope["path_params"] == {"kbid": "123"}

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_context.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+from nucliadb_telemetry import context
+import asyncio
+import pytest
+
+from nucliadb_telemetry import logs
+
+
+@pytest.mark.asyncio
+async def test_logger_with_context(caplog):
+    context_lvl_1 = {}
+    context_lvl_1_after = {}
+    context_lvl_2 = {}
+    context_lvl_2_after = {}
+    context_lvl_3 = {}
+
+    async def task3():
+        context.add_context({"task3": "value", "foo": "daz"})
+        context_lvl_3.update(context.get_context())
+
+    async def task2():
+        context.add_context({"task2": "value", "foo": "baz"})
+        context_lvl_2.update(context.get_context())
+        await asyncio.create_task(task3())
+        context_lvl_2_after.update(context.get_context())
+
+    async def task1():
+        context.add_context({"task1": "value", "foo": "bar"})
+        context_lvl_1.update(context.get_context())
+        await asyncio.create_task(task2())
+        context_lvl_1_after.update(context.get_context())
+
+    await asyncio.create_task(task1())
+
+    assert context_lvl_1 == {
+        "task1": "value",
+        "foo": "bar",
+    }
+    assert context_lvl_1 == context_lvl_1_after
+
+    assert context_lvl_2 == {
+        "task1": "value",
+        "task2": "value",
+        "foo": "baz",
+    }
+    assert context_lvl_2 == context_lvl_2_after
+
+    assert context_lvl_3 == {
+        "task1": "value",
+        "task2": "value",
+        "task3": "value",
+        "foo": "daz",
+    }

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_context.py
@@ -17,12 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
-from nucliadb_telemetry import context
 import asyncio
+
 import pytest
 
-from nucliadb_telemetry import logs
+from nucliadb_telemetry import context, logs
 
 
 @pytest.mark.asyncio

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_context.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_context.py
@@ -21,7 +21,7 @@ import asyncio
 
 import pytest
 
-from nucliadb_telemetry import context, logs
+from nucliadb_telemetry import context
 
 
 @pytest.mark.asyncio

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_logs.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_logs.py
@@ -17,16 +17,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import logging
 from unittest.mock import MagicMock, patch
 
 import orjson
 import pydantic
-from nucliadb_telemetry import context
-import asyncio
 import pytest
 
-from nucliadb_telemetry import logs
+from nucliadb_telemetry import context, logs
 
 
 def test_setup_logging(monkeypatch):

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_tikv_instrumentation.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/unit/test_tikv_instrumentation.py
@@ -113,7 +113,7 @@ async def test_tikv_instrumentation(
                 == expected_attrs[SpanAttributes.DB_OPERATION]
             )
             assert mocked_attrs[SpanAttributes.CODE_FILEPATH] == __file__
-            assert mocked_attrs[SpanAttributes.CODE_FUNCTION] == __name__
+            assert __name__.endswith(mocked_attrs[SpanAttributes.CODE_FUNCTION])
             assert mocked_attrs[SpanAttributes.CODE_LINENO] > 0
 
 

--- a/nucliadb_telemetry/nucliadb_telemetry/utils.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/utils.py
@@ -19,13 +19,12 @@
 
 import asyncio
 import os
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Optional
 
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.b3 import B3MultiFormat
 from opentelemetry.sdk.resources import SERVICE_NAME  # type: ignore
 from opentelemetry.sdk.resources import Resource  # type: ignore
-from opentelemetry.trace import get_current_span
 
 from nucliadb_telemetry.batch_span import BatchSpanProcessor
 from nucliadb_telemetry.jaeger import JaegerExporterAsync
@@ -35,6 +34,10 @@ from nucliadb_telemetry.tracerprovider import (
     AsyncMultiSpanProcessor,
     AsyncTracerProvider,
 )
+
+from .context import set_info_on_span  # noqa: F401
+
+set_info_on_span  # b/w compatible import
 
 GLOBAL_PROVIDER: Dict[str, AsyncTracerProvider] = {}
 
@@ -128,23 +131,3 @@ async def setup_telemetry(service_name: str) -> Optional[AsyncTracerProvider]:
         except ImportError:
             pass
     return tracer_provider
-
-
-def set_info_on_span(
-    headers: Dict[
-        str,
-        Union[
-            str,
-            bool,
-            int,
-            float,
-            Sequence[str],
-            Sequence[bool],
-            Sequence[int],
-            Sequence[float],
-        ],
-    ]
-):
-    if telemetry_settings.jaeger_enabled:
-        span = get_current_span()
-        span.set_attributes(headers)


### PR DESCRIPTION
### Description
This PR implements a contextvar implementation for telemetry.

This enables us to annotate "contextual" info across logs and http requests.

Scope of this PR:
- add `context` module to allow pushing new metadata
- when adding "context", also add to the current active span
- add ContextInjectorMiddleware which automatically injects path params into the context(should allow us to remove a lot of manual context marking for requests)
- automatically add context information to structured logs

### How was this PR tested?
Describe how you tested this PR.
