### PR TITLE
safe tantivy replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,8 @@ dependencies = [
  "prost-types",
  "rayon",
  "serde",
+ "serde_json",
+ "tantivy 0.17.0 (git+https://github.com/nuclia/tantivy.git?branch=original-17)",
  "tempfile",
  "thiserror",
  "tokio",

--- a/nucliadb_core/Cargo.toml
+++ b/nucliadb_core/Cargo.toml
@@ -24,8 +24,10 @@ tonic = "0.7"
 hyper = "0.14.26"
 tower = "0.4.13"
 tokio = "1.32.0"
-tokio-metrics = { version = "0.3.0", features = ["rt"]}
+tokio-metrics = { version = "0.3.0", features = ["rt"] }
 dashmap = "5.4.0"
+tantivy = { git = "https://github.com/nuclia/tantivy.git", branch = "original-17" }
+serde_json = "1.0.111"
 
 [dev-dependencies]
-tokio = { version = "1.32.0", features = ["rt-multi-thread"]}
+tokio = { version = "1.32.0", features = ["rt-multi-thread"] }

--- a/nucliadb_core/src/lib.rs
+++ b/nucliadb_core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod metrics;
 pub mod paragraphs;
 pub mod query_planner;
 pub mod relations;
+pub mod tantivy_replica;
 pub mod texts;
 pub mod vectors;
 
@@ -58,6 +59,8 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use anyhow::{anyhow as node_error, Context, Error};
 use nucliadb_protos::noderesources::{Resource, ResourceId};
 use serde::{Deserialize, Serialize};
+
+use crate::tantivy_replica::TantivyReplicaState;
 pub type NodeResult<O> = anyhow::Result<O>;
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
@@ -133,9 +136,14 @@ pub fn encapsulate_writer<T>(writer: T) -> Arc<RwLock<T>> {
 }
 
 #[derive(Debug)]
-pub struct IndexFiles {
+pub struct RawReplicaState {
     pub metadata_files: HashMap<String, Vec<u8>>,
     pub files: Vec<String>,
+}
+
+pub enum IndexFiles {
+    Tantivy(TantivyReplicaState),
+    Other(RawReplicaState),
 }
 
 pub trait WriterChild: std::fmt::Debug + Send + Sync {

--- a/nucliadb_core/src/tantivy_replica.rs
+++ b/nucliadb_core/src/tantivy_replica.rs
@@ -72,9 +72,12 @@ struct SafeMetadata {
     payload: Option<String>,
 }
 
+/// Needed by [`compute_safe_replica_state`]
 #[derive(Clone, Copy)]
 pub struct ReplicationParameters<'a> {
+    /// Where the index to be replicated is located on disk
     pub path: &'a Path,
+    /// IDs of the segments already present at the replica.
     pub on_replica: &'a [String],
 }
 

--- a/nucliadb_core/src/tantivy_replica.rs
+++ b/nucliadb_core/src/tantivy_replica.rs
@@ -112,12 +112,6 @@ pub fn compute_safe_replica_state(
             segment_id,
         });
 
-        let postings = PathBuf::from(format!("{raw_segment_id}.idx"));
-        let positions = PathBuf::from(format!("{raw_segment_id}.pos"));
-        let terms = PathBuf::from(format!("{raw_segment_id}.term"));
-        let store = PathBuf::from(format!("{raw_segment_id}.store"));
-        let fast_fields = PathBuf::from(format!("{raw_segment_id}.fast"));
-        let field_norms = PathBuf::from(format!("{raw_segment_id}.fieldnorm"));
         let deletes = delete_opstamp
             .map(|stamp| PathBuf::from(format!("{raw_segment_id}.{stamp}.fieldnorm")));
 
@@ -131,6 +125,13 @@ pub fn compute_safe_replica_state(
             // already there.
             continue;
         }
+
+        let postings = PathBuf::from(format!("{raw_segment_id}.idx"));
+        let positions = PathBuf::from(format!("{raw_segment_id}.pos"));
+        let terms = PathBuf::from(format!("{raw_segment_id}.term"));
+        let store = PathBuf::from(format!("{raw_segment_id}.store"));
+        let fast_fields = PathBuf::from(format!("{raw_segment_id}.fast"));
+        let field_norms = PathBuf::from(format!("{raw_segment_id}.fieldnorm"));
 
         if params.path.join(&postings).exists() {
             segment_files.push(postings);

--- a/nucliadb_core/src/tantivy_replica.rs
+++ b/nucliadb_core/src/tantivy_replica.rs
@@ -112,8 +112,8 @@ pub fn compute_safe_replica_state(
             segment_id,
         });
 
-        let deletes = delete_opstamp
-            .map(|stamp| PathBuf::from(format!("{raw_segment_id}.{stamp}.fieldnorm")));
+        let deletes =
+            delete_opstamp.map(|stamp| PathBuf::from(format!("{raw_segment_id}.{stamp}.del")));
 
         if let Some(deletes) = deletes {
             segment_files.push(deletes);

--- a/nucliadb_core/src/tantivy_replica.rs
+++ b/nucliadb_core/src/tantivy_replica.rs
@@ -1,0 +1,212 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+//! The following code works because of the Tantivy version used in this project. Inner Tantivy
+//! files that are not meant to be used are used, this is basically a hack for implementing safe
+//! replication at this moment in time. It should not be seen as the way of doing this, but as a way
+//! last resort.
+//! Ideally we should find a way of implementing safe replication inside Tantivy.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+use tantivy::schema::Schema;
+use tantivy::{Index, IndexSettings, LeasedItem, Opstamp, Result, Searcher, SegmentId};
+
+pub type Json = Value;
+
+/// Using a [`Searcher`] as a guard ensures us that until the
+/// value is dropped the files it has access to are not modified.
+pub struct ReplicationGuard(LeasedItem<Searcher>);
+
+pub struct TantivyReplicaState {
+    pub files: Vec<PathBuf>,
+    pub guard: ReplicationGuard,
+    pub metadata_path: PathBuf,
+    pub index_metadata: Json,
+}
+impl TantivyReplicaState {
+    pub fn metadata_as_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(&self.index_metadata).unwrap()
+    }
+}
+
+#[derive(Serialize)]
+struct SegmentDeletes {
+    num_deleted_docs: u32,
+    opstamp: u64,
+}
+
+#[derive(Serialize)]
+struct SegmentSafeMetadata {
+    segment_id: SegmentId,
+    max_doc: u32,
+    deletes: Option<SegmentDeletes>,
+}
+
+#[derive(Serialize)]
+struct SafeMetadata {
+    index_settings: IndexSettings,
+    segments: Vec<SegmentSafeMetadata>,
+    schema: Schema,
+    opstamp: Opstamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<String>,
+}
+
+pub fn compute_safe_replica_state(path: &Path, index: &Index) -> Result<TantivyReplicaState> {
+    let searcher = index.reader()?.searcher();
+    let index_metadata = index.load_metas()?;
+    let mut segment_files = vec![];
+    let mut safe_metadata = SafeMetadata {
+        index_settings: index_metadata.index_settings,
+        schema: index_metadata.schema,
+        opstamp: index_metadata.opstamp,
+        payload: index_metadata.payload,
+        segments: vec![],
+    };
+    for segment in searcher.segment_readers() {
+        let segment_id = segment.segment_id();
+        let raw_segment_id = segment_id.uuid_string();
+        let max_doc = segment.max_doc();
+        let num_deleted_docs = segment.num_deleted_docs();
+        let delete_opstamp = segment.delete_opstamp();
+        let deletes = delete_opstamp.map(|opstamp| SegmentDeletes {
+            opstamp,
+            num_deleted_docs,
+        });
+
+        safe_metadata.segments.push(SegmentSafeMetadata {
+            deletes,
+            max_doc,
+            segment_id,
+        });
+
+        let postings = PathBuf::from(format!("{raw_segment_id}.idx"));
+        let positions = PathBuf::from(format!("{raw_segment_id}.pos"));
+        let terms = PathBuf::from(format!("{raw_segment_id}.term"));
+        let store = PathBuf::from(format!("{raw_segment_id}.store"));
+        let fast_fields = PathBuf::from(format!("{raw_segment_id}.fast"));
+        let field_norms = PathBuf::from(format!("{raw_segment_id}.fieldnorm"));
+        let deletes = delete_opstamp
+            .map(|stamp| PathBuf::from(format!("{raw_segment_id}.{stamp}.fieldnorm")));
+
+        if path.join(&postings).exists() {
+            segment_files.push(postings);
+        }
+        if path.join(&positions).exists() {
+            segment_files.push(positions);
+        }
+        if path.join(&terms).exists() {
+            segment_files.push(terms);
+        }
+        if path.join(&store).exists() {
+            segment_files.push(store);
+        }
+        if path.join(&fast_fields).exists() {
+            segment_files.push(fast_fields);
+        }
+        if path.join(&field_norms).exists() {
+            segment_files.push(field_norms);
+        }
+        if let Some(deletes) = deletes {
+            segment_files.push(deletes);
+        }
+    }
+
+    Ok(TantivyReplicaState {
+        files: segment_files,
+        guard: ReplicationGuard(searcher),
+        metadata_path: PathBuf::from("meta.json"),
+        index_metadata: serde_json::to_value(safe_metadata)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use tantivy::doc;
+    use tantivy::schema::{Field, Schema, STORED, TEXT};
+
+    use super::*;
+
+    struct TestingSchema {
+        text_field: Field,
+        schema: Schema,
+    }
+
+    fn define_schema() -> TestingSchema {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+        let schema = schema_builder.build();
+        TestingSchema { text_field, schema }
+    }
+
+    #[test]
+    fn metadata_file_validation() {
+        let workspace = tempfile::tempdir().unwrap();
+        let testing_schema = define_schema();
+        let index = Index::create_in_dir(workspace.path(), testing_schema.schema).unwrap();
+        let mut writer = index.writer_with_num_threads(1, 6_000_000).unwrap();
+        writer
+            .add_document(doc!(testing_schema.text_field => "HI IM TEXT"))
+            .unwrap();
+        writer.commit().unwrap();
+
+        let metadata_as_json = serde_json::to_value(index.load_metas().unwrap()).unwrap();
+        let safe_replica_state = compute_safe_replica_state(workspace.path(), &index).unwrap();
+        assert_eq!(safe_replica_state.index_metadata, metadata_as_json);
+    }
+
+    #[test]
+    fn recreate_using_safe_state() {
+        let workspace = tempfile::tempdir().unwrap();
+        let testing_schema = define_schema();
+        let index = Index::create_in_dir(&workspace, testing_schema.schema).unwrap();
+        let mut writer = index.writer_with_num_threads(1, 6_000_000).unwrap();
+        writer
+            .add_document(doc!(testing_schema.text_field => "ONE"))
+            .unwrap();
+        writer.commit().unwrap();
+
+        let replica_workspace = tempfile::tempdir().unwrap();
+        let safe_state = compute_safe_replica_state(workspace.path(), &index).unwrap();
+        let mut metadata_file = File::create(replica_workspace.path().join("meta.json")).unwrap();
+        serde_json::to_writer(&mut metadata_file, &safe_state.index_metadata).unwrap();
+
+        for file_in_replica in &safe_state.files {
+            let source = workspace.path().join(file_in_replica);
+            let target = replica_workspace.path().join(file_in_replica);
+            std::fs::copy(source, target).unwrap();
+        }
+
+        let replica_index = Index::open_in_dir(replica_workspace.path()).unwrap();
+        let reader = replica_index.reader().unwrap();
+        let searcher = reader.searcher();
+        let mut collector = tantivy::collector::DocSetCollector;
+        let docs = searcher
+            .search(&tantivy::query::AllQuery, &mut collector)
+            .unwrap();
+
+        assert_eq!(docs.len(), 1);
+    }
+}

--- a/nucliadb_node/src/shards/shard_writer.rs
+++ b/nucliadb_node/src/shards/shard_writer.rs
@@ -504,27 +504,21 @@ impl ShardWriter {
     pub fn get_shard_files(
         &self,
         ignored_segement_ids: &HashMap<String, Vec<String>>,
-    ) -> NodeResult<Vec<IndexFiles>> {
+    ) -> NodeResult<Vec<(PathBuf, IndexFiles)>> {
         let mut files = Vec::new();
         let _lock = self.write_lock.lock().expect("Poisoned write lock"); // need to make sure more writes don't happen while we are reading
-
-        files.push(
-            paragraph_read(&self.paragraph_writer)
-                .get_index_files(ignored_segement_ids.get("paragraph").unwrap_or(&Vec::new()))?,
-        );
-        files.push(
-            text_read(&self.text_writer)
-                .get_index_files(ignored_segement_ids.get("text").unwrap_or(&Vec::new()))?,
-        );
-        files.push(
-            vector_read(&self.vector_writer)
-                .get_index_files(ignored_segement_ids.get("vector").unwrap_or(&Vec::new()))?,
-        );
-        files.push(
-            relation_read(&self.relation_writer)
-                .get_index_files(ignored_segement_ids.get("relation").unwrap_or(&Vec::new()))?,
-        );
-
+        let paragraph_files = paragraph_read(&self.paragraph_writer)
+            .get_index_files(ignored_segement_ids.get("paragraph").unwrap_or(&Vec::new()))?;
+        let text_files = text_read(&self.text_writer)
+            .get_index_files(ignored_segement_ids.get("text").unwrap_or(&Vec::new()))?;
+        let vector_files = vector_read(&self.vector_writer)
+            .get_index_files(ignored_segement_ids.get("vector").unwrap_or(&Vec::new()))?;
+        let relation_files = relation_read(&self.relation_writer)
+            .get_index_files(ignored_segement_ids.get("relation").unwrap_or(&Vec::new()))?;
+        files.push((PathBuf::from(PARAGRAPHS_DIR), paragraph_files));
+        files.push((PathBuf::from(TEXTS_DIR), text_files));
+        files.push((PathBuf::from(VECTORS_DIR), vector_files));
+        files.push((PathBuf::from(RELATIONS_DIR), relation_files));
         Ok(files)
     }
 }

--- a/nucliadb_paragraphs/src/writer.rs
+++ b/nucliadb_paragraphs/src/writer.rs
@@ -152,9 +152,12 @@ impl WriterChild for ParagraphWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        let path = &self.config.path;
-        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let params = tantivy_replica::ReplicationParameters {
+            path: &self.config.path,
+            on_replica: ignored_segment_ids,
+        };
+        let safe_state = tantivy_replica::compute_safe_replica_state(params, &self.index)?;
         Ok(IndexFiles::Tantivy(safe_state))
     }
 }

--- a/nucliadb_paragraphs/src/writer.rs
+++ b/nucliadb_paragraphs/src/writer.rs
@@ -27,7 +27,7 @@ use nucliadb_core::protos::prost::Message;
 use nucliadb_core::protos::resource::ResourceStatus;
 use nucliadb_core::protos::{Resource, ResourceId};
 use nucliadb_core::tracing::{self, *};
-use nucliadb_core::IndexFiles;
+use nucliadb_core::{tantivy_replica, IndexFiles};
 use nucliadb_procs::measure;
 use regex::Regex;
 use tantivy::collector::Count;
@@ -152,41 +152,10 @@ impl WriterChild for ParagraphWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        // Should be called along with a lock at a higher level to be safe
-        let mut meta_files = HashMap::new();
-        let path = self.config.path.join("meta.json");
-        if !path.exists() {
-            return Ok(IndexFiles {
-                metadata_files: meta_files,
-                files: Vec::new(),
-            });
-        }
-        meta_files.insert("paragraph/meta.json".to_string(), fs::read(path)?);
-
-        let mut files = Vec::new();
-
-        for segment_meta in self.index.searchable_segment_metas()? {
-            if ignored_segment_ids.contains(&segment_meta.id().uuid_string()) {
-                continue;
-            }
-            for seg_file in segment_meta.list_files() {
-                files.push(format!("paragraph/{}", seg_file.to_string_lossy()));
-            }
-        }
-
-        if files.is_empty() {
-            // exit with no changes
-            return Ok(IndexFiles {
-                metadata_files: HashMap::new(),
-                files,
-            });
-        }
-
-        Ok(IndexFiles {
-            metadata_files: meta_files,
-            files,
-        })
+    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let path = &self.config.path;
+        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+        Ok(IndexFiles::Tantivy(safe_state))
     }
 }
 

