### PR TITLE
Fix SDK by increasing pydantic min version

### DIFF
--- a/nucliadb_sdk/requirements.txt
+++ b/nucliadb_sdk/requirements.txt
@@ -3,3 +3,4 @@ requests
 nucliadb-models
 urllib3<1.27,>=1.21.1
 orjson
+pydantic>=1.10.9


### PR DESCRIPTION
### Description
With the new autogenerated documentation, the SDK is using `ModelField.annotation`, which is defined at pydantic 1.10. Increase required pydantic version in the SDK.

### How was this PR tested?
Pytest and local installations (with a lower version, tests fail due to autodoc)
