### PR TITLE
Nucliadb metrics refinement

### DIFF
--- a/nucliadb_core/src/metrics/meters/mod.rs
+++ b/nucliadb_core/src/metrics/meters/mod.rs
@@ -23,16 +23,14 @@ mod prometheus;
 pub use noop::NoOpMeter;
 pub use prometheus::PrometheusMeter;
 
-use crate::metrics::metric::request_time;
+use crate::metrics::metric::grpc_ops::{GrpcOpKey, GrpcOpValue};
+use crate::metrics::metric::request_time::{RequestTimeKey, RequestTimeValue};
 use crate::metrics::task_monitor::{Monitor, TaskId};
 use crate::NodeResult;
 
 pub trait Meter: Send + Sync {
-    fn record_request_time(
-        &self,
-        metric: request_time::RequestTimeKey,
-        value: request_time::RequestTimeValue,
-    );
+    fn record_request_time(&self, metric: RequestTimeKey, value: RequestTimeValue);
+    fn record_grpc_op(&self, method: GrpcOpKey, value: GrpcOpValue);
 
     fn export(&self) -> NodeResult<String>;
 

--- a/nucliadb_core/src/metrics/meters/noop.rs
+++ b/nucliadb_core/src/metrics/meters/noop.rs
@@ -18,18 +18,17 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::metrics::meters::Meter;
-use crate::metrics::metric::request_time;
+use crate::metrics::metric::grpc_ops::{GrpcOpKey, GrpcOpValue};
+use crate::metrics::metric::request_time::{RequestTimeKey, RequestTimeValue};
 use crate::NodeResult;
 
 pub struct NoOpMeter;
 impl Meter for NoOpMeter {
+    fn record_request_time(&self, _metric: RequestTimeKey, _value: RequestTimeValue) {}
+
+    fn record_grpc_op(&self, _method: GrpcOpKey, _value: GrpcOpValue) {}
+
     fn export(&self) -> NodeResult<String> {
         Ok(Default::default())
-    }
-    fn record_request_time(
-        &self,
-        _: request_time::RequestTimeKey,
-        _: request_time::RequestTimeValue,
-    ) {
     }
 }

--- a/nucliadb_core/src/metrics/metric/grpc_ops.rs
+++ b/nucliadb_core/src/metrics/metric/grpc_ops.rs
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::histogram::Histogram;
+use prometheus_client::registry::Registry;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct GrpcOpKey {
+    pub method: String,
+}
+pub type GrpcOpValue = f64;
+
+pub type GrpcOpMetric = Family<GrpcOpKey, Histogram>;
+
+const BUCKETS: [f64; 14] = [
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+    2.5 * 60.0,
+    5.0 * 60.0,
+];
+
+pub fn register_grpc_ops(registry: &mut Registry) -> GrpcOpMetric {
+    let constructor = || Histogram::new(BUCKETS.iter().copied());
+    let metric = GrpcOpMetric::new_with_constructor(constructor);
+    registry.register(
+        "grpc_server_op_duration_seconds",
+        "gRPC server operations duration in seconds",
+        metric.clone(),
+    );
+    metric
+}

--- a/nucliadb_core/src/metrics/metric/mod.rs
+++ b/nucliadb_core/src/metrics/metric/mod.rs
@@ -24,6 +24,7 @@
 //! - If the metric is called SomeName, a struct 'SomeNameKey' must be defined.
 //! - If the metric is called SomeName, a struct 'SomeNameValue' must be defined.
 
+pub mod grpc_ops;
 pub mod request_time;
 pub mod tokio_runtime;
 pub mod tokio_tasks;

--- a/nucliadb_core/src/metrics/mod.rs
+++ b/nucliadb_core/src/metrics/mod.rs
@@ -21,13 +21,14 @@ mod meters;
 mod metric;
 mod task_monitor;
 
+pub use metric::{grpc_ops, request_time};
+
 #[cfg(test)]
 mod tests;
 
 use std::sync::Arc;
 
 use lazy_static::lazy_static;
-pub use metric::request_time;
 
 use self::meters::Meter;
 

--- a/nucliadb_node/src/shards/shard_reader.rs
+++ b/nucliadb_node/src/shards/shard_reader.rs
@@ -94,7 +94,7 @@ impl ShardReader {
         }
     }
 
