### PR TITLE
Limit the amount of exports you can run concurrently

### DIFF
--- a/nucliadb/nucliadb/export_import/exceptions.py
+++ b/nucliadb/nucliadb/export_import/exceptions.py
@@ -70,3 +70,11 @@ class WrongExportStreamFormat(Exception):
     """
 
     pass
+
+
+class MaxRunningExportsReached(Exception):
+    """
+    Raised when there are too many exports ongoing for a KB
+    """
+
+    pass

--- a/nucliadb/nucliadb/reader/api/v1/export_import.py
+++ b/nucliadb/nucliadb/reader/api/v1/export_import.py
@@ -36,8 +36,6 @@ from nucliadb.reader.api.v1.router import KB_PREFIX, api
 from nucliadb_models.export_import import Status, StatusResponse
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
-from nucliadb_utils.const import Features
-from nucliadb_utils.utilities import has_feature
 
 
 @api.get(
@@ -54,7 +52,7 @@ async def download_export_kb_endpoint(request: Request, kbid: str, export_id: st
     if not await exists_kb(context, kbid):
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")
 
-    if in_standalone_mode() or not has_feature(Features.EXPORT_IMPORT_TASKS):
+    if in_standalone_mode():
         # In standalone mode, we stream the export as we generate it.
         return StreamingResponse(
             exporter.export_kb(context, kbid),
@@ -142,7 +140,7 @@ async def _get_status(
     if type not in ("export", "import"):
         raise ValueError(f"Incorrect type: {type}")
 
-    if in_standalone_mode() or not has_feature(Features.EXPORT_IMPORT_TASKS):
+    if in_standalone_mode():
         # In standalone mode exports/imports are not actually run in a background task.
         # We return always FINISHED status to keep the API compatible with the hosted mode.
         return StatusResponse(status=Status.FINISHED)

--- a/nucliadb/nucliadb/tests/integration/export_import/test_datamanager.py
+++ b/nucliadb/nucliadb/tests/integration/export_import/test_datamanager.py
@@ -85,3 +85,15 @@ async def test_import_upload_and_download(datamanager, kbid_with_bucket):
 
     async for chunk in datamanager.download_import(kbid, import_id):
         assert chunk is None
+
+
+async def test_kb_running_exports(datamanager: ExportImportDataManager):
+    kbid = uuid.uuid4().hex
+
+    assert await datamanager.get_running_exports(kbid) == 0
+    await datamanager.inc_running_exports(kbid)
+    await datamanager.inc_running_exports(kbid)
+    assert await datamanager.get_running_exports(kbid) == 2
+    await datamanager.dec_running_exports(kbid)
+    await datamanager.dec_running_exports(kbid)
+    assert await datamanager.get_running_exports(kbid) == 0

--- a/nucliadb/nucliadb/tests/integration/test_export_import.py
+++ b/nucliadb/nucliadb/tests/integration/test_export_import.py
@@ -305,7 +305,7 @@ async def test_max_running_exports(
     # Check for export to finish
     await wait_for(nucliadb_reader, "export", src_kb, export_id_1)
 
-    # Now that the first two have finished, we can start a third one
+    # Now that the first has finished, we can start another one
     resp = await nucliadb_writer.post(f"/kb/{src_kb}/export")
     assert resp.status_code == 200
     export_id_2 = resp.json()["export_id"]

--- a/nucliadb/nucliadb/writer/api/v1/export_import.py
+++ b/nucliadb/nucliadb/writer/api/v1/export_import.py
@@ -46,8 +46,6 @@ from nucliadb_models.export_import import (
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_telemetry import errors
 from nucliadb_utils.authentication import requires_one
-from nucliadb_utils.const import Features
-from nucliadb_utils.utilities import has_feature
 
 
 @api.post(
@@ -65,7 +63,7 @@ async def start_kb_export_endpoint(request: Request, kbid: str):
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")
 
     export_id = uuid4().hex
-    if in_standalone_mode() or not has_feature(Features.EXPORT_IMPORT_TASKS):
+    if in_standalone_mode():
         # In standalone mode, exports are generated at download time.
         # We simply return an export_id to keep the API consistent with hosted nucliadb.
         return CreateExportResponse(export_id=export_id)
@@ -89,7 +87,7 @@ async def start_kb_import_endpoint(request: Request, kbid: str):
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")
 
     import_id = uuid4().hex
-    if in_standalone_mode() or not has_feature(Features.EXPORT_IMPORT_TASKS):
+    if in_standalone_mode():
         # In standalone mode, we import directly from the request content stream.
         # Note that we return an import_id simply to keep the API consistent with hosted nucliadb.
         stream = FastAPIExportStream(request)

--- a/nucliadb_utils/nucliadb_utils/const.py
+++ b/nucliadb_utils/nucliadb_utils/const.py
@@ -75,4 +75,3 @@ class Features:
     DEFAULT_MIN_SCORE = "nucliadb_default_min_score"
     ROLLOVER_SHARDS = "nuclaidb_rollover_shards"
     ASK_YOUR_DOCUMENTS = "nucliadb_ask_your_documents"
-    EXPORT_IMPORT_TASKS = "nucliadb_export_import_tasks"

--- a/nucliadb_utils/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/nucliadb_utils/featureflagging.py
@@ -51,10 +51,6 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["stage", "local"]},
     },
-    const.Features.EXPORT_IMPORT_TASKS: {
-        "rollout": 0,
-        "variants": {"environment": ["stage", "local"]},
-    },
 }
 
 


### PR DESCRIPTION
### Description
Since an export can create a considerable amount of data in cloud storage, this prevents users from abusing the API: Only one export task can be running at a time. 

Also:
- Remove export-import feature flag

### How was this PR tested?
Unit and integration tests
