### PR TITLE
remove par iter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "1"
 members = [
   "nucliadb_core",
   "nucliadb_node",

--- a/nucliadb_vectors/src/data_point/ops_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ops_hnsw.rs
@@ -21,7 +21,6 @@
 use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 
-use nucliadb_core::thread::*;
 use ram_hnsw::*;
 use rand::distributions::Uniform;
 use rand::prelude::*;
@@ -204,7 +203,7 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
         }
         ms_neighbours
             .into_sorted_vec()
-            .into_par_iter()
+            .into_iter()
             .map(|Reverse(Cnx(n, d))| (n, d))
             .collect()
     }


### PR DESCRIPTION
### Description
`nucliadb_vectors` will not use `par_iter` to avoid stealing resources.

### How was this PR tested?
Local tests
