### PR TITLE
Introduced a `node_stack` binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,3 +20,6 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
 rustdocflags = ["--cfg", "tokio_unstable"]
+
+[profile.release]
+debug = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,12 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,7 +1936,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
- "rstack-self",
+ "rstack",
  "sentry",
  "sentry-tracing",
  "serde",
@@ -2805,21 +2799,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
-]
-
-[[package]]
-name = "rstack-self"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd5030da3aba0ec731502f74ec38e63798eea6bc8b8ba5972129afe3eababd2"
-dependencies = [
- "antidote",
- "backtrace",
- "bincode",
- "lazy_static",
- "libc",
- "rstack",
- "serde",
 ]
 
 [[package]]

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -88,5 +88,6 @@ COPY --from=eu.gcr.io/stashify-218417/basenode:latest /bin/grpc_health_probe /bi
 
 COPY --from=builder /nucliadb/bin/node_reader /usr/local/bin/node_reader
 COPY --from=builder /nucliadb/bin/node_writer /usr/local/bin/node_writer
+COPY --from=builder /nucliadb/bin/node_writer /usr/local/bin/node_stack
 
 EXPOSE 4444/udp

--- a/Dockerfile.node_local
+++ b/Dockerfile.node_local
@@ -114,11 +114,13 @@ RUN apt-get -y update \
     && apt-get -y install ca-certificates curl \
     libssl1.1 \
     lmdb-utils \
+    libdw-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=base /bin/grpc_health_probe /bin/grpc_health_probe
 
 COPY --from=builder /nucliadb/bin/node_reader /usr/local/bin/node_reader
 COPY --from=builder /nucliadb/bin/node_writer /usr/local/bin/node_writer
+COPY --from=builder /nucliadb/bin/node_stack /usr/local/bin/node_stack
 
 EXPOSE 4444/udp

--- a/nucliadb_node/Cargo.toml
+++ b/nucliadb_node/Cargo.toml
@@ -10,6 +10,10 @@ homepage = "https://nuclia.com/"
 documentation = "https://nuclia.com"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "node_stack"
+path = "src/bin/node_stack.rs"
+
 
 [[bin]]
 name = "payload_test"
@@ -87,7 +91,7 @@ opentelemetry-zipkin = "0.15.0"
 sentry-tracing = "0.27.0"
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))'.dependencies]
-rstack-self = { version = "0.3.0", features = ["dw"], default-features = false }
+rstack = { version = "0.3.3", features = ["dw"], default-features = false }
 
 # indra
 # indradb-lib = { version = "1", features = ["rocksdb-datastore"] }

--- a/nucliadb_node/src/bin/node_stack.rs
+++ b/nucliadb_node/src/bin/node_stack.rs
@@ -68,7 +68,7 @@ fn main() {
         println!("\"frames\":");
         println!("[");
         for frame in thread.frames() {
-            println!("{");
+            println!("{{");
 
             match frame.symbol() {
                 Some(symbol) => {

--- a/nucliadb_node/src/bin/node_stack.rs
+++ b/nucliadb_node/src/bin/node_stack.rs
@@ -54,12 +54,11 @@ fn main() {
         }
     };
 
-    println!("{");
+    println!("{{");
     println!("  \"threads\":");
-
     println!("[");
     for thread in process.threads() {
-        println!("{}");
+        println!("{{");
         println!("\"thread_id\": {},", thread.id());
         println!(
             "\"thread_name\": \"{}\",",
@@ -83,13 +82,13 @@ fn main() {
                     println!("\"symbol_offset\": \"???\",");
                 }
             }
-            println!("}");
+            println!("}}");
             println!(",");
         }
         println!("]");
-        println!("}");
+        println!("}}");
         println!(",");
     }
     println!("]");
-    println!("}");
+    println!("}}");
 }

--- a/nucliadb_node/src/bin/node_stack.rs
+++ b/nucliadb_node/src/bin/node_stack.rs
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+#[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
+use rstack;
+#[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
+use std::env;
+#[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
+use std::process;
+
+#[cfg(not(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl"))))]
+fn main() {
+    println!("error: rstack is only supported on Linux");
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <pid>", args[0]);
+        process::exit(1);
+    }
+
+    let pid = match args[1].parse() {
+        Ok(pid) => pid,
+        Err(e) => {
+            eprintln!("error parsing PID: {}", e);
+            process::exit(1);
+        }
+    };
+
+    let process = match rstack::trace(pid) {
+        Ok(threads) => threads,
+        Err(e) => {
+            eprintln!("error tracing threads: {}", e);
+            process::exit(1);
+        }
+    };
+
+    for thread in process.threads() {
+        println!(
+            "thread {} - {}",
+            thread.id(),
+            thread.name().unwrap_or("<unknown>")
+        );
+        for frame in thread.frames() {
+            match frame.symbol() {
+                Some(symbol) => println!(
+                    "{:#016x} - {} + {:#x}",
+                    frame.ip(),
+                    symbol.name(),
+                    symbol.offset(),
+                ),
+                None => println!("{:#016x} - ???", frame.ip()),
+            }
+        }
+        println!();
+    }
+}

