### PR TITLE
Return whether paragaph search results are fuzzy

### DIFF
--- a/nucliadb/nucliadb/search/search/merge.py
+++ b/nucliadb/nucliadb/search/search/merge.py
@@ -401,6 +401,7 @@ async def merge_paragraph_results(
                 extracted_text_cache=etcache,
             )
             labels = await get_labels_paragraph(result, kbid)
+            fuzzy_result = len(result.matches) > 0
             new_paragraph = Paragraph(
                 score=result.score.bm25,
                 rid=result.uuid,
@@ -414,6 +415,7 @@ async def merge_paragraph_results(
                     end=result.metadata.position.end,
                     page_number=result.metadata.position.page_number,
                 ),
+                fuzzy_result=fuzzy_result,
             )
             if len(result.metadata.position.start_seconds) or len(
                 result.metadata.position.end_seconds

--- a/nucliadb/nucliadb/tests/integration/search/test_search.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search.py
@@ -1441,3 +1441,61 @@ async def test_facets_validation(
             else:
                 assert resp.status_code == 422
                 assert error_message == resp.json()["detail"][0]["msg"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
+async def test_search_marks_fuzzy_results(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    knowledgebox,
+):
+    resp = await nucliadb_writer.post(
+        f"/kb/{knowledgebox}/resources",
+        json={
+            "slug": "myresource",
+            "title": "My Title",
+        },
+    )
+    assert resp.status_code == 201
+
+    # Should get only one non-fuzzy result
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "query": "Title",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    check_fuzzy_paragraphs(body, fuzzy_result=False, n_expected=1)
+
+    # Should get only one fuzzy result
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "query": "totle",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    check_fuzzy_paragraphs(body, fuzzy_result=True, n_expected=1)
+
+    # Should not get any result if exact match term queried
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/search",
+        json={
+            "query": '"totle"',
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    check_fuzzy_paragraphs(body, fuzzy_result=True, n_expected=0)
+
+
+def check_fuzzy_paragraphs(search_response, *, fuzzy_result: bool, n_expected: int):
+    found = 0
+    for paragraph in search_response["paragraphs"]["results"]:
+        assert paragraph["fuzzy_result"] is fuzzy_result
+        found += 1
+    assert found == n_expected

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -150,6 +150,7 @@ class Paragraph(BaseModel):
     start_seconds: Optional[List[int]] = None
     end_seconds: Optional[List[int]] = None
     position: Optional[TextPosition] = None
+    fuzzy_result: bool = False
 
 
 class Paragraphs(BaseModel):
@@ -825,6 +826,7 @@ class FindParagraph(BaseModel):
     id: str
     labels: Optional[List[str]] = []
     position: Optional[TextPosition] = None
+    fuzzy_result: bool = False
 
 
 @dataclass
@@ -839,6 +841,7 @@ class TempFindParagraph:
     paragraph: Optional[FindParagraph] = None
     vector_index: Optional[DocumentScored] = None
     paragraph_index: Optional[PBParagraphResult] = None
+    fuzzy_result: bool = False
 
 
 class FindField(BaseModel):


### PR DESCRIPTION
### Description
This is useful for users who don't want fuzzy results. This way they can be sure that no fuzzy results are returned.

### How was this PR tested?
Integration tests
