### PR TITLE
Store and retrieve Q/A data

### DIFF
--- a/nucliadb/nucliadb/ingest/fields/base.py
+++ b/nucliadb/nucliadb/ingest/fields/base.py
@@ -158,6 +158,14 @@ class Field:
         await self.delete_extracted_text()
         await self.delete_vectors()
         await self.delete_metadata()
+        await self.delete_question_answers()
+
+    async def delete_question_answers(self) -> None:
+        sf = self.get_storage_field(FieldTypes.QUESTION_ANSWERS)
+        try:
+            await self.storage.delete_upload(sf.key, sf.bucket)
+        except KeyError:
+            pass
 
     async def delete_extracted_text(self) -> None:
         sf = self.get_storage_field(FieldTypes.FIELD_TEXT)

--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -38,6 +38,7 @@ from nucliadb_protos.resources_pb2 import (
     FieldComputedMetadataWrapper,
     FieldID,
     FieldMetadata,
+    FieldQuestionAnswerWrapper,
     FieldText,
     FieldType,
     FileExtractedData,
@@ -152,6 +153,7 @@ class Resource:
         self.slug_modified: bool = False
         self._indexer: Optional[ResourceBrain] = None
         self._modified_extracted_text: list[FieldID] = []
+        self._modified_question_answers: list[FieldID] = []
 
         self.txn = txn
         self.storage = storage
@@ -801,6 +803,9 @@ class Resource:
 
         maybe_update_basic_icon(self.basic, get_text_field_mimetype(message))
 
+        for question_answers in message.question_answers:
+            await self._apply_question_answers(question_answers)
+
         for extracted_text in message.extracted_text:
             await self._apply_extracted_text(extracted_text)
 
@@ -851,6 +856,15 @@ class Resource:
         self._modified_extracted_text.append(
             extracted_text.field,
         )
+
+    async def _apply_question_answers(
+        self, question_answers: FieldQuestionAnswerWrapper
+    ):
+        field = question_answers.field
+        field_obj = await self.get_field(field.field, field.field_type, load=False)
+        await field_obj.set_question_answers(question_answers)
+        # TODO: what is this used for
+        self._modified_question_answers.append(field)
 
     async def _apply_link_extracted_data(self, link_extracted_data: LinkExtractedData):
         assert self.basic is not None

--- a/nucliadb/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/nucliadb/ingest/orm/resource.py
@@ -153,7 +153,6 @@ class Resource:
         self.slug_modified: bool = False
         self._indexer: Optional[ResourceBrain] = None
         self._modified_extracted_text: list[FieldID] = []
-        self._modified_question_answers: list[FieldID] = []
 
         self.txn = txn
         self.storage = storage
@@ -863,8 +862,6 @@ class Resource:
         field = question_answers.field
         field_obj = await self.get_field(field.field, field.field_type, load=False)
         await field_obj.set_question_answers(question_answers)
-        # TODO: what is this used for
-        self._modified_question_answers.append(field)
 
     async def _apply_link_extracted_data(self, link_extracted_data: LinkExtractedData):
         assert self.basic is not None

--- a/nucliadb/nucliadb/ingest/serialize.py
+++ b/nucliadb/nucliadb/ingest/serialize.py
@@ -77,7 +77,6 @@ async def set_resource_field_extracted_data(
     shortened_metadata_wanted = (
         ExtractedDataTypeName.SHORTENED_METADATA in wanted_extracted_data
     )
-
     if metadata_wanted or shortened_metadata_wanted:
         data_fcm = await field.get_field_metadata()
 
@@ -147,8 +146,6 @@ async def serialize(
         return None
 
     resource = Resource(id=orm_resource.uuid)
-
-    # check in extracted if QA, and add it here
 
     include_values = ResourceProperties.VALUES in show
 
@@ -226,7 +223,6 @@ async def serialize(
     if field_type_filter and (include_values or include_extracted_data):
         await orm_resource.get_fields()
         resource.data = ResourceData()
-
         for (field_type, field_id), field in orm_resource.fields.items():
             field_type_name = FIELD_TYPES_MAP[field_type]
             if field_type_name not in field_type_filter:
@@ -441,7 +437,6 @@ async def serialize(
                             text=resource.data.generics[field.id].value
                         )
                     )
-
     asyncio.create_task(txn.abort())
     return resource
 

--- a/nucliadb/nucliadb/ingest/tests/fixtures.py
+++ b/nucliadb/nucliadb/ingest/tests/fixtures.py
@@ -691,6 +691,24 @@ async def create_resource(
     )
     await field_obj.set_user_vectors(user_vectors)
 
+    # Q/A
+    question_answers = rpb.FieldQuestionAnswerWrapper()
+    for i in range(10):
+        qa = rpb.QuestionAnswer()
+
+        qa.question.text = f"My question {i}"
+        qa.question.language = "catalan"
+        qa.question.ids_paragraphs.extend([f"id1/{i}", f"id2/{i}"])
+
+        answer = rpb.Answers()
+        answer.text = f"My answer {i}"
+        answer.language = "catalan"
+        answer.ids_paragraphs.extend([f"id1/{i}", f"id2/{i}"])
+        qa.answers.append(answer)
+        question_answers.question_answers.question_answer.append(qa)
+
+    await field_obj.set_question_answers(question_answers)
+
     await txn.commit()
     return test_resource
 

--- a/nucliadb/nucliadb/ingest/tests/integration/ingest/test_ingest.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/ingest/test_ingest.py
@@ -31,6 +31,7 @@ from nats.js import JetStreamContext
 from nucliadb_protos.audit_pb2 import AuditField, AuditRequest
 from nucliadb_protos.resources_pb2 import (
     TEXT,
+    Answers,
     Classification,
     CloudFile,
     Entity,
@@ -38,12 +39,13 @@ from nucliadb_protos.resources_pb2 import (
     ExtractedVectorsWrapper,
     FieldComputedMetadataWrapper,
     FieldID,
+    FieldQuestionAnswerWrapper,
     FieldType,
     FileExtractedData,
     LargeComputedMetadataWrapper,
 )
 from nucliadb_protos.resources_pb2 import Metadata as PBMetadata
-from nucliadb_protos.resources_pb2 import Origin, Paragraph
+from nucliadb_protos.resources_pb2 import Origin, Paragraph, QuestionAnswer
 from nucliadb_protos.utils_pb2 import Vector
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
@@ -496,6 +498,57 @@ async def test_ingest_audit_stream_files_only(
 
     await client.drain()
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_qa(
+    local_files,
+    gcs_storage: Storage,
+    cache,
+    fake_node,
+    stream_processor,
+    stream_audit: StreamAuditStorage,
+    test_resource: Resource,
+):
+    kbid = test_resource.kb.kbid
+    rid = test_resource.uuid
+    driver = stream_processor.driver
+    message = make_message(kbid, rid)
+    message.account_seq = 2
+    message.files["qa"].file.uri = "http://something"
+    message.files["qa"].file.size = 123
+    message.files["qa"].file.source = CloudFile.Source.LOCAL
+
+    qaw = FieldQuestionAnswerWrapper()
+    qaw.field.field_type = FieldType.FILE
+    qaw.field.field = "qa"
+
+    for i in range(10):
+        qa = QuestionAnswer()
+
+        qa.question.text = f"My question {i}"
+        qa.question.language = "catalan"
+        qa.question.ids_paragraphs.extend([f"id1/{i}", f"id2/{i}"])
+
+        answer = Answers()
+        answer.text = f"My answer {i}"
+        answer.language = "catalan"
+        answer.ids_paragraphs.extend([f"id1/{i}", f"id2/{i}"])
+        qa.answers.append(answer)
+        qaw.question_answers.question_answer.append(qa)
+
+    message.question_answers.append(qaw)
+
+    await stream_processor.process(message=message, seqid=1)
+
+    async with driver.transaction() as txn:
+        kb_obj = KnowledgeBox(txn, gcs_storage, kbid=kbid)
+        r = await kb_obj.get(message.uuid)
+        assert r is not None
+        res = await r.get_field(key="qa", type=FieldType.FILE)
+        res_qa = await res.get_question_answers()
+
+    assert qaw.question_answers == res_qa
 
 
 @pytest.mark.asyncio

--- a/nucliadb/nucliadb/ingest/tests/integration/ingest/test_ingest.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/ingest/test_ingest.py
@@ -550,6 +550,10 @@ async def test_qa(
 
     assert qaw.question_answers == res_qa
 
+    # delete op
+    message = make_message(kbid, rid, message_type=BrokerMessage.MessageType.DELETE)
+    await stream_processor.process(message=message, seqid=2)
+
 
 @pytest.mark.asyncio
 async def test_ingest_audit_stream_mixed(

--- a/nucliadb/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/nucliadb/reader/api/v1/resource.py
@@ -356,7 +356,6 @@ async def _get_resource_field(
             raise HTTPException(status_code=404, detail="Resource does not exist")
 
     resource = ORMResource(txn, storage, kb, rid)
-
     field = await resource.get_field(field_id, pb_field_id, load=True)
     if field is None:
         await txn.abort()

--- a/nucliadb/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/nucliadb/reader/api/v1/resource.py
@@ -157,6 +157,7 @@ async def get_resource_by_uuid(
             ExtractedDataTypeName.METADATA,
             ExtractedDataTypeName.LINK,
             ExtractedDataTypeName.FILE,
+            ExtractedDataTypeName.QA,
         ]
     ),
     x_nucliadb_user: str = Header(""),
@@ -197,6 +198,7 @@ async def get_resource_by_slug(
             ExtractedDataTypeName.METADATA,
             ExtractedDataTypeName.LINK,
             ExtractedDataTypeName.FILE,
+            ExtractedDataTypeName.QA,
         ]
     ),
     x_nucliadb_user: str = Header(""),
@@ -269,6 +271,7 @@ async def get_resource_field_rslug_prefix(
             ExtractedDataTypeName.METADATA,
             ExtractedDataTypeName.LINK,
             ExtractedDataTypeName.FILE,
+            ExtractedDataTypeName.QA,
         ]
     ),
     # not working with latest pydantic/fastapi
@@ -353,6 +356,7 @@ async def _get_resource_field(
             raise HTTPException(status_code=404, detail="Resource does not exist")
 
     resource = ORMResource(txn, storage, kb, rid)
+
     field = await resource.get_field(field_id, pb_field_id, load=True)
     if field is None:
         await txn.abort()

--- a/nucliadb/nucliadb/tests/integration/test_api.py
+++ b/nucliadb/nucliadb/tests/integration/test_api.py
@@ -817,11 +817,13 @@ async def test_question_answer(
         qa.question.language = "catalan"
         qa.question.ids_paragraphs.extend([f"id1/{i}", f"id2/{i}"])
 
-        answer = Answers()
-        answer.text = f"My answer {i}"
-        answer.language = "catalan"
-        answer.ids_paragraphs.extend([f"id1/{i}", f"id2/{i}"])
-        qa.answers.append(answer)
+        for x in range(2):
+            answer = Answers()
+            answer.text = f"My answer {i}{x}"
+            answer.language = "catalan"
+            answer.ids_paragraphs.extend([f"id1/{i}{x}", f"id2/{i}{x}"])
+            qa.answers.append(answer)
+
         qaw.question_answers.question_answer.append(qa)
 
     message.question_answers.append(qaw)
@@ -831,10 +833,8 @@ async def test_question_answer(
     async def iterate(value: BrokerMessage):
         yield value
 
-    # XXX stores in kbs/<kbid>/r/<rid>/e/f/qa/question_answers
     await nucliadb_grpc.ProcessMessage(iterate(message))  # type: ignore
 
-    # XXX try to read back in kbs/<kbid>/r/<rid>/e/t/text1/question_answers
     resp = await nucliadb_reader.get(
         f"/kb/{knowledgebox}/resource/{rid}?show=extracted&extracted=question_answers",
         timeout=None,
@@ -852,9 +852,14 @@ async def test_question_answer(
         },
         "answers": [
             {
-                "text": "My answer 0",
+                "ids_paragraphs": ["id1/00", "id2/00"],
                 "language": "catalan",
-                "ids_paragraphs": ["id1/0", "id2/0"],
-            }
+                "text": "My answer 00",
+            },
+            {
+                "ids_paragraphs": ["id1/01", "id2/01"],
+                "language": "catalan",
+                "text": "My answer 01",
+            },
         ],
     }

--- a/nucliadb_models/nucliadb_models/extracted.py
+++ b/nucliadb_models/nucliadb_models/extracted.py
@@ -293,6 +293,37 @@ class FileExtractedData(BaseModel):
         )
 
 
+class Question(BaseModel):
+    text: str
+    language: str
+    ids_paragraphs: List[str]
+
+
+class Answer(BaseModel):
+    text: str
+    language: str
+    ids_paragraphs: List[str]
+
+
+class QuestionAnswer(BaseModel):
+    question: Question
+    answers: List[Answer]
+
+
+class QuestionAnswers(BaseModel):
+    question_answer: List[QuestionAnswer]
+
+    @classmethod
+    def from_message(cls: Type[_T], message: resources_pb2.QuestionAnswers) -> _T:
+        return cls(
+            **MessageToDict(
+                message,
+                preserving_proto_field_name=True,
+                including_default_value_fields=True,
+            )
+        )
+
+
 def convert_fieldmetadata_pb_to_dict(
     message: resources_pb2.FieldMetadata,
 ) -> Dict[str, Any]:

--- a/nucliadb_models/nucliadb_models/resource.py
+++ b/nucliadb_models/nucliadb_models/resource.py
@@ -36,6 +36,7 @@ from nucliadb_models.extracted import (
     FileExtractedData,
     LargeComputedMetadata,
     LinkExtractedData,
+    QuestionAnswers,
     VectorObject,
 )
 from nucliadb_models.file import FieldFile
@@ -83,6 +84,7 @@ class ExtractedDataTypeName(str, Enum):
     LINK = "link"
     FILE = "file"
     USERVECTORS = "uservectors"
+    QA = "question_answers"
 
 
 class ReleaseChannel(str, Enum):
@@ -165,6 +167,7 @@ class ExtractedData(BaseModel):
     large_metadata: Optional[LargeComputedMetadata] = None
     vectors: Optional[VectorObject] = None
     uservectors: Optional[UserVectorSet] = None
+    question_answers: Optional[QuestionAnswers] = None
 
 
 class TextFieldExtractedData(ExtractedData):


### PR DESCRIPTION
### Description

- Stores Q/A data from `BrokerMessage` into the resource's storage
- Extended the resource `read` API to allow optional retrieval

### How was this PR tested?

unit + functional test
