### PR TITLE
Forked Tantivy 0.17 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,8 +3391,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264c2549892aa83975386a924ef8d0b8e909674c837d37ea58b4bd8739495c6e"
+source = "git+https://github.com/nuclia/tantivy.git?rev=2183120aaa565b14fde05aa35342e5c5a3306d3b#2183120aaa565b14fde05aa35342e5c5a3306d3b"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/nucliadb_paragraphs/Cargo.toml
+++ b/nucliadb_paragraphs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tempfile = "3"
 lazy_static = "1.4.0"
 regex = "1.5.5"
-tantivy = "0.17.0"
+tantivy = { git = "https://github.com/nuclia/tantivy.git", rev = "2183120aaa565b14fde05aa35342e5c5a3306d3b" }
 levenshtein_automata = "0.2.1"
 once_cell = "1.13.1"
 tantivy-fst = "0.3.0"

--- a/nucliadb_relations/Cargo.toml
+++ b/nucliadb_relations/Cargo.toml
@@ -18,8 +18,11 @@ tempfile = "3"
 rand = "0.8.4"
 ring = "0.16.20"
 data-encoding = "2.3.2"
-tantivy = "0.17.0"
-heed = { version = "0.11.0", default-features = false, features = ["lmdb", "sync-read-txn"] }
+tantivy = { git = "https://github.com/nuclia/tantivy.git", rev = "2183120aaa565b14fde05aa35342e5c5a3306d3b" }
+heed = { version = "0.11.0", default-features = false, features = [
+    "lmdb",
+    "sync-read-txn",
+] }
 
 nucliadb_core = { path = "../nucliadb_core" }
 nucliadb_procs = { path = "../nucliadb_procs" }

--- a/nucliadb_texts/Cargo.toml
+++ b/nucliadb_texts/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 tempfile = "3"
-tantivy = "0.17.0"
+tantivy = { git = "https://github.com/nuclia/tantivy.git", rev = "2183120aaa565b14fde05aa35342e5c5a3306d3b" }
 itertools = "0.10.5"
 
 nucliadb_core = { path = "../nucliadb_core" }


### PR DESCRIPTION
### Description
Still using tantivy 0.17 as it was, but from our fork.

### How was this PR tested?
Local tests.
