### PR TITLE
Clear memory leaking resource cache contextvar

### DIFF
--- a/nucliadb/nucliadb/search/search/find_merge.py
+++ b/nucliadb/nucliadb/search/search/find_merge.py
@@ -392,35 +392,36 @@ async def find_merge_results(
         relations.append(response.relation)
 
     rcache = get_resource_cache(clear=True)
+    try:
+        result_paragraphs, merged_next_page = merge_paragraphs_vectors(
+            paragraphs, vectors, count, page, min_score
+        )
+        next_page = next_page or merged_next_page
 
-    result_paragraphs, merged_next_page = merge_paragraphs_vectors(
-        paragraphs, vectors, count, page, min_score
-    )
-    next_page = next_page or merged_next_page
+        api_results = KnowledgeboxFindResults(
+            resources={},
+            facets={},
+            query=real_query,
+            total=total_paragraphs,
+            page_number=page,
+            page_size=count,
+            next_page=next_page,
+            min_score=min_score,
+        )
 
-    api_results = KnowledgeboxFindResults(
-        resources={},
-        facets={},
-        query=real_query,
-        total=total_paragraphs,
-        page_number=page,
-        page_size=count,
-        next_page=next_page,
-        min_score=min_score,
-    )
+        await fetch_find_metadata(
+            api_results.resources,
+            result_paragraphs,
+            kbid,
+            show,
+            field_type_filter,
+            extracted,
+            highlight,
+            ematches,
+        )
+        api_results.relations = merge_relations_results(relations, requested_relations)
 
-    await fetch_find_metadata(
-        api_results.resources,
-        result_paragraphs,
-        kbid,
-        show,
-        field_type_filter,
-        extracted,
-        highlight,
-        ematches,
-    )
-    api_results.relations = merge_relations_results(relations, requested_relations)
-
-    await abort_transaction()
-    rcache.clear()
-    return api_results
+        await abort_transaction()
+        return api_results
+    finally:
+        rcache.clear()

--- a/nucliadb/nucliadb/search/search/find_merge.py
+++ b/nucliadb/nucliadb/search/search/find_merge.py
@@ -391,7 +391,7 @@ async def find_merge_results(
 
         relations.append(response.relation)
 
-    get_resource_cache(clear=True)
+    rcache = get_resource_cache(clear=True)
 
     result_paragraphs, merged_next_page = merge_paragraphs_vectors(
         paragraphs, vectors, count, page, min_score
@@ -422,4 +422,5 @@ async def find_merge_results(
     api_results.relations = merge_relations_results(relations, requested_relations)
 
     await abort_transaction()
+    rcache.clear()
     return api_results

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -553,6 +553,8 @@ async def merge_paragraphs_results(
 
     api_results = ResourceSearchResults()
 
+    rcache = get_resource_cache(clear=True)
+
     resources: List[str] = list()
     api_results.paragraphs = await merge_paragraph_results(
         paragraphs,
@@ -567,6 +569,7 @@ async def merge_paragraphs_results(
             limit=None,
         ),
     )
+    rcache.clear()
     return api_results
 
 

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -72,7 +72,7 @@ from .cache import get_resource_cache, get_resource_from_cache
 from .metrics import merge_observer
 from .paragraphs import ExtractedTextCache, get_paragraph_text, get_text_sentence
 
-Bm25Score = Tuple[int, int]
+Bm25Score = Tuple[float, float]
 TimestampScore = datetime.datetime
 TitleScore = str
 Score = Union[Bm25Score, TimestampScore, TitleScore]
@@ -92,8 +92,10 @@ async def text_score(
     specific case, return None.
 
     """
-    score: Any = None
+    if sort_field == SortField.SCORE:
+        return (item.score.bm25, item.score.booster)
 
+    score: Any = None
     resource = await get_resource_from_cache(kbid, item.uuid)
     if resource is None:
         return score
@@ -101,9 +103,7 @@ async def text_score(
     if basic is None:
         return score
 
-    if sort_field == SortField.SCORE:
-        score = (item.score.bm25, item.score.booster)
-    elif sort_field == SortField.CREATED:
+    if sort_field == SortField.CREATED:
         score = basic.created.ToDatetime()
     elif sort_field == SortField.MODIFIED:
         score = basic.modified.ToDatetime()

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -508,33 +508,34 @@ async def merge_results(
 
     rcache = get_resource_cache(clear=True)
 
-    resources: List[str] = list()
-    api_results.fulltext = await merge_documents_results(
-        documents, resources, count, page, kbid, sort
-    )
+    try:
+        resources: List[str] = list()
+        api_results.fulltext = await merge_documents_results(
+            documents, resources, count, page, kbid, sort
+        )
 
-    api_results.paragraphs = await merge_paragraph_results(
-        paragraphs,
-        resources,
-        kbid,
-        count,
-        page,
-        highlight,
-        sort,
-    )
+        api_results.paragraphs = await merge_paragraph_results(
+            paragraphs,
+            resources,
+            kbid,
+            count,
+            page,
+            highlight,
+            sort,
+        )
 
-    api_results.sentences = await merge_vectors_results(
-        vectors, resources, kbid, count, page, min_score=min_score
-    )
+        api_results.sentences = await merge_vectors_results(
+            vectors, resources, kbid, count, page, min_score=min_score
+        )
 
-    api_results.relations = merge_relations_results(relations, requested_relations)
+        api_results.relations = merge_relations_results(relations, requested_relations)
 
-    api_results.resources = await fetch_resources(
-        resources, kbid, show, field_type_filter, extracted
-    )
-
-    rcache.clear()
-    return api_results
+        api_results.resources = await fetch_resources(
+            resources, kbid, show, field_type_filter, extracted
+        )
+        return api_results
+    finally:
+        rcache.clear()
 
 
 async def merge_paragraphs_results(
@@ -554,23 +555,24 @@ async def merge_paragraphs_results(
     api_results = ResourceSearchResults()
 
     rcache = get_resource_cache(clear=True)
-
-    resources: List[str] = list()
-    api_results.paragraphs = await merge_paragraph_results(
-        paragraphs,
-        resources,
-        kbid,
-        count,
-        page,
-        highlight=highlight_split,
-        sort=SortOptions(
-            field=SortField.SCORE,
-            order=SortOrder.DESC,
-            limit=None,
-        ),
-    )
-    rcache.clear()
-    return api_results
+    try:
+        resources: List[str] = list()
+        api_results.paragraphs = await merge_paragraph_results(
+            paragraphs,
+            resources,
+            kbid,
+            count,
+            page,
+            highlight=highlight_split,
+            sort=SortOptions(
+                field=SortField.SCORE,
+                order=SortOrder.DESC,
+                limit=None,
+            ),
+        )
+        return api_results
+    finally:
+        rcache.clear()
 
 
 async def merge_suggest_entities_results(

--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -506,7 +506,7 @@ async def merge_results(
 
     api_results = KnowledgeboxSearchResults()
 
-    get_resource_cache(clear=True)
+    rcache = get_resource_cache(clear=True)
 
     resources: List[str] = list()
     api_results.fulltext = await merge_documents_results(
@@ -532,6 +532,8 @@ async def merge_results(
     api_results.resources = await fetch_resources(
         resources, kbid, show, field_type_filter, extracted
     )
+
+    rcache.clear()
     return api_results
 
 


### PR DESCRIPTION
### Description
While doing search performance tests, we realised that the memory usage of the search pods was not clearing up. That indicated a memory leak.

<img width="699" alt="Screenshot 2023-10-16 at 07 30 28" src="https://github.com/nuclia/nucliadb/assets/11825427/76e5d62d-7fd4-47cb-9377-8977e46e562f">

By using tracemalloc, I've been able to find that the resource cache usage was the culprit.

This PR makes sure to clear the resource cache context var value. Otherwise we keep accumulating resources in memory and are never garbage collected. See below.

### How was this PR tested?
Ran 100 simultaneous find requests and checked the top 5 memory allocations using [`tracemalloc` doc examples](https://docs.python.org/3/library/tracemalloc.html). Here is the result before and after the fix.

Before the fix
```
Top 10 lines
#1: /Users/ferran/Code/nucliadb/nucliadb/nucliadb/ingest/orm/resource.py:145: 312.2 KiB
    self.fields: dict[Tuple[FieldType.ValueType, str], Field] = {}
#2: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/fastapi/routing.py:144: 162.3 KiB
    value, errors_ = field.validate(response_content, {}, loc=("response",))
#3: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/_weakrefset.py:89: 159.5 KiB
    self.data.add(ref(item, self._remove))
#4: /Users/ferran/Code/nucliadb/nucliadb/nucliadb/ingest/orm/knowledgebox.py:81: 151.9 KiB
    self.txn = txn
#5: /Users/ferran/Code/nucliadb/nucliadb/nucliadb/ingest/fields/base.py:82: 151.9 KiB
    self.value = None
#6: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/asyncio/base_events.py:429: 143.7 KiB
    return futures.Future(loop=self)
#7: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/asyncio/base_events.py:438: 135.3 KiB
    task = tasks.Task(coro, loop=self, name=name)
#8: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/httpx/_models.py:81: 126.1 KiB
    (
#9: /Users/ferran/Code/nucliadb/nucliadb_utils/nucliadb_utils/storages/storage.py:502: 124.9 KiB
    pb = PBKlass()
#10: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/starlette/responses.py:199: 118.3 KiB
    return json.dumps(
1041 other: 4579.6 KiB
Total allocated size: 6165.6 KiB
```
Notice on number 1, 4 and 5 how we are holding references to the field values of resources, and their maindb transaction object.

After the fix
```
#1: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/fastapi/routing.py:144: 193.1 KiB
    value, errors_ = field.validate(response_content, {}, loc=("response",))
#2: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/_weakrefset.py:89: 159.6 KiB
    self.data.add(ref(item, self._remove))
#3: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/httpx/_models.py:81: 140.4 KiB
    (
#4: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/asyncio/base_events.py:438: 133.5 KiB
    task = tasks.Task(coro, loop=self, name=name)
#5: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/asyncio/base_events.py:429: 125.8 KiB
    return futures.Future(loop=self)
#6: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/redis/asyncio/connection.py:1439: 102.9 KiB
    return self.connection_class(**self.connection_kwargs)
#7: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/asyncio/selector_events.py:763: 98.3 KiB
    self._read_ready_cb = None
#8: /Users/ferran/.pyenv/versions/3.9.13/lib/python3.9/asyncio/streams.py:149: 90.3 KiB
    self._loop = loop
#9: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/aiohttp/client_proto.py:213: 88.1 KiB
    messages, upgraded, tail = self._parser.feed_data(data)
#10: /Users/ferran/.pyenv/versions/3.9.13/envs/nucliadb/lib/python3.9/site-packages/redis/asyncio/connection.py:549: 81.0 KiB
    self.retry = Retry(NoBackoff(), 0)
1045 other: 3078.5 KiB
Total allocated size: 4291.5 KiB
```
All previous references to the nucliadb frames are no longer appearing.