### PR TITLE
NucliaDB chart should install always the chart's image version

### DIFF
--- a/charts/nucliadb/templates/sts.yaml
+++ b/charts/nucliadb/templates/sts.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccount:  {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: app
-        image: "{{ .Values.image }}:{{ .Values.imageVersion }}"
+        image: "{{ .Values.image }}:{{ .Chart.Version | replace "+" "_" }} }}"
         securityContext:
           privileged: false
         imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/charts/nucliadb/values.yaml
+++ b/charts/nucliadb/values.yaml
@@ -3,7 +3,6 @@
 # image settings
 imagePullPolicy: IfNotPresent
 image: nuclia/nucliadb
-imageVersion: latest
 
 replicas: 2
 


### PR DESCRIPTION
### Description
Otherwise users can pull latest always and that can be dangerous?

### How was this PR tested?
Describe how you tested this PR.
