### PR TITLE
fix deadlock from search implementation

### DIFF
--- a/nucliadb_paragraphs/src/reader.rs
+++ b/nucliadb_paragraphs/src/reader.rs
@@ -135,6 +135,7 @@ impl ParagraphReader for ParagraphReaderService {
             query: &text,
             page_number: 1,
             results_per_page: 10,
+            searcher: searcher,
         }))
     }
     #[tracing::instrument(skip_all)]
@@ -428,6 +429,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
+                        searcher: searcher,
                     }))
                 }
                 None => {
@@ -445,6 +447,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
+                        searcher: searcher,
                     }))
                 }
             }
@@ -467,6 +470,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
+                        searcher: searcher,
                     }))
                 }
                 None => {
@@ -484,6 +488,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
+                        searcher: searcher,
                     }))
                 }
             }

--- a/nucliadb_paragraphs/src/reader.rs
+++ b/nucliadb_paragraphs/src/reader.rs
@@ -135,7 +135,7 @@ impl ParagraphReader for ParagraphReaderService {
             query: &text,
             page_number: 1,
             results_per_page: 10,
-            searcher: searcher,
+            searcher,
         }))
     }
     #[tracing::instrument(skip_all)]
@@ -429,7 +429,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
-                        searcher: searcher,
+                        searcher,
                     }))
                 }
                 None => {
@@ -447,7 +447,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
-                        searcher: searcher,
+                        searcher,
                     }))
                 }
             }
@@ -470,7 +470,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
-                        searcher: searcher,
+                        searcher,
                     }))
                 }
                 None => {
@@ -488,7 +488,7 @@ impl<'a> Searcher<'a> {
                         query: self.text,
                         page_number: self.request.page_number,
                         results_per_page: self.results as i32,
-                        searcher: searcher,
+                        searcher,
                     }))
                 }
             }

--- a/nucliadb_paragraphs/src/search_response.rs
+++ b/nucliadb_paragraphs/src/search_response.rs
@@ -64,6 +64,7 @@ pub struct SearchBm25Response<'a> {
     pub page_number: i32,
     pub results_per_page: i32,
     pub termc: TermCollector,
+    pub searcher: tantivy::LeasedItem<tantivy::Searcher>,
 }
 
 pub struct SearchIntResponse<'a> {
@@ -76,6 +77,7 @@ pub struct SearchIntResponse<'a> {
     pub page_number: i32,
     pub results_per_page: i32,
     pub termc: TermCollector,
+    pub searcher: tantivy::LeasedItem<tantivy::Searcher>,
 }
 
 pub struct SearchFacetsResponse<'a> {
@@ -107,7 +109,7 @@ impl<'a> From<SearchIntResponse<'a>> for ParagraphSearchResponse {
         let next_page = obtained > requested;
         let no_results = std::cmp::min(obtained, requested);
         let mut results: Vec<ParagraphResult> = Vec::with_capacity(no_results);
-        let searcher = response.text_service.reader.searcher();
+        let searcher = response.searcher;
         let default_split = Value::Str("".to_string());
         for (_, doc_address) in response.top_docs.into_iter().take(no_results) {
             match searcher.doc(doc_address) {
@@ -214,7 +216,7 @@ impl<'a> From<SearchBm25Response<'a>> for ParagraphSearchResponse {
         let next_page = obtained > requested;
         let no_results = std::cmp::min(obtained, requested);
         let mut results: Vec<ParagraphResult> = Vec::with_capacity(no_results);
-        let searcher = response.text_service.reader.searcher();
+        let searcher = response.searcher;
         let default_split = Value::Str("".to_string());
         for (score, doc_address) in response.top_docs.into_iter().take(no_results) {
             match searcher.doc(doc_address) {


### PR DESCRIPTION
### Description
the `searcher()` method returns an instance from a limited pool size

When pulling results, we do not need to get another from the pool, we can just reference the one that is already in scope

The pool size for this is limited to the number of CPUs arbitrarily and there is no way to hook into that pool size to change it

Latest versions of tantivy no longer have the pool limitation.

Technically, this still limits the total number of searches per search to 4(or number of CPUs) always.

### How was this PR tested?
Describe how you tested this PR.
