### PR TITLE
Fix exporting conversations

### DIFF
--- a/nucliadb/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/nucliadb/ingest/fields/conversation.py
@@ -106,7 +106,7 @@ class Conversation(Field):
         await self.db_set_metadata(metadata)
 
     async def get_value(self, page: Optional[int] = None) -> Optional[PBConversation]:
-        # If now page was requested, force fetch of metadata
+        # If no page was requested, force fetch of metadata
         # and set the page to the last page
         if page is None and self.metadata is None:
             await self.get_metadata()

--- a/nucliadb/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/nucliadb/ingest/fields/conversation.py
@@ -58,7 +58,7 @@ class Conversation(Field):
     async def set_value(self, payload: PBConversation):
         last_page: Optional[PBConversation] = None
         metadata = await self.get_metadata()
-        if self._created is False:
+        if self._created is False and metadata.pages > 0:
             try:
                 last_page = await self.db_get_value(page=metadata.pages)
             except PageNotFound:
@@ -138,6 +138,9 @@ class Conversation(Field):
         return self.metadata
 
     async def db_get_value(self, page: int = 1):
+        if page == 0:
+            raise ValueError(f"Conversation pages start at index 1")
+
         if self.value.get(page) is None:
             field_key = KB_RESOURCE_FIELD.format(
                 kbid=self.kbid,

--- a/nucliadb/nucliadb/ingest/tests/fixtures.py
+++ b/nucliadb/nucliadb/ingest/tests/fixtures.py
@@ -37,6 +37,7 @@ from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.consumer import service as consumer_service
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.processor import Processor
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.ingest.service.writer import WriterServicer
 from nucliadb.ingest.settings import settings
 from nucliadb.ingest.tests.vectors import V1, V2, V3
@@ -50,6 +51,7 @@ from nucliadb_utils.cache.nats import NatsPubsub
 from nucliadb_utils.indexing import IndexingUtility
 from nucliadb_utils.settings import indexing_settings, transaction_settings
 from nucliadb_utils.storages.settings import settings as storage_settings
+from nucliadb_utils.storages.storage import Storage
 from nucliadb_utils.utilities import (
     Utility,
     clean_utility,
@@ -496,7 +498,9 @@ def broker_resource(
     return message1
 
 
-async def create_resource(storage, driver: Driver, knowledgebox_ingest: str):
+async def create_resource(
+    storage: Storage, driver: Driver, knowledgebox_ingest: str
+) -> Resource:
     txn = await driver.begin()
 
     rid = str(uuid.uuid4())

--- a/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_resource.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_resource.py
@@ -97,13 +97,13 @@ async def test_create_resource_orm_with_basic(
     o2 = PBOrigin()
     assert o2 is not None
     o2.source = PBOrigin.Source.API
-    o2.source_id = "My Suorce"
+    o2.source_id = "My Source"
     o2.created.FromDatetime(datetime.now())
 
     await r.set_origin(o2)
     o2 = await r.get_origin()
     assert o2 is not None
-    assert o2.source_id == "My Suorce"
+    assert o2.source_id == "My Source"
 
 
 @pytest.mark.asyncio

--- a/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_resource.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_resource.py
@@ -43,7 +43,10 @@ from nucliadb_protos.writer_pb2 import (
 )
 
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.tests.fixtures import create_resource
+from nucliadb_protos import resources_pb2 as rpb
 from nucliadb_protos import utils_pb2
+from nucliadb_protos import utils_pb2 as upb
 
 
 @pytest.mark.asyncio
@@ -94,13 +97,13 @@ async def test_create_resource_orm_with_basic(
     o2 = PBOrigin()
     assert o2 is not None
     o2.source = PBOrigin.Source.API
-    o2.source_id = "My Surce"
+    o2.source_id = "My Suorce"
     o2.created.FromDatetime(datetime.now())
 
     await r.set_origin(o2)
     o2 = await r.get_origin()
     assert o2 is not None
-    assert o2.source_id == "My Surce"
+    assert o2.source_id == "My Suorce"
 
 
 @pytest.mark.asyncio
@@ -217,10 +220,138 @@ async def test_vector_duplicate_fields(
     assert count == 1
 
 
-async def test_generate_field_conversation(
-    gcs_storage, txn, cache, fake_node, knowledgebox_ingest: str
+async def test_generate_broker_message(
+    gcs_storage, maindb_driver, cache, fake_node, knowledgebox_ingest: str
 ):
-    # Create a resource with a conversation field (with multiple pages of messages)
+    # Create a resource with all possible metadata in it
+    resource = await create_resource(gcs_storage, maindb_driver, knowledgebox_ingest)
 
-    # Check that generate field copies over the right data from the conversation
-    pass
+    # Now fetch it
+    async with maindb_driver.transaction() as txn:
+        kb_obj = KnowledgeBox(txn, gcs_storage, kbid=knowledgebox_ingest)
+        r = await kb_obj.get(resource.uuid)
+        assert r is not None
+
+    async with maindb_driver.transaction() as txn:
+        r.txn = txn
+        bm = await r.generate_broker_message()
+
+    # Check generated broker message has the same metadata as the created resource
+
+    # 1. ROOT ELEMENTS
+    # 1.1 BASIC
+    basic = bm.basic
+    assert basic.HasField("created")
+    assert basic.HasField("modified")
+    assert basic.title == "My title"
+    assert basic.summary == "My summary"
+    assert basic.icon == "text/plain"
+    assert basic.layout == "basic"
+    assert basic.thumbnail == "/file"
+    assert basic.last_seqid == 1
+    assert basic.last_account_seq == 2
+    basic_metadata = basic.metadata
+    assert basic_metadata.metadata["key"] == "value"
+    assert basic_metadata.language == "ca"
+    assert basic_metadata.useful is True
+    assert basic_metadata.status == rpb.Metadata.Status.PROCESSED
+    basic_usermetadata = basic.usermetadata
+    assert len(basic_usermetadata.classifications) == 1
+    assert basic_usermetadata.classifications[0].label == "label1"
+    assert basic_usermetadata.classifications[0].labelset == "labelset1"
+    assert len(basic_usermetadata.relations) == 1
+    assert basic_usermetadata.relations[0].to.value == "000001"
+    basic_fieldmetadata = basic.fieldmetadata
+    assert len(basic_fieldmetadata) == 1
+    assert basic_fieldmetadata[0].field.field == "text1"
+    assert basic_fieldmetadata[0].token[0].token == "My home"
+    assert basic_fieldmetadata[0].token[0].klass == "Location"
+
+    # 1.2 RELATIONS
+    assert len(bm.relations) == 1
+    assert bm.relations[0].relation == upb.Relation.CHILD
+    assert bm.relations[0].source.value == resource.uuid
+    assert bm.relations[0].source.ntype == upb.RelationNode.NodeType.RESOURCE
+    assert bm.relations[0].to.value == "000001"
+    assert bm.relations[0].to.ntype == upb.RelationNode.NodeType.RESOURCE
+
+    # 1.3 ORIGIN
+    assert bm.origin.source_id == "My Source"
+    assert bm.origin.source == rpb.Origin.Source.API
+    assert bm.origin.HasField("created")
+    assert bm.origin.HasField("modified")
+
+    # 2. FIELDS
+    # 2.1 FILE FIELD
+    file_field = bm.files["file1"]
+    assert file_field.language == "es"
+    assert file_field.HasField("added")
+    assert file_field.file.uri
+    assert file_field.file.filename == "text.pb"
+    assert file_field.file.source == gcs_storage.source
+    assert file_field.file.bucket_name
+    assert file_field.file.size
+    assert file_field.file.content_type == "application/octet-stream"
+    assert file_field.file.filename == "text.pb"
+    assert file_field.file.md5 == "01cca3f53edb934a445a3112c6caa652"
+
+    # 2.2 LINK FIELD
+    link_field = bm.links["link1"]
+    assert link_field.uri == "htts://nuclia.cloud"
+    assert link_field.language == "ca"
+    assert link_field.HasField("added")
+    assert link_field.headers["AUTHORIZATION"] == "Bearer xxxxx"
+
+    assert len(bm.link_extracted_data) == 1
+    led = bm.link_extracted_data[0]
+    assert led.HasField("date")
+    assert led.language == "ca"
+    assert led.title == "My Title"
+    assert led.field == "link1"
+    assert led.HasField("link_preview")
+    assert led.HasField("link_thumbnail")
+
+    # Link extracted text
+    letxt = [et for et in bm.extracted_text if et.field.field == "link1"][0]
+    assert letxt.body.text == "MyText"
+
+    # Link field computed metadata
+    lfcm = [fcm for fcm in bm.field_metadata if fcm.field.field == "link1"][0]
+    assert lfcm.metadata.metadata.links[0] == "https://nuclia.com"
+    assert len(lfcm.metadata.metadata.paragraphs) == 1
+    assert len(lfcm.metadata.metadata.positions) == 1
+    assert lfcm.metadata.metadata.HasField("last_index")
+    assert lfcm.metadata.metadata.HasField("last_understanding")
+    assert lfcm.metadata.metadata.HasField("last_extract")
+    assert lfcm.metadata.metadata.HasField("last_summary")
+    assert lfcm.metadata.metadata.HasField("thumbnail")
+
+    # Large field metadata
+    llfm = [lfm for lfm in bm.field_large_metadata if lfm.field.field == "link1"][0]
+    assert len(llfm.real.metadata.entities) == 2
+    assert llfm.real.metadata.tokens["tok"] == 3
+
+    # Field vectors
+    lfv = [v for v in bm.field_vectors if v.field.field == "link1"][0]
+    assert len(lfv.vectors.vectors.vectors) == 1
+    assert lfv.vectors.vectors.vectors[0].start == 1
+    assert lfv.vectors.vectors.vectors[0].end == 2
+    assert lfv.vectors.vectors.vectors[0].vector == list(map(int, b"ansjkdn"))
+
+    # 2.3 CONVERSATION FIELD
+    conv_field = bm.conversations["conv1"]
+    assert len(conv_field.messages) == 300
+    for i, msg in enumerate(conv_field.messages):
+        assert msg.HasField("timestamp")
+        assert msg.who == "myself"
+        assert msg.content.text == f"{i} hello"
+        assert msg.content.format == rpb.MessageContent.Format.PLAIN
+        if i == 33:
+            assert len(msg.content.attachments) == 2
+
+    # Extracted text
+    cfet = [et for et in bm.extracted_text if et.field.field == "conv1"][0]
+    assert cfet.body.text == "MyText"
+
+    # TODO: Add checks for remaining field types and
+    # other broker message metadata that is missing

--- a/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_resource.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/orm/test_orm_resource.py
@@ -215,3 +215,12 @@ async def test_vector_duplicate_fields(
                 ), f"bad key {len(sent.vector)} {pkey1} - {pkey2} - {key}"
 
     assert count == 1
+
+
+async def test_generate_field_conversation(
+    gcs_storage, txn, cache, fake_node, knowledgebox_ingest: str
+):
+    # Create a resource with a conversation field (with multiple pages of messages)
+
+    # Check that generate field copies over the right data from the conversation
+    pass


### PR DESCRIPTION
### Description
Since conversations are stored across several pages in different maindb keys, the `get_value` field does not really work when generating the broker message to export a resource.

### How was this PR tested?
Integration tests
