### PR TITLE
Adapt to predict api chat and rephrase updates

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/chat.py
+++ b/nucliadb/nucliadb/search/api/v1/chat.py
@@ -27,7 +27,7 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.find import find
 from nucliadb.search.api.v1.router import KB_PREFIX, api
-from nucliadb.search.search.chat.query import chat, rephrase_query_from_context
+from nucliadb.search.search.chat.query import chat, rephrase_query_from_chat_history
 from nucliadb.search.search.exceptions import IncompleteFindResultsError
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (
@@ -106,7 +106,7 @@ async def chat_knowledgebox(
     user_query = item.query
     rephrased_query = None
     if item.context is not None and len(item.context) > 0:
-        rephrased_query = await rephrase_query_from_context(
+        rephrased_query = await rephrase_query_from_chat_history(
             kbid, item.context, item.query, x_nucliadb_user
         )
 

--- a/nucliadb/nucliadb/search/api/v1/resource/chat.py
+++ b/nucliadb/nucliadb/search/api/v1/resource/chat.py
@@ -27,7 +27,7 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.find import find
 from nucliadb.search.api.v1.router import KB_PREFIX, api
-from nucliadb.search.search.chat.query import chat, rephrase_query_from_context
+from nucliadb.search.search.chat.query import chat, rephrase_query_from_chat_history
 from nucliadb.search.search.exceptions import IncompleteFindResultsError
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (
@@ -97,7 +97,7 @@ async def resource_chat(
     user_query = item.query
     rephrased_query = None
     if item.context and len(item.context) > 0:
-        rephrased_query = await rephrase_query_from_context(
+        rephrased_query = await rephrase_query_from_chat_history(
             kbid, item.context, item.query, x_nucliadb_user
         )
 

--- a/nucliadb/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/nucliadb/search/search/chat/prompt.py
@@ -31,8 +31,6 @@ from nucliadb_utils.utilities import get_storage
 # The hope here is it will be enough to get the answer to the question.
 CONVERSATION_MESSAGE_CONTEXT_EXPANSION = 15
 
-PROMPT_TEXT_RESULT_SEP = " \n\n "
-
 
 async def get_next_conversation_messages(
     *,
@@ -102,7 +100,9 @@ async def get_expanded_conversation_messages(
         )
 
 
-async def format_chat_prompt_content(kbid: str, results: KnowledgeboxFindResults):
+async def get_chat_prompt_context(
+    kbid: str, results: KnowledgeboxFindResults
+) -> list[str]:
     ordered_paras = []
     for result in results.resources.values():
         for field_path, field in result.fields.items():
@@ -139,4 +139,4 @@ async def format_chat_prompt_content(kbid: str, results: KnowledgeboxFindResults
                     pid = f"{rid}/{field_type}/{field_id}/{msg.ident}/0-{len(msg.content.text) + 1}"
                     output[pid] = text
 
-    return PROMPT_TEXT_RESULT_SEP.join(output.values())
+    return list(output.values())

--- a/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
@@ -162,12 +162,12 @@ def _create_find_result(
     )
 
 
-async def test_format_chat_prompt_content(kb):
+async def test_get_chat_prompt_context(kb):
     result_text = " ".join(["text"] * 10)
     with patch("nucliadb.search.search.chat.prompt.get_driver"), patch(
         "nucliadb.search.search.chat.prompt.get_storage"
     ), patch("nucliadb.search.search.chat.prompt.KnowledgeBoxORM", return_value=kb):
-        prompt_result = await chat_prompt.format_chat_prompt_content(
+        prompt_result = await chat_prompt.get_chat_prompt_context(
             "kbid",
             KnowledgeboxFindResults(
                 facets={},
@@ -182,6 +182,4 @@ async def test_format_chat_prompt_content(kb):
                 min_score=-1,
             ),
         )
-        assert prompt_result == chat_prompt.PROMPT_TEXT_RESULT_SEP.join(
-            [result_text, result_text]
-        )
+        assert prompt_result == [result_text, result_text]

--- a/nucliadb/nucliadb/search/tests/unit/test_predict.py
+++ b/nucliadb/nucliadb/search/tests/unit/test_predict.py
@@ -354,7 +354,7 @@ async def test_rephrase():
         "POST", 200, json="rephrased", context_manager=False
     )
 
-    item = RephraseModel(question="question", context=[], user_id="foo")
+    item = RephraseModel(question="question", chat_history=[], user_id="foo")
     rephrased_query = await pe.rephrase_query("kbid", item)
     # The rephrase query should not be wrapped in quotes, otherwise it will trigger an exact match query to the index
     assert rephrased_query.strip('"') == rephrased_query

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -521,8 +521,8 @@ class SearchParamDefaults:
     )
     chat_context = ParamDefault(
         default=None,
-        title="Chat context",
-        description="Use to control the context that is passed as input to the Generative AI model. If not specified, it is generated automatically.",  # noqa
+        title="Chat history",
+        description="Use to rephrase the new LLM query by taking into account the chat conversation history",  # noqa
     )
 
     chat_features = ParamDefault(
@@ -645,10 +645,10 @@ class ChatModel(BaseModel):
     user_id: str
     retrieval: bool = True
     system: Optional[str] = None
-    context: List[ChatContextMessage] = Field(
-        [], description="The information retrieval context for the current question"
+    query_context: List[str] = Field(
+        [], description="The information retrieval context for the current query"
     )
-    conversation: List[ChatContextMessage] = Field(
+    chat_history: List[ChatContextMessage] = Field(
         [], description="The chat conversation history"
     )
     truncate: bool = Field(
@@ -659,7 +659,7 @@ class ChatModel(BaseModel):
 
 class RephraseModel(BaseModel):
     question: str
-    context: List[ChatContextMessage] = []
+    chat_history: List[ChatContextMessage] = []
     user_id: str
 
 


### PR DESCRIPTION
### Description
predict/chat request is now offering two different fields:
 - `query_context`: blocks of text resulting from the information retrieval phase
 - `chat_history`: previous related chat interactions.
Whereas before it was all encapsulated in the same `context` field.

This PR changes how nucliadb uses predict chat api with the above latest changes.

### How was this PR tested?
Describe how you tested this PR.
