### PR TITLE
Fix e2e tests

### DIFF
--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -190,7 +190,7 @@ def _test_predict_proxy_chat(kbid: str):
         json={
             "question": "Who is the best football player?",
             "query_context": [
-                "Many football players have existed. Cristiano Ronaldo and Messi among them, but Messi is by far the greatest."
+                "Many football players have existed. Messi is by far the greatest."
             ],
             "user_id": "someone@company.uk",
         },


### PR DESCRIPTION
### Description
Predict is behaving wrong returning `I'm sorry, but I cannot answer this question as it is based on opinion and not factual information.0` for one of our e2e tests.

I'm changing the context to not make the LLM doubt.

### How was this PR tested?
Describe how you tested this PR.
