### PR TITLE
Use read only transaction more on search

### DIFF
--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -124,12 +124,12 @@ class KBShardManager:
     async def read_only_transaction(self, txn: Transaction):
         self._read_only_txn = txn
         try:
-            yield
+            yield self
         finally:
             self._read_only_txn = None
 
     async def get_shards_by_kbid_inner(self, kbid: str) -> writer_pb2.Shards:
-        cdm = ClusterDataManager(get_driver(), read_only_txn=self.read_only_txn)
+        cdm = ClusterDataManager(get_driver(), read_only_txn=self._read_only_txn)
         result = await cdm.get_kb_shards(kbid)
         if result is None:
             # could be None because /shards doesn't exist, or beacause the

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
-import contextlib
 import logging
 import random
 import uuid
@@ -118,18 +117,8 @@ def remove_index_node(node_id: str, primary_id: Optional[str] = None) -> None:
 
 
 class KBShardManager:
-    _read_only_txn: Optional[Transaction] = None
-
-    @contextlib.asynccontextmanager
-    async def read_only_transaction(self, txn: Transaction):
-        self._read_only_txn = txn
-        try:
-            yield self
-        finally:
-            self._read_only_txn = None
-
     async def get_shards_by_kbid_inner(self, kbid: str) -> writer_pb2.Shards:
-        cdm = ClusterDataManager(get_driver(), read_only_txn=self._read_only_txn)
+        cdm = ClusterDataManager(get_driver())
         result = await cdm.get_kb_shards(kbid)
         if result is None:
             # could be None because /shards doesn't exist, or beacause the

--- a/nucliadb/nucliadb/common/datamanagers/cluster.py
+++ b/nucliadb/nucliadb/common/datamanagers/cluster.py
@@ -17,10 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import contextlib
 import logging
 from typing import Optional
 
-from nucliadb.common.maindb.driver import Driver
+from nucliadb.common.maindb.driver import Driver, Transaction
 from nucliadb_protos import writer_pb2
 from nucliadb_utils.keys import KB_SHARDS  # this should be defined here
 
@@ -30,12 +31,23 @@ logger = logging.getLogger(__name__)
 
 
 class ClusterDataManager:
-    def __init__(self, driver: Driver):
+    def __init__(self, driver: Driver, *, read_only_txn: Optional[Transaction] = None):
         self.driver = driver
+        self._read_only_txn = read_only_txn
+
+    @contextlib.asynccontextmanager
+    async def read_only_transaction(self, wait_for_abort: bool = True):
+        if self._read_only_txn is not None:
+            yield self._read_only_txn
+        else:
+            async with self.driver.transaction(
+                wait_for_abort=wait_for_abort, read_only=True
+            ) as txn:
+                yield txn
 
     async def get_kb_shards(self, kbid: str) -> Optional[writer_pb2.Shards]:
         key = KB_SHARDS.format(kbid=kbid)
-        async with self.driver.transaction(wait_for_abort=False) as txn:
+        async with self.read_only_transaction(wait_for_abort=False) as txn:
             return await get_kv_pb(txn, key, writer_pb2.Shards)
 
     async def update_kb_shards(self, kbid: str, kb_shards: writer_pb2.Shards) -> None:

--- a/nucliadb/nucliadb/common/maindb/pg.py
+++ b/nucliadb/nucliadb/common/maindb/pg.py
@@ -184,7 +184,7 @@ class ReadOnlyPGTransaction(Transaction):
         self.open = True
 
     async def abort(self):
-        # TODO: Figure out why is this empty?
+        # This is a no-op because we don't have a transaction to abort on read-only transactions.
         ...
 
     async def commit(self):

--- a/nucliadb/nucliadb/common/maindb/pg.py
+++ b/nucliadb/nucliadb/common/maindb/pg.py
@@ -184,10 +184,11 @@ class ReadOnlyPGTransaction(Transaction):
         self.open = True
 
     async def abort(self):
+        # TODO: Figure out why is this empty?
         ...
 
     async def commit(self):
