### PR TITLE
/chat ignores empty chunks at the end

### DIFF
--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -236,15 +236,19 @@ async def chat(
     )
 
 
-async def async_gen_lookahead(gen):
-    """
-    Async generator that yields the next chunk and whether it's the last one.
+async def async_gen_lookahead(gen: AsyncIterator[bytes]):
+    """Async generator that yields the next chunk and whether it's the last one.
+    Empty chunks are ignored.
+
     """
     buffered_chunk = None
     async for chunk in gen:
         if buffered_chunk is None:
             # Buffer the first chunk
             buffered_chunk = chunk
+            continue
+
+        if chunk == b"":
             continue
 
         # Yield the previous chunk and buffer the current one

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -248,7 +248,7 @@ async def async_gen_lookahead(gen: AsyncIterator[bytes]):
             buffered_chunk = chunk
             continue
 
-        if chunk == b"":
+        if len(chunk) == 0:
             continue
 
         # Yield the previous chunk and buffer the current one

--- a/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
@@ -67,13 +67,13 @@ async def test_chat_does_not_call_predict_if_no_find_results(
 async def test_async_gen_lookahead():
     async def gen(n):
         for i in range(n):
-            yield i
+            yield f"{i}".encode()
 
     assert [item async for item in async_gen_lookahead(gen(0))] == []
-    assert [item async for item in async_gen_lookahead(gen(1))] == [(0, True)]
+    assert [item async for item in async_gen_lookahead(gen(1))] == [(b"0", True)]
     assert [item async for item in async_gen_lookahead(gen(2))] == [
-        (0, False),
-        (1, True),
+        (b"0", False),
+        (b"1", True),
     ]
 
 

--- a/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/search/chat/test_query.py
@@ -77,6 +77,17 @@ async def test_async_gen_lookahead():
     ]
 
 
+async def test_async_gen_lookahead_last_chunk_is_empty():
+    async def gen():
+        for chunk in [b"empty", b"chunk", b""]:
+            yield chunk
+
+    assert [item async for item in async_gen_lookahead(gen())] == [
+        (b"empty", False),
+        (b"chunk", True),
+    ]
+
+
 @pytest.mark.parametrize(
     "chunk,status_code,error",
     [


### PR DESCRIPTION
### Description
`/chat` was returning the status code because last chunk was empty. So by the time we parsed last empty chunk, the status code had been yielded

### How was this PR tested?
New tests
