### PR TITLE
Remove requirement of providing content length header

### DIFF
--- a/nucliadb/nucliadb/writer/api/v1/export_import.py
+++ b/nucliadb/nucliadb/writer/api/v1/export_import.py
@@ -100,10 +100,6 @@ async def start_kb_import_endpoint(request: Request, kbid: str):
         )
         return CreateImportResponse(import_id=import_id)
     else:
-        content_length = int(request.headers.get("Content-Length", "0"))
-        if content_length == 0:
-            return HTTPClientError(status_code=412, detail="Empty request content")
-
         # TODO: Implement range/resumable uploads to better suppor big exports.
         await upload_import_to_blob_storage(
             context=context,


### PR DESCRIPTION
### Description
There is no need to force users to provide the header. 
Right now this will fail with a 412 if not provided

### How was this PR tested?
Local tests with nuclia.py
