### PR TITLE
renamed `LabelDictionary` to `LabelIndex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,4 +4358,3 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,3 +4358,4 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+

--- a/vectors_benchmark/src/binaries/labels_benchmark.rs
+++ b/vectors_benchmark/src/binaries/labels_benchmark.rs
@@ -23,7 +23,7 @@ use std::time::Instant;
 use std::{fs, mem};
 
 use byte_unit::Byte;
-use nucliadb_vectors::labels::{Label, LabelDictionary};
+use nucliadb_vectors::labels::{Label, LabelIndex};
 use nucliadb_vectors::VectorR;
 use rand::distributions::Alphanumeric;
 use rand::seq::index::sample;
@@ -65,14 +65,14 @@ fn generate_labels(num_structs: usize) -> Vec<Label> {
 }
 
 fn search_benchmark(dir: &TempDir, keys: Vec<String>) -> VectorR<u128> {
-    let labels_dict = LabelDictionary::open(dir.path())?;
+    let label_index = LabelIndex::open(dir.path())?;
     let mut total_elapsed_micros = 0;
 
     for (cycle, key) in keys.iter().enumerate() {
         print!("{} ", cycle);
         let _ = std::io::stdout().flush();
         let start_time = Instant::now();
-        let _ = match labels_dict.get_label(key)? {
+        let _ = match label_index.get_label(key)? {
             None => {
                 println!("Could not find `{}`", key);
                 Err("Not found")
@@ -91,7 +91,7 @@ fn indexing_benchmark(dir: &TempDir, random_labels: Vec<Label>) -> VectorR<u128>
         print!("{} ", cycle);
         let _ = std::io::stdout().flush();
         let start_time = Instant::now();
-        let _ = LabelDictionary::new(dir.path(), random_labels.iter());
+        let _ = LabelIndex::new(dir.path(), random_labels.iter());
         total_elapsed_ms += start_time.elapsed().as_millis();
     }
     println!(" - OK.");


### PR DESCRIPTION
### Description

We're renaming the new class to avoid confusion with the extisting `LabelDictionary` since we've decided to keep it for now

### How was this PR tested?
Describe how you tested this PR.