-    #[measure(actor = "shard", metric = "reader/get_info")]
+    #[measure(actor = "shard", metric = "get_info")]
     #[tracing::instrument(skip_all)]
     pub fn get_info(&self, request: &GetShardRequest) -> NodeResult<Shard> {
         let span = tracing::Span::current();
@@ -161,7 +161,7 @@ impl ShardReader {
         self.relation_reader.get_node_types()
     }
 
-    #[measure(actor = "shard", metric = "reader/new")]
+    #[measure(actor = "shard", metric = "new")]
     #[tracing::instrument(skip_all)]
     pub fn new(id: String, shard_path: &Path) -> NodeResult<ShardReader> {
         let span = tracing::Span::current();
@@ -253,7 +253,7 @@ impl ShardReader {
         prefixes
     }
 
-    #[measure(actor = "shard", metric = "reader/suggest")]
+    #[measure(actor = "shard", metric = "suggest")]
     #[tracing::instrument(skip_all)]
     pub fn suggest(&self, request: SuggestRequest) -> NodeResult<SuggestResponse> {
         let span = tracing::Span::current();

--- a/nucliadb_node/src/shards/shard_writer.rs
+++ b/nucliadb_node/src/shards/shard_writer.rs
@@ -166,7 +166,7 @@ impl ShardWriter {
         ShardWriter::initialize(id, path, metadata, tsc, psc, vsc, rsc)
     }
 
-    #[measure(actor = "shard", metric = "writer/new")]
+    #[measure(actor = "shard", metric = "new")]
     pub fn new(id: String, path: &Path, metadata: ShardMetadata) -> NodeResult<ShardWriter> {
         let tsc = TextConfig {
             path: path.join(TEXTS_DIR),
@@ -196,7 +196,7 @@ impl ShardWriter {
         ShardWriter::initialize(id, path, metadata, tsc, psc, vsc, rsc)
     }
 
-    #[measure(actor = "shard", metric = "writer/open")]
+    #[measure(actor = "shard", metric = "open")]
     pub fn open(id: String, path: &Path) -> NodeResult<ShardWriter> {
         let metadata_path = path.join(METADATA_FILE);
         let metadata = ShardMetadata::open(&metadata_path)?;
@@ -224,7 +224,7 @@ impl ShardWriter {
         ShardWriter::initialize(id, path, metadata, tsc, psc, vsc, rsc)
     }
 
-    #[measure(actor = "shard", metric = "writer/set_resource")]
+    #[measure(actor = "shard", metric = "set_resource")]
     #[tracing::instrument(skip_all)]
     pub fn set_resource(&self, resource: &Resource) -> NodeResult<()> {
         let span = tracing::Span::current();
@@ -296,7 +296,7 @@ impl ShardWriter {
         Ok(())
     }
 
-    #[measure(actor = "shard", metric = "writer/remove_resource")]
+    #[measure(actor = "shard", metric = "remove_resource")]
     #[tracing::instrument(skip_all)]
     pub fn remove_resource(&self, resource: &ResourceId) -> NodeResult<()> {
         let span = tracing::Span::current();
@@ -353,7 +353,7 @@ impl ShardWriter {
         Ok(())
     }
 
-    #[measure(actor = "shard", metric = "writer/get_opstatus")]
+    #[measure(actor = "shard", metric = "get_opstatus")]
     #[tracing::instrument(skip_all)]
     pub fn get_opstatus(&self) -> NodeResult<OpStatus> {
         let span = tracing::Span::current();


### PR DESCRIPTION
### Description
- Remove unneeded shard metrics prefix
- Add `grpc_server_op_duration_seconds` metric in the node (same metric used in other gRPC servers in NucliaDB)
- Measure new metric in middleware

### Comments
- Does it make sense to keep metrics on shards? We can check how much different they are and decide

### How was this PR tested?
Describe how you tested this PR.
