### PR TITLE
Disable volume for nats credentials for read replicas if secret is not set

### DIFF
--- a/charts/nucliadb_node/templates/node.replicas.deploy.yaml
+++ b/charts/nucliadb_node/templates/node.replicas.deploy.yaml
@@ -67,9 +67,11 @@ spec:
       volumes:
       - name: data-dir
         emptyDir:
+{{- with $values.nats.secretName }}
       - name: nats-creds
         secret:
-          secretName: {{ $values.nats.secretName }}
+          secretName: {{ . }}
+{{- end }}
       containers:
       - name: writer
         securityContext:


### PR DESCRIPTION
### Description
Disables volume block from template if nats secret is not set.
### How was this PR tested?
Tested locally via `helm template` and `helm lint`