### PR TITLE
Naming improvements in chat endpoint

### DIFF
--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -126,7 +126,7 @@ def test_search(kbid: str, resource_id: str):
         },
         json={
             "query": "What is Cricket?",
-            "context": [],
+            "chat_history": [],
             "show": ["basic", "values", "origin"],
             "features": ["paragraphs", "relations"],
             "inTitleOnly": False,

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -195,14 +195,14 @@ async def chat(
     origin: str,
 ) -> ChatResult:
     nuclia_learning_id: Optional[str] = None
-    chat_history = chat_request.context or []
+    user_query = chat_request.query
+    chat_history = chat_request.chat_history or []
     start_time = time()
 
-    user_query = chat_request.query
     rephrased_query = None
-    if chat_request.context and len(chat_request.context) > 0:
+    if len(chat_history) > 0:
         rephrased_query = await rephrase_query_from_chat_history(
-            kbid, chat_request.context, user_query, user_id
+            kbid, chat_history, user_query, user_id
         )
 
     find_results: KnowledgeboxFindResults = await get_find_results(

--- a/nucliadb/nucliadb/tests/integration/test_chat.py
+++ b/nucliadb/nucliadb/tests/integration/test_chat.py
@@ -41,9 +41,10 @@ async def test_chat(
     )
     assert resp.status_code == 200
 
-    context = [{"author": "USER", "text": "query"}]
+    chat_history = [{"author": "USER", "text": "query"}]
     resp = await nucliadb_reader.post(
-        f"/kb/{knowledgebox}/chat", json={"query": "query", "context": context}
+        f"/kb/{knowledgebox}/chat",
+        json={"query": "query", "chat_history": chat_history},
     )
     assert resp.status_code == 200
 

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -530,11 +530,6 @@ class SearchParamDefaults:
         title="Vectorset id",
         description="Id of the vectorset to perform the vector search into.",
     )
-    chat_context = ParamDefault(
-        default=None,
-        title="Chat history",
-        description="Use to rephrase the new LLM query by taking into account the chat conversation history",  # noqa
-    )
 
     chat_features = ParamDefault(
         default=[ChatOptions.VECTORS, ChatOptions.PARAGRAPHS, ChatOptions.RELATIONS],
@@ -721,9 +716,13 @@ class ChatRequest(BaseModel):
         ExtractedDataTypeName
     ] = SearchParamDefaults.extracted.to_pydantic_field()
     shards: List[str] = SearchParamDefaults.shards.to_pydantic_field()
-    context: Optional[
-        List[ChatContextMessage]
-    ] = SearchParamDefaults.chat_context.to_pydantic_field()
+    chat_history = Field(
+        default=None,
+        title="Chat history",
+        description="Use to rephrase the new LLM query by taking into account the chat conversation history",  # noqa
+        # B/w compatibility: this field was previously named 'context'
+        validation_alias="context",
+    )
     autofilter: bool = SearchParamDefaults.autofilter.to_pydantic_field()
     highlight: bool = SearchParamDefaults.highlight.to_pydantic_field()
     resource_filters: List[

--- a/nucliadb_sdk/nucliadb_sdk/knowledgebox.py
+++ b/nucliadb_sdk/nucliadb_sdk/knowledgebox.py
@@ -547,7 +547,7 @@ class KnowledgeBox:
 
         args["min_score"] = min_score
         args["fields"] = fields or []
-        args["context"] = context
+        args["chat_history"] = context
         args["extracted"] = extracted
         args["field_type_filter"] = field_type_filter
         args["show"] = show

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import nucliadb_sdk
+from nucliadb_models.search import Author, ChatContextMessage
 
 
 def test_chat_on_kb(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
@@ -25,6 +26,11 @@ def test_chat_on_kb(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
         kbid=docs_dataset,
         query="Nuclia loves Semantic Search",
         prompt="Given this context: {context}. Answer this {question} in a concise way using the provided context",
+        chat_history=[
+            ChatContextMessage(
+                author=Author.USER, text="What is the coldest season in Sevilla?"
+            )
+        ],
     )
     assert result.learning_id == "00"
     assert result.answer == "valid answer  to"

--- a/nucliadb_sdk/nucliadb_sdk/v2/docstrings.py
+++ b/nucliadb_sdk/nucliadb_sdk/v2/docstrings.py
@@ -264,11 +264,11 @@ RESOURCE_CHAT = Docstring(
         ),
         Example(
             description="You can use the `content` parameter to pass previous context to the query",
-            code=""">>> from nucliadb_models.search import ChatRequest, Message
+            code=""">>> from nucliadb_models.search import ChatRequest, ChatContextMessage
 >>> content = ChatRequest()
 >>> content.query = "What is the average temperature?"
->>> content.context.append(Messate(author="USER", text="What is the coldest season in Sevilla?"))
->>> content.context.append(Messate(author="NUCLIA", text="January is the coldest month."))
+>>> content.chat_history.append(ChatContextMessage(author="USER", text="What is the coldest season in Sevilla?"))
+>>> content.chat_history.append(ChatContextMessage(author="NUCLIA", text="January is the coldest month."))
 >>> sdk.chat(kbid="mykbid", content=content).answer
 'According to the context, the average temperature in January in Sevilla is 15.9 °C and 5.2 °C.'
 """,


### PR DESCRIPTION
### Description
Essentially renaming `context` to `chat_history` to better reflect what the parameter is about

### How was this PR tested?
Describe how you tested this PR.
