### PR TITLE
Chat: do not query predict chat if no context is found

### DIFF
--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -77,6 +77,10 @@ async def generate_answer(
         yield len(bytes_results).to_bytes(length=4, byteorder="big", signed=False)
         yield bytes_results
 
+    if results.total == 0:
+        yield NOT_ENOUGH_CONTEXT_ANSWER.encode()
+        return
+
     start_time = time()
     answer = []
     async for data in predict_generator:

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
@@ -29,6 +29,11 @@ def test_chat_on_kb(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
     assert len(result.relations.entities["Nuclia"].related_to) == 18
 
 
+def test_chat_on_kb_no_context_found(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
+    result = sdk.chat(kbid=docs_dataset, query="penguin")
+    assert result.answer == "Not enough data to answer this."
+
+
 def test_chat_on_resource(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
     rid = sdk.list_resources(kbid=docs_dataset).resources[0].id
     result = sdk.chat_on_resource(

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -79,8 +79,11 @@ def chat_response_parser(response: httpx.Response) -> ChatResponse:
     data = raw.read(payload_size)
     find_result = KnowledgeboxFindResults.parse_raw(base64.b64decode(data))
     data = raw.read()
-    answer, relations_payload = data.split(b"_END_")
-
+    try:
+        answer, relations_payload = data.split(b"_END_")
+    except ValueError:
+        answer = data
+        relations_payload = b""
     learning_id = response.headers.get("NUCLIA-LEARNING-ID")
     relations_result = None
     if len(relations_payload) > 0:


### PR DESCRIPTION
### Description
This will prevent "allucinations" for questions that are not found in the KB's corpus/context, because we won't even query the generative model.

### How was this PR tested?
e2e tests with sdk