-        ...
+        raise Exception("Cannot commit transaction in read only mode")
 
     async def batch_get(self, keys: list[str]):
         return await DataLayer(self.pool).batch_get(keys)
@@ -196,10 +197,10 @@ class ReadOnlyPGTransaction(Transaction):
         return await DataLayer(self.pool).get(key)
 
     async def set(self, key: str, value: bytes):
-        await DataLayer(self.pool).set(key, value)
+        raise Exception("Cannot set in read only transaction")
 
     async def delete(self, key: str):
-        await DataLayer(self.pool).delete(key)
+        raise Exception("Cannot delete in read only transaction")
 
     async def keys(
         self,

--- a/nucliadb/nucliadb/common/maindb/tikv.py
+++ b/nucliadb/nucliadb/common/maindb/tikv.py
@@ -267,6 +267,8 @@ class ReadOnlyTiKVTransaction(Transaction):
 
     async def abort(self):
         self.open = False
+        # Read only transactions are implemented as snapshots, which
+        # are read only and isolated, and they don't need to be aborted.
 
     async def commit(self):
         raise Exception("Cannot commit transaction in read only mode")

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -32,7 +32,6 @@ from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb.common.datamanagers.kb import KnowledgeBoxDataManager
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.tests.vectors import Q, Qm2023
-from nucliadb.middleware.transaction import get_read_only_transaction
 from nucliadb.search import logger
 from nucliadb_models.search import (
     AskDocumentModel,
@@ -183,8 +182,7 @@ class PredictEngine:
 
     @alru_cache(maxsize=None)
     async def _get_configuration(self, kbid: str) -> Optional[KBConfiguration]:
-        txn = await get_read_only_transaction()
-        dm = KnowledgeBoxDataManager(get_driver(), read_only_txn=txn)
+        dm = KnowledgeBoxDataManager(get_driver())
         return await dm.get_ml_configuration(kbid)
 
     def check_nua_key_is_configured_for_onprem(self):

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -39,7 +39,6 @@ from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from nucliadb.common.cluster import manager as cluster_manager
 from nucliadb.common.cluster.exceptions import ShardsNotFound
 from nucliadb.common.cluster.utils import get_shard_manager
-from nucliadb.middleware.transaction import get_read_only_transaction
 from nucliadb.search import logger
 from nucliadb.search.search.shards import (
     query_paragraph_shard,

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -39,6 +39,7 @@ from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from nucliadb.common.cluster import manager as cluster_manager
 from nucliadb.common.cluster.exceptions import ShardsNotFound
 from nucliadb.common.cluster.utils import get_shard_manager
+from nucliadb.middleware.transaction import get_read_only_transaction
 from nucliadb.search import logger
 from nucliadb.search.search.shards import (
     query_paragraph_shard,
@@ -135,6 +136,8 @@ async def node_query(
     )
 
     shard_manager = get_shard_manager()
+    txn = await get_read_only_transaction()
+    shard_manager.set_read_only_txn(txn)
 
     try:
         shard_groups: list[PBShardObject] = await shard_manager.get_shards_by_kbid(kbid)

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import contextlib
 from enum import Enum
 from typing import Any, Optional, TypeVar, Union, overload
 
@@ -135,8 +136,8 @@ async def node_query(
         const.Features.READ_REPLICA_SEARCHES, context={"kbid": kbid}
     )
 
+
     shard_manager = get_shard_manager()
-    txn = await get_read_only_transaction()
     shard_manager.set_read_only_txn(txn)
 
     try:
@@ -243,3 +244,11 @@ def validate_node_query_results(results: list[Any]) -> Optional[HTTPException]:
             return HTTPException(status_code=status_code, detail=reason)
 
     return None
+
+
+@contextlib.asynccontextmanager
+async def shard_manager():
+    txn = get_read_only_transaction()
+    shard_manager = get_shard_manager()
+    shard_manager.set_read_only_txn(txn)
+    return shard_manager

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import contextlib
 from enum import Enum
 from typing import Any, Optional, TypeVar, Union, overload
 
@@ -136,10 +135,7 @@ async def node_query(
         const.Features.READ_REPLICA_SEARCHES, context={"kbid": kbid}
     )
 
-
     shard_manager = get_shard_manager()
-    shard_manager.set_read_only_txn(txn)
-
     try:
         shard_groups: list[PBShardObject] = await shard_manager.get_shards_by_kbid(kbid)
     except ShardsNotFound:
@@ -244,11 +240,3 @@ def validate_node_query_results(results: list[Any]) -> Optional[HTTPException]:
             return HTTPException(status_code=status_code, detail=reason)
 
     return None
-
-
-@contextlib.asynccontextmanager
-async def shard_manager():
-    txn = get_read_only_transaction()
-    shard_manager = get_shard_manager()
-    shard_manager.set_read_only_txn(txn)
-    return shard_manager

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -172,7 +172,6 @@ async def get_relations_results(
     *, kbid: str, chat_request: ChatRequest, text_answer: str
 ) -> Relations:
     try:
-        breakpoint()
         predict = get_predict()
         detected_entities = await predict.detect_entities(kbid, text_answer)
         relation_request = RelationSearchRequest()
@@ -193,7 +192,6 @@ async def get_relations_results(
         )
         return merge_relations_results(relations_results, relation_request.subgraph)
     except Exception as exc:
-        breakpoint()
         capture_exception(exc)
         logger.exception("Error getting relations results")
         return Relations(entities={})

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -172,6 +172,7 @@ async def get_relations_results(
     *, kbid: str, chat_request: ChatRequest, text_answer: str
 ) -> Relations:
     try:
+        breakpoint()
         predict = get_predict()
         detected_entities = await predict.detect_entities(kbid, text_answer)
         relation_request = RelationSearchRequest()
@@ -192,6 +193,7 @@ async def get_relations_results(
         )
         return merge_relations_results(relations_results, relation_request.subgraph)
     except Exception as exc:
+        breakpoint()
         capture_exception(exc)
         logger.exception("Error getting relations results")
         return Relations(entities={})

--- a/nucliadb/nucliadb/search/tests/unit/test_predict.py
+++ b/nucliadb/nucliadb/search/tests/unit/test_predict.py
@@ -67,13 +67,12 @@ async def test_dummy_predict_engine():
 
 
 @pytest.fixture(scope="function", autouse=True)
-def txn():
-    txn = mock.MagicMock()
-    txn.get = AsyncMock(return_value=None)
+def get_ml_configuration():
     with mock.patch(
-        "nucliadb.search.predict.get_read_only_transaction", return_value=txn
-    ):
-        yield txn
+        "nucliadb.search.predict.KnowledgeBoxDataManager.get_ml_configuration",
+        return_value=None,
+    ) as get_ml_configuration:
+        yield get_ml_configuration
 
 
 @pytest.mark.asyncio
@@ -444,7 +443,7 @@ async def test_summarize():
 
 
 @pytest.mark.parametrize("onprem", [True, False])
-async def test_get_predict_headers(onprem, txn):
+async def test_get_predict_headers(onprem, get_ml_configuration):
     kb_config = KBConfiguration(
         semantic_model="foo",
         generative_model="bar",
@@ -452,7 +451,7 @@ async def test_get_predict_headers(onprem, txn):
         anonymization_model="qux",
         visual_labeling="quux",
     )
-    txn.get.return_value = kb_config.SerializeToString()
+    get_ml_configuration.return_value = kb_config.SerializeToString()
 
     nua_service_account = "nua-service-account"
     pe = PredictEngine(

--- a/nucliadb/nucliadb/tests/integration/test_chat.py
+++ b/nucliadb/nucliadb/tests/integration/test_chat.py
@@ -181,7 +181,7 @@ async def test_chat_always_returns_relations(
     nucliadb_reader: AsyncClient, knowledgebox
 ):
     resp = await nucliadb_reader.post(
-        f"/kb/{knowledgebox}/chat", json={"query": "summary", "features": ["relations"]}
+        f"/kb/{knowledgebox}/chat", json={"query": "summary", "features": ["relations"]}, timeout=None
     )
     assert resp.status_code == 200
     _, answer, relations_result, _ = parse_chat_response(resp.content)

--- a/nucliadb/nucliadb/tests/integration/test_chat.py
+++ b/nucliadb/nucliadb/tests/integration/test_chat.py
@@ -181,7 +181,9 @@ async def test_chat_always_returns_relations(
     nucliadb_reader: AsyncClient, knowledgebox
 ):
     resp = await nucliadb_reader.post(
-        f"/kb/{knowledgebox}/chat", json={"query": "summary", "features": ["relations"]}, timeout=None
+        f"/kb/{knowledgebox}/chat",
+        json={"query": "summary", "features": ["relations"]},
+        timeout=None,
     )
     assert resp.status_code == 200
     _, answer, relations_result, _ = parse_chat_response(resp.content)

--- a/nucliadb_node/nucliadb_node/tests/fixtures.py
+++ b/nucliadb_node/nucliadb_node/tests/fixtures.py
@@ -187,7 +187,7 @@ def node_single():
 @pytest.fixture(scope="function")
 async def writer_stub(node_single) -> AsyncIterable[NodeWriterStub]:
     channel = aio.insecure_channel(settings.writer_listen_address)
-    stub = NodeWriterStub(channel)
+    stub = NodeWriterStub(channel)  # type: ignore
     yield stub
 
 

--- a/nucliadb_node/nucliadb_node/tests/unit/test_indexer.py
+++ b/nucliadb_node/nucliadb_node/tests/unit/test_indexer.py
@@ -310,7 +310,11 @@ class TestPriorityIndexer:
         self, indexer: PriorityIndexer, writer: AsyncMock
     ):
         writer.set_resource.side_effect = AioRpcError(
-            code=StatusCode.UNKNOWN, initial_metadata=None, trailing_metadata=None
+            code=StatusCode.UNKNOWN,
+            initial_metadata=None,  # type: ignore
+            trailing_metadata=None,  # type: ignore
+            details="node writer error",
+            debug_error_string="node writer error",
         )
         with pytest.raises(AioRpcError):
             pb = IndexMessage()
@@ -318,7 +322,11 @@ class TestPriorityIndexer:
             await indexer._index_message(pb)
 
         writer.delete_resource.side_effect = AioRpcError(
-            code=StatusCode.UNKNOWN, initial_metadata=None, trailing_metadata=None
+            code=StatusCode.UNKNOWN,
+            initial_metadata=None,  # type: ignore
+            trailing_metadata=None,  # type: ignore
+            details="node writer error",
+            debug_error_string="node writer error",
         )
         with pytest.raises(AioRpcError):
             pb = IndexMessage()

--- a/nucliadb_utils/nucliadb_utils/keys.py
+++ b/nucliadb_utils/nucliadb_utils/keys.py
@@ -17,5 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+
 KB_SHARDS = "/kbs/{kbid}/shards"
 KB_UUID = "/kbs/{kbid}/config"
+KB_CONFIGURATION = "/kbs/{kbid}/configuration"


### PR DESCRIPTION
### Description
Even if we had the shared transaction logic in place, many code in the search endpoints was creating extra transactions.
This caused a drop in performance specially when using the PG driver for the maindb (Hybrid on-prem deployments!)

The improvement on the performance tests is around 2x:

On main
```
Metrics summary:
- find_latency_s -> p50: 153.69ms p95: 283.02ms
- search_latency_s -> p50: 873.75ms p95: 1.19s
- suggest_latency_s -> p50: 249.35ms p95: 496.69ms
**** Molotov v2.6. Happy breaking! ****
SUCCESSES: 652 | FAILURES: 0
*** Bye ***
```

On the current branch
```
Metrics summary:
- find_latency_s -> p50: 58.67ms p95: 106.33ms
- search_latency_s -> p50: 443.13ms p95: 562.02ms
- suggest_latency_s -> p50: 118.93ms p95: 224.92ms
**** Molotov v2.6. Happy breaking! ****
SUCCESSES: 1276 | FAILURES: 0
*** Bye ***
```


### How was this PR tested?
Describe how you tested this PR.
