### PR TITLE
Remove `disable_vectors` legacy KB setting

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -447,14 +447,13 @@ class KnowledgeBox:
     async def get(self, uuid: str) -> Optional[Resource]:
         raw_basic = await get_basic(self.txn, self.kbid, uuid)
         if raw_basic:
-            config = await self.get_config()
             return Resource(
                 txn=self.txn,
                 storage=self.storage,
                 kb=self,
                 uuid=uuid,
                 basic=Resource.parse_basic(raw_basic),
-                disable_vectors=config.disable_vectors if config is not None else True,
+                disable_vectors=False,
             )
         else:
             return None
@@ -530,19 +529,17 @@ class KnowledgeBox:
         basic.slug = slug
         fix_paragraph_annotation_keys(uuid, basic)
         await set_basic(self.txn, self.kbid, uuid, basic)
-        config = await self.get_config()
         return Resource(
             storage=self.storage,
             txn=self.txn,
             kb=self,
             uuid=uuid,
             basic=basic,
-            disable_vectors=config.disable_vectors if config is not None else False,
+            disable_vectors=False,
         )
 
     async def iterate_resources(self) -> AsyncGenerator[Resource, None]:
         base = KB_RESOURCE_SLUG_BASE.format(kbid=self.kbid)
-        config = await self.get_config()
         async for key in self.txn.keys(match=base, count=-1):
             slug = key.split("/")[-1]
             uuid = await self.get_resource_uuid_by_slug(slug)
@@ -552,9 +549,7 @@ class KnowledgeBox:
                     self.storage,
                     self,
                     uuid,
-                    disable_vectors=config.disable_vectors
-                    if config is not None
-                    else False,
+                    disable_vectors=False,
                 )
 
 

--- a/nucliadb/nucliadb/standalone/tests/integration/test_services.py
+++ b/nucliadb/nucliadb/standalone/tests/integration/test_services.py
@@ -23,18 +23,6 @@ from nucliadb.search.api.v1.router import KB_PREFIX
 
 
 @pytest.mark.asyncio
-async def test_disable_vectors_service(
-    nucliadb_reader, nucliadb_manager, knowledgebox_one
-) -> None:
-    data = {"disable_vectors": True}
-    resp = await nucliadb_manager.patch(f"/{KB_PREFIX}/{knowledgebox_one}", json=data)
-    assert resp.status_code == 200
-
-    resp = await nucliadb_reader.get(f"/{KB_PREFIX}/{knowledgebox_one}")
-    assert resp.json()["config"]["disable_vectors"]
-
-
-@pytest.mark.asyncio
 async def test_entities_service(
     nucliadb_reader,
     nucliadb_writer,

--- a/nucliadb/nucliadb/writer/api/v1/knowledgebox.py
+++ b/nucliadb/nucliadb/writer/api/v1/knowledgebox.py
@@ -63,8 +63,6 @@ async def create_kb(request: Request, item: KnowledgeBoxConfig):
     if item.similarity:
         requestpb.similarity = item.similarity.to_pb()
 
-    requestpb.config.disable_vectors = item.disable_vectors
-
     requestpb.config.enabled_filters.extend(item.enabled_filters)
     requestpb.config.enabled_insights.extend(item.enabled_insights)
     kbobj: NewKnowledgeBoxResponse = await ingest.NewKnowledgeBox(requestpb)  # type: ignore
@@ -103,8 +101,6 @@ async def update_kb(request: Request, kbid: str, item: KnowledgeBoxConfig):
 
     if item.title:
         pbrequest.config.title = item.title
-
-    pbrequest.config.disable_vectors = item.disable_vectors
 
     if item.description:
         pbrequest.config.description = item.description

--- a/nucliadb/nucliadb/writer/tests/test_knowledgebox.py
+++ b/nucliadb/nucliadb/writer/tests/test_knowledgebox.py
@@ -34,7 +34,6 @@ async def test_knowledgebox_lifecycle(writer_api):
                 "description": "My lovely knowledgebox",
                 "enabled_filters": ["filter1", "filter2"],
                 "enabled_insights": ["insight1", "insight2"],
-                "disable_vectors": True,
             },
         )
         assert resp.status_code == 201
@@ -47,7 +46,6 @@ async def test_knowledgebox_lifecycle(writer_api):
             json={
                 "slug": "kbid2",
                 "description": "My lovely knowledgebox2",
-                "disable_vectors": True,
             },
         )
         assert resp.status_code == 200

--- a/nucliadb_models/nucliadb_models/resource.py
+++ b/nucliadb_models/nucliadb_models/resource.py
@@ -90,7 +90,6 @@ class KnowledgeBoxConfig(BaseModel):
     description: Optional[str] = None
     enabled_filters: List[str] = []
     enabled_insights: List[str] = []
-    disable_vectors: bool = False
     similarity: Optional[VectorSimilarity] = None
 
     @validator("slug")

--- a/nucliadb_protos/knowledgebox.proto
+++ b/nucliadb_protos/knowledgebox.proto
@@ -37,7 +37,7 @@ message KnowledgeBoxConfig {
     repeated string enabled_filters = 3;
     repeated string enabled_insights = 4;
     string slug = 5;
-    bool disable_vectors = 6;
+    bool disable_vectors = 6 [deprecated = true];
     int64 migration_version = 7;
 }
 


### PR DESCRIPTION
### Description
This setting does not seem to be used anymore.
It has polluted the process of serializing search results by introducing an extra maindb lookup for the KB config, simply to get the value of `disable_vectors`.

### How was this PR tested?
Existing tests should cover us
