### PR TITLE
restructure disk management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "nucliadb_node_binding"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "bincode",
  "log",

--- a/nucliadb/nucliadb/common/cluster/standalone/grpc_node_binding.py
+++ b/nucliadb/nucliadb/common/cluster/standalone/grpc_node_binding.py
@@ -250,9 +250,7 @@ class StandaloneWriterWrapper:
     writer: NodeWriter
 
     def __init__(self):
-        data_path = os.environ.get("DATA_PATH")
-        if not (os.path.exists(data_path)):
-            os.mkdir(data_path)
+        os.makedirs(os.environ.get("DATA_PATH"), exist_ok=True)
         self.writer = NodeWriter.new()
         self.executor = ThreadPoolExecutor(settings.local_writer_threads)
 

--- a/nucliadb/nucliadb/common/cluster/standalone/grpc_node_binding.py
+++ b/nucliadb/nucliadb/common/cluster/standalone/grpc_node_binding.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncIterator
@@ -249,6 +250,9 @@ class StandaloneWriterWrapper:
     writer: NodeWriter
 
     def __init__(self):
+        data_path = os.environ.get("DATA_PATH")
+        if not (os.path.exists(data_path)):
+            os.mkdir(data_path)
         self.writer = NodeWriter.new()
         self.executor = ThreadPoolExecutor(settings.local_writer_threads)
 

--- a/nucliadb/nucliadb/common/cluster/standalone/grpc_node_binding.py
+++ b/nucliadb/nucliadb/common/cluster/standalone/grpc_node_binding.py
@@ -250,7 +250,7 @@ class StandaloneWriterWrapper:
     writer: NodeWriter
 
     def __init__(self):
-        os.makedirs(os.environ.get("DATA_PATH"), exist_ok=True)
+        os.makedirs(settings.data_path, exist_ok=True)
         self.writer = NodeWriter.new()
         self.executor = ThreadPoolExecutor(settings.local_writer_threads)
 

--- a/nucliadb_core/src/vectors.rs
+++ b/nucliadb_core/src/vectors.rs
@@ -29,7 +29,6 @@ pub type VectorsWriterPointer = Arc<RwLock<dyn VectorWriter>>;
 #[derive(Clone)]
 pub struct VectorConfig {
     pub similarity: Option<VectorSimilarity>,
-    pub no_results: Option<usize>,
     pub path: PathBuf,
     pub vectorset: PathBuf,
 }

--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## 0.7.8
 
+- restructured disk handling
+
+## 0.7.8
+
 - Upgrade to 1.70.0
 
 ## 0.7.7

--- a/nucliadb_node/binding/CHANGELOG.md
+++ b/nucliadb_node/binding/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 0.7.8
+## 0.7.9
 
 - restructured disk handling
 

--- a/nucliadb_node/binding/Cargo.toml
+++ b/nucliadb_node/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucliadb_node_binding"
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/nucliadb_node/binding/src/lib.rs
+++ b/nucliadb_node/binding/src/lib.rs
@@ -262,18 +262,14 @@ pub struct NodeWriter {
     writer: RustWriterService,
 }
 
