### PR TITLE
fix using auto bump versions in docker release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,3 +1,4 @@
+## XXX This can not currently run with restrictions we have on branch protections
 name: Bump Version
 
 on:

--- a/.github/workflows/nucliadb.yml
+++ b/.github/workflows/nucliadb.yml
@@ -165,51 +165,6 @@ jobs:
           file: ./coverage.xml
           flags: nucliadb
 
-  push:
-    name: Build and push docker image
-    runs-on: ubuntu-latest
-    needs: tests
-    if: github.event_name == 'push'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      # We need to setup buildx to be able to cache with gha
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Get release version
-        id: version_step
-        run: |-
-          python bump.py --build=${{github.run_number}}
-          VERSION=`cat VERSION`
-          HASH=`git rev-parse --short HEAD`
-          echo "version_number=$VERSION" >> $GITHUB_OUTPUT
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            nuclia/nucliadb:latest
-            nuclia/nucliadb:${{ steps.version_step.outputs.version_number }}
-            nuclia/nucliadb:${{ steps.version_step.outputs.hash }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-
   push-dev:
     name: Build dev image and push
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,47 @@ jobs:
       #     repository: nuclia/nuclia.py
       #     event-type: test-stage
       #     client-payload: '{"component": "nucliadb", "commit": "${{ github.sha }}", "user": "${{ github.actor }}"}'
+  
+  push-docker:
+    name: Build and push nucliadb docker image
+    runs-on: ubuntu-latest
+    needs: build_wheels
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      # We need to setup buildx to be able to cache with gha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get release version
+        id: version_step
+        run: |-
+          python bump.py --build=${{github.run_number}}
+          VERSION=`cat VERSION`
+          HASH=`git rev-parse --short HEAD`
+          echo "version_number=$VERSION" >> $GITHUB_OUTPUT
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            nuclia/nucliadb:latest
+            nuclia/nucliadb:${{ steps.version_step.outputs.version_number }}
+            nuclia/nucliadb:${{ steps.version_step.outputs.hash }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min


### PR DESCRIPTION
### Description

We can not mix build numbers that we use for `-post` version numbers so this should be in single workflow


### How was this PR tested?
Describe how you tested this PR.
