### PR TITLE
Remove sort options from find request

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/find.py
+++ b/nucliadb/nucliadb/search/api/v1/find.py
@@ -42,9 +42,6 @@ from nucliadb_models.search import (
     ResourceProperties,
     SearchOptions,
     SearchParamDefaults,
-    SortField,
-    SortOptions,
-    SortOrder,
 )
 from nucliadb_utils.authentication import requires
 from nucliadb_utils.exceptions import LimitsExceededError
@@ -82,9 +79,6 @@ async def find_knowledgebox(
     fields: List[str] = fastapi_query(SearchParamDefaults.fields),
     filters: List[str] = fastapi_query(SearchParamDefaults.filters),
     faceted: List[str] = fastapi_query(SearchParamDefaults.faceted),
-    sort_field: SortField = fastapi_query(SearchParamDefaults.sort_field),
-    sort_limit: Optional[int] = fastapi_query(SearchParamDefaults.sort_limit),
-    sort_order: SortOrder = fastapi_query(SearchParamDefaults.sort_order),
     page_number: int = fastapi_query(SearchParamDefaults.page_number),
     page_size: int = fastapi_query(SearchParamDefaults.page_size),
     min_score: float = fastapi_query(SearchParamDefaults.min_score),
@@ -132,11 +126,6 @@ async def find_knowledgebox(
             fields=fields,
             filters=filters,
             faceted=faceted,
-            sort=(
-                SortOptions(field=sort_field, limit=sort_limit, order=sort_order)
-                if sort_field is not None
-                else None
-            ),
             page_number=page_number,
             page_size=page_size,
             min_score=min_score,

--- a/nucliadb/nucliadb/search/api/v1/find.py
+++ b/nucliadb/nucliadb/search/api/v1/find.py
@@ -32,7 +32,6 @@ from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.requesters.utils import Method, node_query
 from nucliadb.search.search.find_merge import find_merge_results
 from nucliadb.search.search.query import global_query_to_pb, pre_process_query
-from nucliadb.search.search.utils import parse_sort_options
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import (
@@ -196,8 +195,6 @@ async def find(
     audit = get_audit()
     start_time = time()
 
-    sort_options = parse_sort_options(item)
-
     if item.query == "" and (item.vector is None or len(item.vector) == 0):
         # If query is not defined we force to not return vector results
         if SearchOptions.VECTOR in item.features:
@@ -212,7 +209,7 @@ async def find(
         advanced_query=item.advanced_query,
         filters=item.filters,
         faceted=item.faceted,
-        sort=sort_options,
+        sort=None,
         page_number=item.page_number,
         page_size=item.page_size,
         range_creation_start=item.range_creation_start,
@@ -241,7 +238,6 @@ async def find(
         show=item.show,
         field_type_filter=item.field_type_filter,
         extracted=item.extracted,
-        sort=sort_options,
         requested_relations=pb_query.relation_subgraph,
         min_score=item.min_score,
         highlight=item.highlight,

--- a/nucliadb/nucliadb/search/search/find_merge.py
+++ b/nucliadb/nucliadb/search/search/find_merge.py
@@ -41,7 +41,6 @@ from nucliadb_models.search import (
     FindResource,
     KnowledgeboxFindResults,
     ResourceProperties,
-    SortOptions,
     TempFindParagraph,
     TextPosition,
 )
@@ -337,7 +336,6 @@ async def find_merge_results(
     show: List[ResourceProperties],
     field_type_filter: List[FieldTypeName],
     extracted: List[ExtractedDataTypeName],
-    sort: SortOptions,
     requested_relations: EntitiesSubgraphRequest,
     min_score: float = 0.85,
     highlight: bool = False,

--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -55,7 +55,7 @@ async def global_query_to_pb(
     faceted: List[str],
     page_number: int,
     page_size: int,
-    sort: SortOptions,
+    sort: Optional[SortOptions],
     advanced_query: Optional[str] = None,
     range_creation_start: Optional[datetime] = None,
     range_creation_end: Optional[datetime] = None,
@@ -81,7 +81,7 @@ async def global_query_to_pb(
 
     # We need to ask for all and cut later
     request.page_number = 0
-    if sort.limit is not None:
+    if sort and sort.limit is not None:
         # As the index can't sort, we have to do it when merging. To
         # have consistent results, we must limit them
         request.result_per_page = sort.limit
@@ -107,7 +107,7 @@ async def global_query_to_pb(
         request.filter.tags.extend(filters)
         request.faceted.tags.extend(faceted)
 
-        sort_field = SortFieldMap[sort.field]
+        sort_field = SortFieldMap[sort.field] if sort else None
         if sort_field is not None:
             request.order.sort_by = sort_field
             request.order.type = SortOrderMap[sort.order]  # type: ignore

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -516,7 +516,7 @@ class SearchParamDefaults:
     )
 
 
-class SearchRequest(BaseModel):
+class BaseSearchRequest(BaseModel):
     query: str = SearchParamDefaults.query.to_pydantic_field()
     advanced_query: Optional[
         str
@@ -524,7 +524,6 @@ class SearchRequest(BaseModel):
     fields: List[str] = SearchParamDefaults.fields.to_pydantic_field()
     filters: List[str] = SearchParamDefaults.filters.to_pydantic_field()
     faceted: List[str] = SearchParamDefaults.faceted.to_pydantic_field()
-    sort: Optional[SortOptions] = SearchParamDefaults.sort.to_pydantic_field()
     page_number: int = SearchParamDefaults.page_number.to_pydantic_field()
     page_size: int = SearchParamDefaults.page_size.to_pydantic_field()
     min_score: float = SearchParamDefaults.min_score.to_pydantic_field()
@@ -565,6 +564,10 @@ class SearchRequest(BaseModel):
     with_duplicates: bool = SearchParamDefaults.with_duplicates.to_pydantic_field()
     with_synonyms: bool = SearchParamDefaults.with_synonyms.to_pydantic_field()
     autofilter: bool = SearchParamDefaults.autofilter.to_pydantic_field()
+
+
+class SearchRequest(BaseSearchRequest):
+    sort: Optional[SortOptions] = SearchParamDefaults.sort.to_pydantic_field()
 
 
 class Author(str, Enum):
@@ -624,7 +627,7 @@ class ChatRequest(BaseModel):
     highlight: bool = SearchParamDefaults.highlight.to_pydantic_field()
 
 
-class FindRequest(SearchRequest):
+class FindRequest(BaseSearchRequest):
     features: List[
         SearchOptions
     ] = SearchParamDefaults.search_features.to_pydantic_field(


### PR DESCRIPTION
### Description
Find is providing a predefined order of search results, so I don't think it makes sense to provide sorting options on it.

### How was this PR tested?
Describe how you tested this PR.
