### PR TITLE
Prevent icon to be recomputed after a patch

### DIFF
--- a/nucliadb/nucliadb/tests/integration/test_api.py
+++ b/nucliadb/nucliadb/tests/integration/test_api.py
@@ -557,6 +557,7 @@ async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{uuid}")
     assert resp.json()["icon"] == "application/pdf"
 
+    # A partial patch should not change the icon
     resp = await nucliadb_writer.patch(
         f"/kb/{kbid}/resource/{uuid}",
         json={
@@ -569,3 +570,17 @@ async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
 
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{uuid}")
     assert resp.json()["icon"] == "application/pdf"
+
+    # Check that if we change the icon specifically, the change is applied
+    resp = await nucliadb_writer.patch(
+        f"/kb/{kbid}/resource/{uuid}",
+        json={
+            "icon": "text/plain",
+        },
+        headers={"X-SYNCHRONOUS": "True"},
+        timeout=None,
+    )
+    assert resp.status_code == 200
+
+    resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{uuid}")
+    assert resp.json()["icon"] == "text/plain"

--- a/nucliadb/nucliadb/tests/integration/test_api.py
+++ b/nucliadb/nucliadb/tests/integration/test_api.py
@@ -536,3 +536,36 @@ async def test_extra(
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid}?show=extra")
     assert resp.status_code == 200
     assert resp.json()["extra"] == extra
+
+
+@pytest.mark.asyncio
+async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    knowledgebox,
+):
+    kbid = knowledgebox
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/resources",
+        json={"title": "Foo", "icon": "application/pdf"},
+        headers={"X-SYNCHRONOUS": "True"},
+        timeout=None,
+    )
+    assert resp.status_code == 201
+    uuid = resp.json()["uuid"]
+
+    resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{uuid}")
+    assert resp.json()["icon"] == "application/pdf"
+
+    resp = await nucliadb_writer.patch(
+        f"/kb/{kbid}/resource/{uuid}",
+        json={
+            "usermetadata": {"classifications": [{"labelset": "foo", "label": "bar"}]}
+        },
+        headers={"X-SYNCHRONOUS": "True"},
+        timeout=None,
+    )
+    assert resp.status_code == 200
+
+    resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{uuid}")
+    assert resp.json()["icon"] == "application/pdf"

--- a/nucliadb/nucliadb/writer/resource/basic.py
+++ b/nucliadb/nucliadb/writer/resource/basic.py
@@ -85,7 +85,8 @@ def parse_basic_modify(
         bm.basic.thumbnail = item.thumbnail
     if item.layout:
         bm.basic.layout = item.layout
-    parse_icon(bm, item)
+    if item.icon:
+        bm.basic.icon = item.icon
     if item.fieldmetadata is not None:
         for fieldmetadata in item.fieldmetadata:
             userfieldmetadata = UserFieldMetadata()
@@ -208,6 +209,7 @@ def parse_basic(bm: BrokerMessage, item: CreateResourcePayload, toprocess: PushP
 
     if item.title is None:
         item.title = compute_title(item, bm.uuid)
+    parse_icon_on_create(bm, item)
 
     parse_basic_modify(bm, item, toprocess)
 
@@ -254,15 +256,16 @@ def compute_title(item: CreateResourcePayload, rid: str) -> str:
     return item.slug or rid
 
 
-def parse_icon(bm: BrokerMessage, item: ComingResourcePayload):
+def parse_icon_on_create(bm: BrokerMessage, item: CreateResourcePayload):
     if item.icon:
         # User input icon takes precedence
         bm.basic.icon = item.icon
         return
-    elif len(item.texts) > 0:
+
+    icon = GENERIC_MIME_TYPE
+    if len(item.texts) > 0:
         # Infer icon from text file format
         format = next(iter(item.texts.values())).format
-        bm.basic.icon = TEXT_FORMAT_TO_MIMETYPE[format]
-    else:
-        # Default
-        bm.basic.icon = GENERIC_MIME_TYPE
+        icon = TEXT_FORMAT_TO_MIMETYPE[format]
+    item.icon = icon
+    bm.basic.icon = icon

--- a/nucliadb/nucliadb/writer/tests/unit/resources/test_basic.py
+++ b/nucliadb/nucliadb/writer/tests/unit/resources/test_basic.py
@@ -20,7 +20,7 @@
 import pytest
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
-from nucliadb.writer.resource.basic import compute_title, parse_icon
+from nucliadb.writer.resource.basic import compute_title, parse_icon_on_create
 from nucliadb_models.common import File
 from nucliadb_models.file import FileField
 from nucliadb_models.link import LinkField
@@ -75,7 +75,7 @@ def test_compute_title(payload, resource_uuid, expected_title):
         (get_resource_payload(), "application/generic"),
     ],
 )
-def test_parse_icon(payload, expected_icon):
+def test_parse_icon_on_create(payload, expected_icon):
     message = BrokerMessage()
-    parse_icon(message, payload)
+    parse_icon_on_create(message, payload)
     assert message.basic.icon == expected_icon


### PR DESCRIPTION
### Description
Prevent the icon to be reset to application/generic on a resource update

### How was this PR tested?
Unit and integration tests
