### PR TITLE
Split node pull worker by message source and index with priority

### DIFF
--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -24,7 +24,7 @@ import uuid
 from typing import Any, Awaitable, Callable, Optional
 
 from nucliadb_protos.knowledgebox_pb2 import SemanticModelMetadata  # type: ignore
-from nucliadb_protos.nodewriter_pb2 import IndexMessage, TypeMessage
+from nucliadb_protos.nodewriter_pb2 import IndexMessage, IndexMessageSource, TypeMessage
 
 from nucliadb.common.cluster.base import AbstractIndexNode
 from nucliadb.common.cluster.exceptions import (
@@ -293,6 +293,7 @@ class KBShardManager:
         partition: str,
         kb: str,
         reindex_id: Optional[str] = None,
+        source: IndexMessageSource.ValueType = IndexMessageSource.PROCESSOR,
     ) -> None:
         if txid == -1 and reindex_id is None:
             # This means we are injecting a complete resource via ingest gRPC
@@ -320,6 +321,7 @@ class KBShardManager:
         indexpb.kbid = kb
         if partition:
             indexpb.partition = partition
+        indexpb.source = source
 
         for replica_id, node_id in self.indexing_replicas(shard):
             indexpb.node = node_id
@@ -404,6 +406,7 @@ class StandaloneKBShardManager(KBShardManager):
         partition: str,
         kb: str,
         reindex_id: Optional[str] = None,
+        source: IndexMessageSource.ValueType = IndexMessageSource.PROCESSOR,
     ) -> None:
         index_node = None
         for shardreplica in shard.replicas:

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -24,6 +24,7 @@ import uuid
 from typing import Any, Awaitable, Callable, Optional
 
 from nucliadb_protos.knowledgebox_pb2 import SemanticModelMetadata  # type: ignore
