### PR TITLE
Add irsa helm value for disable S3 secret_id and client_id

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -26,8 +26,10 @@ data:
   GCS_PROJECT: {{ .Values.storage.gcs_project }}
   GCS_BUCKET_LABELS: {{ toJson .Values.storage.gcs_bucket_labels | quote }}
 {{- else if eq .Values.storage.file_backend "s3" }}
+{{- if eq .Values.storage.s3_irsa "disabled" }}
   S3_CLIENT_ID: {{ .Values.storage.s3_client_id }}
   S3_CLIENT_SECRET: {{ .Values.storage.s3_client_secret }}
+{{- end }}
 {{- if .Values.storage.s3_ssl }}
   S3_SSL: "True"
 {{- end }}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -25,6 +25,7 @@ storage:
   gcs_deadletter_bucket: XX
   gcs_indexing_bucket: XX
 
+  s3_irsa: disabled
   s3_client_id: XX
   s3_client_secret: XX
   s3_ssl: True


### PR DESCRIPTION
### Description
When using AWS IRSA, client_id and secret_id are not needed. If they are set authentication fails.

### How was this PR tested?
`helm template` and `helm lint`