--- a/nucliadb_node/src/bin/node_stack.rs
+++ b/nucliadb_node/src/bin/node_stack.rs
@@ -18,11 +18,12 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 #[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
-use rstack;
-#[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
 use std::env;
 #[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
 use std::process;
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl")))]
+use rstack;
 
 #[cfg(not(all(target_arch = "x86_64", target_os = "linux", not(target_env = "musl"))))]
 fn main() {

--- a/nucliadb_node/src/bin/node_stack.rs
+++ b/nucliadb_node/src/bin/node_stack.rs
@@ -54,23 +54,42 @@ fn main() {
         }
     };
 
+    println!("{");
+    println!("  \"threads\":");
+
+    println!("[");
     for thread in process.threads() {
+        println!("{}");
+        println!("\"thread_id\": {},", thread.id());
         println!(
-            "thread {} - {}",
-            thread.id(),
+            "\"thread_name\": \"{}\",",
             thread.name().unwrap_or("<unknown>")
         );
+
+        println!("\"frames\":");
+        println!("[");
         for frame in thread.frames() {
+            println!("{");
+
             match frame.symbol() {
-                Some(symbol) => println!(
-                    "{:#016x} - {} + {:#x}",
-                    frame.ip(),
-                    symbol.name(),
-                    symbol.offset(),
-                ),
-                None => println!("{:#016x} - ???", frame.ip()),
+                Some(symbol) => {
+                    println!("\"ip\": \"{:#016x}\",", frame.ip());
+                    println!("\"symbol_name\": \"{}\",", symbol.name());
+                    println!("\"symbol_offset\": \"{:#x}\",", symbol.offset());
+                }
+                None => {
+                    println!("\"ip\": \"{:#016x}\",", frame.ip());
+                    println!("\"symbol_name\": \"???\",");
+                    println!("\"symbol_offset\": \"???\",");
+                }
             }
+            println!("}");
+            println!(",");
         }
-        println!();
+        println!("]");
+        println!("}");
+        println!(",");
     }
+    println!("]");
+    println!("}");
 }

--- a/nucliadb_node/src/http_server/traces_service.rs
+++ b/nucliadb_node/src/http_server/traces_service.rs
@@ -48,14 +48,13 @@ pub async fn thread_dump_service() -> Response {
         }
     };
 
-    let result: String;
-    if output.status.success() {
+    let result = if output.status.success() {
         // Convert the stdout bytes into a String
-        result = String::from_utf8_lossy(&output.stdout).to_string();
+        String::from_utf8_lossy(&output.stdout).to_string()
     } else {
         // Print the error message
-        result = format!("Command failed with error: {:?}", output.status);
-    }
+        format!("Command failed with error: {:?}", output.status)
+    };
 
     Json(Traces { trace: result }).into_response()
 }

--- a/nucliadb_node/src/http_server/traces_service.rs
+++ b/nucliadb_node/src/http_server/traces_service.rs
@@ -17,18 +17,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
-use std::process;
+use std::process::Command;
+use std::{env, process};
+
 use axum::response::{IntoResponse, Json, Response};
 use serde::Serialize;
-use std::env;
-use std::process::Command;
-
 
 #[derive(Serialize)]
 struct Traces {
     trace: String,
 }
-
 
 pub async fn thread_dump_service() -> Response {
     let pid = process::id();
@@ -44,8 +42,9 @@ pub async fn thread_dump_service() -> Response {
         Ok(output) => output,
         Err(e) => {
             return Json(Traces {
-                trace: format!("Failed to execute {:?} command: {}", cmd, e)
-            }).into_response();
+                trace: format!("Failed to execute {:?} command: {}", cmd, e),
+            })
+            .into_response();
         }
     };
 
@@ -53,15 +52,10 @@ pub async fn thread_dump_service() -> Response {
     if output.status.success() {
         // Convert the stdout bytes into a String
         result = String::from_utf8_lossy(&output.stdout).to_string();
-
     } else {
         // Print the error message
         result = format!("Command failed with error: {:?}", output.status);
     }
 
-    Json(Traces {
-            trace: result,
-        })
-        .into_response()
+    Json(Traces { trace: result }).into_response()
 }
-


### PR DESCRIPTION
### Description
fix the `__dump` call


