### PR TITLE
try elock for gc

### DIFF
--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -279,6 +279,11 @@ impl Index {
         }
         Ok(())
     }
+    pub fn try_elock(&self) -> VectorR<ELock> {
+        let lock = fs_state::try_exclusive_lock(&self.location)?;
+        self.update(&lock)?;
+        Ok(lock)
+    }
     pub fn get_elock(&self) -> VectorR<ELock> {
         let lock = fs_state::exclusive_lock(&self.location)?;
         self.update(&lock)?;

--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -323,7 +323,7 @@ impl WriterChild for VectorWriterService {
     fn garbage_collection(&mut self) -> NodeResult<()> {
         let time = SystemTime::now();
 
-        let lock = self.index.get_elock()?;
+        let lock = self.index.try_elock()?;
         self.index.collect_garbage(&lock)?;
 
         let took = time.elapsed().map(|i| i.as_secs_f64()).unwrap_or(f64::NAN);


### PR DESCRIPTION
### Description
Current implementation of GC will block until the operation can be performed.
This is a problem for very active shards, since a thread may be taken hostage for a long time,
this PR fixes this.

### How was this PR tested?
Local tests
