### PR TITLE
Avoid spawning unneeded threads on search

### DIFF
--- a/nucliadb_vectors/src/data_point_provider/state.rs
+++ b/nucliadb_vectors/src/data_point_provider/state.rs
@@ -359,7 +359,7 @@ mod test {
             .collect::<Vec<_>>();
         let new = DataPoint::merge(dir.path(), &work, Similarity::Cosine).unwrap();
         std::mem::drop(work);
-        let _ = state.replace_work_unit(new.meta());
+        state.replace_work_unit(new.meta());
         assert!(state.current_work_unit().is_none());
         assert_eq!(state.work_stack.len(), 0);
         assert_eq!(state.current.size(), 1);

--- a/nucliadb_vectors/src/labels/mod.rs
+++ b/nucliadb_vectors/src/labels/mod.rs
@@ -101,9 +101,7 @@ impl LabelDictionary {
     }
 
     pub fn new<'a, I>(path: &Path, labels: I) -> VectorR<Self>
-    where
-        I: Iterator<Item = &'a Label>,
-    {
+    where I: Iterator<Item = &'a Label> {
         let records_file_path = path.join(Self::LABELS_IDX);
         let fst_file_path = path.join(Self::LABELS_FST);
 

--- a/vectors_benchmark/src/binaries/labels_benchmark.rs
+++ b/vectors_benchmark/src/binaries/labels_benchmark.rs
@@ -17,22 +17,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
+use std::io::Write;
+use std::iter::Iterator;
+use std::time::Instant;
+use std::{fs, mem};
+
+use byte_unit::Byte;
+use nucliadb_vectors::labels::{Label, LabelDictionary};
+use nucliadb_vectors::VectorR;
 use rand::distributions::Alphanumeric;
 use rand::seq::index::sample;
 use rand::Rng;
-use std::fs;
-use std::io::Write;
-use std::iter::Iterator;
-use std::mem;
-use std::time::Instant;
-
-use byte_unit::Byte;
 use serde_json::json;
 use tempfile::{tempdir, TempDir};
-
-use nucliadb_vectors::labels::{Label, LabelDictionary};
-use nucliadb_vectors::VectorR;
-
 use vectors_benchmark::cli_interface::*;
 use vectors_benchmark::json_writer::write_json;
 


### PR DESCRIPTION
### Description
- Add missing `skip_relations`
- Move skip logic to avoid unnecessary thread spawn that won't do anything useful

### How was this PR tested?
- Existing tests
