### PR TITLE
Fix keys counting when there are no matches

### DIFF
--- a/nucliadb/nucliadb/common/maindb/tikv.py
+++ b/nucliadb/nucliadb/common/maindb/tikv.py
@@ -173,16 +173,18 @@ class TiKVTransaction(Transaction):
                 # with a binary search and break out
                 left, right = 0, len(keys) - 1
                 result_index = 0
+                match_found = False
                 while left <= right:
                     mid = left + (right - left) // 2
 
                     if keys[mid].startswith(original_match):
+                        match_found = True
                         left = mid + 1  # Move to the right half
                         result_index = mid
                     else:
                         right = mid - 1  # Move to the left half
-
-                value += result_index + 1
+                if match_found:
+                    value += result_index + 1
                 break
             else:
                 value += len(keys)

--- a/nucliadb/nucliadb/tests/integration/common/maindb/test_drivers.py
+++ b/nucliadb/nucliadb/tests/integration/common/maindb/test_drivers.py
@@ -145,6 +145,7 @@ async def driver_basic(driver: Driver):
 
     async with driver.transaction() as txn:
         assert len(current_internal_kbs_keys) == await txn.count("/internal/kbs")
+        assert await txn.count("/internal/a/foobar") == 0
 
     # but with it it does not return the father
     txn = await driver.begin()


### PR DESCRIPTION
### Description
When there was no match found for the key, we were returning a count of 1 instead of 0

### How was this PR tested?
Integration and local tests
