### PR TITLE
trigger sdk test on stage after publishing a new version

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -86,3 +86,11 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Run Nuclia SDK tests
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GH_CICD_PUBLIC }}
+          repository: nuclia/nuclia.py
+          event-type: test-stage
+          client-payload: '{"component": "nucliadb", "commit": "${{ GITHUB_SHA }}", "user": "${{ github.actor }}"}'


### PR DESCRIPTION
### Description
After publishing a new version on pypi, we will trigger the stage integration tests in the `nuclia.py` repo.

(Not sure yet how we will notify the user in case of failure)

### How was this PR tested?
Describe how you tested this PR.
