### PR TITLE
Purge small fixes

### DIFF
--- a/nucliadb/nucliadb/ingest/purge.py
+++ b/nucliadb/nucliadb/ingest/purge.py
@@ -140,7 +140,9 @@ async def purge_kb_storage(driver: Driver, storage: Storage):
 
 
 async def main():
-    # Clean up all kb marked to delete
+    """
+    This script will purge all knowledge boxes marked to be deleted in maindb.
+    """
     await setup_cluster()
     driver = await setup_driver()
     storage = await get_storage(

--- a/nucliadb/nucliadb/writer/tus/gcs.py
+++ b/nucliadb/nucliadb/writer/tus/gcs.py
@@ -109,7 +109,6 @@ class GCloudBlobStore(BlobStore):
         self.upload_url = (
             object_base_url + "/upload/storage/v1/b/{bucket}/o?uploadType=resumable"
         )  # noqa
-        self.session = aiohttp.ClientSession()
 
         self._credentials = None
 


### PR DESCRIPTION
### Description
- Fix k8s connection leak. (We were seeing some `Unclosed client session ...` warning logs)
- Give some time to k8s cluster discovery to discover the nodes after initialization.
- Fix connection leak on writer/tus/gcs.py (`self.session` was assigned twice in the `__init__`)

### How was this PR tested?
Local tests