### PR TITLE
Fix predict chat response iterator

### DIFF
--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -379,7 +379,11 @@ def get_answer_generator(response: aiohttp.ClientResponse):
     """
 
     async def _iter_answer_chunks(gen):
-        async for chunk, _ in gen:
-            yield chunk
+        buffer = b""
+        async for chunk, end_of_chunk in gen:
+            buffer += chunk
+            if end_of_chunk:
+                yield buffer
+                buffer = b""
 
     return _iter_answer_chunks(response.content.iter_chunks())

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -372,9 +372,14 @@ class PredictEngine:
 
 
 def get_answer_generator(response: aiohttp.ClientResponse):
+    """
+    Returns an async generator that yields the chunks of the response
+    in the same way as received from the server.
+    See: https://docs.aiohttp.org/en/stable/streams.html#aiohttp.StreamReader.iter_chunks
+    """
+
+    async def _iter_answer_chunks(gen):
+        async for chunk, _ in gen:
+            yield chunk
+
     return _iter_answer_chunks(response.content.iter_chunks())
-
-
-async def _iter_answer_chunks(gen):
-    async for chunk, _ in gen:
-        yield chunk

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -303,7 +303,7 @@ class PredictEngine:
         )
         await self.check_response(resp, expected=200)
         ident = resp.headers.get("NUCLIA-LEARNING-ID")
-        return ident, resp.content.iter_any()
+        return ident, get_answer_generator(resp)
 
     @predict_observer.wrap({"type": "ask_document"})
     async def ask_document(
@@ -369,3 +369,12 @@ class PredictEngine:
         data = await resp.json()
 
         return convert_relations(data)
+
+
+def get_answer_generator(response: aiohttp.ClientResponse):
+    return _iter_answer_chunks(response.content.iter_chunks())
+
+
+async def _iter_answer_chunks(gen):
+    async for chunk, _ in gen:
+        yield chunk

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -88,7 +88,7 @@ async def generate_answer(
     async for answer_chunk, is_last_chunk in async_gen_lookahead(answer_generator):
         if is_last_chunk:
             try:
-                status_code = AnswerStatusCode(answer_chunk.decode())
+                status_code = parse_answer_status_code(answer_chunk)
             except ValueError:
                 # TODO: remove this in the future, it's
                 # just for bw compatibility until predict
@@ -245,3 +245,19 @@ async def async_gen_lookahead(gen):
     # Yield the last chunk if there is one
     if buffered_chunk is not None:
         yield buffered_chunk, True
+
+
+def parse_answer_status_code(chunk: bytes) -> AnswerStatusCode:
+    """
+    Parses the status code from the chunk.
+    """
+    try:
+        return AnswerStatusCode(chunk.decode())
+    except ValueError:
+        # In some cases, due to a bug in aiohttp, the final status
+        # chunk is appended to the previous chunk...
+        if chunk == b"":
+            raise
+        if chunk.endswith(b"0"):
+            return AnswerStatusCode.SUCCESS
+        return AnswerStatusCode(chunk[-2:].decode())

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -88,7 +88,7 @@ async def generate_answer(
     async for answer_chunk, is_last_chunk in async_gen_lookahead(answer_generator):
         if is_last_chunk:
             try:
-                status_code = parse_answer_status_code(answer_chunk)
+                status_code = _parse_answer_status_code(answer_chunk)
             except ValueError:
                 # TODO: remove this in the future, it's
                 # just for bw compatibility until predict
@@ -247,15 +247,15 @@ async def async_gen_lookahead(gen):
         yield buffered_chunk, True
 
 
-def parse_answer_status_code(chunk: bytes) -> AnswerStatusCode:
+def _parse_answer_status_code(chunk: bytes) -> AnswerStatusCode:
     """
-    Parses the status code from the chunk.
+    Parses the status code from the last chunk of the answer.
     """
     try:
         return AnswerStatusCode(chunk.decode())
     except ValueError:
-        # In some cases, due to a bug in aiohttp, the final status
-        # chunk is appended to the previous chunk...
+        # In some cases, even if the status code was yield separately
+        # at the server side, the status code is appended to the previous chunk.
         if chunk == b"":
             raise
         if chunk.endswith(b"0"):

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -255,7 +255,10 @@ def _parse_answer_status_code(chunk: bytes) -> AnswerStatusCode:
         return AnswerStatusCode(chunk.decode())
     except ValueError:
         # In some cases, even if the status code was yield separately
-        # at the server side, the status code is appended to the previous chunk.
+        # at the server side, the status code is appended to the previous chunk...
+        # It may be a bug in the aiohttp.StreamResponse implementation,
+        # but we haven't spotted it yet. For now, we just try to parse the status code
+        # from the tail of the chunk.
         if chunk == b"":
             raise
         if chunk.endswith(b"0"):

--- a/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
@@ -22,9 +22,9 @@ import pytest
 
 from nucliadb.search.predict import AnswerStatusCode
 from nucliadb.search.search.chat.query import (
+    _parse_answer_status_code,
     async_gen_lookahead,
     chat,
-    parse_answer_status_code,
 )
 from nucliadb_models.search import (
     ChatRequest,
@@ -93,6 +93,6 @@ async def test_async_gen_lookahead():
 def test_parse_status_code(chunk, status_code, error):
     if error:
         with pytest.raises(ValueError):
-            parse_answer_status_code(chunk)
+            _parse_answer_status_code(chunk)
     else:
-        assert parse_answer_status_code(chunk) == status_code
+        assert _parse_answer_status_code(chunk) == status_code


### PR DESCRIPTION
### Description
Our chat stream protocol is assuming that status codes will be yield on its own, so we can parse them easily.
It seems like `aiohttp.StreamReader.iter_any` doesn't work for us: when the models yield big chunks of text, aiohttp will decide to change how chunks/data is are iterated.

By using `aiohttp.StreamReader.iter_chunks` we make sure that the data is iterated as received from the server.
https://docs.aiohttp.org/en/stable/streams.html#aiohttp.StreamReader.iter_chunks

### How was this PR tested?
Integration and local tests
