### PR TITLE
Fix processor: Can't write more data after commit

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/processor/__init__.py
+++ b/nucliadb/nucliadb/ingest/orm/processor/__init__.py
@@ -240,9 +240,9 @@ class Processor:
                     kb=kb,
                 )
 
-                await txn.commit()
                 if transaction_check:
                     await sequence_manager.set_last_seqid(txn, partition, seqid)
+                await txn.commit()
 
                 if created or resource.slug_modified:
                     await self.commit_slug(resource)


### PR DESCRIPTION
### Description
This bug was introduced in my previous PR: https://github.com/nuclia/nucliadb/pull/916/files#diff-e9a79ae0a9e3dbe27188c7e305a900468cad160d9fd683e8ca51ae3138b7d663R243

### How was this PR tested?
This was not catched by tests because we are using redis maindb mainly and there is no such restriction
