### PR TITLE
increase dependency versions

### DIFF
--- a/nucliadb/requirements-test.txt
+++ b/nucliadb/requirements-test.txt
@@ -3,7 +3,6 @@ pytest-docker-fixtures>=1.3.17
 docker>=6.0.0,<7.0.0
 pytest-asyncio
 aiobotocore
-aioboto3
 s3fs
 datasets
 asyncpg

--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -19,7 +19,8 @@ grpcio-reflection>=1.44.0
 orjson>=3.6.7
 types-setuptools
 pydantic>=1.9.0,<2.0
-aiobotocore>=2.1.1
+aiobotocore>=2.5.2
+aioboto3>=11.2.0
 aioboto3
 botocore
 google-cloud-storage

--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -20,8 +20,6 @@ orjson>=3.6.7
 types-setuptools
 pydantic>=1.9.0,<2.0
 aiobotocore>=2.5.2
-aioboto3>=11.2.0
-aioboto3
 botocore
 google-cloud-storage
 gcloud

--- a/nucliadb_protos/python/requirements.txt
+++ b/nucliadb_protos/python/requirements.txt
@@ -1,4 +1,4 @@
 protobuf
 grpcio>=1.44.0
 grpcio-tools>=1.44.0
-mypy-protobuf>=3.2.0
+mypy-protobuf>=3.4.0

--- a/nucliadb_telemetry/requirements.txt
+++ b/nucliadb_telemetry/requirements.txt
@@ -13,7 +13,7 @@ opentelemetry-proto==1.11.1
 opentelemetry-exporter-jaeger==1.11.1
 opentelemetry-propagator-b3==1.11.1
 opentelemetry-instrumentation-fastapi==0.30b1
-opentelemetry-instrumentation-aiohttp-client>=0.30b1
+opentelemetry-instrumentation-aiohttp-client>=0.39b0
 opentelemetry-semantic-conventions>=0.30b1
 pydantic<2.0
 requests

--- a/nucliadb_telemetry/requirements.txt
+++ b/nucliadb_telemetry/requirements.txt
@@ -13,8 +13,8 @@ opentelemetry-proto==1.11.1
 opentelemetry-exporter-jaeger==1.11.1
 opentelemetry-propagator-b3==1.11.1
 opentelemetry-instrumentation-fastapi==0.30b1
-opentelemetry-instrumentation-aiohttp-client>=0.39b0
-opentelemetry-semantic-conventions>=0.30b1
+opentelemetry-instrumentation-aiohttp-client==0.30b1
+opentelemetry-semantic-conventions==0.30b1
 pydantic<2.0
 requests
 fastapi

--- a/nucliadb_utils/requirements-storages.txt
+++ b/nucliadb_utils/requirements-storages.txt
@@ -1,5 +1,6 @@
 oauth2client>=4.1.3
-aiobotocore>=2.1.1
+aiobotocore>=2.5.2
+aioboto3>=11.2.0
 google-api-python-client>=2.37.0
 types-aiofiles>=0.8.3
 aiofiles>=0.8.0

--- a/nucliadb_utils/requirements-storages.txt
+++ b/nucliadb_utils/requirements-storages.txt
@@ -1,6 +1,5 @@
 oauth2client>=4.1.3
 aiobotocore>=2.5.2
-aioboto3>=11.2.0
 google-api-python-client>=2.37.0
 types-aiofiles>=0.8.3
 aiofiles>=0.8.0


### PR DESCRIPTION
Partly to improve build speeds as pip is funky about these dependencies and has to download many versions to check compat:

For example:
```
pip is looking at multiple versions of opentelemetry-instrumentation-aiohttp-client to determine which version is compatible with other requirements. This could take a while.
```