### PR TITLE
Improve access log format and print absolute paths at startup

### DIFF
--- a/nucliadb/nucliadb/standalone/run.py
+++ b/nucliadb/nucliadb/standalone/run.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 import os
 import sys
+from typing import Optional
 
 import pydantic_argparse
 import uvicorn  # type: ignore
@@ -116,8 +117,7 @@ def run():
     )
 
     installed_version = versions.installed_nucliadb()
-    loop = asyncio.get_event_loop()
-    latest_version = loop.run_until_complete(versions.latest_nucliadb())
+    latest_version = get_latest_nucliadb()
     if latest_version is None:
         version_info_fmted = f"{installed_version} (Update check failed)"
     elif versions.nucliadb_updates_available(installed_version, latest_version):
@@ -138,6 +138,11 @@ def run():
 """
     )
     server.run()
+
+
+def get_latest_nucliadb() -> Optional[str]:
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(versions.latest_nucliadb())
 
 
 async def run_async_nucliadb(settings: Settings) -> uvicorn.Server:

--- a/nucliadb/nucliadb/standalone/run.py
+++ b/nucliadb/nucliadb/standalone/run.py
@@ -20,6 +20,7 @@
 import asyncio
 import logging
 import os
+import pathlib
 import sys
 
 import pydantic_argparse
@@ -34,7 +35,7 @@ from nucliadb.standalone.settings import Settings
 from nucliadb_telemetry import errors
 from nucliadb_telemetry.fastapi import instrument_app
 from nucliadb_telemetry.logs import setup_logging
-from nucliadb_telemetry.settings import LogSettings
+from nucliadb_telemetry.settings import LogOutputType, LogSettings
 from nucliadb_utils.settings import nuclia_settings, storage_settings
 
 logger = logging.getLogger(__name__)
@@ -95,11 +96,15 @@ def run():
         "Blog storage backend": storage_settings.file_backend,
         "Cluster discovery mode": cluster_settings.cluster_discovery_mode,
         "Node replicas": cluster_settings.node_replicas,
-        "Index data path": cluster_settings.data_path,
+        "Index data path": os.path.realpath(cluster_settings.data_path),
         "Node port": cluster_settings.standalone_node_port,
         "Auth policy": settings.auth_policy,
         "Log output type": settings.log_output_type,
     }
+    if settings.log_output_type == LogOutputType.FILE:
+        log_folder = pathlib.Path(os.path.realpath(LogSettings().access_log)).parent
+        settings_to_output["Log folder path"] = log_folder
+
     if nuclia_settings.nuclia_service_account:
         settings_to_output["NUA API key"] = "Configured ✔"
         settings_to_output["NUA API zone"] = nuclia_settings.nuclia_zone

--- a/nucliadb/nucliadb/standalone/run.py
+++ b/nucliadb/nucliadb/standalone/run.py
@@ -20,7 +20,6 @@
 import asyncio
 import logging
 import os
-import pathlib
 import sys
 
 import pydantic_argparse
@@ -102,7 +101,7 @@ def run():
         "Log output type": settings.log_output_type,
     }
     if settings.log_output_type == LogOutputType.FILE:
-        log_folder = pathlib.Path(os.path.realpath(LogSettings().access_log)).parent
+        log_folder = os.path.realpath(os.path.dirname(LogSettings().access_log))
         settings_to_output["Log folder path"] = log_folder
 
     if nuclia_settings.nuclia_service_account:

--- a/nucliadb/nucliadb/standalone/tests/unit/test_run.py
+++ b/nucliadb/nucliadb/standalone/tests/unit/test_run.py
@@ -19,17 +19,27 @@
 #
 from unittest import mock
 
+import pytest
+
 from nucliadb.standalone.run import run, run_async_nucliadb
 from nucliadb.standalone.settings import Settings
 
 
-def test_run():
+@pytest.fixture(scope="function", autouse=True)
+def mocked_deps():
     with mock.patch("uvicorn.Server.run"), mock.patch(
         "pydantic_argparse.ArgumentParser.parse_typed_args", return_value=Settings()
+    ), mock.patch(
+        "nucliadb.standalone.run.get_latest_nucliadb", return_value="1.0.0"
+    ), mock.patch(
+        "uvicorn.Server.startup"
     ):
-        run()
+        yield
+
+
+def test_run():
+    run()
 
 
 async def test_run_async_nucliadb():
-    with mock.patch("uvicorn.Server.startup"):
-        await run_async_nucliadb(Settings())
+    await run_async_nucliadb(Settings())

--- a/nucliadb/nucliadb/standalone/tests/unit/test_run.py
+++ b/nucliadb/nucliadb/standalone/tests/unit/test_run.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from unittest import mock
+
+from nucliadb.standalone.run import run, run_async_nucliadb
+from nucliadb.standalone.settings import Settings
+
+
+def test_run():
+    with mock.patch("uvicorn.Server.run"), mock.patch(
+        "pydantic_argparse.ArgumentParser.parse_typed_args", return_value=Settings()
+    ):
+        run()
+
+
+async def test_run_async_nucliadb():
+    with mock.patch("uvicorn.Server.startup"):
+        await run_async_nucliadb(Settings())

--- a/nucliadb_telemetry/nucliadb_telemetry/logs.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/logs.py
@@ -225,7 +225,6 @@ def setup_access_logging(settings: LogSettings) -> None:
             AccessFormatter(  # not json based
                 fmt=ACCESS_LOG_FMT,
                 datefmt=ACCESS_LOG_DATEFMT,
-                use_colors=True,
             )
         )
 

--- a/nucliadb_telemetry/nucliadb_telemetry/logs.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/logs.py
@@ -74,6 +74,12 @@ _BUILTIN_ATTRS = set(
 )
 
 
+ACCESS_LOG_FMT = (
+    "%(asctime)s.%(msecs)03d - %(client_addr)s - %(request_line)s %(status_code)s"
+)
+ACCESS_LOG_DATEFMT = "%Y-%m-%d,%H:%M:%S"
+
+
 def extra_from_record(record) -> Dict[str, Any]:
     return {
         attr_name: record.__dict__[attr_name]
@@ -205,11 +211,23 @@ def setup_access_logging(settings: LogSettings) -> None:
     else:
         access_handler = logging.StreamHandler()
     access_logger.addHandler(access_handler)
+
     if not settings.debug and settings.log_format_type == LogFormatType.STRUCTURED:
-        access_handler.setFormatter(UvicornAccessFormatter())
+        access_handler.setFormatter(
+            UvicornAccessFormatter(
+                fmt=ACCESS_LOG_FMT,
+                datefmt=ACCESS_LOG_DATEFMT,
+            )
+        )
     else:
         # regular stream access logs
-        access_handler.setFormatter(AccessFormatter())  # not json based
+        access_handler.setFormatter(
+            AccessFormatter(  # not json based
+                fmt=ACCESS_LOG_FMT,
+                datefmt=ACCESS_LOG_DATEFMT,
+                use_colors=True,
+            )
+        )
 
 
 def setup_logging(*, settings: Optional[LogSettings] = None) -> None:


### PR DESCRIPTION
### Description
- If file output type, print absolute path of logs folder
- Print absolute path of index data path
- Access logs have time information now

Before
```
=================================================
||
||   NucliaDB Standalone Server Running!
||
||   Version: 2.34.0 (Update available: 2.36.0.post62)
||
||   Configuration:
||      - API:                        http://0.0.0.0:8080/api
||      - Admin UI:                   http://0.0.0.0:8080/admin
||      - Key-value backend:          pg
||      - Blog storage backend:       pg
||      - Cluster discovery mode:     single_node
||      - Node replicas:              1
||      - Index data path:            ./data/node
||      - Node port:                  10009
||      - Auth policy:                upstream_naive
||      - Log output type:            file
=================================================
[2023-12-20 16:50:35,454.454][INFO][nucliadb.ingest] - ======= Ingest GRPC running on http://0.0.0.0:8030/ ====== -- 
127.0.0.1:59382 - "POST /kbs HTTP/1.1" 419
127.0.0.1:59384 - "GET /kb/s/tiny HTTP/1.1" 200
127.0.0.1:59389 - "POST /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/search HTTP/1.1" 200
127.0.0.1:59388 - "POST /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/search HTTP/1.1" 200
127.0.0.1:59388 - "POST /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/find HTTP/1.1" 200
127.0.0.1:59389 - "POST /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/search HTTP/1.1" 200
```

Now
```
=================================================
||
||   NucliaDB Standalone Server Running!
||
||   Version: 2.34.0 (Update available: 2.36.0.post62)
||
||   Configuration:
||      - API:                        http://0.0.0.0:8080/api
||      - Admin UI:                   http://0.0.0.0:8080/admin
||      - Key-value backend:          pg
||      - Blog storage backend:       pg
||      - Cluster discovery mode:     single_node
||      - Node replicas:              1
||      - Index data path:            /Users/ferran/Code/nucliadb/data/node
||      - Node port:                  10009
||      - Auth policy:                upstream_naive
||      - Log output type:            file
||      - Log folder path:            /Users/ferran/Code/nucliadb/logs
=================================================
[2023-12-20 16:49:19,319.319][INFO][nucliadb.ingest] - ======= Ingest GRPC running on http://0.0.0.0:8030/ ====== -- 
2023-12-20,16:49:25.760 - 127.0.0.1:59248 - POST /kbs HTTP/1.1 419 
2023-12-20,16:49:25.817 - 127.0.0.1:59250 - GET /kb/s/tiny HTTP/1.1 200 OK
2023-12-20,16:49:25.946 - 127.0.0.1:59254 - GET /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/suggest?query=Category&features=paragraph&fields=a/title HTTP/1.1 200 OK
2023-12-20,16:49:25.946 - 127.0.0.1:59255 - GET /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/suggest?query=Category&features=paragraph&fields=a/title HTTP/1.1 200 OK
2023-12-20,16:49:26.126 - 127.0.0.1:59255 - GET /kb/621c7c6e-e44e-475b-86ef-1806a1fd2cd9/suggest?query=ISO&features=paragraph&features=entities HTTP/1.1 200 OK
```

### How was this PR tested?
local tests
