### PR TITLE
Fix date range filtering

### DIFF
--- a/nucliadb/nucliadb/tests/integration/search/test_search.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search.py
@@ -503,7 +503,7 @@ async def test_search_returns_sentence_positions(
     assert "page_number" not in position
 
 
-async def inject_resource_with_a_sentence(knowledgebox, writer):
+def get_resource_with_a_sentence(knowledgebox):
     bm = broker_resource(knowledgebox)
 
     bm.files["file"].file.uri = "http://nofile"
@@ -545,7 +545,11 @@ async def inject_resource_with_a_sentence(knowledgebox, writer):
     ev.vectors.vectors.vectors.append(v1)
 
     bm.field_vectors.append(ev)
+    return bm
 
+
+async def inject_resource_with_a_sentence(knowledgebox, writer):
+    bm = get_resource_with_a_sentence(knowledgebox)
     await inject_message(writer, bm)
 
 

--- a/nucliadb/nucliadb/tests/integration/search/test_search_date_ranges_filter.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search_date_ranges_filter.py
@@ -22,6 +22,10 @@ from datetime import datetime, timedelta
 import pytest
 from httpx import AsyncClient
 
+from nucliadb.ingest.tests.vectors import V1
+from nucliadb.tests.integration.search.test_search import get_resource_with_a_sentence
+from nucliadb.tests.utils import inject_message
+
 NOW = datetime.now()
 ORIGIN_CREATION = datetime(2021, 1, 1)
 ORIGIN_MODIFICATION = datetime(2022, 1, 1)
@@ -36,17 +40,14 @@ def a_week_before(date):
 
 
 @pytest.fixture(scope="function")
-async def resource(nucliadb_writer, knowledgebox):
-    resp = await nucliadb_writer.post(
-        f"/kb/{knowledgebox}/resources",
-        json={
-            "title": "My resource",
-        },
-        headers={"X-Synchronous": "true"},
-    )
-    assert resp.status_code == 201
-    rid = resp.json()["uuid"]
-    return rid
+async def resource(nucliadb_grpc, knowledgebox):
+    bm = get_resource_with_a_sentence(knowledgebox)
+    bm.basic.created.FromDatetime(NOW)
+    bm.basic.modified.FromDatetime(NOW)
+    bm.origin.ClearField("created")
+    bm.origin.ClearField("modified")
+    await inject_message(nucliadb_grpc, bm)
+    return bm.uuid
 
 
 @pytest.mark.parametrize(
@@ -76,6 +77,7 @@ async def resource(nucliadb_writer, knowledgebox):
     "feature",
     [
         "paragraph",
+        "vector",
     ],
 )
 @pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
@@ -133,6 +135,7 @@ async def test_search_with_date_range_filters_nucliadb_dates(
     "feature",
     [
         "paragraph",
+        "vector",
     ],
 )
 @pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
@@ -187,10 +190,7 @@ async def _test_find_date_ranges(
     modification_end,
     found,
 ):
-    payload = {
-        "query": "resource",
-        "features": features,
-    }
+    payload = {"query": "Ramon", "features": features, "vector": V1}
     if creation_start:
         payload["range_creation_start"] = creation_start.isoformat()
     if creation_end:
@@ -206,7 +206,7 @@ async def _test_find_date_ranges(
     paragraphs = parse_paragraphs(body)
     if found:
         assert len(paragraphs) == 1
-        assert "My resource" in paragraphs
+        assert "Ramon" in paragraphs[0]
     else:
         assert len(paragraphs) == 0
 

--- a/nucliadb/nucliadb/tests/integration/search/test_search_date_ranges_filter.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search_date_ranges_filter.py
@@ -190,14 +190,16 @@ async def _test_find_date_ranges(
     modification_end,
     found,
 ):
-    payload = {"query": "Ramon", "features": features, "vector": V1}
-    if creation_start:
+    payload = {"query": "Ramon", "features": features}
+    if "vector" in features:
+        payload["vector"] = V1
+    if creation_start is not None:
         payload["range_creation_start"] = creation_start.isoformat()
-    if creation_end:
+    if creation_end is not None:
         payload["range_creation_end"] = creation_end.isoformat()
-    if modification_start:
+    if modification_start is not None:
         payload["range_modification_start"] = modification_start.isoformat()
-    if modification_end:
+    if modification_end is not None:
         payload["range_modification_end"] = modification_end.isoformat()
 
     resp = await nucliadb_reader.post(f"/kb/{kbid}/find", json=payload)

--- a/nucliadb_core/src/query_planner.rs
+++ b/nucliadb_core/src/query_planner.rs
@@ -86,13 +86,9 @@ impl IndexQueries {
     /// When a pre-filter is run, the result can be used to modify the queries
     /// that the indexes must resolve.
     pub fn apply_pre_filter(&mut self, pre_filtered: PreFilterResponse) {
+        // TODO:
+        //  - Apply to relations?
         if let Some(vectors_request) = self.vectors_request.as_mut() {
-            // TODO:
-            //  - Apply to paragraphs? Otherwise we'll be doing the date filtering twice
-            //  - Apply to relations?
-            //  - Apply to documents? We have the ids already.
-            //  - Also, it should clean up the rest of filtering options from the inner request
-            //    (e.g: the timestamps from the paragraph request)
             IndexQueries::apply_to_vectors(vectors_request, &pre_filtered);
         };
     }

--- a/nucliadb_core/src/query_planner.rs
+++ b/nucliadb_core/src/query_planner.rs
@@ -91,8 +91,8 @@ impl IndexQueries {
             //  - Apply to paragraphs? Otherwise we'll be doing the date filtering twice
             //  - Apply to relations?
             //  - Apply to documents? We have the ids already.
-            //  - Also, it should clean up the rest of filtering options from the inner request (e.g: the
-            //    timestamps from the paragraph request)
+            //  - Also, it should clean up the rest of filtering options from the inner request
+            //    (e.g: the timestamps from the paragraph request)
             IndexQueries::apply_to_vectors(vectors_request, &pre_filtered);
         };
     }

--- a/nucliadb_core/src/query_planner.rs
+++ b/nucliadb_core/src/query_planner.rs
@@ -87,6 +87,12 @@ impl IndexQueries {
     /// that the indexes must resolve.
     pub fn apply_pre_filter(&mut self, pre_filtered: PreFilterResponse) {
         if let Some(vectors_request) = self.vectors_request.as_mut() {
+            // TODO:
+            //  - Apply to paragraphs? Otherwise we'll be doing the date filtering twice
+            //  - Apply to relations?
+            //  - Apply to documents? We have the ids already.
+            //  - Also, it should clean up the rest of filtering options from the inner request (e.g: the
+            //    timestamps from the paragraph request)
             IndexQueries::apply_to_vectors(vectors_request, &pre_filtered);
         };
     }

--- a/nucliadb_node/src/shards/shard_reader.rs
+++ b/nucliadb_node/src/shards/shard_reader.rs
@@ -408,7 +408,16 @@ impl ShardReader {
         // Apply pre-filtering to the query plan
         if let Some(pre_filter) = pre_filter {
             let pre_filtered = self.text_reader.pre_filter(&pre_filter)?;
-            index_queries.apply_pre_filter(pre_filtered);
+            if pre_filtered.valid_fields.is_empty() {
+                return Ok(SearchResponse {
+                    document: None,
+                    paragraph: None,
+                    vector: None,
+                    relation: None,
+                });
+            } else {
+                index_queries.apply_pre_filter(pre_filtered);
+            }
         }
 
         // Run the rest of the plan

--- a/nucliadb_node/tests/test_date_range_search.rs
+++ b/nucliadb_node/tests/test_date_range_search.rs
@@ -172,6 +172,19 @@ async fn test_date_range_search() -> Result<(), Box<dyn std::error::Error>> {
     let vectors = result.vector.unwrap();
     assert_eq!(vectors.documents.len(), 4);
 
+    // Time range allows only second batch, but with modified only
+    let mut request_second_batch = request.clone();
+    request_second_batch.timestamps = Some(Timestamps {
+        from_modified: Some(base_time_plus_one.clone()),
+        to_modified: None,
+        from_created: None,
+        to_created: None,
+    });
+    let result = reader.search(request_second_batch).await.unwrap();
+    let result = result.into_inner();
+    let vectors = result.vector.unwrap();
+    assert_eq!(vectors.documents.len(), 4);
+
     let mut base_time_plus_two = base_time_plus_one.clone();
     base_time_plus_two.seconds += 1;
 

--- a/nucliadb_node/tests/test_date_range_search.rs
+++ b/nucliadb_node/tests/test_date_range_search.rs
@@ -172,5 +172,23 @@ async fn test_date_range_search() -> Result<(), Box<dyn std::error::Error>> {
     let vectors = result.vector.unwrap();
     assert_eq!(vectors.documents.len(), 4);
 
+    let mut base_time_plus_two = base_time_plus_one.clone();
+    base_time_plus_two.seconds += 1;
+
+    // Time range does not match any field, therefore the response has no results
+    let mut request_second_batch = request.clone();
+    request_second_batch.timestamps = Some(Timestamps {
+        from_modified: Some(base_time_plus_two.clone()),
+        to_modified: None,
+        from_created: Some(base_time_plus_two.clone()),
+        to_created: None,
+    });
+    let result = reader.search(request_second_batch).await.unwrap();
+    let result = result.into_inner();
+    assert_eq!(result.document, None);
+    assert_eq!(result.paragraph, None);
+    assert_eq!(result.vector, None);
+    assert_eq!(result.relation, None);
+
     Ok(())
 }

--- a/nucliadb_node/tests/test_date_range_search.rs
+++ b/nucliadb_node/tests/test_date_range_search.rs
@@ -190,5 +190,20 @@ async fn test_date_range_search() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(result.vector, None);
     assert_eq!(result.relation, None);
 
+    // Multiple timestamps are parsed as AND conditions
+    let mut request_second_batch = request.clone();
+    request_second_batch.timestamps = Some(Timestamps {
+        from_modified: Some(base_time_plus_one.clone()),
+        to_modified: None,
+        from_created: Some(base_time_plus_two.clone()),
+        to_created: None,
+    });
+    let result = reader.search(request_second_batch).await.unwrap();
+    let result = result.into_inner();
+    assert_eq!(result.document, None);
+    assert_eq!(result.paragraph, None);
+    assert_eq!(result.vector, None);
+    assert_eq!(result.relation, None);
+
     Ok(())
 }

--- a/nucliadb_texts/src/reader.rs
+++ b/nucliadb_texts/src/reader.rs
@@ -101,7 +101,7 @@ impl FieldReader for TextReaderService {
             };
             if let Some(query) = search_query::produce_date_range_query(field, from, to) {
                 let query: Box<dyn Query> = Box::new(query);
-                timestamp_queries.push((Occur::Should, query));
+                timestamp_queries.push((Occur::Must, query));
             }
         }
         let pre_filter_query = BooleanQuery::new(timestamp_queries);

--- a/nucliadb_texts/src/reader.rs
+++ b/nucliadb_texts/src/reader.rs
@@ -105,16 +105,19 @@ impl FieldReader for TextReaderService {
                 add_to.push((Occur::Should, query));
             }
         }
-        let pre_filter_query: Box<dyn Query> = if created_queries.is_empty() {
-            Box::new(BooleanQuery::new(modified_queries))
-        } else if modified_queries.is_empty() {
-            Box::new(BooleanQuery::new(created_queries))
-        } else {
-            let created_query: Box<dyn Query> = Box::new(BooleanQuery::new(created_queries));
-            let modified_query: Box<dyn Query> = Box::new(BooleanQuery::new(modified_queries));
-            let subqueries = vec![(Occur::Must, created_query), (Occur::Must, modified_query)];
-            Box::new(BooleanQuery::new(subqueries))
-        };
+        let pre_filter_query: Box<dyn Query> =
+            if created_queries.is_empty() && modified_queries.is_empty() {
+                Box::new(AllQuery)
+            } else if created_queries.is_empty() {
+                Box::new(BooleanQuery::new(modified_queries))
+            } else if modified_queries.is_empty() {
+                Box::new(BooleanQuery::new(created_queries))
+            } else {
+                let created_query: Box<dyn Query> = Box::new(BooleanQuery::new(created_queries));
+                let modified_query: Box<dyn Query> = Box::new(BooleanQuery::new(modified_queries));
+                let subqueries = vec![(Occur::Must, created_query), (Occur::Must, modified_query)];
+                Box::new(BooleanQuery::new(subqueries))
+            };
         let searcher = self.reader.searcher();
         let docs_fulfilled = searcher.search(&pre_filter_query, &DocSetCollector)?;
         let mut valid_fields = Vec::new();


### PR DESCRIPTION
### Description
This PR extends the test suite for the date range filtering feature and fixes a couple corner cases:
- When specifing both `range_creation_x` and `range_modification_x` in the same request, they need to be interpreted as AND conditions.

- If there are no matching fields as result of the pre-filter step, no need to do the queries: fail fast!

### How was this PR tested?
Integration tests (rust and python side)
