### PR TITLE
Add extra pod annotations to all nucliadb charts

### DIFF
--- a/charts/nucliadb_ingest/templates/exporter.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/exporter.deploy.yaml
@@ -26,6 +26,9 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: metrics-exporter
         metrics: "enabled"

--- a/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
@@ -24,6 +24,9 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: ingest-orm-grpc
         version: "{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
@@ -24,6 +24,9 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: ingest-processed-consumer
         metrics: "enabled"

--- a/charts/nucliadb_ingest/templates/ingest-subscriber-workers.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-subscriber-workers.deploy.yaml
@@ -24,6 +24,9 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: ingest-subscriber-workers
         metrics: "enabled"

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -32,6 +32,9 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: ingest
         metrics: "enabled"

--- a/charts/nucliadb_ingest/templates/migrator.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/migrator.deploy.yaml
@@ -26,6 +26,9 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{.Values.services.maindb }},{{.Values.services.nats }},20160,2380"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/ingest.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: migrator
         metrics: "enabled"

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -134,3 +134,7 @@ ingest_subscriber_workers_autoscaling:
         target:
           type: Utilization
           averageUtilization: 75
+
+# extra_pod_annotations:
+#   what: "add annotations"
+#   where: "in the pods"

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -29,6 +29,9 @@ spec:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{.Values.serving.metricsPort }},3031,3032"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/node.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       name: node
       labels:
         app: node

--- a/charts/nucliadb_node/values.yaml
+++ b/charts/nucliadb_node/values.yaml
@@ -87,3 +87,7 @@ indexing:
   index_jetstream_auth:
   index_jetstream_servers:
     - nats1
+
+# extra_pod_annotations:
+#   what: "add annotations"
+#   where: "in the pods"

--- a/charts/nucliadb_reader/templates/reader.deploy.yaml
+++ b/charts/nucliadb_reader/templates/reader.deploy.yaml
@@ -24,6 +24,9 @@ spec:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.serving.metricsPort }}"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/reader.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: reader
         version: "{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/nucliadb_reader/values.yaml
+++ b/charts/nucliadb_reader/values.yaml
@@ -74,3 +74,7 @@ tracing:
   jaegerAgentTag: 1.34.1
   jaegerCollectorHost: jaeger-collector.observability.svc.cluster.local
   jaegerCollectorGrpcPort: 14250
+
+# extra_pod_annotations:
+#   what: "add annotations"
+#   where: "in the pods"

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -24,6 +24,9 @@ spec:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.serving.metricsPort }}"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/search.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}
       labels:
         app: search
         version: "{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/nucliadb_search/values.yaml
+++ b/charts/nucliadb_search/values.yaml
@@ -83,3 +83,7 @@ tracing:
   jaegerAgentTag: 1.34.1
   jaegerCollectorHost: jaeger-collector.observability.svc.cluster.local
   jaegerCollectorGrpcPort: 14250
+
+# extra_pod_annotations:
+#   what: "add annotations"
+#   where: "in the pods"

--- a/charts/nucliadb_writer/templates/writer.deploy.yaml
+++ b/charts/nucliadb_writer/templates/writer.deploy.yaml
@@ -30,6 +30,9 @@ spec:
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.serving.metricsPort }}"
         # do not have access to dependency chart cm this component references
         checksum/cm: {{ include (print $.Template.BasePath "/writer.cm.yaml") . | sha256sum }}
+        {{- if hasKey .Values "extra_pod_annotations" }}
+{{ toYaml .Values.extra_pod_annotations | indent 8 }}
+        {{- end }}        
     spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/nucliadb_writer/values.yaml
+++ b/charts/nucliadb_writer/values.yaml
@@ -71,3 +71,7 @@ tracing:
   jaegerAgentTag: 1.34.1
   jaegerCollectorHost: jaeger-collector.observability.svc.cluster.local
   jaegerCollectorGrpcPort: 14250
+
+# extra_pod_annotations:
+#   what: "add annotations"
+#   where: "in the pods"


### PR DESCRIPTION
### Description
This is needed as a pre-requisite to integrate all components with vault secrets

### How was this PR tested?
No tests needed
