### PR TITLE
Removed bottleneck on search [standalone + pg]

### DIFF
--- a/nucliadb/nucliadb/search/search/fetch.py
+++ b/nucliadb/nucliadb/search/search/fetch.py
@@ -25,7 +25,8 @@ from nucliadb_protos.resources_pb2 import Paragraph
 
 from nucliadb.ingest.orm.resource import KB_REVERSE
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
-from nucliadb.ingest.serialize import serialize
+from nucliadb.ingest.serialize import managed_serialize
+from nucliadb.ingest.txn_utils import get_transaction
 from nucliadb.search import SERVICE_NAME, logger
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName, Resource
@@ -46,8 +47,10 @@ async def fetch_resources(
     extracted: list[ExtractedDataTypeName],
 ) -> dict[str, Resource]:
     result = {}
+    txn = await get_transaction(read_only=True)
     for resource in resources:
-        serialization = await serialize(
+        serialization = await managed_serialize(
+            txn,
             kbid,
             resource,
             show,

--- a/nucliadb/nucliadb/tests/integration/test_find.py
+++ b/nucliadb/nucliadb/tests/integration/test_find.py
@@ -239,7 +239,7 @@ async def test_story_7286(
     )
     assert resp.status_code == 200
 
-    with patch("nucliadb.search.search.find_merge.serialize", return_value=None):
+    with patch("nucliadb.search.search.find_merge.managed_serialize", return_value=None):
         # should get no result (because serialize returns None, as the resource is not found in the DB)
         resp = await nucliadb_reader.post(
             f"/kb/{knowledgebox}/find",

--- a/nucliadb/nucliadb/tests/integration/test_find.py
+++ b/nucliadb/nucliadb/tests/integration/test_find.py
@@ -239,7 +239,9 @@ async def test_story_7286(
     )
     assert resp.status_code == 200
 
-    with patch("nucliadb.search.search.find_merge.managed_serialize", return_value=None):
+    with patch(
+        "nucliadb.search.search.find_merge.managed_serialize", return_value=None
+    ):
         # should get no result (because serialize returns None, as the resource is not found in the DB)
         resp = await nucliadb_reader.post(
             f"/kb/{knowledgebox}/find",


### PR DESCRIPTION
### Description
The way resources were serialized when crafting search results was creating too many pg txns and quickly exhausting the pol, therefore causing a performance bottleneck.

### How was this PR tested?
Local performance tests:
Before
```
Metrics summary:
- find_latency_s -> p50: 352.24ms p95: 515.18ms
- search_latency_s -> p50: 2.19s p95: 2.94s
- suggest_latency_s -> p50: 302.58ms p95: 900.45ms
==================================================
Errors summary:
==================================================
**** Molotov v2.6. Happy breaking! ****
SUCCESSES: 90 | FAILURES: 0
```

After:
```
Metrics summary:
- find_latency_s -> p50: 86.31ms p95: 159.79ms
- search_latency_s -> p50: 343.13ms p95: 493.50ms
- suggest_latency_s -> p50: 99.34ms p95: 218.76ms
==================================================
Errors summary:
==================================================
**** Molotov v2.6. Happy breaking! ****
SUCCESSES: 403 | FAILURES: 0
*** Bye ***
```

This means approximately a 4x improvement