### PR TITLE
Migrations should not disrupt the release process

### DIFF
--- a/charts/nucliadb_ingest/templates/migrator.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/migrator.deploy.yaml
@@ -1,42 +1,68 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: migrate-job
+  name: migrator
   labels:
-    app: migrate-job
+    app: migrator
     version: "{{ .Chart.Version | replace "+" "_" }}"
     chart: "{{ .Chart.Name }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
 spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: migrator
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
   template:
     metadata:
-      name: migrate-job
+      name: migrator
       annotations:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{.Values.serving.metricsPort }}"
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
-        sidecar.istio.io/inject: "false"
       labels:
-        app: migrate-job
+        app: migrator
         version: "{{ .Chart.Version | replace "+" "_" }}"
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
-      shareProcessNamespace: true
-      restartPolicy: Never
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      dnsPolicy: ClusterFirst
       containers:
-      - name: migrate-job
+      - name: migrator
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
-        imagePullPolicy: {{.Values.imagePullPolicy}}
-        command: ["/bin/bash", "-c"]
-        # cause other containers to exit when migrate command is done
-        args:
-        - "nucliadb-migrate && pkill cluster_manager || (pkill cluster_manager; exit 1)"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.serving.grpc }}"]
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.serving.grpc }}"]
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        command: [
+          "nucliadb-migration-runner"
+        ]
         envFrom:
         - configMapRef:
             name: nucliadb-config
@@ -51,8 +77,9 @@ spec:
           - name: "{{ $key }}"
             value: {{ tpl $value $ | toJson }}
         {{- end }}
-        resources:
-{{ toYaml .Values.ingest_orm_grpc_resources | indent 10 }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.serving.metricsPort }}
 {{- if .Values.nats.secretName }}
         volumeMounts:
           - name: nats-creds
@@ -77,7 +104,31 @@ spec:
         - name: chitchat
           containerPort: {{ .Values.chitchat.node.chitchat_port }}
           protocol: UDP
-      {{- if .Values.nats.secretName }}
+{{- if .Values.tracing.enabled }}
+      - name: jaeger-agent
+        image: jaegertracing/jaeger-agent:{{ .Values.tracing.jaegerAgentTag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 5775
+            name: zk-compact-trft
+            protocol: UDP
+          - containerPort: 5778
+            name: config-rest
+            protocol: TCP
+          - containerPort: 6831
+            name: jg-compact-trft
+            protocol: UDP
+          - containerPort: 6832
+            name: jg-binary-trft
+            protocol: UDP
+          - containerPort: 14271
+            name: admin-http
+            protocol: TCP
+        args:
+          - --reporter.grpc.host-port=dns:///{{ .Values.tracing.jaegerCollectorHost }}:{{ .Values.tracing.jaegerCollectorGrpcPort }}
+          - --reporter.type=grpc
+{{- end }}
+{{- if .Values.nats.secretName }}
       volumes:
       - name: nats-creds
         secret:
@@ -88,5 +139,3 @@ spec:
         secret:
           secretName: {{ .Values.nats.regionalSecretName }}
 {{- end }}
-
-  backoffLimit: 3

--- a/charts/nucliadb_ingest/templates/migrator.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/migrator.deploy.yaml
@@ -46,20 +46,6 @@ spec:
       - name: migrator
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.serving.grpc }}"]
-          initialDelaySeconds: 10
-          periodSeconds: 20
-          timeoutSeconds: 5
-          failureThreshold: 3
-        livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ .Values.serving.grpc }}"]
-          initialDelaySeconds: 10
-          periodSeconds: 20
-          timeoutSeconds: 5
-          failureThreshold: 3
         command: [
           "nucliadb-migration-runner"
         ]

--- a/nucliadb/README.md
+++ b/nucliadb/README.md
@@ -47,3 +47,6 @@ async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
     - KBs to migrate
 - KB Migration State:
     - current version
+
+- Migrations are currently run with a deployment and will be continuously retried on failure.
+- Running migrations in a deployment is to make sure a migration does not prevent code deployment.

--- a/nucliadb/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/nucliadb/common/cluster/rollover.py
@@ -129,7 +129,7 @@ async def wait_for_node(app_context: ApplicationContext, node_id: str) -> None:
         if consumer_info.num_pending < 5:
             return
         logger.info("Waiting for node to consume messages", extra={"node": node_id})
-        await asyncio.sleep(1)
+        await asyncio.sleep(2)
 
 
 async def index_rollover_shards(

--- a/nucliadb/nucliadb/migrator/command.py
+++ b/nucliadb/nucliadb/migrator/command.py
@@ -28,7 +28,7 @@ from .context import ExecutionContext
 from .settings import Settings
 
 
-async def run():
+async def run(forever: bool = False):
     setup_logging()
     await setup_telemetry("migrator")
 
@@ -37,7 +37,10 @@ async def run():
     await context.initialize()
     metrics_server = await serve_metrics()
     try:
-        await migrator.run(context)
+        if forever:
+            await migrator.run_forever(context)
+        else:
+            await migrator.run(context)
     finally:
         await context.finalize()
         await metrics_server.shutdown()
@@ -45,3 +48,10 @@ async def run():
 
 def main():
     asyncio.run(run())
+
+
+def main_forever():
+    """
+    Keep running migrations forever and retry all failures.
+    """
+    asyncio.run(run(forever=True))

--- a/nucliadb/nucliadb/migrator/migrator.py
+++ b/nucliadb/nucliadb/migrator/migrator.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import asyncio
 import logging
 from typing import Optional
 
@@ -135,3 +136,16 @@ async def run(context: ExecutionContext, target_version: Optional[int] = None) -
             await context.data_manager.update_global_info(target_version=target_version)
             await run_all_kb_migrations(context, target_version)
             await run_global_migrations(context, target_version)
+
+
+async def run_forever(context: ExecutionContext) -> None:
+    """
+    Most of the time this will be a noop but allows
+    retrying failures until everything is done.
+    """
+    while True:
+        try:
+            await run(context)
+        except Exception:
+            logger.exception("Failed to run migrations. Will retry again in 5 minutes")
+        await asyncio.sleep(5 * 60)

--- a/nucliadb/setup.py
+++ b/nucliadb/setup.py
@@ -78,6 +78,7 @@ setup(
             "nucliadb-purge = nucliadb.purge:purge",
             "nucliadb-ingest-purge = nucliadb.ingest.purge:run",
             "nucliadb-migrate = nucliadb.migrator.command:main",
+            "nucliadb-migration-runner = nucliadb.migrator.command:main_forever",
             "nucliadb-rollover-kbid = nucliadb.common.cluster.rollover:rollover_kbid_command",
             "nucliadb-extract-openapi-reader = nucliadb.reader.openapi:command_extract_openapi",
             "nucliadb-extract-openapi-search = nucliadb.search.openapi:command_extract_openapi",


### PR DESCRIPTION
### Description
Migrations can run for a long time. This PR moves migrations to be handled in a deployment with retries so it does not disrupt the release process.

