### PR TITLE
More tweaks for perf tests

### DIFF
--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -63,7 +63,9 @@ def record_filters_counter(filters: list[str], counter: Counter) -> None:
     for fltr in filters:
         if entity_found and label_found:
             break
-        if fltr == "" or fltr[0] != "/":
+        if fltr == "":
+            continue
+        if fltr[0] != "/":
             break
         if not entity_found and fltr.startswith(ENTITY_FILTER_PREFIX):
             entity_found = True

--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -63,7 +63,7 @@ def record_filters_counter(filters: list[str], counter: Counter) -> None:
     for fltr in filters:
         if entity_found and label_found:
             break
-        if fltr[0] != "/":
+        if fltr == "" or fltr[0] != "/":
             break
         if not entity_found and fltr.startswith(ENTITY_FILTER_PREFIX):
             entity_found = True

--- a/nucliadb/nucliadb/search/tests/unit/search/test_query.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_query.py
@@ -144,7 +144,7 @@ async def test_get_kb_model_default_min_score_backward_compatible(has_feature, k
 def test_record_filters_counter():
     counter = Mock()
 
-    record_filters_counter(["/l/ls/l1", "/e/ORG/Nuclia"], counter)
+    record_filters_counter(["", "/l/ls/l1", "/e/ORG/Nuclia"], counter)
 
     counter.inc.assert_has_calls(
         [

--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -1,13 +1,12 @@
 reader_api=http://reader.nucliadb.svc.cluster.local:8080/api
 search_api=http://search.nucliadb.svc.cluster.local:8080/api
-
 error_tolerance=10
 max_workers=100
-duration_s=600
-ramp_up=500
+duration_s=3600
+ramp_up=300
 sizing=--sizing
-kbid=
-
+kbid=tiny
+test=test-search-cluster
 
 RED=\033[0;31m
 NC=\033[0m
@@ -74,22 +73,24 @@ test-search-kb: export KBID=$(kbid)
 test-search-kb: # Stress test search on a KB
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance=$(error_tolerance) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
+	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance=$(error_tolerance) -w $(max_workers) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"
 
 
 pod=''
-start-agent: # Start a 
+install-agent:  # Installs the nucliadb_performance package in a pod
 	echo "Installing agent on ${pod}"
 
 	kubectl cp -n nucliadb nucliadb_performance ${pod}:/usr/src/app/nucliadb_performance
 	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance install
 
+
+start-agent:  # Starts a test in an agent
 	echo "Starting traffic"
-	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance test-search-cluster sizing= max_workers=20 ramp_up=30 duration_s=3600 &
+	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance $(test) kbid=$(kbid) sizing=$(sizing) error_tolerance=$(error_tolerance) max_workers=$(max_workers) ramp_up=$(ramp_up) duration_s=$(duration_s) &
 
 
-stop-agent:
+stop-agent:  # Stops a running test in an agent
 	echo "Stopping ${pod}"
 	kubectl exec -qit -n nucliadb ${pod} -- apt-get install psmisc && killall -s 9 molotov

--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -1,6 +1,7 @@
 reader_api=http://reader.nucliadb.svc.cluster.local:8080/api
 search_api=http://search.nucliadb.svc.cluster.local:8080/api
 
+error_tolerance=10
 max_workers=100
 duration_s=600
 ramp_up=500
@@ -61,7 +62,7 @@ test-search-cluster: export READER_API=$(reader_api)
 test-search-cluster: # Stress test search on a cluster.
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_cluster.py $(sizing) --sizing-tolerance=10 -w $(max_workers) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
+	molotov ./nucliadb_performance/test_search_cluster.py $(sizing) --sizing-tolerance=$(error_tolerance) -w $(max_workers) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"
 
@@ -73,6 +74,22 @@ test-search-kb: export KBID=$(kbid)
 test-search-kb: # Stress test search on a KB
 	echo " *  Test Started at: $$(date -u)"
 
-	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance 10 --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
+	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance=$(error_tolerance) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"
+
+
+pod=''
+start-agent: # Start a 
+	echo "Installing agent on ${pod}"
+
+	kubectl cp -n nucliadb nucliadb_performance ${pod}:/usr/src/app/nucliadb_performance
+	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance install
+
+	echo "Starting traffic"
+	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance test-search-cluster sizing= max_workers=20 ramp_up=30 duration_s=3600 &
+
+
+stop-agent:
+	echo "Stopping ${pod}"
+	kubectl exec -qit -n nucliadb ${pod} -- apt-get install psmisc && killall -s 9 molotov

--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -76,21 +76,3 @@ test-search-kb: # Stress test search on a KB
 	molotov ./nucliadb_performance/test_search_kb.py $(sizing) --sizing-tolerance=$(error_tolerance) -w $(max_workers) --ramp-up $(ramp_up) -d $(duration_s) --force-shutdown
 
 	echo " *  Test Finished at: $$(date -u)"
-
-
-pod=''
-install-agent:  # Installs the nucliadb_performance package in a pod
-	echo "Installing agent on ${pod}"
-
-	kubectl cp -n nucliadb nucliadb_performance ${pod}:/usr/src/app/nucliadb_performance
-	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance install
-
-
-start-agent:  # Starts a test in an agent
-	echo "Starting traffic"
-	kubectl exec -qit -n nucliadb ${pod} -- make -C nucliadb_performance $(test) kbid=$(kbid) sizing=$(sizing) error_tolerance=$(error_tolerance) max_workers=$(max_workers) ramp_up=$(ramp_up) duration_s=$(duration_s) &
-
-
-stop-agent:  # Stops a running test in an agent
-	echo "Stopping ${pod}"
-	kubectl exec -qit -n nucliadb ${pod} -- apt-get install psmisc && killall -s 9 molotov

--- a/nucliadb_performance/kb_requests.json
+++ b/nucliadb_performance/kb_requests.json
@@ -1,0 +1,44 @@
+{
+    "1e11b18a-e829-46ad-91d7-155c4777792b": [
+        {
+            "query": "The Division Bell",
+            "filters": ["/l/resources/label1", "/s/p/en"]
+        },
+        {
+            "query": "The Royal Navy",
+            "filters": ["/l/resources/label2"],
+            "features": ["vector"],
+            "min_score": 0
+        }
+    ],
+    "c02b6960-4c0e-4ee3-b006-53836da5a5a9": [
+        {
+            "query": "When was Vladimir Putin's campaing?",
+            "filters": [
+                "/l/resources/label1"
+            ]
+        },
+        {
+            "query": "who won the Vice Presidential Election?",
+            "filters": [
+                "/l/resources/label2"
+            ],
+            "features": [
+                "vector"
+            ],
+            "min_score": 0
+        }
+    ],
+    "3336b978-6af5-460d-b459-a2fdebcc06df": [
+        {
+            "query": "The Teaching and Learning of Mathematics at University Level",
+            "filters": ["/l/resources/label1", "/s/p/en"]
+        },
+        {
+            "query": "Napoleonic wars",
+            "filters": ["/l/resources/label2"],
+            "features": ["vector"],
+            "min_score": 0
+        }
+    ]
+}

--- a/nucliadb_performance/nucliadb_performance/settings.py
+++ b/nucliadb_performance/nucliadb_performance/settings.py
@@ -7,6 +7,9 @@ class Settings(BaseSettings):
     main_api: str = "http://localhost:8080/api"
     search_api: Optional[str] = None
     reader_api: Optional[str] = None
+    predict_api: str = (
+        "http://predict.learning.svc.cluster.local:8080/api/internal/predict"
+    )
 
 
 def get_search_api_url():
@@ -15,6 +18,10 @@ def get_search_api_url():
 
 def get_reader_api_url():
     return settings.reader_api or settings.main_api
+
+
+def get_predict_api_url():
+    return settings.predict_api
 
 
 settings = Settings()

--- a/nucliadb_performance/nucliadb_performance/utils.py
+++ b/nucliadb_performance/nucliadb_performance/utils.py
@@ -20,6 +20,7 @@ EXCLUDE_KBIDS = [
 ]
 _DATA = {}
 
+MIN_KB_PARAGRAPHS = 5_000
 
 @dataclass
 class Error:
@@ -99,7 +100,8 @@ def get_kbs():
         except CountersError:
             print(f"Error getting counters for {kbid}")
             continue
-        if pars > 0:
+        if pars > MIN_KB_PARAGRAPHS:
+            # Ignore KBs with not a considerable amount of data
             result.append(kbid)
             paragraphs.append(pars)
 

--- a/nucliadb_performance/requirements.txt
+++ b/nucliadb_performance/requirements.txt
@@ -2,3 +2,4 @@ molotov
 nucliadb-sdk
 certifi
 faker
+httpx


### PR DESCRIPTION
### Description
- Fix recording filters metric
- Define a set of queries for each KB
- Precompute vectors to not depend on predict api being slow/not available
- For cluster tests, ignore KBs lower than 5k paragraphs

### How was this PR tested?
Local tests and unit test
