### PR TITLE
Fix transaction contextmanager

### DIFF
--- a/nucliadb/nucliadb/common/maindb/driver.py
+++ b/nucliadb/nucliadb/common/maindb/driver.py
@@ -94,10 +94,8 @@ class Driver:
             error = True
             raise
         finally:
-            if txn is None or not txn.open:
-                # no need to abort
-                return
-            if wait_for_abort or error:
-                await txn.abort()
-            else:
-                asyncio.create_task(txn.abort())
+            if txn is not None and txn.open:
+                if error or wait_for_abort:
+                    await txn.abort()
+                else:
+                    asyncio.create_task(txn.abort())

--- a/nucliadb/nucliadb/tests/unit/common/maindb/test_driver.py
+++ b/nucliadb/nucliadb/tests/unit/common/maindb/test_driver.py
@@ -43,6 +43,16 @@ def driver() -> Driver:  # type: ignore
 
 
 @pytest.mark.asyncio
+async def test_transaction_handles_txn_begin_errors(driver):
+    driver.begin.side_effect = ValueError()
+    testmock = mock.AsyncMock()
+    with pytest.raises(ValueError):
+        async with driver.transaction():
+            testmock()
+    testmock.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_transaction_does_not_abotr_if_commited(driver):
     async with driver.transaction() as txn:
         await txn.commit()


### PR DESCRIPTION
### Description
Can't return on an async context manager, otherwise contextlib throws a:
```
RuntimeError: generator didn't yield
```

### How was this PR tested?
Unit tests
