### PR TITLE
Prefer read replicas when choosing nodes to search

### DIFF
--- a/nucliadb/nucliadb/common/cluster/base.py
+++ b/nucliadb/nucliadb/common/cluster/base.py
@@ -58,6 +58,9 @@ class AbstractIndexNode(metaclass=ABCMeta):
     def __repr__(self):
         return self.__str__()
 
+    def is_read_replica(self) -> bool:
+        return self.primary_id is not None
+
     @property
     @abstractmethod
     def reader(self) -> NodeReaderStub:  # pragma: no cover

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -515,14 +515,14 @@ def choose_node(
 ) -> tuple[AbstractIndexNode, str, str]:
     """Choose an arbitrary node storing `shard` following these rules:
     - nodes containing a shard replica from `target_replicas` are the preferred
-    - if `read_only`, read_replicas are preferred over primaries
+    - when enabled, read replica nodes are preferred over primaries
     - if there's more than one option with the same score, a random choice will
-      be made
+      be made between them.
 
-    According to these rules and considering `read_only == True`, a secondary
-    node containing a shard replica from `target_replicas` is the most
-    preferent, while a primary node with a shard not in `target_replicas` is the
-    least preferent.
+    According to these rules and considering we use read replica nodes, a read
+    replica node containing a shard replica from `target_shard_replicas` is the
+    most preferent, while a primary node with a shard not in
+    `target_shard_replicas` is the least preferent.
 
     """
     target_shard_replicas = target_shard_replicas or []

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -21,7 +21,6 @@ import asyncio
 import logging
 import random
 import uuid
-from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
 import backoff

--- a/nucliadb/nucliadb/search/api/v1/search.py
+++ b/nucliadb/nucliadb/search/api/v1/search.py
@@ -241,10 +241,10 @@ async def catalog(
             kbid,
             Method.SEARCH,
             pb_query,
-            target_replicas=shards,
+            target_shard_replicas=shards,
             # Catalog should not go to read replicas because we want it to be
             # consistent and most up to date results
-            read_only=False,
+            use_read_replica_nodes=False,
         )
 
         # We need to merge
@@ -360,7 +360,7 @@ async def search(
     pb_query, incomplete_results, autofilters = await query_parser.parse()
 
     results, query_incomplete_results, queried_nodes, queried_shards = await node_query(
-        kbid, Method.SEARCH, pb_query, target_replicas=item.shards
+        kbid, Method.SEARCH, pb_query, target_shard_replicas=item.shards
     )
 
     incomplete_results = incomplete_results or query_incomplete_results

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -84,8 +84,8 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: SuggestRequest,
-    target_replicas: Optional[list[str]] = None,
-    read_only: bool = True,
+    target_shard_replicas: Optional[list[str]] = None,
+    use_read_replica_nodes: bool = True,
 ) -> tuple[list[SuggestResponse], bool, list[tuple[str, str, str]], list[str]]:
     ...
 
@@ -95,8 +95,8 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: ParagraphSearchRequest,
-    target_replicas: Optional[list[str]] = None,
-    read_only: bool = True,
+    target_shard_replicas: Optional[list[str]] = None,
+    use_read_replica_nodes: bool = True,
 ) -> tuple[list[ParagraphSearchResponse], bool, list[tuple[str, str, str]], list[str]]:
     ...
 
@@ -106,8 +106,8 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: SearchRequest,
-    target_replicas: Optional[list[str]] = None,
-    read_only: bool = True,
+    target_shard_replicas: Optional[list[str]] = None,
+    use_read_replica_nodes: bool = True,
 ) -> tuple[list[SearchResponse], bool, list[tuple[str, str, str]], list[str]]:
     ...
 
@@ -117,8 +117,8 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: RelationSearchRequest,
-    target_replicas: Optional[list[str]] = None,
-    read_only: bool = True,
+    target_shard_replicas: Optional[list[str]] = None,
+    use_read_replica_nodes: bool = True,
 ) -> tuple[list[RelationSearchResponse], bool, list[tuple[str, str, str]], list[str]]:
     ...
 