-impl Default for NodeWriter {
-    fn default() -> NodeWriter {
-        NodeWriter {
-            writer: RustWriterService::new(),
-        }
-    }
-}
 #[pymethods]
 impl NodeWriter {
     #[staticmethod]
-    pub fn new() -> NodeWriter {
-        Self::default()
+    pub fn new() -> PyResult<NodeWriter> {
+        match RustWriterService::new() {
+            Ok(writer) => Ok(NodeWriter { writer }),
+            Err(e) => Err(exceptions::PyTypeError::new_err(e.to_string())),
+        }
     }
 
     pub fn new_shard<'p>(&self, metadata: RawProtos, py: Python<'p>) -> PyResult<&'p PyAny> {

--- a/nucliadb_node/binding/src/lib.rs
+++ b/nucliadb_node/binding/src/lib.rs
@@ -266,6 +266,7 @@ pub struct NodeWriter {
 impl NodeWriter {
     #[staticmethod]
     pub fn new() -> PyResult<NodeWriter> {
+        let _ = std::fs::create_dir(nucliadb_node::env::data_path());
         match RustWriterService::new() {
             Ok(writer) => Ok(NodeWriter { writer }),
             Err(e) => Err(exceptions::PyTypeError::new_err(e.to_string())),

--- a/nucliadb_node/binding/src/lib.rs
+++ b/nucliadb_node/binding/src/lib.rs
@@ -266,7 +266,6 @@ pub struct NodeWriter {
 impl NodeWriter {
     #[staticmethod]
     pub fn new() -> PyResult<NodeWriter> {
-        let _ = std::fs::create_dir(nucliadb_node::env::data_path());
         match RustWriterService::new() {
             Ok(writer) => Ok(NodeWriter { writer }),
             Err(e) => Err(exceptions::PyTypeError::new_err(e.to_string())),

--- a/nucliadb_node/binding/src/lib.rs
+++ b/nucliadb_node/binding/src/lib.rs
@@ -72,7 +72,9 @@ pub struct NodeReader {
 }
 impl Default for NodeReader {
     fn default() -> NodeReader {
-        NodeReader::new()
+        NodeReader {
+            reader: RustReaderService::new(),
+        }
     }
 }
 
@@ -80,9 +82,7 @@ impl Default for NodeReader {
 impl NodeReader {
     #[staticmethod]
     pub fn new() -> NodeReader {
-        NodeReader {
-            reader: RustReaderService::new(),
-        }
+        Self::default()
     }
 
     pub fn paragraphs(&mut self, shard_id: RawProtos) -> PyResult<PyParagraphProducer> {
@@ -264,16 +264,16 @@ pub struct NodeWriter {
 
 impl Default for NodeWriter {
     fn default() -> NodeWriter {
-        NodeWriter::new()
+        NodeWriter {
+            writer: RustWriterService::new(),
+        }
     }
 }
 #[pymethods]
 impl NodeWriter {
     #[staticmethod]
     pub fn new() -> NodeWriter {
-        NodeWriter {
-            writer: RustWriterService::new(),
-        }
+        Self::default()
     }
 
     pub fn new_shard<'p>(&self, metadata: RawProtos, py: Python<'p>) -> PyResult<&'p PyAny> {

--- a/nucliadb_node/src/bin/payload_test.rs
+++ b/nucliadb_node/src/bin/payload_test.rs
@@ -20,12 +20,13 @@
 use std::io::Cursor;
 
 use nucliadb_core::protos::*;
+use nucliadb_core::NodeResult;
 use nucliadb_node::reader::NodeReaderService;
 use nucliadb_node::writer::NodeWriterService;
 use prost::Message;
 
-fn main() -> anyhow::Result<()> {
-    let writer = NodeWriterService::new();
+fn main() -> NodeResult<()> {
+    let writer = NodeWriterService::new()?;
     let reader = NodeReaderService::new();
 
     let resources_dir = std::path::Path::new("/path/to/data");

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -60,11 +60,16 @@ async fn main() -> NodeResult<()> {
     let start_bootstrap = Instant::now();
     let _guard = init_telemetry()?;
     let metrics = metrics::get_metrics();
+    let data_path = env::data_path();
     let metadata_path = env::metadata_path();
-    let node_metadata = NodeMetadata::load_or_create(&metadata_path)?;
-    let mut node_writer_service = NodeWriterService::new();
 
-    std::fs::create_dir_all(env::shards_path())?;
+    if !data_path.exists() {
+        std::fs::create_dir(data_path)?;
+    }
+
+    let mut node_writer_service = NodeWriterService::new();
+    let node_metadata = NodeMetadata::load_or_create(&metadata_path)?;
+
     if !env::lazy_loading() {
         node_writer_service.load_shards()?;
     }
@@ -273,7 +278,7 @@ pub fn read_or_create_host_key(host_key_path: &Path) -> Result<Uuid> {
     } else {
         if let Some(dir) = host_key_path.parent() {
             if !dir.exists() {
-                fs::create_dir_all(dir).with_context(|| {
+                std::fs::create_dir(dir).with_context(|| {
                     format!("Failed to create host key directory '{}'", dir.display())
                 })?;
             }

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -67,7 +67,7 @@ async fn main() -> NodeResult<()> {
         std::fs::create_dir(data_path)?;
     }
 
-    let mut node_writer_service = NodeWriterService::new();
+    let mut node_writer_service = NodeWriterService::new()?;
     let node_metadata = NodeMetadata::load_or_create(&metadata_path)?;
 
     if !env::lazy_loading() {

--- a/nucliadb_node/src/reader/grpc_driver.rs
+++ b/nucliadb_node/src/reader/grpc_driver.rs
@@ -52,7 +52,6 @@ impl NodeReaderGRPCDriver {
             // If lazy loading is disabled, load
             self.shards.load_all().await?
         }
-
         Ok(())
     }
 

--- a/nucliadb_node/src/services/reader.rs
+++ b/nucliadb_node/src/services/reader.rs
@@ -41,7 +41,6 @@ use crate::shard_metadata::ShardMetadata;
 use crate::telemetry::run_with_telemetry;
 
 const RELOAD_PERIOD: u128 = 5000;
-const FIXED_VECTORS_RESULTS: usize = 10;
 const MAX_SUGGEST_COMPOUND_WORDS: usize = 3;
 const MIN_VIABLE_PREFIX_SUGGEST: usize = 1;
 
@@ -181,7 +180,6 @@ impl ShardReaderService {
 
         let vsc = VectorConfig {
             similarity: None,
-            no_results: Some(FIXED_VECTORS_RESULTS),
             path: shard_path.join(VECTORS_DIR),
             vectorset: shard_path.join(VECTORSET_DIR),
         };

--- a/nucliadb_node/src/services/writer.rs
+++ b/nucliadb_node/src/services/writer.rs
@@ -144,7 +144,7 @@ impl ShardWriterService {
     pub fn clean_and_create(id: String, path: &Path) -> NodeResult<ShardWriterService> {
         let metadata = ShardMetadata::open(&path.join(METADATA_FILE))?;
         std::fs::remove_dir_all(path)?;
-        std::fs::create_dir_all(path)?;
+        std::fs::create_dir(path)?;
         let tsc = TextConfig {
             path: path.join(TEXTS_DIR),
         };
@@ -154,7 +154,6 @@ impl ShardWriterService {
         };
 
         let vsc = VectorConfig {
-            no_results: None,
             similarity: Some(metadata.similarity()),
             path: path.join(VECTORS_DIR),
             vectorset: path.join(VECTORSET_DIR),
@@ -171,7 +170,7 @@ impl ShardWriterService {
     ) -> NodeResult<ShardWriterService> {
         let time = SystemTime::now();
 
-        std::fs::create_dir_all(path)?;
+        std::fs::create_dir(path)?;
         let metadata_path = path.join(METADATA_FILE);
         let similarity = request.similarity();
         let metadata = ShardMetadata::from(request.clone());
@@ -184,7 +183,6 @@ impl ShardWriterService {
         };
 
         let vsc = VectorConfig {
-            no_results: None,
             similarity: Some(similarity),
             path: path.join(VECTORS_DIR),
             vectorset: path.join(VECTORSET_DIR),
@@ -217,7 +215,6 @@ impl ShardWriterService {
         };
 
         let vsc = VectorConfig {
-            no_results: None,
             similarity: None,
             path: path.join(VECTORS_DIR),
             vectorset: path.join(VECTORSET_DIR),

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -40,11 +40,23 @@ pub struct NodeWriterService {
 }
 
 impl NodeWriterService {
-    pub fn new() -> Self {
+    fn initialize_file_system() -> NodeResult<()> {
+        let shards_path = env::shards_path();
+        let data_path = env::data_path();
+        if !data_path.exists() {
+            return Err(node_error!("{:?} is not created", data_path));
+        }
+        if !shards_path.exists() {
+            std::fs::create_dir(&shards_path)?;
+        }
+        Ok(())
+    }
+    pub fn new() -> NodeResult<Self> {
+        Self::initialize_file_system()?;
         // We shallow the error if the threadpools were already initialized
         let _ = ThreadPoolBuilder::new().num_threads(10).build_global();
         let _ = VectorsMerger::install_global().map(std::thread::spawn);
-        Self::default()
+        Ok(Self::default())
     }
 
     #[tracing::instrument(skip_all)]

--- a/nucliadb_node/src/writer/mod.rs
+++ b/nucliadb_node/src/writer/mod.rs
@@ -34,24 +34,17 @@ use uuid::Uuid;
 use crate::env;
 use crate::services::writer::ShardWriterService;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NodeWriterService {
     pub cache: HashMap<String, ShardWriterService>,
 }
 
-impl Default for NodeWriterService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 impl NodeWriterService {
     pub fn new() -> Self {
         // We shallow the error if the threadpools were already initialized
         let _ = ThreadPoolBuilder::new().num_threads(10).build_global();
         let _ = VectorsMerger::install_global().map(std::thread::spawn);
-        Self {
-            cache: HashMap::new(),
-        }
+        Self::default()
     }
 
     #[tracing::instrument(skip_all)]

--- a/nucliadb_node/tests/common/node_services.rs
+++ b/nucliadb_node/tests/common/node_services.rs
@@ -76,6 +76,10 @@ async fn start_writer(addr: SocketAddr) {
 
     if !*initialized_lock {
         tokio::spawn(async move {
+            let data_path = nucliadb_node::env::data_path();
+            if !data_path.exists() {
+                std::fs::create_dir(&data_path).expect("Can not create the data directory");
+            }
             let writer_server =
                 NodeWriterServer::new(NodeWriterGRPCDriver::from(NodeWriterService::new()));
             Server::builder()

--- a/nucliadb_node/tests/common/node_services.rs
+++ b/nucliadb_node/tests/common/node_services.rs
@@ -73,10 +73,6 @@ async fn start_reader(addr: SocketAddr) {
 
 async fn start_writer(addr: SocketAddr) {
     let mut initialized_lock = WRITER_SERVER_INITIALIZED.lock().await;
-    let data_path = nucliadb_node::env::data_path();
-    if !data_path.exists() {
-        std::fs::create_dir(&data_path).unwrap();
-    }
     if *initialized_lock {
         return;
     }

--- a/nucliadb_node/tests/test_search_relations.rs
+++ b/nucliadb_node/tests/test_search_relations.rs
@@ -23,7 +23,7 @@ mod common;
 use std::collections::{HashMap, HashSet};
 use std::time::SystemTime;
 
-use common::{node_services, TestNodeWriter};
+use common::{node_reader, node_writer, TestNodeWriter};
 use nucliadb_core::protos::op_status::Status;
 use nucliadb_core::protos::prost_types::Timestamp;
 use nucliadb_core::protos::relation::RelationType;
@@ -328,7 +328,8 @@ async fn create_knowledge_graph(
 
 #[tokio::test]
 async fn test_search_relations_prefixed() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut reader, mut writer) = node_services().await;
+    let mut writer = node_writer().await;
+    let mut reader = node_reader().await;
 
     let new_shard_response = writer
         .new_shard(Request::new(NewShardRequest::default()))
@@ -488,7 +489,8 @@ async fn test_search_relations_prefixed() -> Result<(), Box<dyn std::error::Erro
 
 #[tokio::test]
 async fn test_search_relations_neighbours() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut reader, mut writer) = node_services().await;
+    let mut writer = node_writer().await;
+    let mut reader = node_reader().await;
 
     let new_shard_response = writer
         .new_shard(Request::new(NewShardRequest::default()))

--- a/nucliadb_node/tests/test_search_sorting.rs
+++ b/nucliadb_node/tests/test_search_sorting.rs
@@ -23,7 +23,7 @@ mod common;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
-use common::{node_services, TestNodeReader, TestNodeWriter};
+use common::{node_reader, node_writer, TestNodeReader, TestNodeWriter};
 use nucliadb_core::protos as nucliadb_protos;
 use nucliadb_protos::op_status::Status;
 use nucliadb_protos::prost_types::Timestamp;
@@ -81,7 +81,8 @@ async fn create_dummy_resources(total: u8, writer: &mut TestNodeWriter, shard_id
 
 #[tokio::test]
 async fn test_search_sorting() -> Result<(), Box<dyn std::error::Error>> {
-    let (mut reader, mut writer) = node_services().await;
+    let mut writer = node_writer().await;
+    let mut reader = node_reader().await;
 
     let new_shard_response = writer
         .new_shard(Request::new(NewShardRequest::default()))

--- a/nucliadb_paragraphs/src/writer.rs
+++ b/nucliadb_paragraphs/src/writer.rs
@@ -182,7 +182,7 @@ impl ParagraphWriterService {
     pub fn new(config: &ParagraphConfig) -> NodeResult<ParagraphWriterService> {
         let paragraph_schema = ParagraphSchema::default();
 
-        fs::create_dir_all(&config.path)?;
+        fs::create_dir(&config.path)?;
 
         let mut index_builder = Index::builder().schema(paragraph_schema.schema.clone());
         let settings = IndexSettings {

--- a/nucliadb_relations/src/service/tests.rs
+++ b/nucliadb_relations/src/service/tests.rs
@@ -208,7 +208,7 @@ fn simple_graph(at: &Path) -> (RelationsWriterService, RelationsReaderService) {
     };
     println!("Writer starts");
     let writer = RelationsWriterService::start(&rsc).unwrap();
-    let reader = RelationsReaderService::open(&rsc).unwrap();
+    let reader = RelationsReaderService::start(&rsc).unwrap();
     (writer, reader)
 }
 

--- a/nucliadb_relations/src/service/writer.rs
+++ b/nucliadb_relations/src/service/writer.rs
@@ -270,7 +270,7 @@ impl RelationsWriterService {
         if path.exists() {
             Err(node_error!("Shard does exist".to_string()))
         } else {
-            std::fs::create_dir_all(path)?;
+            std::fs::create_dir(path)?;
             let (index, wmode) = Index::new_writer(path)?;
             Ok(RelationsWriterService { index, wmode })
         }

--- a/nucliadb_texts/src/writer.rs
+++ b/nucliadb_texts/src/writer.rs
@@ -175,7 +175,7 @@ impl TextWriterService {
     #[tracing::instrument(skip_all)]
     pub fn new(config: &TextConfig) -> NodeResult<Self> {
         let field_schema = TextSchema::new();
-        fs::create_dir_all(&config.path)?;
+        fs::create_dir(&config.path)?;
         let mut index_builder = Index::builder().schema(field_schema.schema.clone());
         let settings = IndexSettings {
             sort_by_field: Some(IndexSortByField {

--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -151,7 +151,7 @@ impl Index {
         Ok(index)
     }
     pub fn new(path: &Path, metadata: IndexMetadata) -> VectorR<Index> {
-        std::fs::create_dir_all(path)?;
+        std::fs::create_dir(path)?;
         fs_state::initialize_disk(path, State::new)?;
         metadata.write(path)?;
         let lock = fs_state::shared_lock(path)?;

--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -267,14 +267,15 @@ mod test {
     #[test]
     fn garbage_collection_test() -> NodeResult<()> {
         let dir = tempfile::tempdir()?;
-        let index = Index::new(dir.path(), IndexMetadata::default())?;
-        let empty_no_entries = std::fs::read_dir(dir.path())?.count();
+        let vectors_path = dir.path().join("vectors");
+        let index = Index::new(&vectors_path, IndexMetadata::default())?;
+        let empty_no_entries = std::fs::read_dir(&vectors_path)?.count();
         for _ in 0..10 {
-            DataPoint::new(dir.path(), vec![], None, Similarity::Cosine).unwrap();
+            DataPoint::new(&vectors_path, vec![], None, Similarity::Cosine).unwrap();
         }
         let lock = index.get_slock()?;
         index.collect_garbage(&lock)?;
-        let no_entries = std::fs::read_dir(dir.path())?.count();
+        let no_entries = std::fs::read_dir(&vectors_path)?.count();
         assert_eq!(no_entries, empty_no_entries);
         Ok(())
     }

--- a/nucliadb_vectors/src/indexset/mod.rs
+++ b/nucliadb_vectors/src/indexset/mod.rs
@@ -39,7 +39,7 @@ pub struct IndexSet {
 impl IndexSet {
     pub fn new(path: &Path, with_check: IndexCheck) -> VectorR<IndexSet> {
         if !path.exists() {
-            std::fs::create_dir_all(path)?;
+            std::fs::create_dir(path)?;
         }
         fs_state::initialize_disk(path, || State::new(path.to_path_buf()))?;
         let lock = fs_state::shared_lock(path)?;

--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -451,7 +451,6 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let vsc = VectorConfig {
             similarity: Some(VectorSimilarity::Cosine),
-            no_results: None,
             path: dir.path().join("vectors"),
             vectorset: dir.path().join("vectorsets"),
         };
@@ -520,7 +519,6 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let vsc = VectorConfig {
             similarity: Some(VectorSimilarity::Cosine),
-            no_results: None,
             path: dir.path().join("vectors"),
             vectorset: dir.path().join("vectorset"),
         };


### PR DESCRIPTION
### Description
This PR moves the responsibility of creating directories and indexes to the node and shard writers. Readers will assume all the file structure has already been created.
Also the use of `create_dir_all` is replaced by `create_dir` to avoid masking behaviour to the users.

### How was this PR tested?
Local tests.
