### PR TITLE
send results as JSON to `nucliadb_performance`

### DIFF
--- a/.github/workflows/nucliadb_nightly_bench.yml
+++ b/.github/workflows/nucliadb_nightly_bench.yml
@@ -1,0 +1,39 @@
+name: nucliadb (rust vector db benchmarks)
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: 0 0 * * 0
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Rust Vector DB Benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Run benchmarks
+        run: |
+          make -C vectors_benchmark vector-bench
+
+      - name: Store on GH Pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: "customSmallerIsBetter"
+          output-file-path: vectors_benchmark/benchmark.json
+          auto-push: true
+          github-token: ${{ secrets.PERFORMANCE_TOKEN }}
+          gh-repository: github.com/nuclia/nucliadb_performance
+          gh-pages-branch: main

--- a/nucliadb_vectors/src/data_point/ops_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ops_hnsw.rs
@@ -264,7 +264,7 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
         with_duplicates: bool,
     ) -> Neighbours {
         let Some(entry_point) = hnsw.get_entry_point() else {
-            return Neighbours::default()
+            return Neighbours::default();
         };
         let mut crnt_layer = entry_point.layer;
         let mut neighbours = vec![(entry_point.node, 0.)];
@@ -294,12 +294,11 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
                 blocked_addresses: &sol_addresses,
                 vec_counter: &vec_counter,
             };
-            let Some((addr, score)) = self.closest_up_node(
-                    addr,
-                    query,
-                    hnsw.get_layer(0),
-                    node_filter,
-                ) else { continue };
+            let Some((addr, score)) =
+                self.closest_up_node(addr, query, hnsw.get_layer(0), node_filter)
+            else {
+                continue;
+            };
             filtered_result.push((addr, score));
             sol_addresses.insert(addr);
             vec_counter.add(self.tracker.get_vector(addr));

--- a/vectors_benchmark/Cargo.toml
+++ b/vectors_benchmark/Cargo.toml
@@ -16,7 +16,6 @@ nucliadb_vectors = {path= "../nucliadb_vectors"}
 lazy_static = "1.4.0"
 memory-stats = "1.0.0"
 byte-unit = "4.0.19"
-samply = "0.11.0"
 
 [[bin]]
 name = "vectors_benchmark"

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -9,8 +9,12 @@ build:
 vector-bench:
 	cargo run --release --bin vectors_benchmark -- -b $(BATCH_SIZE) -i $(INDEX_SIZE)
 
+.PHONY: samply
+samply:
+	samply --help > /dev/null | cargo install samply
+
 .PHONY: samply-vector-bench
-samply-vector-bench:
+samply-vector-bench: samply
 	samply record ../target/release/vectors_benchmark -b $(BATCH_SIZE) -i $(INDEX_SIZE)
 
 

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -11,7 +11,7 @@ vector-bench:
 
 .PHONY: samply
 samply:
-	samply --help > /dev/null | cargo install samply
+	samply --help > /dev/null || cargo install samply
 
 .PHONY: samply-vector-bench
 samply-vector-bench: samply

--- a/vectors_benchmark/src/cli.rs
+++ b/vectors_benchmark/src/cli.rs
@@ -56,6 +56,9 @@ pub struct Args {
     /// Batch size
     #[clap(short, long, default_value_t = 5000)]
     batch_size: usize,
+    /// Path of the json output file
+    #[clap(short, long, default_value_t = String::from("./benchmark.json"))]
+    json_output: String,
 }
 
 impl Default for Args {
@@ -120,5 +123,8 @@ impl Args {
     }
     pub fn embedding_dim(&self) -> usize {
         self.embedding_dim
+    }
+    pub fn json_output(&self) -> String {
+        self.json_output.clone()
     }
 }

--- a/vectors_benchmark/src/json_writer.rs
+++ b/vectors_benchmark/src/json_writer.rs
@@ -17,29 +17,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
-pub mod cli;
-pub mod engines;
-pub mod file_vectors;
-pub mod json_writer;
-pub mod plot_writer;
-pub mod random_vectors;
-pub mod reader;
-pub mod stats;
-pub mod writer;
 
-pub mod cli_interface {
-    pub use super::cli::Args;
-    pub use super::file_vectors::*;
-    pub use super::plot_writer::*;
-    pub use super::random_vectors::*;
-    pub use super::{engines, reader, writer};
-}
+use std::fs::File;
+use std::io::{BufWriter, Write};
 
-pub trait VectorEngine {
-    fn add_batch(&mut self, batch_id: String, keys: Vec<String>, embeddings: Vec<Vec<f32>>);
-    fn search(&self, no_results: usize, query: &[f32]);
-}
-
-pub trait Logger {
-    fn report(&mut self) -> cli::BenchR<()>;
+pub fn write_json(filename: String, values: Vec<serde_json::Value>) -> Result<(), std::io::Error> {
+    let file = File::create(filename)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, &values)?;
+    writer.flush()?;
+    Ok(())
 }


### PR DESCRIPTION
### Description

This PR:
- adds a JSON output that is compatible with `github-action-benchmark`
- adds a GH action that runs daily to send that data to be published in https://nuclia.github.io/nucliadb_performance/dev/bench/


### How was this PR tested?
Describe how you tested this PR.
