### PR TITLE
"pip install nucliadb" is broken

### DIFF
--- a/nucliadb/nucliadb/common/__init__.py
+++ b/nucliadb/nucliadb/common/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#


### PR DESCRIPTION
### Description

Following the doc to run Nuclia locally using pip:

```
➜ pip install "nucliadb[postgres]"
[..]

➜ nucliadb
Traceback (most recent call last):
  File "/private/tmp/d/bin/nucliadb", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/private/tmp/d/lib/python3.11/site-packages/nucliadb/standalone/run.py", line 70, in run
    settings = setup()
               ^^^^^^^
  File "/private/tmp/d/lib/python3.11/site-packages/nucliadb/standalone/run.py", line 50, in setup
    config_nucliadb(nucliadb_args)
  File "/private/tmp/d/lib/python3.11/site-packages/nucliadb/standalone/config.py", line 84, in config_nucliadb
    from nucliadb.common.cluster import manager
ModuleNotFoundError: No module named 'nucliadb.common'
```

This happens because Nuclia's `setup.py` uses setuptools' `find_package()` that will recursively visit Python packages, and `nucliadb.comon` is not added because of the missing dunder init.

On a side-note, the postgres extension is the one used by default, so vanilla `pip install nucliadb` will fail unless you install `asyncpg` manually

### How was this PR tested?

I've verified that `python setup.py sdist` included `common` in the tarball, but the CI could probably catch this better by smoke-testing the produced tarball. I assume this was missed because the Docker dist (or the source install) is the one used in the CI and by folks

