### PR TITLE
added RSS+VMS and disk size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+dependencies = [
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4014,6 +4034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4072,8 +4098,10 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "vectors_benchmark"
 version = "0.1.0"
 dependencies = [
+ "byte-unit",
  "clap",
  "lazy_static",
+ "memory-stats",
  "nucliadb_vectors",
  "rand",
  "serde",

--- a/vectors_benchmark/Cargo.toml
+++ b/vectors_benchmark/Cargo.toml
@@ -16,6 +16,7 @@ nucliadb_vectors = {path= "../nucliadb_vectors"}
 lazy_static = "1.4.0"
 memory-stats = "1.0.0"
 byte-unit = "4.0.19"
+samply = "0.11.0"
 
 [[bin]]
 name = "vectors_benchmark"

--- a/vectors_benchmark/Cargo.toml
+++ b/vectors_benchmark/Cargo.toml
@@ -14,6 +14,8 @@ serde = { version = "1.0", features = ["derive"] }
 clap = { version = "3.1.18", features = ["derive"] }
 nucliadb_vectors = {path= "../nucliadb_vectors"}
 lazy_static = "1.4.0"
+memory-stats = "1.0.0"
+byte-unit = "4.0.19"
 
 [[bin]]
 name = "vectors_benchmark"

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -1,0 +1,11 @@
+BATCH_SIZE:=100
+INDEX_SIZE:=10000
+
+.PHONY: build
+build:
+	cargo build
+
+
+.PHONY: vector-bench
+vector-bench:
+	cargo run --bin vectors_benchmark -- -b $(BATCH_SIZE) -i $(INDEX_SIZE)

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -8,4 +8,4 @@ build:
 
 .PHONY: vector-bench
 vector-bench:
-	cargo run --bin vectors_benchmark -- -b $(BATCH_SIZE) -i $(INDEX_SIZE)
+	cargo run --release --bin vectors_benchmark -- -b $(BATCH_SIZE) -i $(INDEX_SIZE)

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -3,9 +3,14 @@ INDEX_SIZE:=10000
 
 .PHONY: build
 build:
-	cargo build
-
+	cargo build --release
 
 .PHONY: vector-bench
 vector-bench:
 	cargo run --release --bin vectors_benchmark -- -b $(BATCH_SIZE) -i $(INDEX_SIZE)
+
+.PHONY: samply-vector-bench
+samply-vector-bench:
+	samply record ../target/release/vectors_benchmark -b $(BATCH_SIZE) -i $(INDEX_SIZE)
+
+

--- a/vectors_benchmark/README.md
+++ b/vectors_benchmark/README.md
@@ -1,0 +1,13 @@
+# Vector benchmarks
+
+Run a benchmark with:
+
+```
+make vector-bench
+```
+
+Run a profiled benchmark with:
+
+```
+make samply-vector-bench
+```

--- a/vectors_benchmark/src/plot_writer.rs
+++ b/vectors_benchmark/src/plot_writer.rs
@@ -23,6 +23,8 @@ use std::io;
 use std::io::Write;
 use std::time::SystemTime;
 
+use memory_stats::memory_stats;
+
 pub struct PlotWriter {
     start: SystemTime,
     idx: usize,
@@ -39,9 +41,15 @@ impl PlotWriter {
     }
     pub fn add(&mut self) -> io::Result<()> {
         let x = self.idx;
-        let y = self.start.elapsed().unwrap().as_millis();
+        let elapsed = self.start.elapsed().unwrap().as_millis();
+        let mut rss = 0;
+        let mut vms = 0;
+        if let Some(usage) = memory_stats() {
+            rss = usage.physical_mem;
+            vms = usage.virtual_mem;
+        }
         self.idx += 1;
-        writeln!(self.file, "{x} {y}")
+        writeln!(self.file, "{x} {elapsed} {rss} {vms}")
     }
 }
 


### PR DESCRIPTION
### Description

Extends `vector_benchmarks`

- Adds rss and vms to the plot files
- displays the size of the vectors on disk at the end of the test


### How was this PR tested?
Describe how you tested this PR.
