### PR TITLE
Migrate node metrics to use new proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "nucliadb_core",
+ "nucliadb_procs",
  "rand",
  "regex",
  "ring",
@@ -2024,6 +2025,7 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "nucliadb_core",
+ "nucliadb_procs",
  "tantivy",
  "tempfile",
 ]
@@ -2039,6 +2041,7 @@ dependencies = [
  "lazy_static",
  "memmap2",
  "nucliadb_core",
+ "nucliadb_procs",
  "rand",
  "serde",
  "serde_json",

--- a/nucliadb_paragraphs/Cargo.toml
+++ b/nucliadb_paragraphs/Cargo.toml
@@ -14,8 +14,9 @@ levenshtein_automata = "0.2.1"
 once_cell = "1.13.1"
 tantivy-fst = "0.3.0"
 tantivy-common = "0.2.0"
-nucliadb_core = { path = "../nucliadb_core" }
 itertools = "0.10.5"
+
+nucliadb_core = { path = "../nucliadb_core" }
 nucliadb_procs = { path = "../nucliadb_procs" }
 
 [build-dependencies]

--- a/nucliadb_relations/Cargo.toml
+++ b/nucliadb_relations/Cargo.toml
@@ -20,7 +20,9 @@ ring = "0.16.20"
 data-encoding = "2.3.2"
 tantivy = "0.17.0"
 heed = { version = "0.11.0", default-features = false, features = ["lmdb", "sync-read-txn"] }
+
 nucliadb_core = { path = "../nucliadb_core" }
+nucliadb_procs = { path = "../nucliadb_procs" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/nucliadb_texts/Cargo.toml
+++ b/nucliadb_texts/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2021"
 [dependencies]
 tempfile = "3"
 tantivy = "0.17.0"
-nucliadb_core = { path = "../nucliadb_core" }
 itertools = "0.10.5"
+
+nucliadb_core = { path = "../nucliadb_core" }
+nucliadb_procs = { path = "../nucliadb_procs" }

--- a/nucliadb_vectors/Cargo.toml
+++ b/nucliadb_vectors/Cargo.toml
@@ -15,10 +15,12 @@ memmap2 = "0.5.3"
 fs2 = "0.4.3"
 thiserror = "1.0.31"
 serde_json = "1.0.82"
-nucliadb_core = { path = "../nucliadb_core" }
 crossbeam = "0.8.2"
 fst = "0.4.7"
 bincode = "1.3.3"
+
+nucliadb_core = { path = "../nucliadb_core" }
+nucliadb_procs = { path = "../nucliadb_procs" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/nucliadb_vectors/src/service/reader.rs
+++ b/nucliadb_vectors/src/service/reader.rs
@@ -20,8 +20,6 @@
 use std::fmt::Debug;
 use std::time::SystemTime;
 
-use nucliadb_core::metrics;
-use nucliadb_core::metrics::request_time;
 use nucliadb_core::prelude::*;
 use nucliadb_core::protos::prost::Message;
 use nucliadb_core::protos::{
@@ -29,6 +27,7 @@ use nucliadb_core::protos::{
     VectorSearchResponse,
 };
 use nucliadb_core::tracing::{self, *};
+use nucliadb_procs::measure;
 
 use crate::data_point_provider::*;
 use crate::formula::{AtomClause, CompoundClause, Formula};
@@ -65,44 +64,25 @@ impl Debug for VectorReaderService {
 impl VectorReader for VectorReaderService {
     #[tracing::instrument(skip_all)]
     fn count(&self, vectorset: &str) -> NodeResult<usize> {
-        let time = SystemTime::now();
-
         let indexet_slock = self.indexset.get_slock()?;
         if vectorset.is_empty() {
             debug!("Id for the vectorset is empty");
-            let index_slock = self.index.get_slock()?;
-            let no_nodes = self.index.no_nodes(&index_slock);
-            std::mem::drop(index_slock);
-
-            let metrics = metrics::get_metrics();
-            let took = time.elapsed().map(|i| i.as_secs_f64()).unwrap_or(f64::NAN);
-            let metric = request_time::RequestTimeKey::vectors("count".to_string());
-            metrics.record_request_time(metric, took);
-            debug!("Ending at {took} ms");
-
-            Ok(no_nodes)
+            self.index_count(&self.index)
         } else if let Some(index) = self.indexset.get(vectorset, &indexet_slock)? {
             debug!("Counting nodes for {vectorset}");
-            let lock = index.get_slock()?;
-            let no_nodes = index.no_nodes(&lock);
-            std::mem::drop(lock);
-
-            let metrics = metrics::get_metrics();
-            let took = time.elapsed().map(|i| i.as_secs_f64()).unwrap_or(f64::NAN);
-            let metric = request_time::RequestTimeKey::vectors("count".to_string());
-            metrics.record_request_time(metric, took);
-            debug!("Ending at {took} ms");
-
-            Ok(no_nodes)
+            self.index_count(&index)
         } else {
             debug!("There was not a set called {vectorset}");
             Ok(0)
         }
     }
 }
+
 impl ReaderChild for VectorReaderService {
     type Request = VectorSearchRequest;
     type Response = VectorSearchResponse;
+
+    #[measure(actor = "vectors", metric = "search")]
     #[tracing::instrument(skip_all)]
     fn search(&self, request: &Self::Request) -> NodeResult<Self::Response> {
         let time = SystemTime::now();
@@ -173,10 +153,7 @@ impl ReaderChild for VectorReaderService {
             debug!("{id:?} - Creating results: ends at {v} ms");
         }
 
-        let metrics = metrics::get_metrics();
         let took = time.elapsed().map(|i| i.as_secs_f64()).unwrap_or(f64::NAN);
-        let metric = request_time::RequestTimeKey::vectors("search".to_string());
-        metrics.record_request_time(metric, took);
         debug!("{id:?} - Ending at {took} ms");
 
         Ok(VectorSearchResponse {
@@ -185,6 +162,8 @@ impl ReaderChild for VectorReaderService {
             result_per_page: request.result_per_page,
         })
     }
+
+    #[measure(actor = "vectors", metric = "stored_ids")]
     #[tracing::instrument(skip_all)]
     fn stored_ids(&self) -> NodeResult<Vec<String>> {
         let time = SystemTime::now();
@@ -217,6 +196,7 @@ impl TryFrom<Neighbour> for DocumentScored {
         })
     }
 }
+
 impl VectorReaderService {
     #[tracing::instrument(skip_all)]
     pub fn start(config: &VectorConfig) -> NodeResult<Self> {
@@ -230,6 +210,14 @@ impl VectorReaderService {
             index: Index::open(&config.path)?,
             indexset: IndexSet::new(&config.vectorset)?,
         })
+    }
+
+    #[measure(actor = "vectors", metric = "count")]
+    fn index_count(&self, index: &Index) -> NodeResult<usize> {
+        let lock = index.get_slock()?;
+        let no_nodes = index.no_nodes(&lock);
+        std::mem::drop(lock);
+        Ok(no_nodes)
     }
 }
 


### PR DESCRIPTION
### Description
- Use new `nucliadb_procs::measure` macro for the current metrics

### How was this PR tested?
Describe how you tested this PR.