--- a/nucliadb_relations/src/service/writer.rs
+++ b/nucliadb_relations/src/service/writer.rs
@@ -25,7 +25,7 @@ use nucliadb_core::prelude::*;
 use nucliadb_core::protos::resource::ResourceStatus;
 use nucliadb_core::protos::{Resource, ResourceId};
 use nucliadb_core::tracing::{self, *};
-use nucliadb_core::IndexFiles;
+use nucliadb_core::{IndexFiles, RawReplicaState};
 use nucliadb_procs::measure;
 
 use super::utils::*;
@@ -153,10 +153,10 @@ impl WriterChild for RelationsWriterService {
 
     fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
         // not implemented, not supported right now
-        Ok(IndexFiles {
+        Ok(IndexFiles::Other(RawReplicaState {
             metadata_files: HashMap::new(),
             files: Vec::new(),
-        })
+        }))
     }
 }
 

--- a/nucliadb_relations2/src/writer.rs
+++ b/nucliadb_relations2/src/writer.rs
@@ -109,9 +109,12 @@ impl WriterChild for RelationsWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        let path = &self.config.path;
-        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let params = tantivy_replica::ReplicationParameters {
+            path: &self.config.path,
+            on_replica: ignored_segment_ids,
+        };
+        let safe_state = tantivy_replica::compute_safe_replica_state(params, &self.index)?;
         Ok(IndexFiles::Tantivy(safe_state))
     }
 }

