### PR TITLE
fix calling sync fastapi functions from decorator

### DIFF
--- a/nucliadb_utils/nucliadb_utils/authentication.py
+++ b/nucliadb_utils/nucliadb_utils/authentication.py
@@ -153,7 +153,10 @@ def requires(
             # Handle sync request/response functions.
             @functools.wraps(func)
             def sync_wrapper(*args: typing.Any, **kwargs: typing.Any) -> Response:
-                request = kwargs.get("request", args[idx])
+                try:
+                    request = kwargs["request"]
+                except KeyError:
+                    request = args[idx]
                 assert isinstance(request, Request)
 
                 if not has_required_scope(request, scopes_list):

--- a/nucliadb_utils/nucliadb_utils/tests/unit/test_authentication.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/test_authentication.py
@@ -80,6 +80,12 @@ class TestRequires:
 
         assert authentication.requires(["admin"])(lambda request: None)(req) is None
 
+        # test passed as kwargs
+        assert (
+            authentication.requires(["admin"])(lambda request: None)(request=req)
+            is None
+        )
+
     def test_requires_sync_returns_status(self):
         req = Request({"type": "http", "auth": Mock(scopes=["admin"])})
 


### PR DESCRIPTION
### Description
In FastAPI, when a sync handler is defined, the request seems to be passed in as a kwarg arg and `args` is an empty tuple.

### How was this PR tested?
Unit
