### PR TITLE
Safer resource slug patching

### DIFF
--- a/nucliadb/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/nucliadb/common/datamanagers/resources.py
@@ -185,11 +185,14 @@ class ResourcesDataManager:
         if basic is None:
             raise NotFoundError()
         old_slug = basic.slug
-        slug_exists = (
-            await cls.get_resource_uuid_from_slug(txn, kbid, new_slug) is not None
-        )
-        if slug_exists:
-            raise ConflictError(f"Slug {new_slug} already exists")
+
+        uuid_for_new_slug = await cls.get_resource_uuid_from_slug(txn, kbid, new_slug)
+        if uuid_for_new_slug is not None:
+            if uuid_for_new_slug == rid:
+                # Nothing to change
+                return old_slug
+            else:
+                raise ConflictError(f"Slug {new_slug} already exists")
         key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=old_slug)
         await txn.delete(key)
         key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=new_slug)

--- a/nucliadb/nucliadb/tests/integration/test_resources.py
+++ b/nucliadb/nucliadb/tests/integration/test_resources.py
@@ -17,7 +17,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+from unittest import mock
+
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 
 from nucliadb.writer.api.v1.router import KB_PREFIX, RESOURCES_PREFIX
@@ -286,34 +289,6 @@ async def test_resource_slug_modification(
         nucliadb_reader, knowledgebox, rid, new_slug, title="New title"
     )
 
-    # Check that conflicts are detected
-    if update_by == "slug":
-        path = f"/{KB_PREFIX}/{knowledgebox}/slug/{new_slug}"
-    else:
-        path = f"/{KB_PREFIX}/{knowledgebox}/resource/{rid}"
-    resp = await nucliadb_writer.patch(
-        path,
-        headers={"X-Synchronous": "true"},
-        json={
-            "slug": new_slug,
-        },
-    )
-    assert resp.status_code == 409
-
-    # Check that unknown resources are detected
-    if update_by == "slug":
-        path = f"/{KB_PREFIX}/{knowledgebox}/slug/foobar"
-    else:
-        path = f"/{KB_PREFIX}/{knowledgebox}/resource/foobar"
-    resp = await nucliadb_writer.patch(
-        path,
-        headers={"X-Synchronous": "true"},
-        json={
-            "slug": new_slug,
-        },
-    )
-    assert resp.status_code == 404
-
 
 async def check_resource(nucliadb_reader, kbid, rid, slug, **body_checks):
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid}")
@@ -326,3 +301,96 @@ async def check_resource(nucliadb_reader, kbid, rid, slug, **body_checks):
     assert body["id"] == rid
     for key, value in body_checks.items():
         assert body[key] == value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