--- a/nucliadb_relations2/src/writer.rs
+++ b/nucliadb_relations2/src/writer.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs;
 use std::path::Path;
@@ -28,7 +27,7 @@ use nucliadb_core::protos::prost::Message;
 use nucliadb_core::protos::resource::ResourceStatus;
 use nucliadb_core::protos::{Resource, ResourceId};
 use nucliadb_core::tracing::{self, *};
-use nucliadb_core::IndexFiles;
+use nucliadb_core::{tantivy_replica, IndexFiles};
 use nucliadb_procs::measure;
 use tantivy::collector::Count;
 use tantivy::query::AllQuery;
@@ -110,41 +109,10 @@ impl WriterChild for RelationsWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        // Should be called along with a lock at a higher level to be safe
-        let mut meta_files = HashMap::new();
-        let path = self.config.path.join("meta.json");
-        if !path.exists() {
-            return Ok(IndexFiles {
-                metadata_files: meta_files,
-                files: Vec::new(),
-            });
-        }
-        meta_files.insert("text/meta.json".to_string(), fs::read(path)?);
-
-        let mut files = Vec::new();
-
-        for segment_meta in self.index.searchable_segment_metas()? {
-            if ignored_segment_ids.contains(&segment_meta.id().uuid_string()) {
-                continue;
-            }
-            for seg_file in segment_meta.list_files() {
-                files.push(format!("text/{}", seg_file.to_string_lossy()));
-            }
-        }
-
-        if files.is_empty() {
-            // exit with no changes
-            return Ok(IndexFiles {
-                metadata_files: HashMap::new(),
-                files,
-            });
-        }
-
-        Ok(IndexFiles {
-            metadata_files: meta_files,
-            files,
-        })
+    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let path = &self.config.path;
+        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+        Ok(IndexFiles::Tantivy(safe_state))
     }
 }
 

