### PR TITLE
use crossbeam threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "axum-server",
  "backoff",
  "bincode",
+ "crossbeam-utils",
  "derive_builder",
  "futures",
  "futures-core",

--- a/nucliadb_node/Cargo.toml
+++ b/nucliadb_node/Cargo.toml
@@ -59,6 +59,7 @@ tracing-opentelemetry = "0.17.2"
 reqwest = "0.11.16"
 derive_builder = "0.12.0"
 num_cpus = "1.16.0"
+crossbeam-utils = "0.8.16"
 
 # Text Service
 async-stream = "0.3.2"

--- a/nucliadb_node/src/shards/shard_reader.rs
+++ b/nucliadb_node/src/shards/shard_reader.rs
@@ -19,6 +19,7 @@
 use std::path::Path;
 use std::time::SystemTime;
 
+use crossbeam_utils::thread as crossbeam_thread;
 use nucliadb_core::metrics::{self, request_time};
 use nucliadb_core::prelude::*;
 use nucliadb_core::protos::shard_created::{
@@ -109,11 +110,12 @@ impl ShardReader {
         let mut text_result = Ok(0);
         let mut paragraph_result = Ok(0);
         let mut vector_result = Ok(0);
-        thread::scope(|s| {
+        crossbeam_thread::scope(|s| {
             s.spawn(|_| text_result = text_task());
             s.spawn(|_| paragraph_result = paragraph_task());
             s.spawn(|_| vector_result = vector_task());
-        });
+        })
+        .expect("Failed to join threads");
 
         let metrics = metrics::get_metrics();
         let took = time.elapsed().map(|i| i.as_secs_f64()).unwrap_or(f64::NAN);
@@ -197,12 +199,13 @@ impl ShardReader {
         let mut paragraph_result = None;
         let mut vector_result = None;
         let mut relation_result = None;
-        thread::scope(|s| {
+        crossbeam_thread::scope(|s| {
             s.spawn(|_| text_result = text_task());
             s.spawn(|_| paragraph_result = paragraph_task());
             s.spawn(|_| vector_result = vector_task());
             s.spawn(|_| relation_result = relation_task());
-        });
+        })
+        .expect("Failed to join threads");
         let fields = text_result.transpose()?;
         let paragraphs = paragraph_result.transpose()?;
         let vectors = vector_result.transpose()?;
@@ -398,7 +401,7 @@ impl ShardReader {
         let mut rvector = None;
         let mut rrelation = None;
 
-        thread::scope(|s| {
+        crossbeam_thread::scope(|s| {
             if !skip_fields {
                 s.spawn(|_| rtext = text_task());
             }
@@ -411,7 +414,8 @@ impl ShardReader {
             if !skip_relations {
                 s.spawn(|_| rrelation = relation_task());
             }
-        });
+        })
+        .expect("Failed to join threads");
 
         let metrics = metrics::get_metrics();
         let took = time.elapsed().map(|i| i.as_secs_f64()).unwrap_or(f64::NAN);


### PR DESCRIPTION
### Description
The use of the global rayon thread pool causes potential deadlocks with tantivy due to it's work stealing algorithm.

### How was this PR tested?
Describe how you tested this PR.
