### PR TITLE
Bench runner against real shards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ dependencies = [
  "home",
  "once_cell",
  "serde",
- "toml",
+ "toml 0.8.0",
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -648,6 +648,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -793,7 +806,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -892,6 +905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,7 +946,7 @@ checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -989,10 +1008,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1152,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1341,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1483,6 +1533,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b297dc40733f23a0e52728a58fa9489a5b7638a324932de16b41adc3ef80730"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,7 +1577,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1531,7 +1594,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
  "rustix 0.38.13",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1565,6 +1628,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kv"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620727085ac39ee9650b373fe6d8073a0aee6f99e52a9c72b25f7671078039ab"
+dependencies = [
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sled",
+ "thiserror",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1769,7 +1846,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1811,7 +1888,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2058,6 +2135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,7 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2272,12 +2355,37 @@ checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2288,9 +2396,9 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2360,8 +2468,14 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -2430,7 +2544,7 @@ checksum = "e227aeb6c2cfec819e999c4773b35f8c7fa37298a203ff46420095458eee567e"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot",
+ "parking_lot 0.12.1",
  "prometheus-client-derive-encode",
 ]
 
@@ -2510,7 +2624,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -2634,6 +2748,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2788,7 +2911,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2801,7 +2924,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.7",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2862,7 +2985,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3106,7 +3229,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serial_test_derive",
 ]
 
@@ -3165,6 +3288,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,7 +3326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3342,6 +3481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,9 +3505,9 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix 0.38.13",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3481,12 +3631,12 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3565,6 +3715,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3876,6 +4035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,14 +4141,20 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "vectors_benchmark"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.4",
  "byte-unit",
  "clap",
+ "flate2",
+ "indicatif",
+ "kv",
  "lazy_static",
  "memory-stats",
  "nucliadb_vectors",
  "rand",
+ "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "thiserror",
 ]
