### PR TITLE
Use stored model min score

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/find.py
+++ b/nucliadb/nucliadb/search/api/v1/find.py
@@ -31,7 +31,11 @@ from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.requesters.utils import Method, node_query
 from nucliadb.search.search.find_merge import find_merge_results
-from nucliadb.search.search.query import global_query_to_pb, pre_process_query
+from nucliadb.search.search.query import (
+    get_default_min_score,
+    global_query_to_pb,
+    pre_process_query,
+)
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import (
@@ -201,6 +205,10 @@ async def find(
         if SearchOptions.VECTOR in item.features:
             item.features.remove(SearchOptions.VECTOR)
 
+    min_score = item.min_score
+    if min_score is None:
+        min_score = await get_default_min_score(kbid)
+
     # We need to query all nodes
     processed_query = pre_process_query(item.query)
     pb_query, incomplete_results, autofilters = await global_query_to_pb(
@@ -213,7 +221,7 @@ async def find(
         sort=None,
         page_number=item.page_number,
         page_size=item.page_size,
-        min_score=item.min_score,
+        min_score=min_score,
         range_creation_start=item.range_creation_start,
         range_creation_end=item.range_creation_end,
         range_modification_start=item.range_modification_start,
@@ -242,7 +250,7 @@ async def find(
         field_type_filter=item.field_type_filter,
         extracted=item.extracted,
         requested_relations=pb_query.relation_subgraph,
-        min_score=item.min_score,
+        min_score=min_score,
         highlight=item.highlight,
     )
 

--- a/nucliadb/nucliadb/search/api/v1/find.py
+++ b/nucliadb/nucliadb/search/api/v1/find.py
@@ -26,6 +26,7 @@ from fastapi import Body, Header, Request, Response
 from fastapi_versioning import version
 from pydantic.error_wrappers import ValidationError
 
+from nucliadb.ingest.orm.exceptions import KnowledgeBoxNotFound
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
@@ -154,6 +155,8 @@ async def find_knowledgebox(
             response, kbid, item, x_ndb_client, x_nucliadb_user, x_forwarded_for
         )
         return results
+    except KnowledgeBoxNotFound:
+        return HTTPClientError(status_code=404, detail="Knowledge Box not found")
     except LimitsExceededError as exc:
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)
 

--- a/nucliadb/nucliadb/search/api/v1/search.py
+++ b/nucliadb/nucliadb/search/api/v1/search.py
@@ -24,13 +24,18 @@ from typing import List, Optional, Tuple, Union
 from fastapi import Body, Header, Request, Response
 from fastapi_versioning import version
 
+from nucliadb.ingest.orm.exceptions import KnowledgeBoxNotFound
 from nucliadb.ingest.txn_utils import abort_transaction
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.requesters.utils import Method, node_query
 from nucliadb.search.search.merge import merge_results
-from nucliadb.search.search.query import global_query_to_pb, pre_process_query
+from nucliadb.search.search.query import (
+    get_default_min_score,
+    global_query_to_pb,
+    pre_process_query,
+)
 from nucliadb.search.search.utils import parse_sort_options
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.metadata import ResourceProcessingStatus
@@ -268,6 +273,8 @@ async def _search_endpoint(
         )
         response.status_code = 206 if incomplete else 200
         return results
+    except KnowledgeBoxNotFound:
+        return HTTPClientError(status_code=404, detail="Knowledge Box not found")
     except LimitsExceededError as exc:
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)
 
@@ -291,6 +298,10 @@ async def search(
         if SearchOptions.VECTOR in item.features:
             item.features.remove(SearchOptions.VECTOR)
 
+    min_score = item.min_score
+    if min_score is None:
+        min_score = await get_default_min_score(kbid)
+
     # We need to query all nodes
     processed_query = pre_process_query(item.query)
     pb_query, incomplete_results, autofilters = await global_query_to_pb(
@@ -303,7 +314,7 @@ async def search(
         sort=sort_options,
         page_number=item.page_number,
         page_size=item.page_size,
-        min_score=item.min_score,
+        min_score=min_score,
         range_creation_start=item.range_creation_start,
         range_creation_end=item.range_creation_end,
         range_modification_start=item.range_modification_start,
@@ -334,7 +345,7 @@ async def search(
         extracted=item.extracted,
         sort=sort_options,
         requested_relations=pb_query.relation_subgraph,
-        min_score=item.min_score,
+        min_score=min_score,
         highlight=item.highlight,
     )
     await abort_transaction()

--- a/nucliadb/nucliadb/search/search/find_merge.py
+++ b/nucliadb/nucliadb/search/search/find_merge.py
@@ -337,7 +337,7 @@ async def find_merge_results(
     field_type_filter: List[FieldTypeName],
     extracted: List[ExtractedDataTypeName],
     requested_relations: EntitiesSubgraphRequest,
-    min_score: float = 0.85,
+    min_score: float,
     highlight: bool = False,
 ) -> KnowledgeboxFindResults:
     # force getting transaction on current asyncio task
@@ -385,6 +385,7 @@ async def find_merge_results(
         page_number=page,
         page_size=count,
         next_page=next_page,
+        min_score=min_score,
     )
 
     await fetch_find_metadata(

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -252,7 +252,7 @@ async def merge_vectors_results(
     kbid: str,
     count: int,
     page: int,
-    min_score: float = 0.70,
+    min_score: float,
 ):
     facets: Dict[str, Any] = {}
     raw_vectors_list: List[DocumentScored] = []
@@ -312,7 +312,11 @@ async def merge_vectors_results(
             resources.append(rid)
 
     return Sentences(
-        results=result_sentence_list, facets=facets, page_number=page, page_size=count
+        results=result_sentence_list,
+        facets=facets,
+        page_number=page,
+        page_size=count,
+        min_score=min_score,
     )
 
 
@@ -474,7 +478,7 @@ async def merge_results(
     extracted: List[ExtractedDataTypeName],
     sort: SortOptions,
     requested_relations: EntitiesSubgraphRequest,
-    min_score: float = 0.85,
+    min_score: float,
     highlight: bool = False,
 ) -> KnowledgeboxSearchResults:
     paragraphs = []

--- a/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
@@ -179,6 +179,7 @@ async def test_format_chat_prompt_content(kb):
                         "vecid/c/conv/ident", result_text, SCORE_TYPE.VECTOR
                     ),
                 },
+                min_score=-1,
             ),
         )
         assert prompt_result == chat_prompt.PROMPT_TEXT_RESULT_SEP.join(
@@ -205,7 +206,7 @@ async def test_format_chat_prompt_content_truncates(kb):
     ), patch("nucliadb.search.search.chat.prompt.KnowledgeBoxORM", return_value=kb):
         prompt_result = await chat_prompt.format_chat_prompt_content(
             "kbid",
-            KnowledgeboxFindResults(facets={}, resources=resources),
+            KnowledgeboxFindResults(facets={}, resources=resources, min_score=-1),
         )
 
     assert prompt_result == chat_prompt.PROMPT_TEXT_RESULT_SEP.join(

--- a/nucliadb/nucliadb/tests/integration/common/maindb/test_drivers.py
+++ b/nucliadb/nucliadb/tests/integration/common/maindb/test_drivers.py
@@ -33,6 +33,7 @@ async def test_redis_driver(redis):
 
 
 @pytest.mark.asyncio
+@pytest.mark.flaky(reruns=5)
 async def test_tikv_driver(tikvd):
     url = [f"{tikvd[0]}:{tikvd[2]}"]
     driver = TiKVDriver(url=url)

--- a/nucliadb/nucliadb/tests/integration/search/test_search.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search.py
@@ -1375,3 +1375,22 @@ async def test_search_two_logic_shards(
     assert len(content1["sentences"]["results"]) == len(
         content2["sentences"]["results"]
     )
+
+
+async def test_search_min_score(
+    nucliadb_reader: AsyncClient,
+    knowledgebox,
+):
+    # When not specifying the min score on the request, it should default to 0.7
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search", json={"query": "dummy"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["sentences"]["min_score"] == 0.7
+
+    # If we specify a min score, it should be used
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search", json={"query": "dummy", "min_score": 0.5}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["sentences"]["min_score"] == 0.5

--- a/nucliadb/nucliadb/tests/integration/test_api.py
+++ b/nucliadb/nucliadb/tests/integration/test_api.py
@@ -55,6 +55,7 @@ async def test_kb_creation_with_similarity(
     assert resp.status_code == 200
     body = resp.json()
     assert body["similarity"] == "cosine"
+    assert body["model"]["similarity_function"] == "cosine"
 
     # Check that we can define it to dot similarity
     resp = await nucliadb_manager.post(
@@ -67,6 +68,7 @@ async def test_kb_creation_with_similarity(
     assert resp.status_code == 200
     body = resp.json()
     assert body["similarity"] == "dot"
+    assert body["model"]["similarity_function"] == "dot"
 
 
 @pytest.mark.asyncio

--- a/nucliadb/nucliadb/tests/integration/test_find.py
+++ b/nucliadb/nucliadb/tests/integration/test_find.py
@@ -171,3 +171,22 @@ async def test_find_resource_filters(
         body = resp.json()
         assert len(body["resources"]) == 1
         assert rid in body["resources"]
+
+
+async def test_find_min_score(
+    nucliadb_reader: AsyncClient,
+    knowledgebox,
+):
+    # When not specifying the min score on the request, it should default to 0.7
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/find", json={"query": "dummy"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["min_score"] == 0.7
+
+    # If we specify a min score, it should be used
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/find", json={"query": "dummy", "min_score": 0.5}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["min_score"] == 0.5

--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -55,3 +55,4 @@ idna>=3.3
 sniffio>=1.2.0
 
 tiktoken==0.4.0
+async_lru==2.0.2

--- a/nucliadb_models/nucliadb_models/resource.py
+++ b/nucliadb_models/nucliadb_models/resource.py
@@ -52,7 +52,11 @@ from nucliadb_models.metadata import (
 )
 from nucliadb_models.text import FieldText
 from nucliadb_models.utils import SlugString
-from nucliadb_models.vectors import UserVectorSet, VectorSimilarity
+from nucliadb_models.vectors import (
+    SemanticModelMetadata,
+    UserVectorSet,
+    VectorSimilarity,
+)
 
 _T = TypeVar("_T")
 
@@ -125,6 +129,7 @@ class KnowledgeBoxObj(BaseModel):
     slug: Optional[SlugString] = None
     uuid: str
     config: Optional[KnowledgeBoxConfig] = None
+    model: Optional[SemanticModelMetadata] = None
 
 
 class KnowledgeBoxList(BaseModel):

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -48,7 +48,7 @@ class ModelParamDefaults:
     min_score = ParamDefault(
         default=...,
         title="Minimum score",
-        description="Minimum similarity score applied to the vector index search. Results with a lower score have been ignored.",  # noqa
+        description="Minimum similarity score used to filter vector index search. Results with a lower score will be ignored.",  # noqa
     )
 
 

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -748,6 +748,7 @@ class KnowledgeboxFindResults(BaseModel):
     nodes: Optional[List[Tuple[str, str, str]]]
     shards: Optional[List[str]]
     autofilters: List[str] = ModelParamDefaults.applied_autofilters.to_pydantic_field()
+    min_score: float = ModelParamDefaults.min_score.to_pydantic_field()
 
 
 class FeedbackTasks(str, Enum):

--- a/nucliadb_models/nucliadb_models/vectors.py
+++ b/nucliadb_models/nucliadb_models/vectors.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional, Tuple, Type, TypeVar
 from google.protobuf.json_format import MessageToDict
 from nucliadb_protos.utils_pb2 import VectorSimilarity as PBVectorSimilarity
 from nucliadb_protos.writer_pb2 import VectorSet as PBVectorSet
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from nucliadb_models import FieldID
-from nucliadb_protos import resources_pb2
+from nucliadb_protos import knowledgebox_pb2, resources_pb2
 
 UserVectorPosition = Tuple[int, int]
 _T = TypeVar("_T")
@@ -50,6 +50,34 @@ VECTOR_SIMILARITY_ENUM_TO_PB = {
     VectorSimilarity.DOT.value: PBVectorSimilarity.DOT,
 }
 VECTOR_SIMILARITY_PB_TO_ENUM = {v: k for k, v in VECTOR_SIMILARITY_ENUM_TO_PB.items()}
+
+
+class SemanticModelMetadata(BaseModel):
+    """
+    Metadata of the semantic model associated to the KB
+    """
+
+    similarity_function: VectorSimilarity = Field(
+        description="Vector similarity algorithm that is applied on search"
+    )
+    vector_dimension: Optional[int] = Field(
+        description="Dimension of the indexed vectors/embeddings"
+    )
+    default_min_score: Optional[float] = Field(
+        description="Default minimum similarity value at which results are ignored"
+    )
+
+    @classmethod
+    def from_message(cls, message: knowledgebox_pb2.SemanticModelMetadata):
+        as_dict = MessageToDict(
+            message,
+            preserving_proto_field_name=True,
+            including_default_value_fields=True,
+        )
+        as_dict["similarity_function"] = VectorSimilarity.from_message(
+            message.similarity_function
+        )
+        return cls(**as_dict)
 
 
 class VectorSet(BaseModel):


### PR DESCRIPTION
### Description
New KBs created in the cloud offering are created specifying the default min score for the semantic model associated to that KB.
This PR aims to utilize this min score as default for all search operations. 

### How was this PR tested?
Integration and unit tests