### PR TITLE
Maintain Python 3.8 support for nucliadb_models

### DIFF
--- a/nucliadb_models/setup.py
+++ b/nucliadb_models/setup.py
@@ -33,6 +33,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -40,7 +41,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     url="https://nuclia.com",
-    python_requires=">=3.9, <4",
+    python_requires=">=3.8, <4",
     license="BSD",
     setup_requires=[
         "pytest-runner",


### PR DESCRIPTION
### Description
Langchain expects nucliadb_models to be compatible with Python `>=3.8,<4`

### How was this PR tested?
Describe how you tested this PR.
