### PR TITLE
force the nodes platform so the test don't choke on silicon chips

### DIFF
--- a/nucliadb_node/nucliadb_node/tests/fixtures.py
+++ b/nucliadb_node/nucliadb_node/tests/fixtures.py
@@ -95,6 +95,8 @@ class nucliadbNodeReader(BaseImage):
     def get_image_options(self):
         options = super(nucliadbNodeReader, self).get_image_options()
         options["volumes"] = {self._volume.name: {"bind": "/data"}}
+        # Forces the plaform so the test works on Apple Silicon series
+        options["platform"] = "linux/amd64"
         return options
 
     def check(self):
@@ -120,6 +122,8 @@ class nucliadbNodeWriter(BaseImage):
     def get_image_options(self):
         options = super(nucliadbNodeWriter, self).get_image_options()
         options["volumes"] = {self._volume.name: {"bind": "/data"}}
+        # Forces the plaform so the test works on Apple Silicon series
+        options["platform"] = "linux/amd64"
         return options
 
     def check(self):


### PR DESCRIPTION
### Description

The `nucliadb_node` test fails on M1/M2 because it tries to pull `eu.gcr.io/stashify-218417/node:f9b58f6` and we don't publish under that platform

### How was this PR tested?

`make test` now works on M1+M2