@@ -127,10 +127,10 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: REQUEST_TYPE,
-    target_replicas: Optional[list[str]] = None,
-    read_only: bool = True,
+    target_shard_replicas: Optional[list[str]] = None,
+    use_read_replica_nodes: bool = True,
 ) -> tuple[list[T], bool, list[tuple[str, str, str]], list[str]]:
-    read_only = read_only and has_feature(
+    use_read_replica_nodes = use_read_replica_nodes and has_feature(
         const.Features.READ_REPLICA_SEARCHES, context={"kbid": kbid}
     )
 
@@ -151,7 +151,9 @@ async def node_query(
     for shard_obj in shard_groups:
         try:
             node, shard_id, node_id = cluster_manager.choose_node(
-                shard_obj, read_only=read_only, target_replicas=target_replicas
+                shard_obj,
+                use_read_replica_nodes=use_read_replica_nodes,
+                target_shard_replicas=target_shard_replicas,
             )
         except KeyError:
             incomplete_results = True

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -188,7 +188,7 @@ async def get_relations_results(
             kbid,
             Method.RELATIONS,
             relation_request,
-            target_replicas=chat_request.shards,
+            target_shard_replicas=chat_request.shards,
         )
         return merge_relations_results(relations_results, relation_request.subgraph)
     except Exception as exc:

--- a/nucliadb/nucliadb/search/search/find.py
+++ b/nucliadb/nucliadb/search/search/find.py
@@ -71,7 +71,7 @@ async def find(
     )
     pb_query, incomplete_results, autofilters = await query_parser.parse()
     results, query_incomplete_results, queried_nodes, queried_shards = await node_query(
-        kbid, Method.SEARCH, pb_query, target_replicas=item.shards
+        kbid, Method.SEARCH, pb_query, target_shard_replicas=item.shards
     )
     incomplete_results = incomplete_results or query_incomplete_results
 

--- a/nucliadb/nucliadb/tests/integration/common/cluster/test_manager.py
+++ b/nucliadb/nucliadb/tests/integration/common/cluster/test_manager.py
@@ -152,14 +152,14 @@ async def test_choose_node_attempts_target_replicas_but_is_not_imperative(shards
     r1 = shard.replicas[1].shard.id
     n1 = shard.replicas[1].node
 
-    _, replica_id, node_id = manager.choose_node(shard, target_replicas=[r0])
+    _, replica_id, node_id = manager.choose_node(shard, target_shard_replicas=[r0])
     assert replica_id == r0
     assert node_id == n0
 
     # Change the node-0 to a non-existent node id in order to
-    # test the target_replicas logic is not imperative
+    # test the target_shard_replicas logic is not imperative
     shard.replicas[0].node = "I-do-not-exist"
-    _, replica_id, node_id = manager.choose_node(shard, target_replicas=[r0])
+    _, replica_id, node_id = manager.choose_node(shard, target_shard_replicas=[r0])
     assert replica_id == r1
     assert node_id == n1
 

--- a/nucliadb/nucliadb/tests/unit/common/cluster/test_manager.py
+++ b/nucliadb/nucliadb/tests/unit/common/cluster/test_manager.py
@@ -208,7 +208,7 @@ def repeated_choose_node(
     return shard_ids, node_ids
 
 
-def test_choose_node_with_nodes_and_replicas():
+def test_choose_node_with_nodes_and_replicas(standalone_mode_off):
     """Validate how choose node selects between different options depending on
     configuration.
 

--- a/nucliadb/nucliadb/tests/unit/common/cluster/test_manager.py
+++ b/nucliadb/nucliadb/tests/unit/common/cluster/test_manager.py
@@ -87,20 +87,30 @@ async def test_standalone_node_garbage_collects(fake_node):
     assert len(fake_node.writer.calls["GC"]) == 1
 
 
-def test_choose_node():
+def add_index_node(id: str):
+    manager.add_index_node(
+        id=id,
+        address="nohost",
+        shard_count=0,
+        dummy=True,
+    )
+
+
+def add_read_replica_node(id: str, primary_id: str):
+    manager.add_index_node(
+        id=id,
+        address="nohost",
+        shard_count=0,
+        dummy=True,
+        primary_id=primary_id,
+    )
+
+
+def test_choose_node_with_two_primary_nodes():
     manager.INDEX_NODES.clear()
-    manager.add_index_node(
-        id="node-0",
-        address="nohost",
-        shard_count=0,
-        dummy=True,
-    )
-    manager.add_index_node(
-        id="node-1",
-        address="nohost",
-        shard_count=0,
-        dummy=True,
-    )
+    add_index_node("node-0")
+    add_index_node("node-1")
+
     _, _, node_id = manager.choose_node(
         writer_pb2.ShardObject(
             replicas=[
@@ -123,20 +133,17 @@ def test_choose_node():
     assert node_id == "node-1"
 
     manager.INDEX_NODES.clear()
-    manager.add_index_node(
-        id="node-replica-0",
-        address="nohost",
-        shard_count=0,
-        dummy=True,
-        primary_id="node-0",
-    )
-    manager.add_index_node(
-        id="node-replica-1",
-        address="nohost",
-        shard_count=0,
-        dummy=True,
-        primary_id="node-1",
-    )
+
+
+def test_choose_node_with_two_read_replicas():
+    """Test choose_node with two replica nodes pointing to two different primary
+    nodes.
+
+    """
+    manager.INDEX_NODES.clear()
+    add_read_replica_node("node-replica-0", primary_id="node-0")
+    add_read_replica_node("node-replica-1", primary_id="node-1")
+
     _, _, node_id = manager.choose_node(
         writer_pb2.ShardObject(
             replicas=[
@@ -160,19 +167,152 @@ def test_choose_node():
     )
     assert node_id == "node-replica-1"
 
-    manager.remove_index_node("node-replica-0", "node-0")
+    manager.INDEX_NODES.clear()
+
+
+def test_choose_node_no_healthy_node_available():
+    """There's only one read replica for node-0 and we try to choose a node for
+    a shard in node-1. We expect it to fail as there's no possible valid node to
+    choose.
+
+    """
+    manager.INDEX_NODES.clear()
+    add_read_replica_node("node-replica-0", primary_id="node-0")
 
     with pytest.raises(NoHealthyNodeAvailable):
         manager.choose_node(
             writer_pb2.ShardObject(
                 replicas=[
                     writer_pb2.ShardReplica(
-                        shard=writer_pb2.ShardCreated(id="123"), node="node-0"
+                        shard=writer_pb2.ShardCreated(id="123"), node="node-1"
                     )
                 ]
             ),
             read_only=True,
         )
+
+    manager.INDEX_NODES.clear()
+
+
+def repeated_choose_node(
+    count: int, shard: writer_pb2.ShardObject, **kwargs
+) -> tuple[list[str], list[str]]:
+    shard_ids = []
+    node_ids = []
+
+    for _ in range(count):
+        _, shard_id, node_id = manager.choose_node(shard, **kwargs)
+        shard_ids.append(shard_id)
+        node_ids.append(node_id)
+
+    return shard_ids, node_ids
+
+
+def test_choose_node_with_nodes_and_replicas():
+    """Validate how choose node selects between different options depending on
+    configuration.
+
+    As some choices can be random between a subset of nodes, choose_node is
+    called multiple times per assert.
+
+    """
+    TRIES_PER_ASSERT = 10
+
+    shard = writer_pb2.ShardObject(
+        replicas=[
+            writer_pb2.ShardReplica(
+                shard=writer_pb2.ShardCreated(id="123"),
+                node="node-0",
+            ),
+            writer_pb2.ShardReplica(
+                shard=writer_pb2.ShardCreated(id="456"),
+                node="node-1",
+            ),
+        ]
+    )
+
+    # Start with 2 nodes and 1 read replica each
+    manager.INDEX_NODES.clear()
+    add_index_node("node-0")
+    add_index_node("node-1")
+    add_read_replica_node("node-replica-0", primary_id="node-0")
+    add_read_replica_node("node-replica-1", primary_id="node-1")
+
+    # Without read replicas, we only choose primaries
+    shard_ids, node_ids = repeated_choose_node(TRIES_PER_ASSERT, shard, read_only=False)
+    assert set(shard_ids) == {"123", "456"}
+    assert set(node_ids) == {"node-0", "node-1"}
+
+    # Secondaries are preferred
+    shard_ids, node_ids = repeated_choose_node(TRIES_PER_ASSERT, shard, read_only=True)
+    assert set(shard_ids) == {"123", "456"}
+    assert set(node_ids) == {"node-replica-0", "node-replica-1"}
+
+    # Target replicas take more preference
+    shard_ids, node_ids = repeated_choose_node(
+        TRIES_PER_ASSERT, shard, read_only=False, target_replicas=["456"]
+    )
+    assert set(shard_ids) == {"456"}
+    assert set(node_ids) == {"node-1"}
+
+    shard_ids, node_ids = repeated_choose_node(
+        TRIES_PER_ASSERT, shard, read_only=True, target_replicas=["456"]
+    )
+    assert set(shard_ids) == {"456"}
+    assert set(node_ids) == {"node-replica-1"}
+
+    # Let's remove a node so it becomes unavailable, replica keeps working
+    manager.INDEX_NODES.clear()
+    add_index_node("node-0")
+    add_read_replica_node("node-replica-0", primary_id="node-0")
+    add_read_replica_node("node-replica-1", primary_id="node-1")
+
+    shard_ids, node_ids = repeated_choose_node(TRIES_PER_ASSERT, shard, read_only=False)
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-0"}
+
+    shard_ids, node_ids = repeated_choose_node(TRIES_PER_ASSERT, shard, read_only=True)
+    assert set(shard_ids) == {"123", "456"}
+    assert set(node_ids) == {"node-replica-0", "node-replica-1"}
+
+    # target replicas is ignored but only primaries are used
+    shard_ids, node_ids = repeated_choose_node(
+        TRIES_PER_ASSERT, shard, read_only=False, target_replicas=["456"]
+    )
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-0"}
+
+    shard_ids, node_ids = repeated_choose_node(
+        TRIES_PER_ASSERT, shard, read_only=True, target_replicas=["456"]
+    )
+    assert set(shard_ids) == {"456"}
+    assert set(node_ids) == {"node-replica-1"}
+
+    # Now let's add again the node but remove the replica
+    manager.INDEX_NODES.clear()
+    add_index_node("node-0")
+    add_index_node("node-1")
+    add_read_replica_node("node-replica-0", primary_id="node-0")
+
+    shard_ids, node_ids = repeated_choose_node(TRIES_PER_ASSERT, shard, read_only=False)
+    assert set(shard_ids) == {"123", "456"}
+    assert set(node_ids) == {"node-0", "node-1"}
+
+    shard_ids, node_ids = repeated_choose_node(TRIES_PER_ASSERT, shard, read_only=True)
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-replica-0"}
+
+    shard_ids, node_ids = repeated_choose_node(
+        TRIES_PER_ASSERT, shard, read_only=False, target_replicas=["456"]
+    )
+    assert set(shard_ids) == {"456"}
+    assert set(node_ids) == {"node-1"}
+
+    shard_ids, node_ids = repeated_choose_node(
+        TRIES_PER_ASSERT, shard, read_only=True, target_replicas=["456"]
+    )
+    assert set(shard_ids) == {"456"}
+    assert set(node_ids) == {"node-1"}
 
     manager.INDEX_NODES.clear()
 


### PR DESCRIPTION
### Description
Change logic around `choose_node` so read replicas are preferred over primary index nodes

### Potential improvements
With this logic, if we call `choose_node(shard, read_only=True)` and there's 1 read replica and 2 primary nodes, searches will always go to the secondary. Maybe a better load balancing can be thought.

### How was this PR tested?
Unit tests
