### PR TITLE
Improve perf makefile

### DIFF
--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -13,8 +13,9 @@ default: help
 
 .PHONY: help
 help: # Show help for each of the Makefile recipes.
+	@echo "----------------------------------"
 	@echo "NucliaDB Performance testing tool"
-	@echo "---------------------------------\n"
+	@echo "----------------------------------\n"
 	@echo "Available options:\n"
 	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
 	@echo ""

--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -1,51 +1,74 @@
+reader_api=http://reader.nucliadb.svc.cluster.local:8080/api
+search_api=http://search.nucliadb.svc.cluster.local:8080/api
+
+max_workers=100
+duration_s=600
+ramp_up=500
+sizing=--sizing
+
+RED=\033[0;31m
+NC=\033[0m
+
+default: help
+
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@echo "NucliaDB Performance testing tool"
+	@echo "---------------------------------\n"
+	@echo "Available options:\n"
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+	@echo ""
+	@echo "Example usages:\n"
+	@echo "By default, tests take 10 minutes, but use the ${RED}duration_s${NC} param to change it.\nWorkers are added incrementally up to 100 or ${RED}max_workers${NC} param.\n"
+	@echo "- To run with a fixed number of workers\n"
+	@echo "    make test-search-cluster max_workers=100 sizing= ramp_up=0 duration_s=30\n"
+	@echo "- To point to a local NucliaDB, use the ${RED}reader_api${NC} and ${RED}search_api${NC} params\n"
+	@echo "    make test-search-cluster reader_api=http://localhost:8080/api search_api=http://localhost:8080/api\n"
+
+
 .PHONY: install
-install:
+install: # Install the package
 	pip install --upgrade pip wheel
 	pip install -e .
 
 
 .PHONY: install-dev
-install-dev:
+install-dev: # Install the package for development
 	pip install --upgrade pip wheel
 	pip install -r ../test-requirements.txt -r ../code-requirements.txt -r requirements.txt
 	pip install -e .
 
 
 .PHONY: format
-format:
+format: # Format the code
 	cd .. && isort --profile black nucliadb_performance
 	black .
 
 .PHONY: lint
-lint:
+lint: # Run lint checks
 	flake8 nucliadb_performance --config=setup.cfg
 	cd .. && isort -c --profile black nucliadb_performance
 	black --check .
 	MYPYPATH=../mypy_stubs mypy --config-file=../mypy.ini . --show-traceback
 
-max_workers=100
-duration=600
-ramp_up=500
-sizing="--sizing"
-
 
 .PHONY: test-search-cluster
-test-search-cluster: export READER_API=http://reader.nucliadb.svc.cluster.local:8080/api
-test-search-cluster: export SEARCH_API=http://search.nucliadb.svc.cluster.local:8080/api
-test-search-cluster:
+test-search-cluster: export SEARCH_API=$(search_api)
+test-search-cluster: export READER_API=$(reader_api)
+test-search-cluster: # Stress test search on a cluster.
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_cluster.py $(sizing) --sizing-tolerance=10 -w $(max_workers) --ramp-up $(ramp_up) -d $(duration) --force-shutdown
+	molotov ./nucliadb_performance/test_search_cluster.py $(sizing) --sizing-tolerance=10 -w $(max_workers) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"
 
 
 .PHONY: test-search-kb
-test-search-kb: export READER_API=http://reader.nucliadb.svc.cluster.local:8080/api
-test-search-kb: export SEARCH_API=http://search.nucliadb.svc.cluster.local:8080/api
-test-search-kb:
+test-search-kb: export SEARCH_API=$(search_api)
+test-search-kb: export READER_API=$(reader_api)
+test-search-kb: # Stress test search on a KB
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance 10 --ramp-up $(ramp_up) -d $(duration) --force-shutdown
+	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance 10 --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"

--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -1,8 +1,15 @@
+.PHONY: install
+install:
+	pip install --upgrade pip wheel
+	pip install -e .
+
+
 .PHONY: install-dev
 install-dev:
 	pip install --upgrade pip wheel
 	pip install -r ../test-requirements.txt -r ../code-requirements.txt -r requirements.txt
 	pip install -e .
+
 
 .PHONY: format
 format:
@@ -16,6 +23,10 @@ lint:
 	black --check .
 	MYPYPATH=../mypy_stubs mypy --config-file=../mypy.ini . --show-traceback
 
+max_workers=100
+duration=600
+ramp_up=500
+sizing="--sizing"
 
 
 .PHONY: test-search-cluster
@@ -24,7 +35,7 @@ test-search-cluster: export SEARCH_API=http://search.nucliadb.svc.cluster.local:
 test-search-cluster:
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_cluster.py --sizing --sizing-tolerance=10 -w 100 --ramp-up 500 -d 600 --force-shutdown
+	molotov ./nucliadb_performance/test_search_cluster.py $(sizing) --sizing-tolerance=10 -w $(max_workers) --ramp-up $(ramp_up) -d $(duration) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"
 
@@ -35,6 +46,6 @@ test-search-kb: export SEARCH_API=http://search.nucliadb.svc.cluster.local:8080/
 test-search-kb:
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_kb.py --sizing --sizing-tolerance=10 --ramp-up 500 -d 600 --force-shutdown
+	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance 10 --ramp-up $(ramp_up) -d $(duration) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"


### PR DESCRIPTION
### Description
Be able to parametrize
Add help target with docs

```
$ make help
---------------------------------
NucliaDB Performance testing tool
---------------------------------

Available options:

format: Format the code
help: Show help for each of the Makefile recipes.
install-dev: Install the package for development
install: Install the package
lint: Run lint checks
test-search-cluster: Stress test search on a cluster.
test-search-kb: Stress test search on a KB

Example usages:

By default, tests take 10 minutes, but use the duration_s param to change it.
Workers are added incrementally up to 100 or max_workers param.

- To run with a fixed number of workers

    make test-search-cluster max_workers=100 sizing= ramp_up=0 duration_s=30

- To point to a local NucliaDB, use the reader_api and search_api params

    make test-search-cluster reader_api=http://localhost:8080/api search_api=http://localhost:8080/api

```

### How was this PR tested?
local tests