@@ -4168,7 +4339,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -4177,7 +4357,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4186,14 +4381,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4203,9 +4404,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4215,9 +4428,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4227,9 +4452,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4253,7 +4490,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/nucliadb_core/src/fs_state.rs
+++ b/nucliadb_core/src/fs_state.rs
@@ -89,15 +89,11 @@ pub fn load_state<S>(path: &Path) -> FsResult<S>
 where
     S: DeserializeOwned,
 {
-    println!("Loading state at {:?}", path.join(names::STATE));
-
     let mut file = BufReader::new(
         OpenOptions::new()
             .read(true)
             .open(path.join(names::STATE))?,
     );
-    println!("OK");
-
     Ok(bincode::deserialize_from(&mut file)?)
 }
 pub fn crnt_version(path: &Path) -> FsResult<Version> {

--- a/nucliadb_core/src/fs_state.rs
+++ b/nucliadb_core/src/fs_state.rs
@@ -67,7 +67,9 @@ pub fn shared_lock(path: &Path) -> FsResult<SLock> {
 }
 
 pub fn persist_state<S>(path: &Path, state: &S) -> FsResult<()>
-where S: Serialize {
+where
+    S: Serialize,
+{
     let temporal_path = path.join(names::TEMP);
     let state_path = path.join(names::STATE);
     let mut file = BufWriter::new(
@@ -84,12 +86,18 @@ where S: Serialize {
 }
 
 pub fn load_state<S>(path: &Path) -> FsResult<S>
-where S: DeserializeOwned {
+where
+    S: DeserializeOwned,
+{
+    println!("Loading state at {:?}", path.join(names::STATE));
+
     let mut file = BufReader::new(
         OpenOptions::new()
             .read(true)
             .open(path.join(names::STATE))?,
     );
+    println!("OK");
+
     Ok(bincode::deserialize_from(&mut file)?)
 }
 pub fn crnt_version(path: &Path) -> FsResult<Version> {

--- a/nucliadb_vectors/src/data_point/ops_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ops_hnsw.rs
@@ -145,11 +145,22 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
         let mut candidates = VecDeque::from([x]);
         loop {
             let best_so_far = candidates.pop_front();
+
+            // HOT POINT similarity
             match best_so_far.map(|n| (n, self.similarity(n, query))) {
                 None => break None,
-                Some((_, score)) if score < self.tracker.min_score() => break None,
-                Some((n, score)) if filter.is_valid(n, score) => break Some((n, score)),
+                Some((_, score)) if score < self.tracker.min_score() => {
+                    println!("min score not reached");
+
+                    break None;
+                }
+                Some((n, score)) if filter.is_valid(n, score) => {
+                    println!("Filter is valid");
+                    break Some((n, score));
+                }
                 Some((down, _)) => {
+                    println!("score down: {:?}", down);
+                    println!("visited nodes {:?}", visited_nodes.len());
                     let mut sorted_out: Vec<_> = layer.get_out_edges(down).collect();
                     sorted_out.sort_by(|a, b| b.1.dist.total_cmp(&a.1.dist));
                     sorted_out.into_iter().for_each(|(new_candidate, _)| {
@@ -284,6 +295,10 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
             sol_addresses.insert(addr);
             vec_counter.add(self.tracker.get_vector(addr));
         });
+
+        println!("\nNumber of results is {:?}", result.len());
+        // here we can remove nodes that are not matching the filter directly
+
         for (addr, _) in result {
             sol_addresses.remove(&addr);
             vec_counter.sub(self.tracker.get_vector(addr));
@@ -293,15 +308,22 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
                 blocked_addresses: &sol_addresses,
                 vec_counter: &vec_counter,
             };
+            // XXX HOT POINT
             let Some((addr, score)) =
                 self.closest_up_node(addr, query, hnsw.get_layer(0), node_filter)
             else {
                 continue;
             };
+            println!("Got a match");
             filtered_result.push((addr, score));
             sol_addresses.insert(addr);
             vec_counter.add(self.tracker.get_vector(addr));
         }
+        println!(
+            "\nNumber of filtered results is {:?}",
+            filtered_result.len()
+        );
+
         // order may be lost
         filtered_result.sort_by(|a, b| b.1.total_cmp(&a.1));
         filtered_result

--- a/nucliadb_vectors/src/data_point/ops_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ops_hnsw.rs
@@ -146,7 +146,6 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
         loop {
             let best_so_far = candidates.pop_front();
 
-            // HOT POINT similarity
             match best_so_far.map(|n| (n, self.similarity(n, query))) {
                 None => break None,
                 Some((_, score)) if score < self.tracker.min_score() => break None,
@@ -286,7 +285,6 @@ impl<'a, DR: DataRetriever> HnswOps<'a, DR> {
             sol_addresses.insert(addr);
             vec_counter.add(self.tracker.get_vector(addr));
         });
-
         for (addr, _) in result {
             sol_addresses.remove(&addr);
             vec_counter.sub(self.tracker.get_vector(addr));

--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -67,6 +67,8 @@ impl IndexMetadata {
     }
     pub fn open(path: &Path) -> VectorR<Option<IndexMetadata>> {
         let path = &path.join(METADATA);
+        println!("{:?}", path);
+
         if !path.is_file() {
             return Ok(None);
         }
@@ -91,7 +93,7 @@ pub struct Index {
     dimension: RwLock<Option<u64>>,
 }
 impl Index {
-    fn get_dimension(&self) -> Option<u64> {
+    pub fn get_dimension(&self) -> Option<u64> {
         *self.dimension.read().unwrap_or_else(|e| e.into_inner())
     }
     fn set_dimension(&self, dimension: Option<u64>) {
@@ -128,6 +130,8 @@ impl Index {
         Ok(())
     }
     pub fn open(path: &Path) -> VectorR<Index> {
+        println!("{:?}", path);
+
         let state = fs_state::load_state::<State>(path)?;
         let date = fs_state::crnt_version(path)?;
         let dimension_used = state.stored_len(path)?;

--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -67,8 +67,6 @@ impl IndexMetadata {
     }
     pub fn open(path: &Path) -> VectorR<Option<IndexMetadata>> {
         let path = &path.join(METADATA);
-        println!("{:?}", path);
-
         if !path.is_file() {
             return Ok(None);
         }
@@ -130,8 +128,6 @@ impl Index {
         Ok(())
     }
     pub fn open(path: &Path) -> VectorR<Index> {
-        println!("{:?}", path);
-
         let state = fs_state::load_state::<State>(path)?;
         let date = fs_state::crnt_version(path)?;
         let dimension_used = state.stored_len(path)?;

--- a/nucliadb_vectors/src/formula/mod.rs
+++ b/nucliadb_vectors/src/formula/mod.rs
@@ -20,14 +20,14 @@
 
 use crate::data_point::{Address, DataRetriever};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum AtomKind {
     KeyPrefix,
     Label,
 }
 
 /// Is a singleton clause.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct AtomClause {
     kind: AtomKind,
     value: String,
@@ -53,7 +53,7 @@ impl AtomClause {
 /// Is a clause formed by the conjuction of several LabelClauses. Additionally this
 /// clause has a threshold that specifies the minimum number of AtomClauses that have to
 /// succeed in order for the overall conjuction to be satisfied.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct CompoundClause {
     threshold: usize,
     labels: Vec<AtomClause>,
@@ -84,7 +84,7 @@ impl CompoundClause {
 }
 
 /// Wrapper that unifies the different types of clauses a formula may have.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub enum Clause {
     Atom(AtomClause),
     Compound(CompoundClause),
@@ -115,7 +115,7 @@ impl From<CompoundClause> for Clause {
 /// The clauses in a formula are connected by intersections, and they are formed
 /// by strings. Once applied to a given address, the formula becomes a boolean
 /// expression that evaluates to whether the address is valid or not.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Formula {
     clauses: Vec<Clause>,
 }
@@ -124,7 +124,9 @@ impl Formula {
         Formula::default()
     }
     pub fn extend<C>(&mut self, clause: C)
-    where Clause: From<C> {
+    where
+        Clause: From<C>,
+    {
         self.clauses.push(clause.into())
     }
     pub fn run<D: DataRetriever>(&self, x: Address, retriever: &D) -> bool {

--- a/vectors_benchmark/Cargo.toml
+++ b/vectors_benchmark/Cargo.toml
@@ -16,6 +16,10 @@ nucliadb_vectors = {path= "../nucliadb_vectors"}
 lazy_static = "1.4.0"
 memory-stats = "1.0.0"
 byte-unit = "4.0.19"
+reqwest = { version = "0.11.20", features = ["blocking"] }
+indicatif = "0.17.6"
+tar = "0.4.40"
+flate2 = "1.0.27"
 
 [[bin]]
 name = "vectors_benchmark"
@@ -28,3 +32,9 @@ path = "src/binaries/1m_stats.rs"
 [[bin]]
 name = "labels_benchmark"
 path = "src/binaries/labels_benchmark.rs"
+
+[[bin]]
+name = "real_data_benchmark"
+path = "src/binaries/real_data_benchmark.rs"
+
+

--- a/vectors_benchmark/Cargo.toml
+++ b/vectors_benchmark/Cargo.toml
@@ -20,6 +20,8 @@ reqwest = { version = "0.11.20", features = ["blocking"] }
 indicatif = "0.17.6"
 tar = "0.4.40"
 flate2 = "1.0.27"
+base64 = "0.21.4"
+kv = { version = "0.24.0", features = ["json-value"] }
 
 [[bin]]
 name = "vectors_benchmark"

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -30,3 +30,7 @@ samply-vector-bench: samply
 .PHONY: label-bench
 label-bench:
 	cargo run --release --locked --bin labels_benchmark
+
+.PHONY: real-data
+real-data:
+	cargo run --locked --release --bin real_data_benchmark -- --datasets datasets/dataset.json --dataset-name large

--- a/vectors_benchmark/Makefile
+++ b/vectors_benchmark/Makefile
@@ -31,6 +31,6 @@ samply-vector-bench: samply
 label-bench:
 	cargo run --release --locked --bin labels_benchmark
 
-.PHONY: real-data
-real-data:
+.PHONY: real-data-bench
+real-data-bench:
 	cargo run --locked --release --bin real_data_benchmark -- --datasets datasets/dataset.json --dataset-name large

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -1,0 +1,15 @@
+{
+  "datasets": [
+    {
+      "name": "large",
+      "shards": {
+        "url": "https://storage.cloud.google.com/somewhere.tgz"
+      },
+      "queries": [
+        {
+          "query": "blah"
+        }
+      ]
+    }
+  ]
+}

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -3,7 +3,11 @@
     {
       "name": "large",
       "shards": {
-        "url": "https://storage.cloud.google.com/somewhere.tgz"
+        "url": "http://ziade.org/cov.tgz",
+        "root_path": "shards",
+        "ids": [
+          "4508ea2f-b3e2-41ca-89b6-224172f5bb3e"
+        ]
       },
       "queries": [
         {

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -4,7 +4,7 @@
       "name": "large",
       "shards": {
         "url": "https://storage.googleapis.com/nucliadb_indexer/4508ea2f-b3e2-41ca-89b6-224172f5bb3e.tar.gz",
-        "root_path": "shards",
+        "root_path": "data/shards",
         "ids": [
           "4508ea2f-b3e2-41ca-89b6-224172f5bb3e"
         ]

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -11,8 +11,12 @@
       },
       "queries": [
         {
-          "name": "query_one",
-          "query": "blah",
+          "name": "unfiltered-1",
+          "query": "test"
+        },
+        {
+          "name": "filtered-1",
+          "query": "test",
           "tags": [
             "one",
             "two"

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -12,7 +12,8 @@
       "queries": [
         {
           "name": "unfiltered-1",
-          "query": "test"
+          "query": "what are the best things in the world?",
+          "min_results": 5
         },
         {
           "name": "filtered-1",
@@ -24,7 +25,8 @@
           "key_filters": [
             "some",
             "things"
-          ]
+          ],
+          "min_results": 0
         }
       ]
     }

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -3,7 +3,7 @@
     {
       "name": "large",
       "shards": {
-        "url": "http://ziade.org/cov.tgz",
+        "url": "https://storage.googleapis.com/nucliadb_indexer/4508ea2f-b3e2-41ca-89b6-224172f5bb3e.tar.gz",
         "root_path": "shards",
         "ids": [
           "4508ea2f-b3e2-41ca-89b6-224172f5bb3e"

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -11,17 +11,20 @@
       },
       "queries": [
         {
-          "name": "unfiltered-1",
+          "name": "unfiltered",
           "query": "la entrada de un ejército en un país",
           "min_results": 5
         },
         {
-          "name": "filtered-1",
+          "name": "single-match-key-prefix",
           "query": "la entrada de un ejército en un país",
           "tags": [
-            "e/indias"
+            "f/ecc8c259cf0d926fcf4e140621f1615b"
           ],
-          "min_results": 0
+          "key_prefixes": [
+            "ecc8c259cf0d926fcf4e140621f1615b/f/ecc8c259cf0d926fcf4e140621f1615b/175/84949"
+          ],
+          "num_results": 1
         }
       ]
     }

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -12,7 +12,15 @@
       "queries": [
         {
           "name": "query_one",
-          "query": "blah"
+          "query": "blah",
+          "tags": [
+            "one",
+            "two"
+          ],
+          "key_filters": [
+            "some",
+            "things"
+          ]
         }
       ]
     }

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -12,19 +12,14 @@
       "queries": [
         {
           "name": "unfiltered-1",
-          "query": "what are the best things in the world?",
+          "query": "la entrada de un ejército en un país",
           "min_results": 5
         },
         {
           "name": "filtered-1",
-          "query": "test",
+          "query": "la entrada de un ejército en un país",
           "tags": [
-            "one",
-            "two"
-          ],
-          "key_filters": [
-            "some",
-            "things"
+            "e/indias"
           ],
           "min_results": 0
         }

--- a/vectors_benchmark/datasets/dataset.json
+++ b/vectors_benchmark/datasets/dataset.json
@@ -11,6 +11,7 @@
       },
       "queries": [
         {
+          "name": "query_one",
           "query": "blah"
         }
       ]

--- a/vectors_benchmark/src/binaries/real_data_benchmark.rs
+++ b/vectors_benchmark/src/binaries/real_data_benchmark.rs
@@ -134,7 +134,7 @@ fn create_request(
     }
 
     // Calling the NUA service to convert the query as a vector
-    let json: PredictResults = get_vectorset(&query, "multilingual");
+    let json: PredictResults = get_vector(&query, "multilingual");
 
     if json.data.len() != dimension {
         panic!(

--- a/vectors_benchmark/src/binaries/real_data_benchmark.rs
+++ b/vectors_benchmark/src/binaries/real_data_benchmark.rs
@@ -1,0 +1,341 @@
+use std::fs;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use rand::seq::SliceRandom;
+use rand::Rng;
+use reqwest::blocking::Client;
+use serde_json::json;
+use tar::Archive;
+
+use nucliadb_vectors::data_point_provider::*;
+use nucliadb_vectors::formula::*;
+use vectors_benchmark::json_writer::write_json;
+use vectors_benchmark::random_vectors::RandomVectors;
+use vectors_benchmark::stats::Stats;
+
+const NO_NEIGHBOURS: usize = 5;
+const LABELS: [&str; 5] = [
+    "nucliad_db_has_label_1",
+    "nucliad_db_has_label_2",
+    "nucliad_db_has_label_3",
+    "nucliad_db_has_label_4",
+    "nucliad_db_has_label_5",
+];
+const CYCLES: usize = 25;
+const CHUNK_SIZE: usize = 1024 * 1024;
+
+macro_rules! measure_time {
+    ( seconds $code:block ) => {{
+        let start_time = std::time::Instant::now();
+        let result = $code;
+        let elapsed_time = start_time.elapsed().as_secs_f64();
+        (result, elapsed_time)
+    }};
+    ( milliseconds $code:block ) => {{
+        let start_time = std::time::Instant::now();
+        let result = $code;
+        let elapsed_time = start_time.elapsed().as_millis() as f64;
+        (result, elapsed_time)
+    }};
+    ( microseconds $code:block ) => {{
+        let start_time = std::time::Instant::now();
+        let result = $code;
+        let elapsed_time = start_time.elapsed().as_micros() as f64;
+        (result, elapsed_time)
+    }};
+}
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// Path of the dataset definitions file
+    #[clap(short, long)]
+    datasets: String,
+    /// Name of the dataset to use
+    #[clap(short, long)]
+    dataset_name: String,
+    /// Number of search cycles
+    #[clap(short, long, default_value_t = CYCLES)]
+    cycles: usize,
+    /// Path of the json output file
+    #[clap(short, long, default_value_t = String::from("./benchmark.json"))]
+    json_output: String,
+    /// Merge results if json output file exists
+    #[clap(short, long, action)]
+    merge: bool,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Args::new()
+    }
+}
+impl Args {
+    pub fn new() -> Args {
+        Args::parse()
+    }
+}
+
+struct Request {
+    vector: Vec<f32>,
+    filter: Formula,
+}
+impl SearchRequest for Request {
+    fn with_duplicates(&self) -> bool {
+        true
+    }
+    fn get_query(&self) -> &[f32] {
+        &self.vector
+    }
+
+    fn get_filter(&self) -> &Formula {
+        &self.filter
+    }
+
+    fn no_results(&self) -> usize {
+        NO_NEIGHBOURS
+    }
+    fn min_score(&self) -> f32 {
+        -1.0
+    }
+}
+
+fn vector_random_subset<T: Clone>(vector: Vec<T>) -> Vec<T> {
+    let mut rng = rand::thread_rng();
+    let size = vector.len();
+    let subset_size = rng.gen_range(1..=size);
+    let mut random_indices: Vec<usize> = (0..size).collect();
+    random_indices.shuffle(&mut rng);
+    random_indices.truncate(subset_size);
+    random_indices
+        .iter()
+        .map(|&index| vector[index].clone())
+        .collect()
+}
+
+fn create_filtered_request(dimension: usize) -> Request {
+    let random_subset = vector_random_subset(LABELS.to_vec().clone());
+
+    let formula = random_subset
+        .clone()
+        .into_iter()
+        .fold(Formula::new(), |mut acc, i| {
+            acc.extend(AtomClause::label(i.to_string()));
+            acc
+        });
+
+    Request {
+        filter: formula,
+        vector: RandomVectors::new(dimension).next().unwrap(),
+    }
+}
+
+fn download_and_decompress_tarball(
+    url: &str,
+    destination_dir: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Create a progress bar
+    let pb = ProgressBar::new(0);
+    pb.set_style(ProgressStyle::default_bar()
+        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+        .unwrap()
+        .progress_chars("#>-"));
+
+    // Get the download path
+    let download_path = format!("{}/download.tar.gz", destination_dir);
+
+    // Check if the partially downloaded file exists
+    let mut downloaded_bytes = 0;
+    if Path::new(&download_path).exists() {
+        // Open the file for appending and get the current file size
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(&download_path)?;
+
+        // Seek to the end to continue the download
+        downloaded_bytes = file.seek(SeekFrom::End(0))?;
+    } else {
+        // Create a new file for downloading
+        let mut file = File::create(&download_path)?;
+        file.set_len(0)?;
+    }
+
+    // Create a request with the Range header to resume the download
+    let client = Client::new();
+    let response = client
+        .get(url)
+        .header("Range", format!("bytes={}-", downloaded_bytes))
+        .send()?;
+
+    if response.status().is_success() {
+        // Append the downloaded data to the file
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(&download_path)?;
+
+        let mut buffer = vec![0; CHUNK_SIZE];
+        let mut content = response.bytes()?;
+
+        while !content.is_empty() {
+            let chunk_size = std::cmp::min(buffer.len(), content.len());
+            let chunk = content.split_to(chunk_size);
+            downloaded_bytes += chunk.len() as u64;
+            pb.set_position(downloaded_bytes);
+        }
+
+        pb.finish_and_clear();
+    }
+
+    let tarball_file = File::open(&download_path)?;
+    let tar = flate2::read::GzDecoder::new(tarball_file);
+    let mut archive = Archive::new(tar);
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        let entry_destination = format!("{}/{}", destination_dir, path.display());
+
+        if entry.header().entry_type().is_dir() {
+            std::fs::create_dir_all(&entry_destination)?;
+        } else {
+            let mut file = File::create(&entry_destination)?;
+            io::copy(&mut entry, &mut file)?;
+        }
+    }
+
+    std::fs::remove_file(&download_path)?;
+    Ok(())
+}
+
+fn test_datapoint(cycles: usize) -> Stats {
+    let _ = Merger::install_global().map(std::thread::spawn);
+
+    // let at = tempfile::TempDir::new().unwrap();
+    let db_location = Path::new(
+        "/Users/tarekziade/Downloads/huge_data/shards/4508ea2f-b3e2-41ca-89b6-224172f5bb3e/vectors",
+    );
+    let reader = Index::open(&db_location).unwrap();
+    let vector_dims = reader.get_dimension().unwrap() as usize;
+
+    let mut stats = Stats {
+        writing_time: 0,
+        read_time: 0,
+        tagged_time: 0,
+    };
+
+    let mut filtered_requests: Vec<Request> = vec![];
+    for _ in 0..cycles {
+        filtered_requests.push(create_filtered_request(vector_dims));
+    }
+
+    let lock = reader.get_slock().unwrap();
+
+    let unfiltered_request = Request {
+        filter: Formula::new(),
+        vector: RandomVectors::new(vector_dims).next().unwrap(),
+    };
+
+    for cycle in 0..0 {
+        print!(
+            "Unfiltered Search => cycle {} of {}      \r",
+            (cycle + 1),
+            cycles
+        );
+        let _ = std::io::stdout().flush();
+
+        let (_, elapsed_time) = measure_time!(microseconds {
+            reader.search(&unfiltered_request, &lock).unwrap();
+        });
+        stats.read_time += elapsed_time as u128;
+    }
+
+    stats.read_time /= cycles as u128;
+    println!();
+    let mut filtered_requests: Vec<Request> = vec![];
+    for _ in 0..cycles {
+        filtered_requests.push(create_filtered_request(vector_dims));
+    }
+
+    for (cycle, filtered_request) in filtered_requests.iter().enumerate().take(cycles) {
+        print!(
+            "Filtered Search => cycle {} of {}      \r",
+            (cycle + 1),
+            cycles
+        );
+        let _ = std::io::stdout().flush();
+
+        let (_, elapsed_time) = measure_time!(microseconds {
+            reader.search(filtered_request, &lock).unwrap();
+        });
+        stats.tagged_time += elapsed_time as u128;
+    }
+
+    println!();
+    stats.tagged_time /= cycles as u128;
+    std::mem::drop(lock);
+    stats
+}
+
+fn main() {
+    let args = Args::new();
+
+    // open the dataset definition
+    let datasets = fs::read_to_string(args.datasets.clone()).expect("Unable to read file");
+    let dataset_definition: serde_json::Value =
+        serde_json::from_str(&datasets).expect("Unable to parse");
+
+    let defs = dataset_definition["datasets"].as_array().unwrap();
+
+    for dataset in defs {
+        if dataset["name"] == args.dataset_name {
+            let url = dataset["shards"]["url"].as_str().unwrap();
+            println!("Shard located at : {}", url);
+            let mut target = PathBuf::from(args.datasets.clone());
+            target.pop();
+            let root_dir = target.clone();
+            target = fs::canonicalize(&target).unwrap();
+            target.push(args.dataset_name.clone());
+
+            println!("Target path is {:?}", target);
+            if target.exists() {
+                println!("Already exists");
+            } else {
+                println!("Downloading {:?} to {:?}", url, root_dir);
+                download_and_decompress_tarball(url, root_dir.to_str().unwrap()).unwrap();
+            }
+        }
+    }
+
+    let mut json_results = vec![];
+
+    let stats = test_datapoint(args.cycles);
+
+    json_results.extend(vec![
+        json!({
+            "name": format!("Writing Time"),
+            "unit": "ms",
+            "value": stats.writing_time,
+        }),
+        json!({
+        "name": format!("Reading Time"),
+        "unit": "µs",
+        "value": stats.read_time,
+
+        }),
+        json!({
+        "name": format!("Reading Time with Labels"),
+        "unit": "µs",
+        "value": stats.tagged_time,
+
+        }),
+    ]);
+
+    let pjson = serde_json::to_string_pretty(&json_results).unwrap();
+    println!("{}", pjson);
+    write_json(args.json_output, json_results, args.merge).unwrap();
+}

--- a/vectors_benchmark/src/binaries/real_data_benchmark.rs
+++ b/vectors_benchmark/src/binaries/real_data_benchmark.rs
@@ -285,8 +285,13 @@ fn test_search(dataset: &Dataset, cycles: usize) -> Vec<(String, Vec<u128>)> {
 
             });
 
-            if search_result.is_empty() {
-                panic!("No results found for query {}", query.name);
+            if search_result.len() < query.min_results {
+                panic!(
+                    "Not enough results found for query {}. Found {}, Expected at least {}",
+                    query.name,
+                    search_result.len(),
+                    query.min_results
+                );
             }
             elapsed_times.push(elapsed_time as u128);
         }
@@ -301,6 +306,7 @@ fn test_search(dataset: &Dataset, cycles: usize) -> Vec<(String, Vec<u128>)> {
 struct Query {
     name: String,
     request: Request,
+    min_results: usize,
 }
 
 struct Dataset {
@@ -382,6 +388,7 @@ fn get_dataset(definition_file: String, dataset_name: String) -> Option<Dataset>
                 queries.push(Query {
                     name: query_name,
                     request,
+                    min_results: query["min_results"].as_u64().unwrap() as usize,
                 });
             }
             found = true;

--- a/vectors_benchmark/src/binaries/real_data_benchmark.rs
+++ b/vectors_benchmark/src/binaries/real_data_benchmark.rs
@@ -96,8 +96,20 @@ impl SearchRequest for Request {
     }
 }
 
-// TODO: convert the query in vectors with predict
 fn create_request(query: String, dimension: usize) -> Request {
+
+    // TODO: convert the query in vectors with predict
+    let client = Client::new();
+
+    text query
+    model multilingual
+
+    let json_response = client
+        .get("https://europe-1.nuclia.cloud/api/v1/predict/sentence")
+        .header("X-STF-NUAKEY", format!("Bearer {key}"))
+        json();
+
+    // formula
     let formula = Formula::new();
 
     Request {
@@ -210,7 +222,7 @@ fn test_search(dataset: &Dataset, cycles: usize) -> Vec<(String, u128)> {
     for (i, query) in dataset.queries.iter().enumerate() {
         for cycle in 0..cycles {
             print!(
-                "Request {} Search => cycle {} of {}      \r",
+                "Request {} => cycle {} of {}      \r",
                 i,
                 (cycle + 1),
                 cycles

--- a/vectors_benchmark/src/binaries/real_data_benchmark.rs
+++ b/vectors_benchmark/src/binaries/real_data_benchmark.rs
@@ -29,7 +29,7 @@ use nucliadb_vectors::data_point_provider::*;
 use nucliadb_vectors::formula::*;
 use vectors_benchmark::downloader::download_shard;
 use vectors_benchmark::json_writer::write_json;
-use vectors_benchmark::predict::{get_vectorset, PredictResults};
+use vectors_benchmark::predict::{get_vector, PredictResults};
 
 const NO_NEIGHBOURS: usize = 5;
 const CYCLES: usize = 25;

--- a/vectors_benchmark/src/binaries/real_data_benchmark.rs
+++ b/vectors_benchmark/src/binaries/real_data_benchmark.rs
@@ -1,29 +1,38 @@
-use std::env::var;
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
 use std::fs;
-use std::fs::{File, OpenOptions};
-use std::io::{self, Seek, SeekFrom, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::str::FromStr;
 
-use byte_unit::Byte;
 use clap::Parser;
-use indicatif::ProgressBar;
 use kv::*;
-use reqwest::blocking::Client;
-use reqwest::blocking::Response;
-use reqwest::header::{HeaderValue, CONTENT_LENGTH, RANGE};
-use reqwest::StatusCode;
 use serde_json::{json, Map};
-use tar::Archive;
 
 use nucliadb_vectors::data_point_provider::*;
 use nucliadb_vectors::formula::*;
+use vectors_benchmark::downloader::download_shard;
 use vectors_benchmark::json_writer::write_json;
+use vectors_benchmark::predict::{get_vectorset, PredictResults};
 
 const NO_NEIGHBOURS: usize = 5;
 const CYCLES: usize = 25;
-const CHUNK_SIZE: u32 = 1024 * 1024;
 
 macro_rules! measure_time {
     ( seconds $code:block ) => {{
@@ -103,11 +112,6 @@ impl SearchRequest for Request {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-struct PredictResults {
-    data: Vec<f32>,
-}
-
 fn create_request(
     dataset_name: String,
     query_name: String,
@@ -130,21 +134,7 @@ fn create_request(
     }
 
     // Calling the NUA service to convert the query as a vector
-    let client = Client::new();
-    let nua_key = var("NUA_KEY").unwrap();
-
-    let response = client
-        .get("https://europe-1.stashify.cloud/api/v1/predict/sentence")
-        .query(&[("text", query), ("model", "multilingual".to_string())])
-        .header("X-STF-NUAKEY", format!("Bearer {nua_key}"))
-        .send()
-        .unwrap();
-
-    if response.status().as_u16() > 299 {
-        panic!("[predict] Got a {} response from nua", response.status());
-    }
-
-    let json: PredictResults = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+    let json: PredictResults = get_vectorset(&query, "multilingual");
 
     if json.data.len() != dimension {
         panic!(
@@ -177,188 +167,6 @@ fn create_request(
     res
 }
 
-struct PartialRangeIter {
-    start: u64,
-    end: u64,
-    buffer_size: u32,
-}
-
-impl PartialRangeIter {
-    pub fn new(start: u64, end: u64, buffer_size: u32) -> Result<Self, Box<dyn std::error::Error>> {
-        if buffer_size == 0 {
-            Err("invalid buffer_size, give a value greater than zero.")?;
-        }
-        Ok(PartialRangeIter {
-            start,
-            end,
-            buffer_size,
-        })
-    }
-}
-
-impl Iterator for PartialRangeIter {
-    type Item = HeaderValue;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.start > self.end {
-            None
-        } else {
-            let prev_start = self.start;
-            self.start += std::cmp::min(self.buffer_size as u64, self.end - self.start + 1);
-            Some(
-                HeaderValue::from_str(&format!("bytes={}-{}", prev_start, self.start - 1))
-                    .expect("string provided by format!"),
-            )
-        }
-    }
-}
-
-fn get_gcp_token() -> String {
-    let output = Command::new("gcloud")
-        .args(["auth", "application-default", "print-access-token"])
-        .output()
-        .expect("Failed to execute gcloud command.");
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        panic!("gcloud error:\n{}", stderr);
-    }
-
-    let res = String::from_utf8_lossy(&output.stdout);
-    res.trim_end_matches(|c| c == '\n' || c == '\r').to_string()
-}
-
-fn get_content_length(url: &str) -> u64 {
-    let client = reqwest::blocking::Client::new();
-    let mut request = client.head(url);
-
-    if url.starts_with("https://storage.googleapis.com") {
-        request = request.bearer_auth(get_gcp_token());
-    } else if let Ok(dataset_auth) = var("DATASET_AUTH") {
-        let (user_name, password) = dataset_auth.split_once(':').unwrap();
-        request = request.basic_auth(user_name, Some(password));
-    }
-    let response = request.send().unwrap();
-    let status = response.status();
-
-    if !(status == StatusCode::OK || status == StatusCode::PARTIAL_CONTENT) {
-        panic!("Unexpected server response: {}", status)
-    }
-
-    let length = response
-        .headers()
-        .get(CONTENT_LENGTH)
-        .ok_or("response doesn't include the content length")
-        .unwrap();
-
-    u64::from_str(length.to_str().unwrap())
-        .map_err(|_| "invalid Content-Length header")
-        .unwrap()
-}
-
-fn range_request(url: &str, range: &HeaderValue) -> Response {
-    let client = Client::new();
-    let mut request = client.get(url).header(RANGE, range);
-
-    if url.starts_with("https://storage.googleapis.com") {
-        request = request.bearer_auth(get_gcp_token());
-    } else if let Ok(dataset_auth) = var("DATASET_AUTH") {
-        let (user_name, password) = dataset_auth.split_once(':').unwrap();
-        request = request.basic_auth(user_name, Some(password));
-    }
-
-    request.send().unwrap()
-}
-
-fn download_and_decompress_tarball(
-    url: &str,
-    destination_dir: &str,
-    dataset_name: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let download_path = format!("{}/download.tar.gz", destination_dir);
-
-    // Check if the partially downloaded file exists
-    let mut downloaded_bytes = 0;
-    if Path::new(&download_path).exists() {
-        // Open the file for appending and get the current file size
-        let mut file = OpenOptions::new()
-            .write(true)
-            .append(true)
-            .open(&download_path)?;
-
-        // Seek to the end to continue the download
-        downloaded_bytes = file.seek(SeekFrom::End(0))?;
-    } else {
-        // Create a new file for downloading
-        let file = File::create(&download_path)?;
-        file.set_len(0)?;
-    }
-
-    let content_length = get_content_length(url);
-
-    if downloaded_bytes < content_length {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .append(true)
-            .open(&download_path)?;
-
-        println!(
-            "Downloading {}",
-            Byte::from_bytes(content_length as u128).get_appropriate_unit(true),
-        );
-
-        let pb = ProgressBar::new(content_length);
-
-        for range in PartialRangeIter::new(0, content_length - 1, CHUNK_SIZE)? {
-            let mut response = range_request(url, &range);
-            let status = response.status();
-
-            if !(status == StatusCode::OK || status == StatusCode::PARTIAL_CONTENT) {
-                panic!("Unexpected server response: {}", status)
-            }
-            std::io::copy(&mut response, &mut file).unwrap();
-
-            // really???
-            let length = u64::from_str(
-                response
-                    .headers()
-                    .get("Content-Length")
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-            )
-            .unwrap();
-            downloaded_bytes += length;
-            pb.set_position(downloaded_bytes);
-            pb.tick();
-        }
-
-        pb.finish_and_clear();
-    }
-    let tarball_file = File::open(&download_path)?;
-    let tar = flate2::read::GzDecoder::new(tarball_file);
-    let mut archive = Archive::new(tar);
-
-    let mut destination_dir = PathBuf::from(destination_dir);
-    destination_dir.push(dataset_name);
-    fs::create_dir_all(destination_dir.as_path())?;
-
-    for entry in archive.entries()? {
-        let mut entry = entry?;
-        let path = entry.path()?;
-        let entry_destination = format!("{}/{}", destination_dir.display(), path.display());
-
-        if entry.header().entry_type().is_dir() {
-            std::fs::create_dir_all(&entry_destination)?;
-        } else {
-            let mut file = File::create(&entry_destination)?;
-            io::copy(&mut entry, &mut file)?;
-        }
-    }
-
-    std::fs::remove_file(&download_path)?;
-    Ok(destination_dir.into_os_string().into_string().unwrap())
-}
-
 fn get_num_dimensions(vectors_path: &Path) -> usize {
     let reader = Index::open(vectors_path).unwrap();
     reader.get_dimension().unwrap() as usize
@@ -386,7 +194,6 @@ fn test_search(dataset: &Dataset, cycles: usize) -> Vec<(String, Vec<u128>)> {
 
             let search_result;
 
-            //println!("{} {:?}", query.name, query.request.filter);
             let (_, elapsed_time) = measure_time!(microseconds {
                 search_result = reader.search(&query.request, &lock).unwrap();
 
@@ -464,8 +271,7 @@ fn get_dataset(definition_file: String, dataset_name: String) -> Option<Dataset>
             let url = dataset["shards"]["url"].as_str().unwrap();
             if !target.exists() {
                 println!("Downloading {:?} to {:?}", url, root_dir);
-                download_and_decompress_tarball(url, root_dir.to_str().unwrap(), &dataset_name)
-                    .unwrap();
+                download_shard(url, root_dir.to_str().unwrap(), &dataset_name).unwrap();
             }
             target.push(dataset["shards"]["root_path"].as_str().unwrap());
             // picking the first id for now

--- a/vectors_benchmark/src/downloader.rs
+++ b/vectors_benchmark/src/downloader.rs
@@ -1,0 +1,219 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::env::var;
+use std::fs;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str::FromStr;
+
+use byte_unit::Byte;
+use indicatif::ProgressBar;
+use reqwest::blocking::Client;
+use reqwest::blocking::Response;
+use reqwest::header::{HeaderValue, CONTENT_LENGTH, RANGE};
+use reqwest::StatusCode;
+use tar::Archive;
+
+const CHUNK_SIZE: u32 = 1024 * 1024;
+
+struct PartialRangeIter {
+    start: u64,
+    end: u64,
+    buffer_size: u32,
+}
+
+impl PartialRangeIter {
+    pub fn new(start: u64, end: u64, buffer_size: u32) -> Result<Self, Box<dyn std::error::Error>> {
+        if buffer_size == 0 {
+            Err("invalid buffer_size, give a value greater than zero.")?;
+        }
+        Ok(PartialRangeIter {
+            start,
+            end,
+            buffer_size,
+        })
+    }
+}
+
+impl Iterator for PartialRangeIter {
+    type Item = HeaderValue;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start > self.end {
+            None
+        } else {
+            let prev_start = self.start;
+            self.start += std::cmp::min(self.buffer_size as u64, self.end - self.start + 1);
+            Some(
+                HeaderValue::from_str(&format!("bytes={}-{}", prev_start, self.start - 1))
+                    .expect("string provided by format!"),
+            )
+        }
+    }
+}
+
+fn get_gcp_token() -> String {
+    let output = Command::new("gcloud")
+        .args(["auth", "application-default", "print-access-token"])
+        .output()
+        .expect("Failed to execute gcloud command.");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("gcloud error:\n{}", stderr);
+    }
+
+    let res = String::from_utf8_lossy(&output.stdout);
+    res.trim_end_matches(|c| c == '\n' || c == '\r').to_string()
+}
+
+fn get_content_length(url: &str) -> u64 {
+    let client = reqwest::blocking::Client::new();
+    let mut request = client.head(url);
+
+    if url.starts_with("https://storage.googleapis.com") {
+        request = request.bearer_auth(get_gcp_token());
+    } else if let Ok(dataset_auth) = var("DATASET_AUTH") {
+        let (user_name, password) = dataset_auth.split_once(':').unwrap();
+        request = request.basic_auth(user_name, Some(password));
+    }
+    let response = request.send().unwrap();
+    let status = response.status();
+
+    if !(status == StatusCode::OK || status == StatusCode::PARTIAL_CONTENT) {
+        panic!("Unexpected server response: {}", status)
+    }
+
+    let length = response
+        .headers()
+        .get(CONTENT_LENGTH)
+        .ok_or("response doesn't include the content length")
+        .unwrap();
+
+    u64::from_str(length.to_str().unwrap())
+        .map_err(|_| "invalid Content-Length header")
+        .unwrap()
+}
+
+fn range_request(url: &str, range: &HeaderValue) -> Response {
+    let client = Client::new();
+    let mut request = client.get(url).header(RANGE, range);
+
+    if url.starts_with("https://storage.googleapis.com") {
+        request = request.bearer_auth(get_gcp_token());
+    } else if let Ok(dataset_auth) = var("DATASET_AUTH") {
+        let (user_name, password) = dataset_auth.split_once(':').unwrap();
+        request = request.basic_auth(user_name, Some(password));
+    }
+
+    request.send().unwrap()
+}
+
+pub fn download_shard(
+    url: &str,
+    destination_dir: &str,
+    dataset_name: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let download_path = format!("{}/download.tar.gz", destination_dir);
+
+    // Check if the partially downloaded file exists
+    let mut downloaded_bytes = 0;
+    if Path::new(&download_path).exists() {
+        // Open the file for appending and get the current file size
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(&download_path)?;
+
+        // Seek to the end to continue the download
+        downloaded_bytes = file.seek(SeekFrom::End(0))?;
+    } else {
+        // Create a new file for downloading
+        let file = File::create(&download_path)?;
+        file.set_len(0)?;
+    }
+
+    let content_length = get_content_length(url);
+
+    if downloaded_bytes < content_length {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(&download_path)?;
+
+        println!(
+            "Downloading {}",
+            Byte::from_bytes(content_length as u128).get_appropriate_unit(true),
+        );
+
+        let pb = ProgressBar::new(content_length);
+
+        for range in PartialRangeIter::new(0, content_length - 1, CHUNK_SIZE)? {
+            let mut response = range_request(url, &range);
+            let status = response.status();
+
+            if !(status == StatusCode::OK || status == StatusCode::PARTIAL_CONTENT) {
+                panic!("Unexpected server response: {}", status)
+            }
+            std::io::copy(&mut response, &mut file).unwrap();
+
+            // really???
+            let length = u64::from_str(
+                response
+                    .headers()
+                    .get("Content-Length")
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+            )
+            .unwrap();
+            downloaded_bytes += length;
+            pb.set_position(downloaded_bytes);
+            pb.tick();
+        }
+
+        pb.finish_and_clear();
+    }
+    let tarball_file = File::open(&download_path)?;
+    let tar = flate2::read::GzDecoder::new(tarball_file);
+    let mut archive = Archive::new(tar);
+
+    let mut destination_dir = PathBuf::from(destination_dir);
+    destination_dir.push(dataset_name);
+    fs::create_dir_all(destination_dir.as_path())?;
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        let entry_destination = format!("{}/{}", destination_dir.display(), path.display());
+
+        if entry.header().entry_type().is_dir() {
+            std::fs::create_dir_all(&entry_destination)?;
+        } else {
+            let mut file = File::create(&entry_destination)?;
+            io::copy(&mut entry, &mut file)?;
+        }
+    }
+
+    std::fs::remove_file(&download_path)?;
+    Ok(destination_dir.into_os_string().into_string().unwrap())
+}

--- a/vectors_benchmark/src/predict.rs
+++ b/vectors_benchmark/src/predict.rs
@@ -28,10 +28,11 @@ pub struct PredictResults {
 /// Calls the predict service to convert the query as a vector set
 pub fn get_vectorset(query: &str, model: &str) -> PredictResults {
     let client = Client::new();
-    let nua_key = env!(
-        "NUA_KEY",
-        "You need to set your NUA_KEY environment variable to call the predict service"
-    );
+
+    let nua_key = env::var("NUA_KEY").unwrap_or_else(|_| {
+        panic!("You need to set your NUA_KEY environment variable to call the predict service");
+    });
+
     let response = client
         .get("https://europe-1.stashify.cloud/api/v1/predict/sentence")
         .query(&[("text", query), ("model", model)])

--- a/vectors_benchmark/src/predict.rs
+++ b/vectors_benchmark/src/predict.rs
@@ -26,7 +26,7 @@ pub struct PredictResults {
 }
 
 /// Calls the predict service to convert the query as a vector set
-pub fn get_vectorset(query: &str, model: &str) -> PredictResults {
+pub fn get_vector(query: &str, model: &str) -> PredictResults {
     let client = Client::new();
 
     let nua_key = env::var("NUA_KEY").unwrap_or_else(|_| {

--- a/vectors_benchmark/src/predict.rs
+++ b/vectors_benchmark/src/predict.rs
@@ -18,7 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 use reqwest::blocking::Client;
-use std::env::var;
+use std::env;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct PredictResults {
@@ -28,8 +28,10 @@ pub struct PredictResults {
 /// Calls the predict service to convert the query as a vector set
 pub fn get_vectorset(query: &str, model: &str) -> PredictResults {
     let client = Client::new();
-    let nua_key = var("NUA_KEY").unwrap();
-
+    let nua_key = env!(
+        "NUA_KEY",
+        "You need to set your NUA_KEY environment variable to call the predict service"
+    );
     let response = client
         .get("https://europe-1.stashify.cloud/api/v1/predict/sentence")
         .query(&[("text", query), ("model", model)])


### PR DESCRIPTION
### Description

Introduces a new bench runner that does the following:

- reads a JSON file containing a description of shards along with a set of queries against it
- runs a benchmark using the queries and produce a JSON output that can be used in our bench infra

The tool calls the predict API to convert queries into vectors, given a model (with a local cache) and offers resumable downloads for downloading shards. 

Shards are tarballs, and can be stored in GCP or on any HTTP url.

### How was this PR tested?

run `make real-data-bench` for trying the flow.
