### PR TITLE
Change generation folder

### DIFF
--- a/.github/workflows/nucliadb_reader.yml
+++ b/.github/workflows/nucliadb_reader.yml
@@ -194,4 +194,4 @@ jobs:
 
       - name: Upload docs
         run: |
-          gsutil copy /tmp/openapi/$COMPONENT.json gs://stashify-docs/api/regional/v$API_VERSION/$COMPONENT/spec.json
+          gsutil copy /tmp/openapi/$COMPONENT.json gs://stashify-docs/api/nucliadb/v$API_VERSION/$COMPONENT/spec.json

--- a/.github/workflows/nucliadb_search.yml
+++ b/.github/workflows/nucliadb_search.yml
@@ -303,4 +303,4 @@ jobs:
 
       - name: Upload docs
         run: |
-          gsutil copy /tmp/openapi/$COMPONENT.json gs://stashify-docs/api/regional/v$API_VERSION/$COMPONENT/spec.json
+          gsutil copy /tmp/openapi/$COMPONENT.json gs://stashify-docs/api/nucliadb/v$API_VERSION/$COMPONENT/spec.json

--- a/.github/workflows/nucliadb_writer.yml
+++ b/.github/workflows/nucliadb_writer.yml
@@ -191,4 +191,4 @@ jobs:
 
       - name: Upload docs
         run: |
-          gsutil copy /tmp/openapi/$COMPONENT.json gs://stashify-docs/api/regional/v$API_VERSION/$COMPONENT/spec.json
+          gsutil copy /tmp/openapi/$COMPONENT.json gs://stashify-docs/api/nucliadb/v$API_VERSION/$COMPONENT/spec.json


### PR DESCRIPTION
### Description
We just splitted api docs generation in nucliadb and nuclia understanding API, this is a rename, as "regional" does not make sense anymore
### How was this PR tested?
Does not apply
