### PR TITLE
fix test

### DIFF
--- a/nucliadb_node/src/settings/providers.rs
+++ b/nucliadb_node/src/settings/providers.rs
@@ -150,6 +150,8 @@ pub mod env {
         #[test]
         #[serial]
         fn test_default_env_settings() {
+            // The system may have DATA_PATH set
+            std::env::remove_var("DATA_PATH");
             let settings = EnvSettingsProvider::generate_settings().unwrap();
             assert_eq!(settings.shards_path().to_str().unwrap(), "data/shards")
         }

--- a/nucliadb_node/src/settings/providers.rs
+++ b/nucliadb_node/src/settings/providers.rs
@@ -150,28 +150,54 @@ pub mod env {
         #[test]
         #[serial]
         fn test_default_env_settings() {
-            // The system may have DATA_PATH set
+            // Safe current state of DATA_PATH
+            let data_path_copy = std::env::var("DATA_PATH");
+            // Remove DATA_PATH for the test
             std::env::remove_var("DATA_PATH");
+
             let settings = EnvSettingsProvider::generate_settings().unwrap();
+
+            if let Ok(value) = data_path_copy {
+                // The state needs to be restored
+                std::env::set_var("DATA_PATH", value);
+            }
+
             assert_eq!(settings.shards_path().to_str().unwrap(), "data/shards")
         }
 
         #[test]
         #[serial]
         fn test_env_settings_data_path() {
+            // Safe current state of DATA_PATH
+            let data_path_copy = std::env::var("DATA_PATH");
+            // set DATA_PATH for the test
             std::env::set_var("DATA_PATH", "mydata");
+
             let settings = EnvSettingsProvider::generate_settings().unwrap();
+
+            match data_path_copy {
+                Ok(value) => std::env::set_var("DATA_PATH", value),
+                Err(_) => std::env::remove_var("DATA_PATH"),
+            }
+
             assert_eq!(settings.shards_path().to_str().unwrap(), "mydata/shards");
-            std::env::remove_var("DATA_PATH");
         }
 
         #[test]
         #[serial]
         fn test_disable_sentry() {
+            // Safe current state of DISABLE_SENTRY
+            let disable_sentry_copy = std::env::var("DISABLE_SENTRY");
+            // set DISABLE_SENTRY for the test
             std::env::set_var("DISABLE_SENTRY", "true");
+
             let settings = EnvSettingsProvider::generate_settings().unwrap();
+            match disable_sentry_copy {
+                Ok(value) => std::env::set_var("DISABLE_SENTRY", value),
+                Err(_) => std::env::remove_var("DISABLE_SENTRY"),
+            }
+
             assert!(!settings.sentry_enabled);
-            std::env::remove_var("DISABLE_SENTRY");
         }
     }
 }

--- a/nucliadb_node/src/utils.rs
+++ b/nucliadb_node/src/utils.rs
@@ -159,7 +159,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[serial]
     fn test_lookup_localhost() {
         let hosts = vec!["127.0.0.1", "localhost", "localhost:8080"];
         for host in hosts.into_iter() {
@@ -169,7 +168,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_parse_log_levels() {
         let levels = "nucliadb=INFO,node_*=DEBUG,*=TRACE";
         let res = parse_log_levels(levels);
@@ -184,7 +182,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_parse_node_role() {
         matches!(parse_node_role("primary"), NodeRole::Primary);
         matches!(parse_node_role("secondary"), NodeRole::Secondary);

--- a/nucliadb_node/src/utils.rs
+++ b/nucliadb_node/src/utils.rs
@@ -153,11 +153,13 @@ pub async fn list_shards(shards_path: PathBuf) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
     use tempfile::TempDir;
 
     use super::*;
 
     #[test]
+    #[serial]
     fn test_lookup_localhost() {
         let hosts = vec!["127.0.0.1", "localhost", "localhost:8080"];
         for host in hosts.into_iter() {
@@ -167,6 +169,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_parse_log_levels() {
         let levels = "nucliadb=INFO,node_*=DEBUG,*=TRACE";
         let res = parse_log_levels(levels);
@@ -181,12 +184,14 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_parse_node_role() {
         matches!(parse_node_role("primary"), NodeRole::Primary);
         matches!(parse_node_role("secondary"), NodeRole::Secondary);
     }
 
     #[test]
+    #[serial]
     fn test_set_primary_id() {
         let tempdir = TempDir::new().expect("Unable to create temporary data directory");
         // set env variable


### PR DESCRIPTION
### Description
The following test: 
```rust
 fn test_default_env_settings() {
     let settings = EnvSettingsProvider::generate_settings().unwrap();
     assert_eq!(settings.shards_path().to_str().unwrap(), "data/shards")
}
```
Did not take into account that the system running it may already have `DATA_PATH` set, failing in such case.
More problematic, is that this tests change the state of the system running it after being ran, due to changes in env vars that are not reverted. For this reason, a system that already has `DATA_PATH` set will only have a successful run of `test_default_env_settings` if `test_env_settings_data_path` is ran before.
This PR ensures that the env vars are in the expected state before running the test and that after running such tests the state is restored.

### How was this PR tested?
Test past even with the env vars already set.
