### PR TITLE
Don't suggest resources

### DIFF
--- a/nucliadb/nucliadb/tests/integration/test_suggest.py
+++ b/nucliadb/nucliadb/tests/integration/test_suggest.py
@@ -216,7 +216,7 @@ async def test_suggest_related_entities(
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/suggest?query=Ann")
     assert resp.status_code == 200
     body = resp.json()
-    assert set(body["entities"]["entities"]) == {"Anastasia", "Anna", "Anthony"}
+    assert set(body["entities"]["entities"]) == {"Anna", "Anthony"}
 
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/suggest?query=joh")
     assert resp.status_code == 200
@@ -259,7 +259,7 @@ async def test_suggest_related_entities(
     resp = await nucliadb_reader.get(f"/kb/{knowledgebox}/suggest?query=Solomon+Is")
     assert resp.status_code == 200
     body = resp.json()
-    assert set(body["entities"]["entities"]) == {"Solomon Islands", "Israel", "Irene"}
+    assert set(body["entities"]["entities"]) == {"Solomon Islands", "Israel"}
 
 
 @pytest.mark.asyncio
@@ -349,7 +349,7 @@ async def test_suggest_features(
         }
 
     def assert_expected_entities(response):
-        expected = {"Anastasia", "Anna", "Anthony"}
+        expected = {"Anna", "Anthony"}
         assert response["entities"]["total"] == len(expected)
         assert set(response["entities"]["entities"]) == expected
 

--- a/nucliadb_node/src/shards/shard_reader.rs
+++ b/nucliadb_node/src/shards/shard_reader.rs
@@ -344,24 +344,12 @@ impl ShardReader {
                     .filter(|prefix| prefix.len() >= MIN_VIABLE_PREFIX_SUGGEST)
                     .cloned()
                     .map(|prefix| RelationSearchRequest {
-                        shard_id: String::default(), // REVIEW: really?
                         prefix: Some(RelationPrefixSearchRequest {
                             prefix,
-                            // Any type that is not Resource (avoid suggesting resource UUIDs)
-                            node_filters: vec![
-                                RelationNodeFilter {
-                                    node_type: NodeType::Entity.into(),
-                                    ..Default::default()
-                                },
-                                RelationNodeFilter {
-                                    node_type: NodeType::Label.into(),
-                                    ..Default::default()
-                                },
-                                RelationNodeFilter {
-                                    node_type: NodeType::User.into(),
-                                    ..Default::default()
-                                },
-                            ],
+                            node_filters: vec![RelationNodeFilter {
+                                node_type: NodeType::Entity.into(),
+                                ..Default::default()
+                            }],
                         }),
                         ..Default::default()
                     });

--- a/nucliadb_node/src/shards/shard_reader.rs
+++ b/nucliadb_node/src/shards/shard_reader.rs
@@ -38,6 +38,8 @@ use nucliadb_core::query_planner::QueryPlan;
 use nucliadb_core::thread::*;
 use nucliadb_core::tracing::{self, *};
 use nucliadb_procs::measure;
+use nucliadb_protos::nodereader::RelationNodeFilter;
+use nucliadb_protos::utils::relation_node::NodeType;
 
 use crate::disk_structure::*;
 use crate::shards::metadata::ShardMetadata;
@@ -345,7 +347,21 @@ impl ShardReader {
                         shard_id: String::default(), // REVIEW: really?
                         prefix: Some(RelationPrefixSearchRequest {
                             prefix,
-                            ..Default::default()
+                            // Any type that is not Resource (avoid suggesting resource UUIDs)
+                            node_filters: vec![
+                                RelationNodeFilter {
+                                    node_type: NodeType::Entity.into(),
+                                    ..Default::default()
+                                },
+                                RelationNodeFilter {
+                                    node_type: NodeType::Label.into(),
+                                    ..Default::default()
+                                },
+                                RelationNodeFilter {
+                                    node_type: NodeType::User.into(),
+                                    ..Default::default()
+                                },
+                            ],
                         }),
                         ..Default::default()
                     });

--- a/nucliadb_node/tests/test_suggest.rs
+++ b/nucliadb_node/tests/test_suggest.rs
@@ -31,7 +31,6 @@ use nucliadb_core::protos::{
     op_status, Filter, NewShardRequest, ReleaseChannel, SuggestFeatures, SuggestRequest,
     SuggestResponse,
 };
-use nucliadb_protos::utils::relation_node::NodeType;
 use rstest::*;
 use tonic::Request;
 
@@ -158,7 +157,7 @@ async fn test_suggest_entities(
     // basic suggests
     expect_entities(
         &suggest_entities(&mut reader, &shard.id, "Ann").await,
-        &["Anastasia", "Anna", "Anthony"],
+        &["Anna", "Anthony"],
     );
 
     expect_entities(
@@ -216,15 +215,6 @@ async fn test_suggest_entities(
         &[],
     );
 
-    // This is just here to make compilation fail if adding a new NodeType and to remind you to
-    // update the filter in ShardReader::suggest so it searches for all node types except Resource
-    match NodeType::Entity {
-        NodeType::Entity => {}
-        NodeType::Label => {}
-        NodeType::Resource => {}
-        NodeType::User => {}
-    };
-
     Ok(())
 }
 
@@ -257,7 +247,7 @@ async fn test_suggest_features(
     let response = suggest_entities(&mut reader, &shard.id, "ann").await;
     assert_eq!(response.total, 0);
     assert!(response.results.is_empty());
-    expect_entities(&response, &["Anastasia", "Anna", "Anthony"]);
+    expect_entities(&response, &["Anna", "Anthony"]);
 
     Ok(())
 }

--- a/nucliadb_node/tests/test_suggest.rs
+++ b/nucliadb_node/tests/test_suggest.rs
@@ -31,6 +31,7 @@ use nucliadb_core::protos::{
     op_status, Filter, NewShardRequest, ReleaseChannel, SuggestFeatures, SuggestRequest,
     SuggestResponse,
 };
+use nucliadb_protos::utils::relation_node::NodeType;
 use rstest::*;
 use tonic::Request;
 
@@ -207,6 +208,22 @@ async fn test_suggest_entities(
     assert_eq!(response.entities.as_ref().unwrap().total, 2);
     assert!(response.entities.as_ref().unwrap().entities[0] == *"Solomon Islands");
     assert!(response.entities.as_ref().unwrap().entities[1] == *"Israel");
+
+    // Does not find resources by UUID prefix
+    let pap_uuid = &shard.resources["pap"];
+    expect_entities(
+        &suggest_entities(&mut reader, &shard.id, &pap_uuid[0..6]).await,
+        &[],
+    );
+
+    // This is just here to make compilation fail if adding a new NodeType and to remind you to
+    // update the filter in ShardReader::suggest so it searches for all node types except Resource
+    match NodeType::Entity {
+        NodeType::Entity => {}
+        NodeType::Label => {}
+        NodeType::Resource => {}
+        NodeType::User => {}
+    };
 
     Ok(())
 }

--- a/nucliadb_protos/rust/build.rs
+++ b/nucliadb_protos/rust/build.rs
@@ -26,7 +26,6 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=../noderesources.proto");
     println!("cargo:rerun-if-changed=../utils.proto");
     println!("cargo:rerun-if-changed=../writer.proto");
-    println!("cargo:rerun-if-changed=../nodesidecar.proto");
     println!("cargo:rerun-if-changed=../nodewriter.proto");
     println!("cargo:rerun-if-changed=../nodereader.proto");
     println!("cargo:rerun-if-changed=../replication.proto");


### PR DESCRIPTION
### Description
Avoid returning suggestions that match a prefix search on the resource ID (can happen under normal use for UUIDs & searches starting with a-f)

### How was this PR tested?
Describe how you tested this PR.
