### PR TITLE
enable forking standalone process

### DIFF
--- a/nucliadb/nucliadb/standalone/run.py
+++ b/nucliadb/nucliadb/standalone/run.py
@@ -71,6 +71,13 @@ def run():
     settings = setup()
     app, server = get_server(settings)
     instrument_app(app, excluded_urls=["/"], metrics=True)
+
+    if settings.fork:
+        pid = os.fork()
+        if pid != 0:
+            logger.warning(f"Server forked and running on pid {pid}")
+            return
+
     logger.warning(
         f"======= Starting server on http://0.0.0.0:{settings.http_port}/ ======"
     )

--- a/nucliadb/nucliadb/standalone/run.py
+++ b/nucliadb/nucliadb/standalone/run.py
@@ -72,7 +72,7 @@ def run():
     app, server = get_server(settings)
     instrument_app(app, excluded_urls=["/"], metrics=True)
 
-    if settings.fork:
+    if settings.fork:  # pragma: no cover
         pid = os.fork()
         if pid != 0:
             logger.warning(f"Server forked and running on pid {pid}")

--- a/nucliadb/nucliadb/standalone/settings.py
+++ b/nucliadb/nucliadb/standalone/settings.py
@@ -111,3 +111,5 @@ Examples:
     )
 
     cluster_discovery_mode: StandaloneDiscoveryMode = StandaloneDiscoveryMode.DEFAULT
+
+    fork: bool = pydantic.Field(False, description="Fork process on startup")


### PR DESCRIPTION
### Description

This change allows you to run:

```
nucliadb --fork
```

to fork the process and run ndb in the background

### How was this PR tested?
Describe how you tested this PR.
