### PR TITLE
Improve progress reporting on imports

### DIFF
--- a/nucliadb/nucliadb/export_import/datamanager.py
+++ b/nucliadb/nucliadb/export_import/datamanager.py
@@ -88,7 +88,7 @@ class ExportImportDataManager:
         export_bytes: AsyncGenerator[bytes, None],
         kbid: str,
         export_id: str,
-    ):
+    ) -> int:
         key = STORAGE_EXPORT_KEY.format(export_id=export_id)
         cf = resources_pb2.CloudFile()
         cf.bucket_name = self.storage.get_bucket_name(kbid)
@@ -97,6 +97,7 @@ class ExportImportDataManager:
         field: StorageField = self._get_storage_field(kbid, key, cf)
         iterator = iterate_storage_compatible(export_bytes, self.storage, cf)
         await self.storage.uploaditerator(iterator, field, cf)
+        return cf.size
 
     async def download_export(
         self, kbid: str, export_id: str

--- a/nucliadb/nucliadb/export_import/datamanager.py
+++ b/nucliadb/nucliadb/export_import/datamanager.py
@@ -111,7 +111,7 @@ class ExportImportDataManager:
         import_bytes: AsyncGenerator[bytes, None],
         kbid: str,
         import_id: str,
-    ):
+    ) -> int:
         key = STORAGE_IMPORT_KEY.format(import_id=import_id)
         cf = resources_pb2.CloudFile()
         cf.bucket_name = self.storage.get_bucket_name(kbid)
@@ -119,6 +119,7 @@ class ExportImportDataManager:
         field: StorageField = self._get_storage_field(kbid, key, cf)
         iterator = iterate_storage_compatible(import_bytes, self.storage, cf)
         await self.storage.uploaditerator(iterator, field, cf)
+        return cf.size
 
     async def download_import(self, kbid: str, import_id: str):
         key = STORAGE_IMPORT_KEY.format(import_id=import_id)

--- a/nucliadb/nucliadb/export_import/exporter.py
+++ b/nucliadb/nucliadb/export_import/exporter.py
@@ -80,10 +80,14 @@ async def export_kb_to_blob_storage(
     retry_handler = TaskRetryHandler("export", dm, metadata)
 
     @retry_handler.wrap
-    async def upload_export_retried(iterator, kbid, export_id):
-        await dm.upload_export(iterator, kbid, export_id)
+    async def upload_export_retried(iterator, kbid, export_id) -> int:
+        return await dm.upload_export(iterator, kbid, export_id)
 
-    await upload_export_retried(iterator, kbid, export_id)
+    export_size = await upload_export_retried(iterator, kbid, export_id)
+
+    # Store export size
+    metadata.total = metadata.processed = export_size
+    await dm.set_metadata("export", metadata)
 
 
 async def export_resources(

--- a/nucliadb/nucliadb/export_import/importer.py
+++ b/nucliadb/nucliadb/export_import/importer.py
@@ -57,9 +57,9 @@ async def import_kb(
     dm = ExportImportDataManager(context.kv_driver, context.blob_storage)
     stream_reader = ExportStreamReader(stream)
 
-    if metadata is not None and metadata.total > 0:
+    if metadata is not None and metadata.processed > 0:
         # Resuming task in a retry
-        await stream_reader.seek(metadata.total)
+        await stream_reader.seek(metadata.processed)
 
     items_count = 0
     async for item_type, data in stream_reader.iter_items():

--- a/nucliadb/nucliadb/export_import/models.py
+++ b/nucliadb/nucliadb/export_import/models.py
@@ -66,7 +66,7 @@ class ExportMetadata(Metadata):
 
 
 class ImportMetadata(Metadata):
-    read_bytes: int = 0
+    ...
 
 
 class NatsTaskMessage(BaseModel):

--- a/nucliadb/nucliadb/reader/api/v1/export_import.py
+++ b/nucliadb/nucliadb/reader/api/v1/export_import.py
@@ -61,12 +61,13 @@ async def download_export_kb_endpoint(request: Request, kbid: str, export_id: st
             headers={"Content-Disposition": f"attachment; filename={kbid}.export"},
         )
     try:
-        # TODO: Support range downloads to better support big export downloads.
         return StreamingResponse(
             await download_export_from_blob_storage(context, kbid, export_id),
             status_code=200,
             media_type="application/octet-stream",
-            headers={"Content-Disposition": f"attachment; filename={kbid}.export"},
+            headers={
+                "Content-Disposition": f"attachment; filename={kbid}.export",
+            },
         )
     except export_exceptions.MetadataNotFound:
         return HTTPClientError(status_code=404, detail="Export not found")

--- a/nucliadb/nucliadb/writer/api/v1/export_import.py
+++ b/nucliadb/nucliadb/writer/api/v1/export_import.py
@@ -98,22 +98,21 @@ async def start_kb_import_endpoint(request: Request, kbid: str):
         )
         return CreateImportResponse(import_id=import_id)
     else:
-        # TODO: Implement range/resumable uploads to better suppor big exports.
-        await upload_import_to_blob_storage(
+        import_size = await upload_import_to_blob_storage(
             context=context,
             request=request,
             kbid=kbid,
             import_id=import_id,
         )
-        await start_import_task(context, kbid, import_id)
+        await start_import_task(context, kbid, import_id, import_size)
         return CreateImportResponse(import_id=import_id)
 
 
 async def upload_import_to_blob_storage(
     context: ApplicationContext, request: Request, kbid: str, import_id: str
-):
+) -> int:
     dm = ExportImportDataManager(context.kv_driver, context.blob_storage)
-    await dm.upload_import(
+    return await dm.upload_import(
         import_bytes=request.stream(),
         kbid=kbid,
         import_id=import_id,
@@ -138,10 +137,13 @@ async def start_export_task(context: ApplicationContext, kbid: str, export_id: s
         raise
 
 
-async def start_import_task(context: ApplicationContext, kbid: str, import_id: str):
+async def start_import_task(
+    context: ApplicationContext, kbid: str, import_id: str, import_size: int
+):
     dm = ExportImportDataManager(context.kv_driver, context.blob_storage)
     metadata = ImportMetadata(kbid=kbid, id=import_id)
     metadata.task.status = Status.SCHEDULED
+    metadata.total = import_size
     await dm.set_metadata("import", metadata)
     try:
         producer = await get_imports_producer(context)


### PR DESCRIPTION
### Description
The progress of import tasks is reported with `total` and `processed` by setting the total size of the import blob and the bytes read from the stream so far.

### How was this PR tested?
Existing tests should cover it