### How was this PR tested?

Tested on a vanilla linux using the docker node local

```
tarek@verkut:~$ curl -v http://localhost:3031/__dump
*   Trying ::1:3031...
* TCP_NODELAY set
* Connected to localhost (::1) port 3031 (#0)
> GET /__dump HTTP/1.1
> Host: localhost:3031
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: application/json
< content-length: 14747
< date: Thu, 07 Sep 2023 12:27:06 GMT
<
{"trace":"thread 1 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f7234f9 - _ZN11parking_lot7condvar7Condvar19wait_until_internal17h2096526148879715E + 0x299\n0x0055988f702dee - _ZN5tokio7runtime4park5Inner4park17h6d470ab2a58b9bbcE.llvm.3004131406099940709 + 0x5e\n0x0055988ed207be - _ZN5tokio7runtime4park16CachedParkThread8block_on17h3b3fd09d6647d2b5E + 0x13de\n0x0055988ed21dae - _ZN5tokio7runtime7context7runtime13enter_runtime17h0913163deed00db1E + 0x18e\n0x0055988eca2cc5 - _ZN5tokio7runtime7runtime7Runtime8block_on17ha66cc5e4a238a79eE + 0x65\n0x0055988ec77bed - _ZN11node_reader4main17hc3d158d53e771247E + 0xad\n0x0055988ec90243 - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hb71f4cfe4602eabbE + 0x3\n0x0055988ed13cbd - _ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h84b600cc8753673aE.llvm.3908288260592005527 + 0xd\n0x0055988f741c2b - _ZN3std2rt19lang_start_internal17h5f408694586c2a05E + 0x41b\n0x0055988ec77cd5 - main + 0x25\n0x007f837fa7ed0a - __libc_start_main + 0xea\n0x0055988ebe0b5a - _start + 0x2a\n\nthread 7 - tokio-runtime-w\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f7234f9 - _ZN11parking_lot7condvar7Condvar19wait_until_internal17h2096526148879715E + 0x299\n0x0055988f70ea8e - _ZN5tokio7runtime9scheduler12multi_thread4park6Parker4park17had92ffd4069fa47fE + 0xfe\n0x0055988f6e8b98 - _ZN5tokio7runtime9scheduler12multi_thread6worker7Context12park_timeout17h3a4e4cd0464f611fE + 0x98\n0x0055988f6e81dc - _ZN5tokio7runtime9scheduler12multi_thread6worker7Context3run17h50ced082f3d685e3E + 0xefc\n0x0055988f6eb0c6 - _ZN5tokio7runtime7context6scoped15Scoped$LT$T$GT$3set17had5651626db720e4E + 0x36\n0x0055988f70e6b1 - _ZN5tokio7runtime7context7runtime13enter_runtime17h752ddcf962f14481E + 0x1e1\n0x0055988f6e7245 - _ZN5tokio7runtime9scheduler12multi_thread6worker3run17hbad259991d0b4323E + 0x55\n0x0055988f70597f - _ZN115_$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$9call_once17h7c8206b100ff8eebE + 0xcf\n0x0055988f6dde9a - _ZN5tokio7runtime4task7harness20Harness$LT$T$C$S$GT$4poll17heef39cefd2161cb2E + 0x9a\n0x0055988f6ff9a6 - _ZN5tokio7runtime8blocking4pool5Inner3run17hfe4620ad97b39773E + 0xf6\n0x0055988f708c02 - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h040460878d2e568eE + 0xe2\n0x0055988f701359 - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h184d91deaaa5a507E + 0xa9\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 8 - tokio-runtime-w\n0x007f837fb4a96f - __poll + 0x4f\n0x0055988f751a7f - _ZN3std3sys4unix4pipe5read217hb3d6f052056d8e84E + 0xcf\n0x0055988f74be21 - _ZN3std7process7Command6output17ha96942c2fa6f5078E + 0xc1\n0x0055988ecd3275 - _ZN79_$LT$F$u20$as$u20$axum..handler..Handler$LT$$LP$$LP$$RP$$C$$RP$$C$S$C$B$GT$$GT$4call28_$u7b$$u7b$closure$u7d$$u7d$17hf091f31291f2b458E.llvm.2325526581047101603 + 0x1b5\n0x0055988eced6e5 - _ZN102_$LT$futures_util..future..future..map..Map$LT$Fut$C$F$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h5fa19b6ba5422b15E + 0x35\n0x0055988ecedb3a - _ZN102_$LT$futures_util..future..future..map..Map$LT$Fut$C$F$GT$$u20$as$u20$core..future..future..Future$GT$4poll17hce85e3f78806ce9eE + 0x2a\n0x0055988ec3d049 - _ZN106_$LT$tower..util..map_response..MapResponseFuture$LT$F$C$N$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h499b716397868767E + 0x9\n0x0055988ed23212 - _ZN93_$LT$tower..util..oneshot..Oneshot$LT$S$C$Req$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h5c21a04d60d5df43E + 0xd2\n0x0055988ece6175 - _ZN5hyper5proto2h18dispatch32Dispatcher$LT$D$C$Bs$C$I$C$T$GT$10poll_catch17h509f4969b26a1be8E + 0x10b5\n0x0055988ec8928d - _ZN62_$LT$$RF$mut$u20$F$u20$as$u20$core..future..future..Future$GT$4poll17ha573f98d042fde99E + 0x5d\n0x0055988ec0ea74 - _ZN88_$LT$tokio..future..poll_fn..PollFn$LT$F$GT$$u20$as$u20$core..future..future..Future$GT$4poll17h4aa00303c54bae31E + 0x104\n0x0055988eca9968 - _ZN11axum_server6server15Server$LT$A$GT$5serve28_$u7b$$u7b$closure$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$17heed5d68b8fe759c4E.llvm.18231117198896671183 + 0x358\n0x0055988ecba68e - _ZN5tokio7runtime4task4core17Core$LT$T$C$S$GT$4poll17h0f3dd9cda9b39beaE + 0x3e\n0x0055988ec30760 - _ZN5tokio7runtime4task7harness20Harness$LT$T$C$S$GT$4poll17h1fe7963096e451c5E + 0x60\n0x0055988f6e86fc - _ZN5tokio7runtime9scheduler12multi_thread6worker7Context8run_task17h43aa35c279dba7b4E + 0x13c\n0x0055988f6e7d2d - _ZN5tokio7runtime9scheduler12multi_thread6worker7Context3run17h50ced082f3d685e3E + 0xa4d\n0x0055988f6eb0c6 - _ZN5tokio7runtime7context6scoped15Scoped$LT$T$GT$3set17had5651626db720e4E + 0x36\n0x0055988f70e6b1 - _ZN5tokio7runtime7context7runtime13enter_runtime17h752ddcf962f14481E + 0x1e1\n0x0055988f6e7245 - _ZN5tokio7runtime9scheduler12multi_thread6worker3run17hbad259991d0b4323E + 0x55\n0x0055988f70597f - _ZN115_$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$9call_once17h7c8206b100ff8eebE + 0xcf\n0x0055988f6dde9a - _ZN5tokio7runtime4task7harness20Harness$LT$T$C$S$GT$4poll17heef39cefd2161cb2E + 0x9a\n0x0055988f6ff9a6 - _ZN5tokio7runtime8blocking4pool5Inner3run17hfe4620ad97b39773E + 0xf6\n0x0055988f708c02 - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h040460878d2e568eE + 0xe2\n0x0055988f701359 - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h184d91deaaa5a507E + 0xa9\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 9 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 10 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 11 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 12 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 13 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 14 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 15 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 16 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 17 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 18 - node_reader\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f755fe1 - _ZN3std3sys4unix5locks13futex_condvar7Condvar4wait17h8da631a1dbfcc0bfE + 0x91\n0x0055988ebcd153 - _ZN10rayon_core5sleep5Sleep5sleep17h5192656a3a5df9faE + 0x253\n0x0055988ebcc8b3 - _ZN10rayon_core8registry12WorkerThread15wait_until_cold17h0fab6b9163ce2bc5E + 0xb3\n0x0055988f5d8148 - _ZN10rayon_core8registry13ThreadBuilder3run17hb77c7a5d1c95bc86E + 0xe8\n0x0055988f5dfc5a - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hca972e2b9355faefE + 0x4a\n0x0055988f5ddf1f - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hebc519c6e2eb831fE + 0x12f\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\nthread 19 - sentry-session-\n0x007f837fb4ff29 - syscall + 0x19\n0x0055988f751094 - _ZN3std3sys4unix5futex10futex_wait17he5285c4763803bcaE + 0xa4\n0x0055988f75606a - _ZN3std3sys4unix5locks13futex_condvar7Condvar12wait_timeout17h840cb187c3d15968* Connection #0 to host localhost left intact
E + 0x4a\n0x0055988f13854e - _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17hd66600422f9ea23eE + 0x17e\n0x0055988f149409 - _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h5837267ee2bbb14fE + 0xa9\n0x0055988f7546a5 - _ZN3std3sys4unix6thread6Thread3new12thread_start17h04c8e9c7d83d3bd5E + 0x25\n0x007f837fd80ea7 - start_thread + 0xd7\n0x007f837fb56a2f - __clone + 0x3f\n\n"}
```
