### PR TITLE
disable livenessProbe for read replica

### DIFF
--- a/charts/nucliadb_node/templates/node.replicas.deploy.yaml
+++ b/charts/nucliadb_node/templates/node.replicas.deploy.yaml
@@ -109,10 +109,13 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
           failureThreshold: 10
-        livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:{{ $values.serving.grpc_reader }}", "-service=nodereader.NodeReader"]
-          initialDelaySeconds: 2
+        # Disable livenessProbe for now since
+        # we need a different livenessProbe than readinessProbe
+        # for a read replica
+        # livenessProbe:
+        #   exec:
+        #     command: ["/bin/grpc_health_probe", "-addr=:{{ $values.serving.grpc_reader }}", "-service=nodereader.NodeReader"]
+        #   initialDelaySeconds: 2
         command: ["node_reader"]
         envFrom:
         - configMapRef:


### PR DESCRIPTION
### Description
Since it might take a long time to initial load the replica, we need a different probe from readiness


### How was this PR tested?
Describe how you tested this PR.
