### PR TITLE
Move metrics gRPC middleware to nucliadb_node

### DIFF
--- a/nucliadb_core/src/metrics/mod.rs
+++ b/nucliadb_core/src/metrics/mod.rs
@@ -17,8 +17,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-pub mod middleware;
-
 mod meters;
 mod metric;
 mod task_monitor;

--- a/nucliadb_node/src/bin/reader.rs
+++ b/nucliadb_node/src/bin/reader.rs
@@ -21,11 +21,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
-use nucliadb_core::metrics::middleware::MetricsLayer;
 use nucliadb_core::protos::node_reader_server::NodeReaderServer;
 use nucliadb_core::tracing::*;
 use nucliadb_core::{node_error, NodeResult};
-use nucliadb_node::grpc::middleware::{GrpcDebugLogsLayer, GrpcInstrumentorLayer};
+use nucliadb_node::grpc::middleware::{
+    GrpcDebugLogsLayer, GrpcInstrumentorLayer, GrpcTasksMetricsLayer,
+};
 use nucliadb_node::grpc::reader::NodeReaderGRPCDriver;
 use nucliadb_node::http_server::{run_http_metrics_server, MetricsServerOptions};
 use nucliadb_node::lifecycle;
@@ -99,7 +100,7 @@ pub async fn start_grpc_service(grpc_driver: NodeReaderGRPCDriver, listen_addres
 
     let tracing_middleware = GrpcInstrumentorLayer::default();
     let debug_logs_middleware = GrpcDebugLogsLayer::default();
-    let metrics_middleware = MetricsLayer::default();
+    let metrics_middleware = GrpcTasksMetricsLayer::default();
 
     let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter.set_serving::<GrpcServer>().await;

--- a/nucliadb_node/src/bin/writer.rs
+++ b/nucliadb_node/src/bin/writer.rs
@@ -22,11 +22,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
-use nucliadb_core::metrics::middleware::MetricsLayer;
 use nucliadb_core::protos::node_writer_server::NodeWriterServer;
 use nucliadb_core::tracing::*;
 use nucliadb_core::{metrics, NodeResult};
-use nucliadb_node::grpc::middleware::{GrpcDebugLogsLayer, GrpcInstrumentorLayer};
+use nucliadb_node::grpc::middleware::{
+    GrpcDebugLogsLayer, GrpcInstrumentorLayer, GrpcTasksMetricsLayer,
+};
 use nucliadb_node::grpc::writer::{NodeWriterEvent, NodeWriterGRPCDriver};
 use nucliadb_node::http_server::{run_http_metrics_server, MetricsServerOptions};
 use nucliadb_node::node_metadata::NodeMetadata;
@@ -123,7 +124,7 @@ pub async fn start_grpc_service(grpc_driver: NodeWriterGRPCDriver, listen_addres
 
     let tracing_middleware = GrpcInstrumentorLayer::default();
     let debug_logs_middleware = GrpcDebugLogsLayer::default();
-    let metrics_middleware = MetricsLayer::default();
+    let metrics_middleware = GrpcTasksMetricsLayer::default();
 
     let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter.set_serving::<GrpcServer>().await;

--- a/nucliadb_node/src/grpc/middleware/mod.rs
+++ b/nucliadb_node/src/grpc/middleware/mod.rs
@@ -18,7 +18,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 mod debug;
+mod metrics;
 mod telemetry;
 
 pub use debug::GrpcDebugLogsLayer;
+pub use metrics::GrpcTasksMetricsLayer;
 pub use telemetry::GrpcInstrumentorLayer;


### PR DESCRIPTION
### Description
Metrics gRPC middleware makes more sense in `nucliadb_node` (where gRPC servers and other middlewares are implemented) than in `nucliadb_core`. 

### How was this PR tested?
Describe how you tested this PR.
