### PR TITLE
Unify release channel in config and shards obj

### DIFF
--- a/nucliadb/nucliadb/ingest/service/writer.py
+++ b/nucliadb/nucliadb/ingest/service/writer.py
@@ -203,12 +203,14 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
         self, request: KnowledgeBoxNew, context=None
     ) -> NewKnowledgeBoxResponse:
         try:
+            release_channel = get_release_channel(request)
+            request.config.release_channel = release_channel
             kbid = await self.proc.create_kb(
                 request.slug,
                 request.config,
                 parse_model_metadata(request),
                 forceuuid=request.forceuuid,
-                release_channel=get_release_channel(request),
+                release_channel=release_channel,
             )
         except KnowledgeBoxConflict:
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.CONFLICT)

--- a/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
@@ -77,7 +77,7 @@ async def get_kb_shards(txn, kbid) -> PBShards:
     return kb_shards
 
 
-async def get_kb_config(txn, kbid) -> knowledgebox_pb2.KnowledgeBoxConfig():
+async def get_kb_config(txn, kbid) -> knowledgebox_pb2.KnowledgeBoxConfig:
     key = KB_UUID.format(kbid=kbid)
     binary = await txn.get(key)
     assert binary, "Config object not found!"

--- a/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
@@ -24,7 +24,7 @@ from nucliadb_protos.writer_pb2 import Shards as PBShards
 from nucliadb.common.maindb.local import LocalDriver
 from nucliadb.ingest.tests.fixtures import IngestFixture
 from nucliadb_protos import knowledgebox_pb2, utils_pb2, writer_pb2, writer_pb2_grpc
-from nucliadb_utils.keys import KB_SHARDS
+from nucliadb_utils.keys import KB_SHARDS, KB_UUID
 
 
 @pytest.mark.asyncio
@@ -68,13 +68,26 @@ async def test_create_knowledgebox(grpc_servicer: IngestFixture, maindb_driver):
     result = await stub.DeleteKnowledgeBox(pbid)  # type: ignore
 
 
-async def get_kb_similarity(txn, kbid) -> utils_pb2.VectorSimilarity.ValueType:
+async def get_kb_shards(txn, kbid) -> PBShards:
     kb_shards_key = KB_SHARDS.format(kbid=kbid)
     kb_shards_binary = await txn.get(kb_shards_key)
     assert kb_shards_binary, "Shards object not found!"
     kb_shards = PBShards()
     kb_shards.ParseFromString(kb_shards_binary)
-    return kb_shards.similarity
+    return kb_shards
+
+
+async def get_kb_config(txn, kbid) -> knowledgebox_pb2.KnowledgeBoxConfig():
+    key = KB_UUID.format(kbid=kbid)
+    binary = await txn.get(key)
+    assert binary, "Config object not found!"
+    config = knowledgebox_pb2.KnowledgeBoxConfig()
+    config.ParseFromString(binary)
+    return config
+
+
+async def get_kb_similarity(txn, kbid) -> utils_pb2.VectorSimilarity.ValueType:
+    return await get_kb_shards(txn, kbid).similarity
 
 
 @pytest.mark.asyncio
@@ -140,3 +153,28 @@ async def test_delete_knowledgebox_handles_unexisting_kb(
     pbid = knowledgebox_pb2.KnowledgeBoxID(uuid="idonotexist", slug="meneither")
     result = await stub.DeleteKnowledgeBox(pbid)  # type: ignore
     assert result.status == knowledgebox_pb2.KnowledgeBoxResponseStatus.OK
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "release_channel",
+    [utils_pb2.ReleaseChannel.EXPERIMENTAL, utils_pb2.ReleaseChannel.STABLE],
+)
+async def test_create_knowledgebox_release_channel(
+    grpc_servicer: IngestFixture,
+    release_channel,
+):
+    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)  # type: ignore
+    pb = knowledgebox_pb2.KnowledgeBoxNew(
+        slug="test-default", release_channel=release_channel
+    )
+    pb.config.title = "My Title"
+    result = await stub.NewKnowledgeBox(pb)  # type: ignore
+    assert result.status == knowledgebox_pb2.KnowledgeBoxResponseStatus.OK
+    kbid = result.uuid
+
+    driver = grpc_servicer.servicer.driver
+    async with driver.transaction() as txn:
+        shards = await get_kb_shards(txn, kbid)
+        config = await get_kb_config(txn, kbid)
+        assert shards.release_channel == config.release_channel == release_channel

--- a/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
@@ -87,7 +87,7 @@ async def get_kb_config(txn, kbid) -> knowledgebox_pb2.KnowledgeBoxConfig():
 
 
 async def get_kb_similarity(txn, kbid) -> utils_pb2.VectorSimilarity.ValueType:
-    return await get_kb_shards(txn, kbid).similarity
+    return (await get_kb_shards(txn, kbid)).similarity
 
 
 @pytest.mark.asyncio

--- a/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
+++ b/nucliadb/nucliadb/ingest/tests/integration/servicer/test_knowledgebox_servicer.py
@@ -87,7 +87,8 @@ async def get_kb_config(txn, kbid) -> knowledgebox_pb2.KnowledgeBoxConfig():
 
 
 async def get_kb_similarity(txn, kbid) -> utils_pb2.VectorSimilarity.ValueType:
-    return (await get_kb_shards(txn, kbid)).similarity
+    shards = await get_kb_shards(txn, kbid)
+    return shards.similarity
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description
Otherwise the values can end up in an inconsistent state

### How was this PR tested?
Integration tests
