### PR TITLE
Address github action deprecation warnings

### DIFF
--- a/.github/workflows/lint_helm.yml
+++ b/.github/workflows/lint_helm.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_ingest.yml
+++ b/.github/workflows/nucliadb_ingest.yml
@@ -153,7 +153,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_node.yml
+++ b/.github/workflows/nucliadb_node.yml
@@ -402,7 +402,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_reader.yml
+++ b/.github/workflows/nucliadb_reader.yml
@@ -158,7 +158,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_search.yml
+++ b/.github/workflows/nucliadb_search.yml
@@ -267,7 +267,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_shared.yml
+++ b/.github/workflows/nucliadb_shared.yml
@@ -34,7 +34,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_train.yml
+++ b/.github/workflows/nucliadb_train.yml
@@ -170,7 +170,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/nucliadb_writer.yml
+++ b/.github/workflows/nucliadb_writer.yml
@@ -155,7 +155,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/public_release.yml
+++ b/.github/workflows/public_release.yml
@@ -50,7 +50,7 @@ jobs:
           cmd: yq -i '.appVersion = "${{ steps.version_step.outputs.version_number }}"' 'charts/nucliadb/Chart.yaml'
 
       - name: Install Helm
-        uses: azure/setup-helm@v2.0
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 


### PR DESCRIPTION
### Description
More github actions that were pinned to old versions and were using the `set-output` command, which is deprecated.

### How was this PR tested?
Describe how you tested this PR.
