### PR TITLE
Revert "Fix predict chat response iterator (#1231)"

### DIFF
--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -303,7 +303,7 @@ class PredictEngine:
         )
         await self.check_response(resp, expected=200)
         ident = resp.headers.get("NUCLIA-LEARNING-ID")
-        return ident, get_answer_generator(resp)
+        return ident, resp.content.iter_any()
 
     @predict_observer.wrap({"type": "ask_document"})
     async def ask_document(
@@ -369,21 +369,3 @@ class PredictEngine:
         data = await resp.json()
 
         return convert_relations(data)
-
-
-def get_answer_generator(response: aiohttp.ClientResponse):
-    """
-    Returns an async generator that yields the chunks of the response
-    in the same way as received from the server.
-    See: https://docs.aiohttp.org/en/stable/streams.html#aiohttp.StreamReader.iter_chunks
-    """
-
-    async def _iter_answer_chunks(gen):
-        buffer = b""
-        async for chunk, end_of_chunk in gen:
-            buffer += chunk
-            if end_of_chunk:
-                yield buffer
-                buffer = b""
-
-    return _iter_answer_chunks(response.content.iter_chunks())

--- a/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
@@ -20,12 +20,7 @@ from unittest import mock
 
 import pytest
 
-from nucliadb.search.predict import AnswerStatusCode
-from nucliadb.search.search.chat.query import (
-    _parse_answer_status_code,
-    async_gen_lookahead,
-    chat,
-)
+from nucliadb.search.search.chat.query import async_gen_lookahead, chat
 from nucliadb_models.search import (
     ChatRequest,
     KnowledgeboxFindResults,
@@ -75,24 +70,3 @@ async def test_async_gen_lookahead():
         (0, False),
         (1, True),
     ]
-
-
-@pytest.mark.parametrize(
-    "chunk,status_code,error",
-    [
-        (b"", None, True),
-        (b"errorcodeisnotpresetn", None, True),
-        (b"0", AnswerStatusCode.SUCCESS, False),
-        (b"-1", AnswerStatusCode.ERROR, False),
-        (b"-2", AnswerStatusCode.NO_CONTEXT, False),
-        (b"foo.0", AnswerStatusCode.SUCCESS, False),
-        (b"bar.-1", AnswerStatusCode.ERROR, False),
-        (b"baz.-2", AnswerStatusCode.NO_CONTEXT, False),
-    ],
-)
-def test_parse_status_code(chunk, status_code, error):
-    if error:
-        with pytest.raises(ValueError):
-            _parse_answer_status_code(chunk)
-    else:
-        assert _parse_answer_status_code(chunk) == status_code


### PR DESCRIPTION
This reverts commit cc10aa3ce6fbe5dffc157314fd41a8505469dfe5.

### Description
- This should have solved /chat endpoint showing a status code (0, -1 or -2) at the end of it's response but seems that the problem appears more after this. Reverting to validate

### How was this PR tested?
Describe how you tested this PR.
