### PR TITLE
pin the protobuf lib

### DIFF
--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -7,7 +7,8 @@ lru-dict>=1.1.7
 backoff
 aiofiles>=0.8.0
 types-aiofiles>=0.8.3
-protobuf>=3.20.2
+# the latest protobuf segfaults
+protobuf==4.22.3
 types-protobuf>=3.19.20,<4.0
 grpcio>=1.44.0
 grpcio-health-checking>=1.44.0


### PR DESCRIPTION
### Description

The latest `4.24.0` segfaults on our code.

For reference:
```
Fatal Python error: Segmentation fault

Current thread 0x00000001ebc09e00 (most recent call first):
  File "/Users/tarekziade/Dev/nucliadb/nucliadb/nucliadb/ingest/service/writer.py", line 187 in SetVectors
  File "/Users/tarekziade/Dev/nucliadb/nucliadb/nucliadb/ingest/tests/unit/service/test_writer.py", line 200 in test_SetVectors_error
  File "/Users/tarekziade/.pyenv/versions/3.11.4/lib/python3.11/asyncio/events.py", line 80 in _run
  File "/Users/tarekziade/.pyenv/versions/3.11.4/lib/python3.11/asyncio/base_events.py", line 1922 in _run_once
  File "/Users/tarekziade/.pyenv/versions/3.11.4/lib/python3.11/asyncio/base_events.py", line 607 in run_forever
  File "/Users/tarekziade/.pyenv/versions/3.11.4/lib/python3.11/asyncio/base_events.py", line 640 in run_until_complete
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pytest_asyncio/plugin.py", line 454 in inner
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/python.py", line 183 in pytest_pyfunc_call
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/python.py", line 1641 in runtest
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 162 in pytest_runtest_call
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 255 in <lambda>
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 311 in from_call
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 254 in call_runtest_hook
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 215 in call_and_report
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 126 in runtestprotocol
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/runner.py", line 109 in pytest_runtest_protocol
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/main.py", line 348 in pytest_runtestloop
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/main.py", line 323 in _main
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/main.py", line 269 in wrap_session
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/main.py", line 316 in pytest_cmdline_main
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_callers.py", line 80 in _multicall
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_manager.py", line 112 in _hookexec
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/pluggy/_hooks.py", line 433 in __call__
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/config/__init__.py", line 162 in main
  File "/Users/tarekziade/.pyenv/versions/3.11.4/envs/nucliadb/lib/python3.11/site-packages/_pytest/config/__init__.py", line 185 in console_main
  File "/Users/tarekziade/.pyenv/versions/nucliadb/bin/pytest", line 8 in <module>
```

pinning it to a working version for now

### How was this PR tested?
Describe how you tested this PR.
