### PR TITLE
Fix parsing rephrase response so that it does not include " characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ python-code-lint:
 	make -C nucliadb_models/ format
 	make -C nucliadb_sdk/ format
 	make -C nucliadb_node/ format
-	make -C nucliadb_node_binding/ format
+#	make -C nucliadb_node_binding/ format
 	make -C nucliadb_utils/ format
 	make -C nucliadb/ format
 	make -C nucliadb_telemetry/ format
@@ -79,7 +79,7 @@ python-code-lint:
 	make -C nucliadb_client/ lint
 	make -C nucliadb_models/ lint
 	make -C nucliadb_node/ lint
-	make -C nucliadb_node_binding/ lint
+#	make -C nucliadb_node_binding/ lint
 
 
 rust-code-lint:

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -262,7 +262,7 @@ class PredictEngine:
             headers=self.get_predict_headers(kbid),
         )
         await self.check_response(resp, expected=200)
-        return await resp.text()
+        return await resp.json()
 
     @predict_observer.wrap({"type": "chat"})
     async def chat_query(


### PR DESCRIPTION
### Description
This was making the whole rephrase feature not work, because it was causing an exact match search on the successive find request to retrieve context for chat.

### How was this PR tested?
Local tests