--- a/nucliadb_texts/src/writer.rs
+++ b/nucliadb_texts/src/writer.rs
@@ -152,9 +152,12 @@ impl WriterChild for TextWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        let path = &self.config.path;
-        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let params = tantivy_replica::ReplicationParameters {
+            path: &self.config.path,
+            on_replica: ignored_segment_ids,
+        };
+        let safe_state = tantivy_replica::compute_safe_replica_state(params, &self.index)?;
         Ok(IndexFiles::Tantivy(safe_state))
     }
 }

--- a/nucliadb_texts/src/writer.rs
+++ b/nucliadb_texts/src/writer.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs;
 use std::path::Path;
@@ -28,7 +27,7 @@ use nucliadb_core::prelude::*;
 use nucliadb_core::protos::resource::ResourceStatus;
 use nucliadb_core::protos::{Resource, ResourceId};
 use nucliadb_core::tracing::{self, *};
-use nucliadb_core::IndexFiles;
+use nucliadb_core::{tantivy_replica, IndexFiles};
 use nucliadb_procs::measure;
 use tantivy::collector::Count;
 use tantivy::query::AllQuery;
@@ -153,41 +152,10 @@ impl WriterChild for TextWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        // Should be called along with a lock at a higher level to be safe
-        let mut meta_files = HashMap::new();
-        let path = self.config.path.join("meta.json");
-        if !path.exists() {
-            return Ok(IndexFiles {
-                metadata_files: meta_files,
-                files: Vec::new(),
-            });
-        }
-        meta_files.insert("text/meta.json".to_string(), fs::read(path)?);
-
-        let mut files = Vec::new();
-
-        for segment_meta in self.index.searchable_segment_metas()? {
-            if ignored_segment_ids.contains(&segment_meta.id().uuid_string()) {
-                continue;
-            }
-            for seg_file in segment_meta.list_files() {
-                files.push(format!("text/{}", seg_file.to_string_lossy()));
-            }
-        }
-
-        if files.is_empty() {
-            // exit with no changes
-            return Ok(IndexFiles {
-                metadata_files: HashMap::new(),
-                files,
-            });
-        }
-
-        Ok(IndexFiles {
-            metadata_files: meta_files,
-            files,
-        })
+    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let path = &self.config.path;
+        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+        Ok(IndexFiles::Tantivy(safe_state))
     }
 }
 

