### PR TITLE
dont rely on the fs for vectorset updates

### DIFF
--- a/nucliadb_vectors/src/indexset/mod.rs
+++ b/nucliadb_vectors/src/indexset/mod.rs
@@ -73,14 +73,11 @@ impl IndexSet {
     }
     fn update(&self, lock: &fs_state::Lock) -> VectorR<()> {
         let disk_v = fs_state::crnt_version(lock)?;
-        let date = *self.date.read().unwrap();
-        if disk_v > date {
-            let new_state = fs_state::load_state(lock)?;
-            let mut state = self.state.write().unwrap();
-            let mut date = self.date.write().unwrap();
-            *state = new_state;
-            *date = disk_v;
-        }
+        let new_state = fs_state::load_state(lock)?;
+        let mut state = self.state.write().unwrap();
+        let mut date = self.date.write().unwrap();
+        *state = new_state;
+        *date = disk_v;
         Ok(())
     }
     pub fn index_keys<C: IndexKeyCollector>(&self, c: &mut C, _: &Lock) {


### PR DESCRIPTION
### Description
Relying on the file system for identifying now or deleted vector sets can be problematic due to data races. This PR fixes it by assuming the cost of reloading the vector set list (usually VERY small) even when it has not changed.

### How was this PR tested?
Local tests.
