### PR TITLE
Leave only one driver-storage combination on search tests

### DIFF
--- a/.github/workflows/nucliadb_search.yml
+++ b/.github/workflows/nucliadb_search.yml
@@ -77,15 +77,15 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - maindb_driver: "tikv"
-            storage_backend: "gcs"
-            python-version: "3.11"
+          # - maindb_driver: "tikv"
+          #   storage_backend: "gcs"
+          #   python-version: "3.11"
           - maindb_driver: "tikv"
             storage_backend: "s3"
             python-version: "3.11"
-          - maindb_driver: "pg"
-            storage_backend: "gcs"
-            python-version: "3.11"
+          # - maindb_driver: "pg"
+          #   storage_backend: "gcs"
+          #   python-version: "3.11"
 
     steps:
       - name: Checkout the repository
@@ -159,7 +159,7 @@ jobs:
           TESTING_MAINDB_DRIVER: ${{ matrix.maindb_driver }}
           TESTING_STORAGE_BACKEND: ${{ matrix.storage_backend }}
         run: |
-          pytest -rfE --cov=nucliadb.search -s --tb=native -v --cov-report xml --cov-append --benchmark-json benchmarks.json nucliadb/nucliadb/search
+          pytest -x -rfE --cov=nucliadb.search -s --tb=native -v --cov-report xml --cov-append --benchmark-json benchmarks.json nucliadb/nucliadb/search
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
### Description
The purpose of this is try to avoid docker problems with port assignment reducing the amount of executed test combinations. Long term, we should solve this problem with docker and/or move integration tests to unit to avoid having too many tests here.

It also adds a `-x` flag to `pytest` so test failures can be detected faster and make reruns quicker.

### How was this PR tested?
Describe how you tested this PR.
