### PR TITLE
Upgrade tokio metrics to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,12 +3509,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60ac6224d622f71d0b80546558eedf8ff6c2d3817517a9d3ed87ce24fccf6a6"
+checksum = "d4b2fc67d5dec41db679b9b052eb572269616926040b7831e32c8a152df77b84"
 dependencies = [
  "futures-util",
  "pin-project-lite",
+ "tokio",
  "tokio-stream",
 ]
 

--- a/nucliadb_core/Cargo.toml
+++ b/nucliadb_core/Cargo.toml
@@ -23,5 +23,5 @@ futures = "0.3.17"
 tonic = "0.7"
 hyper = "0.14.26"
 tower = "0.4.13"
-tokio-metrics = { version = "0.2.2", default-features = false }
+tokio-metrics = "0.3.0"
 dashmap = "5.4.0"


### PR DESCRIPTION
### Description
Upgrade `tokio-metrics` crate to 0.3.0 to be able to use newer runtime metrics

### How was this PR tested?
Existing tests
