### PR TITLE
[sdk] Be able to properly stream downloads to a file

### DIFF
--- a/nucliadb_sdk/nucliadb_sdk/tests/test_export_import.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_export_import.py
@@ -47,7 +47,7 @@ def test_export_import_kb(src_kbid, dst_kbid, sdk: nucliadb_sdk.NucliaDB):
     export_generator = sdk.download_export(kbid=src_kbid, export_id=export_id)
 
     # Import to dst kb
-    resp = sdk.start_import(kbid=dst_kbid, content=export_generator)
+    resp = sdk.start_import(kbid=dst_kbid, content=export_generator(chunk_size=1024))
     import_id = resp.import_id
     assert sdk.import_status(kbid=dst_kbid, import_id=import_id).status == "finished"
 

--- a/nucliadb_sdk/nucliadb_sdk/v2/docstrings.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/docstrings.py
@@ -214,6 +214,83 @@ DELETE_LABELSET = Docstring(
     path_param_doc={"labelset": "Id of the labelset to delete"},
 )
 
+START_EXPORT = Docstring(
+    doc="Start a new export for a Knowledge Box",
+    examples=[
+        Example(
+            description="Start an export on a KB",
+            code=""">>> from nucliadb_sdk import *
+export_id = sdk.start_export(kbid="mykbid").export_id
+print(export_id)
+'925796f7-3820-44c9-b306-6e69148d02c3'
+""",
+        )
+    ],
+)
+
+EXPORT_STATUS = Docstring(
+    doc="Check the status of an export",
+    path_param_doc={"export_id": "Id of the export to check"},
+    examples=[
+        Example(
+            description="Check the status of an export",
+            code=""">>> from nucliadb_sdk import *
+resp = sdk.export_status(kbid="mykbid", export_id=export_id)
+print(resp.status.value)
+'finished'
+""",
+        )
+    ],
+)
+
+DOWNLOAD_EXPORT = Docstring(
+    doc="Download the export of the Knowledge Box",
+    path_param_doc={"export_id": "Id of the export to check"},
+    examples=[
+        Example(
+            description="Download the export content once it has finished",
+            code=""">>> from nucliadb_sdk import *
+resp = sdk.export_status(kbid="mykbid", export_id=export_id)
+assert resp.status.value == 'finished'
+resp_bytes_gen = sdk.download_export(kbid="mykbid", export_id=export_id)
+with open("my-kb.export", "wb") as f:
+    for chunk in resp_bytes_gen(chunk_size=1024):
+        f.write(chunk)
+""",
+        )
+    ],
+)
+
+START_IMPORT = Docstring(
+    doc="Start a new import for a Knowledge Box",
+    examples=[
+        Example(
+            description="Import to a KB from an export file",
+            code=""">>> from nucliadb_sdk import *
+resp =  sdk.start_import(kbid="mykbid", content=open("my-kb.export", "rb"))
+import_id = resp.import_id
+print(import_id)
+'b17337ca-5b1b-431b-b9b7-5ecb2241c78a'
+""",
+        )
+    ],
+)
+
+IMPORT_STATUS = Docstring(
+    doc="Check the status of an import",
+    path_param_doc={"import_id": "Id of the import to check"},
+    examples=[
+        Example(
+            description="Check the status of an import",
+            code=""">>> from nucliadb_sdk import *
+resp = sdk.import_status(kbid="mykbid", import_id=import_id)
+print(resp.status.value)
+'finished'
+""",
+        )
+    ],
+)
+
 
 def inject_documentation(
     func,

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -22,6 +22,7 @@ import enum
 import io
 from typing import (
     Any,
+    AsyncGenerator,
     AsyncIterable,
     Callable,
     Dict,
@@ -599,6 +600,7 @@ class _NucliaDBBase:
         path_params=("kbid",),
         request_type=None,
         response_type=CreateExportResponse,
+        docstring=docstrings.START_EXPORT,
     )
 
     export_status = _request_builder(
@@ -608,6 +610,7 @@ class _NucliaDBBase:
         path_params=("kbid", "export_id"),
         request_type=None,
         response_type=StatusResponse,
+        docstring=docstrings.EXPORT_STATUS,
     )
 
     download_export = _request_builder(
@@ -618,6 +621,7 @@ class _NucliaDBBase:
         request_type=None,
         response_type=None,
         stream_response=True,
+        docstring=docstrings.DOWNLOAD_EXPORT,
     )
 
     start_import = _request_builder(
@@ -627,6 +631,7 @@ class _NucliaDBBase:
         path_params=("kbid",),
         request_type=None,
         response_type=CreateImportResponse,
+        docstring=docstrings.START_IMPORT,
     )
 
     import_status = _request_builder(
@@ -636,6 +641,7 @@ class _NucliaDBBase:
         path_params=("kbid", "import_id"),
         request_type=None,
         response_type=StatusResponse,
+        docstring=docstrings.IMPORT_STATUS,
     )
 
 
@@ -716,7 +722,7 @@ class NucliaDB(_NucliaDBBase):
         method: str,
         data: Optional[Union[str, bytes]] = None,
         query_params: Optional[Dict[str, str]] = None,
-    ):
+    ) -> Callable[[Optional[int]], Iterator[bytes]]:
         url = f"{self.base_url}{path}"
         opts: Dict[str, Any] = {}
         if data is not None:
@@ -724,7 +730,7 @@ class NucliaDB(_NucliaDBBase):
         if query_params is not None:
             opts["params"] = query_params
 
-        def iter_bytes(chunk_size=None):
+        def iter_bytes(chunk_size=None) -> Iterator[bytes]:
             with self.session.stream(method.lower(), url=url, **opts) as response:
                 self._check_response(response)
                 for chunk in response.iter_raw(chunk_size=chunk_size):
@@ -808,7 +814,7 @@ class NucliaDBAsync(_NucliaDBBase):
         method: str,
         data: Optional[Union[str, bytes]] = None,
         query_params: Optional[Dict[str, str]] = None,
-    ):
+    ) -> Callable[[Optional[int]], AsyncGenerator[bytes, None]]:
         url = f"{self.base_url}{path}"
         opts: Dict[str, Any] = {}
         if data is not None:
@@ -816,7 +822,7 @@ class NucliaDBAsync(_NucliaDBBase):
         if query_params is not None:
             opts["params"] = query_params
 
-        async def iter_bytes(chunk_size=None):
+        async def iter_bytes(chunk_size=None) -> AsyncGenerator[bytes, None]:
             async with self.session.stream(method.lower(), url=url, **opts) as response:
                 self._check_response(response)
                 async for chunk in response.aiter_raw(chunk_size=chunk_size):

--- a/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/sdk.py
@@ -817,7 +817,7 @@ class NucliaDBAsync(_NucliaDBBase):
             opts["params"] = query_params
 
         async def iter_bytes(chunk_size=None):
-            with self.session.stream(method.lower(), url=url, **opts) as response:
+            async with self.session.stream(method.lower(), url=url, **opts) as response:
                 self._check_response(response)
                 async for chunk in response.aiter_raw(chunk_size=chunk_size):
                     yield chunk


### PR DESCRIPTION
### Description
Download export requests return an (async) iterator of bytes from the streamed response that can be used to store the bytes into a file without having to accumulate all the response content in memory

### How was this PR tested?
unit and local tests