--- a/nucliadb_texts2/src/writer.rs
+++ b/nucliadb_texts2/src/writer.rs
@@ -151,9 +151,12 @@ impl WriterChild for TextWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        let path = &self.config.path;
-        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let params = tantivy_replica::ReplicationParameters {
+            path: &self.config.path,
+            on_replica: ignored_segment_ids,
+        };
+        let safe_state = tantivy_replica::compute_safe_replica_state(params, &self.index)?;
         Ok(IndexFiles::Tantivy(safe_state))
     }
 }

--- a/nucliadb_texts2/src/writer.rs
+++ b/nucliadb_texts2/src/writer.rs
@@ -18,7 +18,6 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fs;
 use std::path::Path;
@@ -28,7 +27,7 @@ use nucliadb_core::prelude::*;
 use nucliadb_core::protos::resource::ResourceStatus;
 use nucliadb_core::protos::{Resource, ResourceId};
 use nucliadb_core::tracing::{self, *};
-use nucliadb_core::IndexFiles;
+use nucliadb_core::{tantivy_replica, IndexFiles};
 use nucliadb_procs::measure;
 use tantivy::collector::Count;
 use tantivy::query::AllQuery;
@@ -152,41 +151,10 @@ impl WriterChild for TextWriterService {
             .collect())
     }
 
