### PR TITLE
Always install asyncpg as Postgres is the default driver

### DIFF
--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -43,6 +43,7 @@ nucliadb-protos
 nucliadb-models>=2.15.1.post353
 nucliadb-contributor-assets~=1.0.0
 
+asyncpg>=0.27.0
 tikv-client>=0.0.3
 
 # improve dependency resolution

--- a/nucliadb/setup.py
+++ b/nucliadb/setup.py
@@ -90,6 +90,5 @@ setup(
     },
     extras_require={
         "redis": ["redis>=4.3.4"],
-        "postgres": ["asyncpg>=0.27.0"],
     },
 )


### PR DESCRIPTION
### Description
We use Postgres as default driver, but `asyncpg` was still an extra requirement. I've changed it to always install it (although it might not be necessary for some configurations).

### How was this PR tested?
Describe how you tested this PR.
