### PR TITLE
do not default to searching relations with chat

### DIFF
--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -526,7 +526,7 @@ class SearchParamDefaults:
     )
 
     chat_features = ParamDefault(
-        default=[ChatOptions.PARAGRAPHS, ChatOptions.RELATIONS],
+        default=[ChatOptions.PARAGRAPHS],
         title="Chat features",
         description="Features enabled for the chat endpoint. If `paragraphs` is included, the paragraphs from which the answer is generated are returned. If `relations` is included, a graph of entities related to the answer is returned.",  # noqa
     )


### PR DESCRIPTION
### Description
Relations are not currently shown anyways with chat so let's default to know querying them.
