### PR TITLE
handle none value in field serialize

### DIFF
--- a/nucliadb/nucliadb/ingest/serialize.py
+++ b/nucliadb/nucliadb/ingest/serialize.py
@@ -256,10 +256,15 @@ async def serialize(
                     resource.data.files = {}
                 if field.id not in resource.data.files:
                     resource.data.files[field.id] = FileFieldData()
-                if include_value and value is not None:
-                    resource.data.files[field.id].value = models.FieldFile.from_message(
-                        value  # type: ignore
-                    )
+                if include_value:
+                    if value is not None:
+                        resource.data.files[
+                            field.id
+                        ].value = models.FieldFile.from_message(
+                            value  # type: ignore
+                        )
+                    else:
+                        resource.data.files[field.id].value = None
 
                 if include_errors:
                     error = await field.get_error()

--- a/nucliadb/nucliadb/ingest/serialize.py
+++ b/nucliadb/nucliadb/ingest/serialize.py
@@ -256,7 +256,7 @@ async def serialize(
                     resource.data.files = {}
                 if field.id not in resource.data.files:
                     resource.data.files[field.id] = FileFieldData()
-                if include_value:
+                if include_value and value is not None:
                     resource.data.files[field.id].value = models.FieldFile.from_message(
                         value  # type: ignore
                     )


### PR DESCRIPTION
To address:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 404, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/debug.py", line 106, in __call__
    raise exc from None
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/debug.py", line 103, in __call__
    await self.app(scope, receive, inner_send)
  File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 292, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.11/site-packages/sentry_sdk/integrations/asgi.py", line 146, in _run_asgi3
    return await self._run_app(scope, receive, send, asgi_version=3)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sentry_sdk/integrations/asgi.py", line 241, in _run_app
    raise exc from None
  File "/usr/local/lib/python3.11/site-packages/sentry_sdk/integrations/asgi.py", line 234, in _run_app
    return await self.app(
           ^^^^^^^^^^^^^^^
  File "/usr/src/app/nucliadb_telemetry/nucliadb_telemetry/fastapi/tracing.py", line 316, in __call__
    await self.app(scope, receive, otel_send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 109, in __call__
    await response(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 270, in __call__
    async with anyio.create_task_group() as task_group:
  File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 597, in __aexit__
    raise exceptions[0]
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 273, in wrap
    await func()
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 134, in stream_response
    return await super().stream_response(send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 262, in stream_response
    async for chunk in self.body_iterator:
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 98, in body_stream
    raise app_exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 109, in __call__
    await response(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 270, in __call__
    async with anyio.create_task_group() as task_group:
  File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 597, in __aexit__
    raise exceptions[0]
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 273, in wrap
    await func()
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 134, in stream_response
    return await super().stream_response(send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 262, in stream_response
    async for chunk in self.body_iterator:
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 98, in body_stream
    raise app_exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 109, in __call__
    await response(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 270, in __call__
    async with anyio.create_task_group() as task_group:
  File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 597, in __aexit__
    raise exceptions[0]
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 273, in wrap
    await func()
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 134, in stream_response
    return await super().stream_response(send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/starlette/responses.py", line 262, in stream_response
    async for chunk in self.body_iterator:
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 98, in body_stream
    raise app_exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 91, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 146, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/authentication.py", line 48, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/usr/local/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 443, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 292, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 91, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 146, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/authentication.py", line 48, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/usr/local/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 273, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 190, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/nucliadb_utils/nucliadb_utils/authentication.py", line 148, in async_wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/nucliadb/nucliadb/reader/api/v1/resource.py", line 165, in get_resource_by_uuid
    return await _get_resource(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/nucliadb/nucliadb/reader/api/v1/resource.py", line 235, in _get_resource
    result = await serialize(
             ^^^^^^^^^^^^^^^^
  File "/usr/src/app/nucliadb/nucliadb/ingest/serialize.py", line 260, in serialize
    resource.data.files[field.id].value = models.FieldFile.from_message(
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/nucliadb_models/nucliadb_models/file.py", line 47, in from_message
    **MessageToDict(
      ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/google/protobuf/json_format.py", line 170, in MessageToDict
    return printer._MessageToJsonObject(message)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/google/protobuf/json_format.py", line 205, in _MessageToJsonObject
    message_descriptor = message.DESCRIPTOR
                         ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'DESCRIPTOR'
```
