### PR TITLE
Fix gcloud overlapping log key

### DIFF
--- a/nucliadb_node/nucliadb_node/indexer.py
+++ b/nucliadb_node/nucliadb_node/indexer.py
@@ -367,7 +367,7 @@ class PriorityIndexer:
             "Message indexing finished",
             extra={
                 **_extra,
-                "time": time.time() - start,
+                "indexing_time": time.time() - start,
             },
         )
 


### PR DESCRIPTION
### Description
`time` key overlaps with timestamp used by gcloud logs. As it was before, logs containing our `time` key don't appear on the console (but are printed to stdout).

### How was this PR tested?
Describe how you tested this PR.