+from nucliadb_protos.nodewriter_pb2 import IndexMessage, TypeMessage
 
 from nucliadb.common.cluster.base import AbstractIndexNode
 from nucliadb.common.cluster.exceptions import (
@@ -301,16 +302,24 @@ class KBShardManager:
         storage = await get_storage()
         indexing = get_indexing()
 
-        indexpb: nodewriter_pb2.IndexMessage
+        indexpb = IndexMessage()
 
         if reindex_id is not None:
-            indexpb = await storage.reindexing(
+            storage_key = await storage.reindexing(
                 resource, reindex_id, partition, kb=kb, logical_shard=shard.shard
             )
+            indexpb.reindex_id = reindex_id
         else:
-            indexpb = await storage.indexing(
+            storage_key = await storage.indexing(
                 resource, txid, partition, kb=kb, logical_shard=shard.shard
             )
+            indexpb.txid = txid
+
+        indexpb.typemessage = TypeMessage.CREATION
+        indexpb.storage_key = storage_key
+        indexpb.kbid = kb
+        if partition:
+            indexpb.partition = partition
 
         for replica_id, node_id in self.indexing_replicas(shard):
             indexpb.node = node_id

--- a/nucliadb_node/nucliadb_node/coordination.py
+++ b/nucliadb_node/nucliadb_node/coordination.py
@@ -119,13 +119,7 @@ class ShardIndexingCoordinator:
         self.shard_locks = {}
         self.lock_klass = lock_klass
 
-    async def request_shard(self, shard_id: str):
-        await self._request_shard(shard_id, Priority.LOW)
-
-    async def request_shard_fast(self, shard_id: str):
-        await self._request_shard(shard_id, Priority.HIGH)
-
-    async def _request_shard(self, shard_id: str, priority: Priority):
+    async def request_shard(self, shard_id: str, priority: Priority = Priority.LOW):
         async with self.lock:
             lock = self.shard_locks.setdefault(shard_id, self.lock_klass())
         await lock.acquire(priority)

--- a/nucliadb_node/nucliadb_node/coordination.py
+++ b/nucliadb_node/nucliadb_node/coordination.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from abc import ABC, abstractmethod
+from enum import Enum
+from functools import total_ordering
+
+
+@total_ordering
+class Priority(Enum):
+    # Used for messages coming from processing, as they take long to process it
+    # doesn't matter if we let some other messages be indexed before
+    LOW = 0
+
+    # High priority. Used for small messages coming from the writer that need to
+    # be indexed before slow ones
+    HIGH = 1
+
+    def __eq__(self, other):
+        return self.value.__eq__(other.value)
+
+    def __lt__(self, other):
+        return self.value.__lt__(other.value)
+
+    def __hash__(self):
+        return self.value.__hash__()
+
+
+class QueueLock(ABC):
+    """A queue lock represents a lockable resource with an specific release order"""
+
+    @abstractmethod
+    async def acquire(self):
+        ...
+
+    @abstractmethod
+    async def release(self):
+        ...
+
+    @abstractmethod
+    def locked(self):
+        ...
+
+
+class FifoLock(QueueLock):
+    """Fifo lock queue relies on asyncio.Lock acquire *fair* behaviour to provide
+    the desired order: first acquired will be the first released
+
+    """
+
+    def __init__(self):
+        self.lock = asyncio.Lock()
+
+    async def acquire(self, *args):
+        await self.lock.acquire()
+
+    async def release(self, *args):
+        self.lock.release()
+
+    def locked(self):
+        return self.lock.locked()
+
+
+class PriorityLock(QueueLock):
+    def __init__(self):
+        self.locks = {p: asyncio.Lock() for p in Priority}
+
+    async def acquire(self, priority: Priority = Priority.LOW):
+        await self.locks[priority].acquire()
+
+    async def release(self, priority: Priority = Priority.LOW):
+        for priority in reversed(sorted(Priority)):
+            lock = self.locks[priority]
+            if lock.locked():
+                lock.release()
+                break
+
+    def locked(self, priority: Priority = Priority.LOW):
+        for priority in Priority:
+            if self.locks[priority].locked():
+                return True
+        return False
+
+
+class ShardIndexingCoordinator:
+    def __init__(self, lock_klass):
+        self.lock = asyncio.Lock()
+        self.shard_locks = {}
+        self.lock_klass = lock_klass
+
+    async def request_shard(self, shard_id: str):
+        async with self.lock:
+            lock, priority = self.shard_locks.setdefault(
+                shard_id, (self.lock_klass(), Priority.LOW)
+            )
+        await lock.acquire(priority)
+
+    async def request_shard_fast(self, shard_id: str):
+        async with self.lock:
+            lock, priority = self.shard_locks.setdefault(
+                shard_id, (self.lock_klass(), Priority.HIGH)
+            )
+        await lock.acquire(priority)
+
+    async def release_shard(self, shard_id: str):
+        async with self.lock:
+            lock, priority = self.shard_locks.get(shard_id)
+            if lock is None:
+                raise ValueError(f"Shard {shard_id} wasn't requested")
+
+            if not lock.locked():
+                self.shard_locks.pop(shard_id)
+
+        await lock.release(priority)

--- a/nucliadb_node/nucliadb_node/tests/unit/test_queue_locks.py
+++ b/nucliadb_node/nucliadb_node/tests/unit/test_queue_locks.py
@@ -229,7 +229,7 @@ async def test_shard_indexing_coordinator_single_shard_with_priority(lock_klass)
         nonlocal events, shard, sic
 
         events.record(Event("1", When.BEFORE, LockStatus.ACQUIRE))
-        await sic.request_shard(shard)
+        await sic.request_shard(shard, Priority.LOW)
         events.record(Event("1", When.AFTER, LockStatus.ACQUIRE))
 
         # simulate some async work
@@ -246,7 +246,7 @@ async def test_shard_indexing_coordinator_single_shard_with_priority(lock_klass)
         await asyncio.sleep(0)
 
         events.record(Event("2", When.BEFORE, LockStatus.ACQUIRE))
-        await sic.request_shard(shard)
+        await sic.request_shard(shard, Priority.LOW)
         events.record(Event("2", When.AFTER, LockStatus.ACQUIRE))
 
         # simulate some async work
@@ -264,7 +264,7 @@ async def test_shard_indexing_coordinator_single_shard_with_priority(lock_klass)
         await asyncio.sleep(0)
 
         events.record(Event("3", When.BEFORE, LockStatus.ACQUIRE))
-        await sic.request_shard_fast(shard)
+        await sic.request_shard(shard, Priority.HIGH)
         events.record(Event("3", When.AFTER, LockStatus.ACQUIRE))
 
         # simulate some async work

--- a/nucliadb_node/nucliadb_node/tests/unit/test_queue_locks.py
+++ b/nucliadb_node/nucliadb_node/tests/unit/test_queue_locks.py
@@ -1,0 +1,211 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+
+import pytest
+
+from nucliadb_node.coordination import (
+    FifoLock,
+    Priority,
+    PriorityLock,
+    ShardIndexingCoordinator,
+)
+
+
+class LockStatus(Enum):
+    ACQUIRE = "acquired"
+    RELEASE = "released"
+
+
+class When(Enum):
+    BEFORE = "before"
+    AFTER = "after"
+
+
+@dataclass
+class Event:
+    task: str
+    lock: LockStatus
+    when: When
+
+
+class EventRecorder:
+    def __init__(self):
+        self._events = []
+
+    @property
+    def events(self):
+        return self._events
+
+    def record(self, event: Event):
+        self._events.append(event)
+
+
+def test_priority_ordering():
+    assert Priority.LOW < Priority.HIGH
+
+    expected = [Priority.LOW, Priority.HIGH]
+    for a, b in zip(expected, sorted(Priority)):
+        assert a == b
+
+
+@pytest.mark.parametrize("lock_klass", [FifoLock, PriorityLock])
+@pytest.mark.asyncio
+async def test_shard_indexing_coordinator_with_fifo_lock_queue_single_shard(lock_klass):
+    """Test how coordination works with a FifoLock and 3 tasks competing for the
+    same shard.
+
+    We expect tasks to synchronize and make progress one after the other in the
+    request shard order.
+
+    """
+    sic = ShardIndexingCoordinator(lock_klass)
+    shard = "my-shard"
+    events = EventRecorder()
+
+    async def task_1():
+        nonlocal events, shard, sic
+
+        events.record(Event("1", When.BEFORE, LockStatus.ACQUIRE))
+        await sic.request_shard(shard)
+        events.record(Event("1", When.AFTER, LockStatus.ACQUIRE))
+
+        # simulate some async work
+        await asyncio.sleep(0.010)
+
+        events.record(Event("1", When.BEFORE, LockStatus.RELEASE))
+        await sic.release_shard(shard)
+        events.record(Event("1", When.AFTER, LockStatus.RELEASE))
+
+    async def task_2():
+        nonlocal events, shard, sic
+
+        # let's task 1 start the sequence
+        await asyncio.sleep(0)
+
+        events.record(Event("2", When.BEFORE, LockStatus.ACQUIRE))
+        await sic.request_shard(shard)
+        events.record(Event("2", When.AFTER, LockStatus.ACQUIRE))
+
+        # simulate some async work
+        await asyncio.sleep(0.010)
+
+        events.record(Event("2", When.BEFORE, LockStatus.RELEASE))
+        await sic.release_shard(shard)
+        events.record(Event("2", When.AFTER, LockStatus.RELEASE))
+
+    async def task_3():
+        nonlocal events, shard, sic
+
+        # let's tasks 1 and 2 start the sequence
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        events.record(Event("3", When.BEFORE, LockStatus.ACQUIRE))
+        await sic.request_shard(shard)
+        events.record(Event("3", When.AFTER, LockStatus.ACQUIRE))
+
+        # simulate some async work
+        await asyncio.sleep(0.010)
+
+        events.record(Event("3", When.BEFORE, LockStatus.RELEASE))
+        await sic.release_shard(shard)
+        events.record(Event("3", When.AFTER, LockStatus.RELEASE))
+
+    await asyncio.gather(task_1(), task_2(), task_3())
+
+    expected = [
+        Event("1", When.BEFORE, LockStatus.ACQUIRE),
+        Event("1", When.AFTER, LockStatus.ACQUIRE),
+        Event("2", When.BEFORE, LockStatus.ACQUIRE),
+        Event("3", When.BEFORE, LockStatus.ACQUIRE),
+        Event("1", When.BEFORE, LockStatus.RELEASE),
+        Event("1", When.AFTER, LockStatus.RELEASE),
+        Event("2", When.AFTER, LockStatus.ACQUIRE),
+        Event("2", When.BEFORE, LockStatus.RELEASE),
+        Event("2", When.AFTER, LockStatus.RELEASE),
+        Event("3", When.AFTER, LockStatus.ACQUIRE),
+        Event("3", When.BEFORE, LockStatus.RELEASE),
+        Event("3", When.AFTER, LockStatus.RELEASE),
+    ]
+    assert events.events == expected
+
+
+@pytest.mark.parametrize("lock_klass", [FifoLock, PriorityLock])
+@pytest.mark.asyncio
+async def test_shard_indexing_coordinator_with_fifo_lock_queue_multiple_shards(
+    lock_klass,
+):
+    """Test how coordination works with a FifoLock and 2 tasks competing for
+    different shards.
+
+    The expected behaviour is a non blocking scenario where both tasks can get
+    and release the locks independently.
+
+    """
+    sic = ShardIndexingCoordinator(lock_klass)
+    events = EventRecorder()
+
+    async def task_1():
+        nonlocal events, sic
+
+        events.record(Event("1", When.BEFORE, LockStatus.ACQUIRE))
+        await sic.request_shard("shard-1")
+        events.record(Event("1", When.AFTER, LockStatus.ACQUIRE))
+
+        # simulate some async work
+        await asyncio.sleep(0.010)
+
+        events.record(Event("1", When.BEFORE, LockStatus.RELEASE))
+        await sic.release_shard("shard-1")
+        events.record(Event("1", When.AFTER, LockStatus.RELEASE))
+
+    async def task_2():
+        nonlocal events, sic
+
+        # let's task 1 start the sequence
+        await asyncio.sleep(0)
+
+        events.record(Event("2", When.BEFORE, LockStatus.ACQUIRE))
+        await sic.request_shard("shard-2")
+        events.record(Event("2", When.AFTER, LockStatus.ACQUIRE))
+
+        # simulate some async work
+        await asyncio.sleep(0.010)
+
+        events.record(Event("2", When.BEFORE, LockStatus.RELEASE))
+        await sic.release_shard("shard-2")
+        events.record(Event("2", When.AFTER, LockStatus.RELEASE))
+
+    await asyncio.gather(task_1(), task_2())
+
+    expected = [
+        Event("1", When.BEFORE, LockStatus.ACQUIRE),
+        Event("1", When.AFTER, LockStatus.ACQUIRE),
+        Event("2", When.BEFORE, LockStatus.ACQUIRE),
+        Event("2", When.AFTER, LockStatus.ACQUIRE),
+        Event("1", When.BEFORE, LockStatus.RELEASE),
+        Event("1", When.AFTER, LockStatus.RELEASE),
+        Event("2", When.BEFORE, LockStatus.RELEASE),
+        Event("2", When.AFTER, LockStatus.RELEASE),
+    ]
+    assert events.events == expected

--- a/nucliadb_protos/nodewriter.proto
+++ b/nucliadb_protos/nodewriter.proto
@@ -26,6 +26,11 @@ enum TypeMessage {
     DELETION = 1;
 }
 
+enum IndexMessageSource {
+    PROCESSOR = 0;
+    WRITER = 1;
+}
+
 message IndexMessage {
     string node = 1;
     string shard = 2;  // physical shard message is for
@@ -36,6 +41,7 @@ message IndexMessage {
     optional string partition = 7;
     string storage_key = 8;
     string kbid = 9;
+    IndexMessageSource source = 10;
 }
 
 message SetGraph {

--- a/nucliadb_protos/python/nucliadb_protos/nodewriter_pb2.py
+++ b/nucliadb_protos/python/nucliadb_protos/nodewriter_pb2.py
@@ -19,7 +19,7 @@ except AttributeError:
 
 from nucliadb_protos.noderesources_pb2 import *
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n nucliadb_protos/nodewriter.proto\x12\nnodewriter\x1a#nucliadb_protos/noderesources.proto\"\xc9\x01\n\x08OpStatus\x12+\n\x06status\x18\x01 \x01(\x0e\x32\x1b.nodewriter.OpStatus.Status\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\x12\x13\n\x0b\x66ield_count\x18\x03 \x01(\x04\x12\x17\n\x0fparagraph_count\x18\x05 \x01(\x04\x12\x16\n\x0esentence_count\x18\x06 \x01(\x04\x12\x10\n\x08shard_id\x18\x04 \x01(\t\"(\n\x06Status\x12\x06\n\x02OK\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\t\n\x05\x45RROR\x10\x02\"\xd6\x01\n\x0cIndexMessage\x12\x0c\n\x04node\x18\x01 \x01(\t\x12\r\n\x05shard\x18\x02 \x01(\t\x12\x0c\n\x04txid\x18\x03 \x01(\x04\x12\x10\n\x08resource\x18\x04 \x01(\t\x12,\n\x0btypemessage\x18\x05 \x01(\x0e\x32\x17.nodewriter.TypeMessage\x12\x12\n\nreindex_id\x18\x06 \x01(\t\x12\x16\n\tpartition\x18\x07 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x0bstorage_key\x18\x08 \x01(\t\x12\x0c\n\x04kbid\x18\t \x01(\tB\x0c\n\n_partition\"U\n\x08SetGraph\x12(\n\x08shard_id\x18\x01 \x01(\x0b\x32\x16.noderesources.ShardId\x12\x1f\n\x05graph\x18\x02 \x01(\x0b\x32\x10.utils.JoinGraph\"`\n\x10\x44\x65leteGraphNodes\x12(\n\x08shard_id\x18\x02 \x01(\x0b\x32\x16.noderesources.ShardId\x12\"\n\x05nodes\x18\x01 \x03(\x0b\x32\x13.utils.RelationNode\"\x81\x01\n\x0fNewShardRequest\x12+\n\nsimilarity\x18\x01 \x01(\x0e\x32\x17.utils.VectorSimilarity\x12\x0c\n\x04kbid\x18\x02 \x01(\t\x12\x33\n\x0frelease_channel\x18\x03 \x01(\x0e\x32\x1a.nodewriter.ReleaseChannel\"j\n\x13NewVectorSetRequest\x12&\n\x02id\x18\x01 \x01(\x0b\x32\x1a.noderesources.VectorSetID\x12+\n\nsimilarity\x18\x02 \x01(\x0e\x32\x17.utils.VectorSimilarity*)\n\x0bTypeMessage\x12\x0c\n\x08\x43REATION\x10\x00\x12\x0c\n\x08\x44\x45LETION\x10\x01*.\n\x0eReleaseChannel\x12\n\n\x06STABLE\x10\x00\x12\x10\n\x0c\x45XPERIMENTAL\x10\x01\x32\x96\x07\n\nNodeWriter\x12\x46\n\x08NewShard\x12\x1b.nodewriter.NewShardRequest\x1a\x1b.noderesources.ShardCreated\"\x00\x12M\n\x14\x43leanAndUpgradeShard\x12\x16.noderesources.ShardId\x1a\x1b.noderesources.ShardCleaned\"\x00\x12?\n\x0b\x44\x65leteShard\x12\x16.noderesources.ShardId\x1a\x16.noderesources.ShardId\"\x00\x12\x42\n\nListShards\x12\x19.noderesources.EmptyQuery\x1a\x17.noderesources.ShardIds\"\x00\x12<\n\x02GC\x12\x16.noderesources.ShardId\x1a\x1c.noderesources.EmptyResponse\"\x00\x12>\n\x0bSetResource\x12\x17.noderesources.Resource\x1a\x14.nodewriter.OpStatus\"\x00\x12K\n\x13\x44\x65leteRelationNodes\x12\x1c.nodewriter.DeleteGraphNodes\x1a\x14.nodewriter.OpStatus\"\x00\x12\x39\n\tJoinGraph\x12\x14.nodewriter.SetGraph\x1a\x14.nodewriter.OpStatus\"\x00\x12\x43\n\x0eRemoveResource\x12\x19.noderesources.ResourceID\x1a\x14.nodewriter.OpStatus\"\x00\x12G\n\x0c\x41\x64\x64VectorSet\x12\x1f.nodewriter.NewVectorSetRequest\x1a\x14.nodewriter.OpStatus\"\x00\x12\x45\n\x0fRemoveVectorSet\x12\x1a.noderesources.VectorSetID\x1a\x14.nodewriter.OpStatus\"\x00\x12H\n\x0eListVectorSets\x12\x16.noderesources.ShardId\x1a\x1c.noderesources.VectorSetList\"\x00\x12G\n\x0bGetMetadata\x12\x19.noderesources.EmptyQuery\x1a\x1b.noderesources.NodeMetadata\"\x00P\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n nucliadb_protos/nodewriter.proto\x12\nnodewriter\x1a#nucliadb_protos/noderesources.proto\"\xc9\x01\n\x08OpStatus\x12+\n\x06status\x18\x01 \x01(\x0e\x32\x1b.nodewriter.OpStatus.Status\x12\x0e\n\x06\x64\x65tail\x18\x02 \x01(\t\x12\x13\n\x0b\x66ield_count\x18\x03 \x01(\x04\x12\x17\n\x0fparagraph_count\x18\x05 \x01(\x04\x12\x16\n\x0esentence_count\x18\x06 \x01(\x04\x12\x10\n\x08shard_id\x18\x04 \x01(\t\"(\n\x06Status\x12\x06\n\x02OK\x10\x00\x12\x0b\n\x07WARNING\x10\x01\x12\t\n\x05\x45RROR\x10\x02\"\x86\x02\n\x0cIndexMessage\x12\x0c\n\x04node\x18\x01 \x01(\t\x12\r\n\x05shard\x18\x02 \x01(\t\x12\x0c\n\x04txid\x18\x03 \x01(\x04\x12\x10\n\x08resource\x18\x04 \x01(\t\x12,\n\x0btypemessage\x18\x05 \x01(\x0e\x32\x17.nodewriter.TypeMessage\x12\x12\n\nreindex_id\x18\x06 \x01(\t\x12\x16\n\tpartition\x18\x07 \x01(\tH\x00\x88\x01\x01\x12\x13\n\x0bstorage_key\x18\x08 \x01(\t\x12\x0c\n\x04kbid\x18\t \x01(\t\x12.\n\x06source\x18\n \x01(\x0e\x32\x1e.nodewriter.IndexMessageSourceB\x0c\n\n_partition\"U\n\x08SetGraph\x12(\n\x08shard_id\x18\x01 \x01(\x0b\x32\x16.noderesources.ShardId\x12\x1f\n\x05graph\x18\x02 \x01(\x0b\x32\x10.utils.JoinGraph\"`\n\x10\x44\x65leteGraphNodes\x12(\n\x08shard_id\x18\x02 \x01(\x0b\x32\x16.noderesources.ShardId\x12\"\n\x05nodes\x18\x01 \x03(\x0b\x32\x13.utils.RelationNode\"\x81\x01\n\x0fNewShardRequest\x12+\n\nsimilarity\x18\x01 \x01(\x0e\x32\x17.utils.VectorSimilarity\x12\x0c\n\x04kbid\x18\x02 \x01(\t\x12\x33\n\x0frelease_channel\x18\x03 \x01(\x0e\x32\x1a.nodewriter.ReleaseChannel\"j\n\x13NewVectorSetRequest\x12&\n\x02id\x18\x01 \x01(\x0b\x32\x1a.noderesources.VectorSetID\x12+\n\nsimilarity\x18\x02 \x01(\x0e\x32\x17.utils.VectorSimilarity*)\n\x0bTypeMessage\x12\x0c\n\x08\x43REATION\x10\x00\x12\x0c\n\x08\x44\x45LETION\x10\x01*/\n\x12IndexMessageSource\x12\r\n\tPROCESSOR\x10\x00\x12\n\n\x06WRITER\x10\x01*.\n\x0eReleaseChannel\x12\n\n\x06STABLE\x10\x00\x12\x10\n\x0c\x45XPERIMENTAL\x10\x01\x32\x96\x07\n\nNodeWriter\x12\x46\n\x08NewShard\x12\x1b.nodewriter.NewShardRequest\x1a\x1b.noderesources.ShardCreated\"\x00\x12M\n\x14\x43leanAndUpgradeShard\x12\x16.noderesources.ShardId\x1a\x1b.noderesources.ShardCleaned\"\x00\x12?\n\x0b\x44\x65leteShard\x12\x16.noderesources.ShardId\x1a\x16.noderesources.ShardId\"\x00\x12\x42\n\nListShards\x12\x19.noderesources.EmptyQuery\x1a\x17.noderesources.ShardIds\"\x00\x12<\n\x02GC\x12\x16.noderesources.ShardId\x1a\x1c.noderesources.EmptyResponse\"\x00\x12>\n\x0bSetResource\x12\x17.noderesources.Resource\x1a\x14.nodewriter.OpStatus\"\x00\x12K\n\x13\x44\x65leteRelationNodes\x12\x1c.nodewriter.DeleteGraphNodes\x1a\x14.nodewriter.OpStatus\"\x00\x12\x39\n\tJoinGraph\x12\x14.nodewriter.SetGraph\x1a\x14.nodewriter.OpStatus\"\x00\x12\x43\n\x0eRemoveResource\x12\x19.noderesources.ResourceID\x1a\x14.nodewriter.OpStatus\"\x00\x12G\n\x0c\x41\x64\x64VectorSet\x12\x1f.nodewriter.NewVectorSetRequest\x1a\x14.nodewriter.OpStatus\"\x00\x12\x45\n\x0fRemoveVectorSet\x12\x1a.noderesources.VectorSetID\x1a\x14.nodewriter.OpStatus\"\x00\x12H\n\x0eListVectorSets\x12\x16.noderesources.ShardId\x1a\x1c.noderesources.VectorSetList\"\x00\x12G\n\x0bGetMetadata\x12\x19.noderesources.EmptyQuery\x1a\x1b.noderesources.NodeMetadata\"\x00P\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -27,24 +27,26 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'nucliadb_protos.nodewriter_
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _globals['_TYPEMESSAGE']._serialized_start=931
-  _globals['_TYPEMESSAGE']._serialized_end=972
-  _globals['_RELEASECHANNEL']._serialized_start=974
-  _globals['_RELEASECHANNEL']._serialized_end=1020
+  _globals['_TYPEMESSAGE']._serialized_start=979
+  _globals['_TYPEMESSAGE']._serialized_end=1020
+  _globals['_INDEXMESSAGESOURCE']._serialized_start=1022
+  _globals['_INDEXMESSAGESOURCE']._serialized_end=1069
+  _globals['_RELEASECHANNEL']._serialized_start=1071
+  _globals['_RELEASECHANNEL']._serialized_end=1117
   _globals['_OPSTATUS']._serialized_start=86
   _globals['_OPSTATUS']._serialized_end=287
   _globals['_OPSTATUS_STATUS']._serialized_start=247
   _globals['_OPSTATUS_STATUS']._serialized_end=287
   _globals['_INDEXMESSAGE']._serialized_start=290
-  _globals['_INDEXMESSAGE']._serialized_end=504
-  _globals['_SETGRAPH']._serialized_start=506
-  _globals['_SETGRAPH']._serialized_end=591
-  _globals['_DELETEGRAPHNODES']._serialized_start=593
-  _globals['_DELETEGRAPHNODES']._serialized_end=689
-  _globals['_NEWSHARDREQUEST']._serialized_start=692
-  _globals['_NEWSHARDREQUEST']._serialized_end=821
-  _globals['_NEWVECTORSETREQUEST']._serialized_start=823
-  _globals['_NEWVECTORSETREQUEST']._serialized_end=929
-  _globals['_NODEWRITER']._serialized_start=1023
-  _globals['_NODEWRITER']._serialized_end=1941
+  _globals['_INDEXMESSAGE']._serialized_end=552
+  _globals['_SETGRAPH']._serialized_start=554
+  _globals['_SETGRAPH']._serialized_end=639
+  _globals['_DELETEGRAPHNODES']._serialized_start=641
+  _globals['_DELETEGRAPHNODES']._serialized_end=737
+  _globals['_NEWSHARDREQUEST']._serialized_start=740
+  _globals['_NEWSHARDREQUEST']._serialized_end=869
+  _globals['_NEWVECTORSETREQUEST']._serialized_start=871
+  _globals['_NEWVECTORSETREQUEST']._serialized_end=977
+  _globals['_NODEWRITER']._serialized_start=1120
+  _globals['_NODEWRITER']._serialized_end=2038
 # @@protoc_insertion_point(module_scope)

--- a/nucliadb_protos/python/nucliadb_protos/nodewriter_pb2.pyi
+++ b/nucliadb_protos/python/nucliadb_protos/nodewriter_pb2.pyi
@@ -59,6 +59,21 @@ CREATION: TypeMessage.ValueType  # 0
 DELETION: TypeMessage.ValueType  # 1
 global___TypeMessage = TypeMessage
 
+class _IndexMessageSource:
+    ValueType = typing.NewType("ValueType", builtins.int)
+    V: typing_extensions.TypeAlias = ValueType
+
+class _IndexMessageSourceEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[_IndexMessageSource.ValueType], builtins.type):
+    DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
+    PROCESSOR: _IndexMessageSource.ValueType  # 0
+    WRITER: _IndexMessageSource.ValueType  # 1
+
+class IndexMessageSource(_IndexMessageSource, metaclass=_IndexMessageSourceEnumTypeWrapper): ...
+
+PROCESSOR: IndexMessageSource.ValueType  # 0
+WRITER: IndexMessageSource.ValueType  # 1
+global___IndexMessageSource = IndexMessageSource
+
 class _ReleaseChannel:
     ValueType = typing.NewType("ValueType", builtins.int)
     V: typing_extensions.TypeAlias = ValueType
@@ -132,6 +147,7 @@ class IndexMessage(google.protobuf.message.Message):
     PARTITION_FIELD_NUMBER: builtins.int
     STORAGE_KEY_FIELD_NUMBER: builtins.int
     KBID_FIELD_NUMBER: builtins.int
+    SOURCE_FIELD_NUMBER: builtins.int
     node: builtins.str
     shard: builtins.str
     """physical shard message is for"""
@@ -142,6 +158,7 @@ class IndexMessage(google.protobuf.message.Message):
     partition: builtins.str
     storage_key: builtins.str
     kbid: builtins.str
+    source: global___IndexMessageSource.ValueType
     def __init__(
         self,
         *,
@@ -154,9 +171,10 @@ class IndexMessage(google.protobuf.message.Message):
         partition: builtins.str | None = ...,
         storage_key: builtins.str = ...,
         kbid: builtins.str = ...,
+        source: global___IndexMessageSource.ValueType = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["_partition", b"_partition", "partition", b"partition"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["_partition", b"_partition", "kbid", b"kbid", "node", b"node", "partition", b"partition", "reindex_id", b"reindex_id", "resource", b"resource", "shard", b"shard", "storage_key", b"storage_key", "txid", b"txid", "typemessage", b"typemessage"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_partition", b"_partition", "kbid", b"kbid", "node", b"node", "partition", b"partition", "reindex_id", b"reindex_id", "resource", b"resource", "shard", b"shard", "source", b"source", "storage_key", b"storage_key", "txid", b"txid", "typemessage", b"typemessage"]) -> None: ...
     def WhichOneof(self, oneof_group: typing_extensions.Literal["_partition", b"_partition"]) -> typing_extensions.Literal["partition"] | None: ...
 
 global___IndexMessage = IndexMessage

--- a/nucliadb_protos/rust/src/nodewriter.rs
+++ b/nucliadb_protos/rust/src/nodewriter.rs
@@ -44,6 +44,8 @@ pub struct IndexMessage {
     pub storage_key: ::prost::alloc::string::String,
     #[prost(string, tag="9")]
     pub kbid: ::prost::alloc::string::String,
+    #[prost(enumeration="IndexMessageSource", tag="10")]
+    pub source: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetGraph {
@@ -82,6 +84,12 @@ pub struct NewVectorSetRequest {
 pub enum TypeMessage {
     Creation = 0,
     Deletion = 1,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum IndexMessageSource {
+    Processor = 0,
+    Writer = 1,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/nucliadb_utils/nucliadb_utils/storages/storage.py
+++ b/nucliadb_utils/nucliadb_utils/storages/storage.py
@@ -37,7 +37,7 @@ from typing import (
 )
 
 from nucliadb_protos.noderesources_pb2 import Resource as BrainResource
-from nucliadb_protos.nodewriter_pb2 import IndexMessage, TypeMessage
+from nucliadb_protos.nodewriter_pb2 import IndexMessage
 from nucliadb_protos.resources_pb2 import CloudFile
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
@@ -176,7 +176,7 @@ class Storage:
         partition: Optional[str],
         kb: str,
         logical_shard: str,
-    ) -> IndexMessage:
+    ) -> str:
         if self.indexing_bucket is None:
             raise AttributeError()
         if txid < 0:
@@ -189,14 +189,8 @@ class Storage:
             txid=txid,
         )
         await self.uploadbytes(self.indexing_bucket, key, message.SerializeToString())
-        response = IndexMessage()
-        response.txid = txid
-        response.typemessage = TypeMessage.CREATION
-        response.storage_key = key
-        response.kbid = kb
-        if partition:
-            response.partition = partition
-        return response
+
+        return key
 
     async def reindexing(
         self,
@@ -205,7 +199,7 @@ class Storage:
         partition: Optional[str],
         kb: str,
         logical_shard: str,
-    ) -> IndexMessage:
+    ) -> str:
         if self.indexing_bucket is None:
             raise AttributeError()
         key = self.get_indexing_storage_key(
@@ -218,14 +212,7 @@ class Storage:
         logger.debug("Starting to upload bytes")
         await self.uploadbytes(self.indexing_bucket, key, message_serialized)
         logger.debug("Finished to upload bytes")
-        response = IndexMessage()
-        response.reindex_id = reindex_id
-        response.typemessage = TypeMessage.CREATION
-        response.storage_key = key
-        response.kbid = kb
-        if partition:
-            response.partition = partition
-        return response
+        return key
 
     async def get_indexing(self, payload: IndexMessage) -> BrainResource:
         if self.indexing_bucket is None:


### PR DESCRIPTION
### Description
- Add a new consumer in nucliadb_node to index messages from processing or writer with different priorities

### WIP
- Remove seqid logic from nucliadb_node pull workers
- Add some integration test to validate prioritary indexing 

### How was this PR tested?
Describe how you tested this PR.