-    fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
-        // Should be called along with a lock at a higher level to be safe
-        let mut meta_files = HashMap::new();
-        let path = self.config.path.join("meta.json");
-        if !path.exists() {
-            return Ok(IndexFiles {
-                metadata_files: meta_files,
-                files: Vec::new(),
-            });
-        }
-        meta_files.insert("text/meta.json".to_string(), fs::read(path)?);
-
-        let mut files = Vec::new();
-
-        for segment_meta in self.index.searchable_segment_metas()? {
-            if ignored_segment_ids.contains(&segment_meta.id().uuid_string()) {
-                continue;
-            }
-            for seg_file in segment_meta.list_files() {
-                files.push(format!("text/{}", seg_file.to_string_lossy()));
-            }
-        }
-
-        if files.is_empty() {
-            // exit with no changes
-            return Ok(IndexFiles {
-                metadata_files: HashMap::new(),
-                files,
-            });
-        }
-
-        Ok(IndexFiles {
-            metadata_files: meta_files,
-            files,
-        })
+    fn get_index_files(&self, _ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
+        let path = &self.config.path;
+        let safe_state = tantivy_replica::compute_safe_replica_state(path, &self.index)?;
+        Ok(IndexFiles::Tantivy(safe_state))
     }
 }
 

--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -746,8 +746,10 @@ mod tests {
 
         let segments = writer.get_segment_ids().unwrap();
         assert_eq!(segments.len(), 2);
-        let existing_segs: Vec<String> = Vec::new();
-        let index_files = writer.get_index_files(&existing_segs).unwrap();
+        let existing_secs: Vec<String> = Vec::new();
+        let Ok(IndexFiles::Other(index_files)) = writer.get_index_files(&existing_secs) else {
+            panic!("Expected another outcome");
+        };
         let mut expected_files = Vec::new();
         for segment in segments {
             expected_files.push(format!("vectors/{}/index.hnsw", segment));

--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -28,7 +28,7 @@ use nucliadb_core::protos::prost::Message;
 use nucliadb_core::protos::resource::ResourceStatus;
 use nucliadb_core::protos::{Resource, ResourceId, VectorSetId, VectorSimilarity};
 use nucliadb_core::tracing::{self, *};
-use nucliadb_core::{metrics, Channel, IndexFiles};
+use nucliadb_core::{metrics, Channel, IndexFiles, RawReplicaState};
 use nucliadb_procs::measure;
 
 use crate::data_point::{DataPoint, Elem, LabelDictionary};
@@ -347,12 +347,12 @@ impl WriterChild for VectorWriterService {
 
     fn get_index_files(&self, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
         // Should be called along with a lock at a higher level to be safe
-        let mut meta_files = HashMap::new();
-        meta_files.insert(
+        let mut metadata_files = HashMap::new();
+        metadata_files.insert(
             "vectors/state.bincode".to_string(),
             fs::read(self.config.path.join("state.bincode"))?,
         );
-        meta_files.insert(
+        metadata_files.insert(
             "vectors/metadata.json".to_string(),
             fs::read(self.config.path.join("metadata.json"))?,
         );
@@ -377,7 +377,7 @@ impl WriterChild for VectorWriterService {
 
         let vectorsets = self.list_vectorsets()?;
         if !vectorsets.is_empty() {
-            meta_files.insert(
+            metadata_files.insert(
                 "vectorset/state.bincode".to_string(),
                 fs::read(self.config.vectorset.join("state.bincode"))?,
             );
@@ -399,11 +399,11 @@ impl WriterChild for VectorWriterService {
                         files.push(format!("vectors/{}/fst/labels.idx", segment_id));
                     }
                 }
-                meta_files.insert(
+                metadata_files.insert(
                     format!("vectorset/{}/state.bincode", vs),
                     fs::read(self.config.vectorset.join(format!("{}/state.bincode", vs)))?,
                 );
-                meta_files.insert(
+                metadata_files.insert(
                     format!("vectorset/{}/metadata.json", vs),
                     fs::read(self.config.vectorset.join(format!("{}/metadata.json", vs)))?,
                 );
@@ -412,16 +412,16 @@ impl WriterChild for VectorWriterService {
 
         if files.is_empty() {
             // exit with no changes
-            return Ok(IndexFiles {
+            return Ok(IndexFiles::Other(RawReplicaState {
                 metadata_files: HashMap::new(),
                 files,
-            });
+            }));
         }
 
-        Ok(IndexFiles {
-            metadata_files: meta_files,
+        Ok(IndexFiles::Other(RawReplicaState {
+            metadata_files,
             files,
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
### Description
This PR uses a different approach to replication in Tantivy indexes. We were getting errors due to data race conditions, which are a result of us directly accessing Tantivy files without proper safeguards. 

### How was this PR tested?
Local tests.
