### PR TITLE
Find endpoint returns wrong resource ids

### DIFF
--- a/nucliadb/nucliadb/search/search/find_merge.py
+++ b/nucliadb/nucliadb/search/search/find_merge.py
@@ -106,6 +106,10 @@ async def set_resource_metadata_value(
         )
         if serialized_resource is not None:
             find_resources[resource].updated_from(serialized_resource)
+        else:
+            logger.warning(f"Resource {resource} not found in {kbid}")
+            find_resources.pop(resource, None)
+
     finally:
         max_operations.release()
 

--- a/nucliadb/nucliadb/tests/integration/test_find.py
+++ b/nucliadb/nucliadb/tests/integration/test_find.py
@@ -18,9 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from httpx import AsyncClient
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 
@@ -199,6 +199,7 @@ async def test_story_7286(
     nucliadb_writer: AsyncClient,
     nucliadb_grpc: WriterStub,
     knowledgebox,
+    caplog,
 ):
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
@@ -251,5 +252,4 @@ async def test_story_7286(
         assert resp.status_code == 200
     body = resp.json()
     assert len(body["resources"]) == 0
-
-    # TODO: assert the warning  Resource 4d8dc1aea04d4d078fcd4b03e44d7215 not found in b4f1475e-59b4-4ac1-b6dd-b2923ab15702
+    assert caplog.record_tuples[0][2] == f"Resource {rid} not found in {knowledgebox}"


### PR DESCRIPTION
### Description

When `serialize` returns `None` it creates havoc in the result creation, rewriting the resource id.

In this patch we drop that result and issue a warning. 

(the remaining question is why do we get such a empty result there)


### How was this PR tested?

Unit test