+async def test_resource_slug_modification_rollbacks(
+    nucliadb_reader,
+    nucliadb_writer,
+    knowledgebox,
+):
+    old_slug = "my-resource"
+    resp = await nucliadb_writer.post(
+        f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
+        headers={"X-Synchronous": "true"},
+        json={
+            "title": "Old title",
+            "slug": old_slug,
+        },
+    )
+    assert resp.status_code == 201
+    rid = resp.json()["uuid"]
+
+    await check_resource(nucliadb_reader, knowledgebox, rid, old_slug)
+
+    # Mock an error in the sending to process
+    with mock.patch(
+        "nucliadb.writer.api.v1.resource.maybe_send_to_process",
+        side_effect=HTTPException(status_code=506),
+    ):
+        resp = await nucliadb_writer.patch(
+            f"/{KB_PREFIX}/{knowledgebox}/resource/{rid}",
+            headers={"X-Synchronous": "true"},
+            json={
+                "slug": "my-resource-2",
+                "title": "New title",
+            },
+        )
+        assert resp.status_code == 506
+
+    # Check that slug and title were not updated
+    await check_resource(
+        nucliadb_reader, knowledgebox, rid, old_slug, title="Old title"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
+async def test_resource_slug_modification_handles_conflicts(
+    nucliadb_writer,
+    knowledgebox,
+):
+    rids = []
+    slugs = []
+    for i in range(2):
+        slug = f"my-resource-{i}"
+        slugs.append(slug)
+        resp = await nucliadb_writer.post(
+            f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
+            headers={"X-Synchronous": "true"},
+            json={
+                "title": "My Resource",
+                "slug": slug,
+            },
+        )
+        assert resp.status_code == 201
+        rid = resp.json()["uuid"]
+        rids.append(rid)
+
+    # Check that conflicts on slug are detected
+    path = f"/{KB_PREFIX}/{knowledgebox}/resource/{rids[0]}"
+    resp = await nucliadb_writer.patch(
+        path,
+        headers={"X-Synchronous": "true"},
+        json={
+            "slug": slugs[1],
+        },
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
+async def test_resource_slug_modification_handles_unknown_resources(
+    nucliadb_writer,
+    knowledgebox,
+):
+    resp = await nucliadb_writer.patch(
+        f"/{KB_PREFIX}/{knowledgebox}/resource/foobar",
+        headers={"X-Synchronous": "true"},
+        json={
+            "slug": "foo",
+        },
+    )
+    assert resp.status_code == 404

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -17,8 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import contextlib
 from time import time
-from typing import Optional, cast
+from typing import Optional
 from uuid import uuid4
 
 from fastapi import HTTPException, Query, Response
@@ -38,12 +39,12 @@ from starlette.requests import Request
 
 from nucliadb.common.context.fastapi import get_app_context
 from nucliadb.common.datamanagers.resources import ResourcesDataManager
-from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.driver import Driver
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.processing import ProcessingInfo, PushPayload, Source
-from nucliadb.writer import SERVICE_NAME
+from nucliadb.writer import SERVICE_NAME, logger
 from nucliadb.writer.api.constants import SKIP_STORE_DEFAULT, SYNC_CALL, X_NUCLIADB_USER
 from nucliadb.writer.api.v1.router import (
     KB_PREFIX,
@@ -77,6 +78,7 @@ from nucliadb_models.writer import (
     ResourceUpdated,
     UpdateResourcePayload,
 )
+from nucliadb_telemetry.errors import capture_exception
 from nucliadb_utils.authentication import requires
 from nucliadb_utils.exceptions import LimitsExceededError, SendToProcessError
 from nucliadb_utils.utilities import (
@@ -260,22 +262,30 @@ async def modify_resource_endpoint(
     path_rid: Optional[str] = None,
     path_rslug: Optional[str] = None,
 ):
-    response = await modify_resource(
-        request,
-        item,
-        kbid,
-        x_skip_store=x_skip_store,
-        x_synchronous=x_synchronous,
-        x_nucliadb_user=x_nucliadb_user,
-        rid=path_rid,
-        rslug=path_rslug,
-    )
-    if item.slug:
-        # Slug is modified in a separate transaction
-        await update_resource_slug(
-            request, kbid, rid=path_rid, slug=path_rslug, new_slug=item.slug
+    resource_uuid = await get_rid_from_params_or_raise_error(kbid, path_rid, path_rslug)
+    if item.slug is None:
+        return await modify_resource(
+            request,
+            item,
+            kbid,
+            x_skip_store=x_skip_store,
+            x_synchronous=x_synchronous,
+            x_nucliadb_user=x_nucliadb_user,
+            rid=resource_uuid,
         )
-    return response
+
+    async with safe_update_resource_slug(
+        request, kbid, rid=resource_uuid, new_slug=item.slug
+    ):
+        return await modify_resource(
+            request,
+            item,
+            kbid,
+            x_skip_store=x_skip_store,
+            x_synchronous=x_synchronous,
+            x_nucliadb_user=x_nucliadb_user,
+            rid=resource_uuid,
+        )
 
 
 async def modify_resource(
@@ -285,13 +295,11 @@ async def modify_resource(
     x_skip_store: bool,
     x_synchronous: bool,
     x_nucliadb_user: str,
-    rid: Optional[str] = None,
-    rslug: Optional[str] = None,
+    *,
+    rid: str,
 ):
     transaction = get_transaction_utility()
     partitioning = get_partitioning()
-
-    rid = await get_rid_from_params_or_raise_error(kbid, rid, rslug)
 
     partition = partitioning.generate_partition(kbid, rid)
 
@@ -345,48 +353,54 @@ async def modify_resource(
     return ResourceUpdated(seqid=seqid)
 
 
-async def update_resource_slug(
-    request: Request,
+@contextlib.asynccontextmanager
+async def safe_update_resource_slug(
+    request,
     kbid: str,
+    *,
+    rid: str,
     new_slug: str,
-    rid: Optional[str] = None,
-    slug: Optional[str] = None,
 ):
+    old_slug = None
+    driver = get_app_context(request.app).kv_driver
     try:
-        driver = get_app_context(request.app).kv_driver
-        async with driver.transaction() as txn:
-            await _update_resource_slug(
-                txn, kbid, rid=rid, slug=slug, new_slug=new_slug
-            )
-            await txn.commit()
+        old_slug = await update_resource_slug(driver, kbid, rid=rid, new_slug=new_slug)
     except NotFoundError:
         raise HTTPException(status_code=404, detail=f"Resource does not exist: {rid}")
     except ConflictError:
         raise HTTPException(status_code=409, detail=f"Slug already exists: {new_slug}")
+    try:
+        yield
+    except Exception:
+        if old_slug is None:
+            return
+        # Rollback slug update if something goes wrong
+        try:
+            await update_resource_slug(driver, kbid, rid=rid, new_slug=old_slug)
+        except Exception as ex:
+            capture_exception(ex)
+            logger.exception("Error while rolling back slug update")
+        raise
 
 
-async def _update_resource_slug(
-    txn: Transaction,
+async def update_resource_slug(
+    driver: Driver,
     kbid: str,
     *,
+    rid: str,
     new_slug: str,
-    rid: Optional[str] = None,
-    slug: Optional[str] = None,
-) -> str:
-    if all([rid, slug]) or not any([rid, slug]):
-        raise ValueError("Either rid or slug must be set")
-
-    if rid is None:
-        slug = cast(str, slug)
-        resource_uuid = await ResourcesDataManager.get_resource_uuid_from_slug(
-            txn, kbid, slug
-        )
-        if resource_uuid is None:
-            raise NotFoundError()
-        rid = resource_uuid
-
-    await ResourcesDataManager.modify_slug(txn, kbid, rid=rid, new_slug=new_slug)
-    return rid
+):
+    try:
+        async with driver.transaction() as txn:
+            old_slug = await ResourcesDataManager.modify_slug(
+                txn, kbid, rid=rid, new_slug=new_slug
+            )
+            await txn.commit()
+            return old_slug
+    except NotFoundError:
+        raise HTTPException(status_code=404, detail=f"Resource does not exist: {rid}")
+    except ConflictError:
+        raise HTTPException(status_code=409, detail=f"Slug already exists: {new_slug}")
 
 
 @api.post(


### PR DESCRIPTION
### Description
I think this is the best way to handle this, because the other options always have a situation where the patch has partially been applied.

- Option 1)  Modify slug first, and only commit if modify_resource was successful: This is problematic because modify_resource changes things on the basic metadata too, where the slug is, therefore some changes are undone.

- Option 2) Modify slug at the end, after modify_resource: this is problematic too if the modify_slug fails, we have already sent the data to processing and can't be undone.

- **Option 3) What I propose in this PR: modify slug first in a separate txn, commit it and then modify_resource. If somethig fails, then rollback the slug changes.**


### How was this PR tested?
integration tests
