### PR TITLE
Add support for service account on ingest components

### DIFF
--- a/charts/nucliadb/templates/rbac.yaml
+++ b/charts/nucliadb/templates/rbac.yaml
@@ -41,5 +41,5 @@ roleRef:
   name: statefulset-viewer
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ .Values.serviceAccount | default "default" }}
   namespace: {{ .Release.Namespace }}

--- a/charts/nucliadb/templates/sts.yaml
+++ b/charts/nucliadb/templates/sts.yaml
@@ -39,6 +39,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount:  {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: app
         image: "{{ .Values.image }}:{{ .Values.imageVersion }}"

--- a/charts/nucliadb_ingest/templates/exporter.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/exporter.deploy.yaml
@@ -46,6 +46,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ ((.Values.exporter).serviceAccount) | default "default" }}
       containers:
       - name: metrics-exporter
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
@@ -43,6 +43,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ ((.Values.ingest_orm_grpc).serviceAccount) | default "default" }}
       containers:
       - name: ingest-orm-grpc
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
@@ -43,6 +43,7 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      serviceAccount: {{ ((.Values.ingest_processed_consumer).serviceAccount) | default "default" }}
       dnsPolicy: ClusterFirst
       containers:
       - name: ingest-processed-consumer

--- a/charts/nucliadb_ingest/templates/ingest-subscriber-workers.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-subscriber-workers.deploy.yaml
@@ -44,6 +44,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ ((.Values.ingest_subscriber_workers).serviceAccount) | default "default" }}
       containers:
       - name: ingest-subscriber-workers
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -55,6 +55,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ ((.Values.ingest).serviceAccount) | default "default" }}
       containers:
       - name: ingest
         securityContext:

--- a/charts/nucliadb_ingest/templates/migrator.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/migrator.deploy.yaml
@@ -46,6 +46,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount:  {{ ((.Values.migrator).serviceAccount) | default "default" }}
       containers:
       - name: migrator
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_node/templates/node.replicas.deploy.yaml
+++ b/charts/nucliadb_node/templates/node.replicas.deploy.yaml
@@ -63,6 +63,7 @@ spec:
 {{ toYaml $values.readReplicas.tolerations | indent 8 }}
 {{- end }}
       dnsPolicy: ClusterFirst
+      serviceAccount:  {{ (($values.readReplicas).serviceAccount) | default "default" }}
       volumes:
       - name: data-dir
         emptyDir:

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -53,6 +53,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ .Values.serviceAccount | default "default" }}
 {{- if .Values.nats.secretName }}
       volumes:
       - name: nats-creds

--- a/charts/nucliadb_reader/templates/reader.deploy.yaml
+++ b/charts/nucliadb_reader/templates/reader.deploy.yaml
@@ -42,6 +42,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: reader
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -42,6 +42,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: search
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_train/templates/train.deploy.yaml
+++ b/charts/nucliadb_train/templates/train.deploy.yaml
@@ -42,6 +42,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: train
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_writer/templates/writer.deploy.yaml
+++ b/charts/nucliadb_writer/templates/writer.deploy.yaml
@@ -42,6 +42,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       dnsPolicy: ClusterFirst
+      serviceAccount: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: writer
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"


### PR DESCRIPTION
### Description
Add support for kubernetes service accounts in deployments and statefulsets for ingest chart. 

### How was this PR tested?
Tested locally using `helm template` and `helm lint`
