### PR TITLE
More idiomatic replication settings using Duration

### DIFF
--- a/nucliadb_node/src/replication/health.rs
+++ b/nucliadb_node/src/replication/health.rs
@@ -72,7 +72,6 @@ impl ReplicationHealthManager {
         }
         let metadata = metaddata.unwrap();
         metadata.modified().unwrap()
-            > std::time::SystemTime::now()
-                - std::time::Duration::from_secs(self.settings.replication_healthy_delay())
+            > std::time::SystemTime::now() - self.settings.replication_healthy_delay()
     }
 }

--- a/nucliadb_node/src/replication/replicator.rs
+++ b/nucliadb_node/src/replication/replicator.rs
@@ -349,8 +349,8 @@ pub async fn connect_to_primary_and_replicate(
         //
         // 1. If we're healthy, we'll sleep for a while and check again.
         // 2. If backed up replicating, we'll try replicating again immediately and check again.
-        let elapsed = start.elapsed().as_secs_f64();
-        if elapsed < settings.replication_healthy_delay() as f64 {
+        let elapsed = start.elapsed();
+        if elapsed < settings.replication_healthy_delay() {
             // only update healthy marker if we're up-to-date in the configured healthy time
             repl_health_mng.update_healthy();
         }
@@ -358,10 +358,7 @@ pub async fn connect_to_primary_and_replicate(
         if no_shards_to_sync && no_shards_to_remove {
             // if we have any changes, check again immediately
             // otherwise, wait for a bit
-            tokio::time::sleep(std::time::Duration::from_secs(
-                settings.replication_delay_seconds(),
-            ))
-            .await;
+            tokio::time::sleep(settings.replication_delay()).await;
         }
     }
 }
@@ -392,9 +389,6 @@ pub async fn connect_to_primary_and_replicate_forever(
             "Error happened during replication. Will retry: {:?}",
             result
         );
-        tokio::time::sleep(std::time::Duration::from_secs(
-            settings.replication_delay_seconds(),
-        ))
-        .await;
+        tokio::time::sleep(settings.replication_delay()).await;
     }
 }

--- a/nucliadb_node/src/settings/inner_settings.rs
+++ b/nucliadb_node/src/settings/inner_settings.rs
@@ -32,6 +32,7 @@
 
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use derive_builder::Builder;
 use nucliadb_core::tracing::{error, Level};
@@ -112,15 +113,14 @@ pub struct InnerSettings {
     pub primary_address: String,
     #[builder(default = "parse_node_role(\"primary\")")]
     pub node_role: NodeRole,
-    #[builder(default = "3")]
-    pub replication_delay_seconds: u64,
+    #[builder(default = "Duration::from_secs(3)")]
+    pub replication_delay: Duration,
     #[builder(default = "3")]
     pub replication_max_concurrency: u64,
 
-    // number of seconds since last replication for
-    // node to be considered healthy
-    #[builder(default = "30")]
-    pub replication_healthy_delay: u64,
+    // time since last replication for node to be considered healthy
+    #[builder(default = "Duration::from_secs(30)")]
+    pub replication_healthy_delay: Duration,
 
     // max number of replicas per node
     #[builder(default = "800")]

--- a/nucliadb_node/src/settings/mod.rs
+++ b/nucliadb_node/src/settings/mod.rs
@@ -36,6 +36,7 @@ pub mod providers;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use inner_settings::InnerSettings;
 pub use inner_settings::InnerSettingsBuilder;
@@ -174,15 +175,15 @@ impl Settings {
     pub fn node_role(&self) -> NodeRole {
         self.inner.node_role
     }
-    pub fn replication_delay_seconds(&self) -> u64 {
-        self.inner.replication_delay_seconds
+    pub fn replication_delay(&self) -> Duration {
+        self.inner.replication_delay
     }
 
     pub fn replication_max_concurrency(&self) -> u64 {
         self.inner.replication_max_concurrency
     }
 
-    pub fn replication_healthy_delay(&self) -> u64 {
+    pub fn replication_healthy_delay(&self) -> Duration {
         self.inner.replication_healthy_delay
     }
 

--- a/nucliadb_node/src/settings/providers.rs
+++ b/nucliadb_node/src/settings/providers.rs
@@ -28,6 +28,8 @@ pub trait SettingsProvider {
 }
 
 pub mod env {
+    use std::time::Duration;
+
     use nucliadb_core::NodeResult;
 
     use crate::settings::providers::SettingsProvider;
@@ -125,7 +127,7 @@ pub mod env {
             if let Ok(Ok(replication_delay_seconds)) =
                 std::env::var("REPLICATION_DELAY_SECONDS").map(|v| v.parse::<u64>())
             {
-                builder.replication_delay_seconds(replication_delay_seconds);
+                builder.replication_delay(Duration::from_secs(replication_delay_seconds));
             }
 
             if let Ok(Ok(replication_max_concurrency)) =
@@ -137,7 +139,7 @@ pub mod env {
             if let Ok(Ok(replication_healthy_delay)) =
                 std::env::var("REPLICATION_HEALTHY_DELAY").map(|v| v.parse::<u64>())
             {
-                builder.replication_healthy_delay(replication_healthy_delay);
+                builder.replication_healthy_delay(Duration::from_secs(replication_healthy_delay));
             }
 
             builder.build()

--- a/nucliadb_node/tests/common/node_services.rs
+++ b/nucliadb_node/tests/common/node_services.rs
@@ -127,7 +127,7 @@ impl NodeFixture {
             .data_path(secondary_tempdir.path())
             .reader_listen_address(secondary_reader_addr.to_string())
             .primary_address(writer_addr.to_string())
-            .replication_delay_seconds(1_u64)
+            .replication_delay(Duration::from_secs(1))
             .build()
             .expect("Error while building test settings");
 


### PR DESCRIPTION
### Description
Use `std::time::Duration` instead of an `u64` for replication settings

### How was this PR tested?
Describe how you tested this PR.
