### PR TITLE
Retry query to primary if secondary (read replica) fails

### DIFF
--- a/nucliadb/nucliadb/ingest/consumer/auditing.py
+++ b/nucliadb/nucliadb/ingest/consumer/auditing.py
@@ -119,7 +119,7 @@ class IndexAuditHandler:
         total_paragraphs = 0
 
         for shard_obj in shard_groups:
-            node, shard_id, _ = choose_node(shard_obj)
+            node, shard_id = choose_node(shard_obj)
             shard: nodereader_pb2.Shard = await node.reader.GetShard(
                 nodereader_pb2.GetShardRequest(shard_id=noderesources_pb2.ShardId(id=shard_id))  # type: ignore
             )

--- a/nucliadb/nucliadb/ingest/consumer/shard_creator.py
+++ b/nucliadb/nucliadb/ingest/consumer/shard_creator.py
@@ -92,7 +92,7 @@ class ShardCreatorHandler:
         kb_shards = await self.shard_manager.get_shards_by_kbid_inner(kbid)
         current_shard: writer_pb2.ShardObject = kb_shards.shards[kb_shards.actual]
 
-        node, shard_id, _ = choose_node(current_shard)
+        node, shard_id = choose_node(current_shard)
         shard: nodereader_pb2.Shard = await node.reader.GetShard(
             nodereader_pb2.GetShardRequest(shard_id=noderesources_pb2.ShardId(id=shard_id))  # type: ignore
         )

--- a/nucliadb/nucliadb/ingest/orm/entities.py
+++ b/nucliadb/nucliadb/ingest/orm/entities.py
@@ -195,7 +195,7 @@ class EntitiesManager:
         shard_manager = get_shard_manager()
 
         async def do_entities_search(
-            node: AbstractIndexNode, shard_id: str, node_id: str
+            node: AbstractIndexNode, shard_id: str
         ) -> RelationSearchResponse:
             request = RelationSearchRequest(
                 shard_id=shard_id,
@@ -288,7 +288,7 @@ class EntitiesManager:
         shard_manager = get_shard_manager()
 
         async def query_indexed_entities_group_names(
-            node: AbstractIndexNode, shard_id: str, node_id: str
+            node: AbstractIndexNode, shard_id: str
         ) -> TypeList:
             return await node.reader.RelationTypes(ShardId(id=shard_id))  # type: ignore
 

--- a/nucliadb/nucliadb/ingest/settings.py
+++ b/nucliadb/nucliadb/ingest/settings.py
@@ -49,7 +49,10 @@ class DriverSettings(BaseSettings):
     )
     driver_tikv_url: Optional[list[str]] = Field(
         default=None,
-        description="TiKV PD (Placement Dricer) URL. The URL to the cluster manager of TiKV. Example: tikv-pd.svc:2379",
+        description=(
+            "TiKV PD (Placement Driver) URLs. The URL to the cluster manager of"
+            "TiKV. Example: tikv-pd.svc:2379"
+        ),
     )
     driver_local_url: Optional[str] = Field(
         default=None,

--- a/nucliadb/nucliadb/ingest/settings.py
+++ b/nucliadb/nucliadb/ingest/settings.py
@@ -51,7 +51,7 @@ class DriverSettings(BaseSettings):
         default=None,
         description=(
             "TiKV PD (Placement Driver) URLs. The URL to the cluster manager of"
-            "TiKV. Example: tikv-pd.svc:2379"
+            "TiKV. Example: '[\"tikv-pd.svc:2379\"]'"
         ),
     )
     driver_local_url: Optional[str] = Field(

--- a/nucliadb/nucliadb/ingest/tests/unit/consumer/test_auditing.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/consumer/test_auditing.py
@@ -52,7 +52,7 @@ def shard_manager(reader):
         "nucliadb.ingest.consumer.auditing.get_shard_manager", return_value=nm
     ), patch(
         "nucliadb.ingest.consumer.auditing.choose_node",
-        return_value=(node, "shard_id", None),
+        return_value=(node, "shard_id"),
     ):
         yield nm
 

--- a/nucliadb/nucliadb/ingest/tests/unit/consumer/test_shard_creator.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/consumer/test_shard_creator.py
@@ -64,7 +64,7 @@ def shard_manager(reader):
         "nucliadb.ingest.consumer.shard_creator.get_shard_manager", return_value=sm
     ), patch(
         "nucliadb.ingest.consumer.shard_creator.choose_node",
-        return_value=(node, "shard_id", None),
+        return_value=(node, "shard_id"),
     ):
         yield sm
 

--- a/nucliadb/nucliadb/search/api/v1/knowledgebox.py
+++ b/nucliadb/nucliadb/search/api/v1/knowledgebox.py
@@ -103,7 +103,7 @@ async def knowledgebox_counters(
     queried_shards = []
     for shard_object in shard_groups:
         try:
-            node, shard_id, _ = choose_node(shard_object)
+            node, shard_id = choose_node(shard_object)
         except KeyError:
             raise HTTPException(
                 status_code=500,

--- a/nucliadb/nucliadb/search/api/v1/resource/search.py
+++ b/nucliadb/nucliadb/search/api/v1/resource/search.py
@@ -26,7 +26,7 @@ from fastapi_versioning import version
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
-from nucliadb.search.requesters.utils import Method, node_query
+from nucliadb.search.requesters.utils import Method, debug_nodes_info, node_query
 from nucliadb.search.search.exceptions import InvalidQueryError
 from nucliadb.search.search.merge import merge_paragraphs_results
 from nucliadb.search.search.query import paragraph_query_to_pb
@@ -118,7 +118,7 @@ async def resource_search(
     except InvalidQueryError as exc:
         return HTTPClientError(status_code=412, detail=str(exc))
 
-    results, incomplete_results, queried_nodes, queried_shards = await node_query(
+    results, incomplete_results, queried_nodes = await node_query(
         kbid, Method.PARAGRAPH, pb_query, shards
     )
 
@@ -136,7 +136,8 @@ async def resource_search(
 
     response.status_code = 206 if incomplete_results else 200
     if debug:
-        search_results.nodes = queried_nodes
+        search_results.nodes = debug_nodes_info(queried_nodes)
 
+    queried_shards = [shard_id for _, shard_id in queried_nodes]
     search_results.shards = queried_shards
     return search_results

--- a/nucliadb/nucliadb/search/api/v1/suggest.py
+++ b/nucliadb/nucliadb/search/api/v1/suggest.py
@@ -148,7 +148,7 @@ async def suggest(
         range_modification_start,
         range_modification_end,
     )
-    results, incomplete_results, _, queried_shards = await node_query(
+    results, incomplete_results, queried_nodes = await node_query(
         kbid, Method.SUGGEST, pb_query
     )
 
@@ -162,6 +162,8 @@ async def suggest(
     )
 
     response.status_code = 206 if incomplete_results else 200
+
+    queried_shards = [shard_id for _, shard_id in queried_nodes]
     if debug and queried_shards:
         search_results.shards = queried_shards
 

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -263,4 +263,5 @@ def debug_nodes_info(
         }
         if node.primary_id:
             info["primary_id"] = node.primary_id
+        details.append(info)
     return details

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -183,7 +183,6 @@ async def get_relations_results(
             relations_results,
             _,
             _,
-            _,
         ) = await node_query(
             kbid,
             Method.RELATIONS,

--- a/nucliadb/nucliadb/search/search/find.py
+++ b/nucliadb/nucliadb/search/search/find.py
@@ -70,7 +70,7 @@ async def find(
         security=item.security,
     )
     pb_query, incomplete_results, autofilters = await query_parser.parse()
-    results, query_incomplete_results, queried_nodes, queried_shards = await node_query(
+    results, query_incomplete_results, queried_nodes = await node_query(
         kbid, Method.SEARCH, pb_query, target_shard_replicas=item.shards
     )
     incomplete_results = incomplete_results or query_incomplete_results
@@ -102,6 +102,7 @@ async def find(
     if item.debug:
         search_results.nodes = queried_nodes
 
+    queried_shards = [shard_id for _, shard_id in queried_nodes]
     search_results.shards = queried_shards
     search_results.autofilters = autofilters
     return search_results, incomplete_results

--- a/nucliadb/nucliadb/search/search/find.py
+++ b/nucliadb/nucliadb/search/search/find.py
@@ -19,7 +19,7 @@
 #
 from time import time
 
-from nucliadb.search.requesters.utils import Method, node_query
+from nucliadb.search.requesters.utils import Method, debug_nodes_info, node_query
 from nucliadb.search.search.find_merge import find_merge_results
 from nucliadb.search.search.query import QueryParser
 from nucliadb.search.search.utils import should_disable_vector_search
@@ -100,7 +100,7 @@ async def find(
             len(search_results.resources),
         )
     if item.debug:
-        search_results.nodes = queried_nodes
+        search_results.nodes = debug_nodes_info(queried_nodes)
 
     queried_shards = [shard_id for _, shard_id in queried_nodes]
     search_results.shards = queried_shards

--- a/nucliadb/nucliadb/search/tests/integration/requesters/test_utils.py
+++ b/nucliadb/nucliadb/search/tests/integration/requesters/test_utils.py
@@ -50,6 +50,6 @@ async def test_vector_result_metadata(
         ),
     ).parse()
 
-    results, _, _, _ = await node_query(kbid, Method.SEARCH, pb_query)
+    results, _, _ = await node_query(kbid, Method.SEARCH, pb_query)
     assert len(results[0].vector.documents) > 0
     assert results[0].vector.documents[0].HasField("metadata")

--- a/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
@@ -134,7 +134,7 @@ async def test_node_query_retries_primary_if_secondary_fails(
     )
     # secondary succeeds, no fallback call to primary
     assert search_methods[utils.Method.PARAGRAPH].await_count == 1
-    assert len(queried_nodes) == 2
+    assert len(queried_nodes) == 1
     assert queried_nodes[0][0].is_read_replica()
 
 

--- a/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
@@ -76,6 +76,7 @@ def kb(field_obj):
     mock.get.return_value.get_field.return_value = field_obj
     yield mock
 
+
 @pytest.mark.asyncio
 async def test_get_next_conversation_messages(field_obj, messages):
     assert (

--- a/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
@@ -32,8 +32,6 @@ from nucliadb_models.search import (
 )
 from nucliadb_protos import resources_pb2
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 def messages():
@@ -78,7 +76,7 @@ def kb(field_obj):
     mock.get.return_value.get_field.return_value = field_obj
     yield mock
 
-
+@pytest.mark.asyncio
 async def test_get_next_conversation_messages(field_obj, messages):
     assert (
         len(
@@ -107,18 +105,21 @@ async def test_get_next_conversation_messages(field_obj, messages):
     ) == [messages[3]]
 
 
+@pytest.mark.asyncio
 async def test_find_conversation_message(field_obj, messages):
     assert await chat_prompt.find_conversation_message(
         field_obj=field_obj, mident="3"
     ) == (messages[2], 1, 2)
 
 
+@pytest.mark.asyncio
 async def test_get_expanded_conversation_messages(kb, messages):
     assert await chat_prompt.get_expanded_conversation_messages(
         kb=kb, rid="rid", field_id="field_id", mident="3"
     ) == [messages[3]]
 
 
+@pytest.mark.asyncio
 async def test_get_expanded_conversation_messages_question(kb, messages):
     assert (
         await chat_prompt.get_expanded_conversation_messages(
@@ -133,6 +134,7 @@ async def test_get_expanded_conversation_messages_question(kb, messages):
     )
 
 
+@pytest.mark.asyncio
 async def test_get_expanded_conversation_messages_missing(kb, messages):
     assert (
         await chat_prompt.get_expanded_conversation_messages(
@@ -163,6 +165,7 @@ def _create_find_result(
     )
 
 
+@pytest.mark.asyncio
 async def test_default_prompt_context(kb):
     result_text = " ".join(["text"] * 10)
     with patch("nucliadb.search.search.chat.prompt.get_read_only_transaction"), patch(
@@ -215,6 +218,7 @@ def find_results():
     )
 
 
+@pytest.mark.asyncio
 async def test_prompt_context_builder_prepends_user_context(
     find_results: KnowledgeboxFindResults,
 ):

--- a/nucliadb/nucliadb/tests/integration/common/cluster/test_manager.py
+++ b/nucliadb/nucliadb/tests/integration/common/cluster/test_manager.py
@@ -140,8 +140,8 @@ async def test_choose_node(shards, shard_index: int, nodes: set):
     shard = shards.shards[shard_index]
     node_ids = set()
     for i in range(100):
-        _, _, node_id = manager.choose_node(shard)
-        node_ids.add(node_id)
+        node, _ = manager.choose_node(shard)
+        node_ids.add(node.id)
     assert node_ids == nodes, "Random numbers have defeat this test"
 
 
@@ -152,16 +152,16 @@ async def test_choose_node_attempts_target_replicas_but_is_not_imperative(shards
     r1 = shard.replicas[1].shard.id
     n1 = shard.replicas[1].node
 
-    _, replica_id, node_id = manager.choose_node(shard, target_shard_replicas=[r0])
+    node, replica_id = manager.choose_node(shard, target_shard_replicas=[r0])
     assert replica_id == r0
-    assert node_id == n0
+    assert node.id == n0
 
     # Change the node-0 to a non-existent node id in order to
     # test the target_shard_replicas logic is not imperative
     shard.replicas[0].node = "I-do-not-exist"
-    _, replica_id, node_id = manager.choose_node(shard, target_shard_replicas=[r0])
+    node, replica_id = manager.choose_node(shard, target_shard_replicas=[r0])
     assert replica_id == r1
-    assert node_id == n1
+    assert node.id == n1
 
 
 async def test_choose_node_raises_if_no_nodes(shards):
@@ -182,8 +182,8 @@ async def test_apply_for_all_shards(fake_kbid: str, shards, maindb_driver: Drive
 
     nodes = []
 
-    async def fun(node: AbstractIndexNode, shard_id: str, node_id: str):
-        nodes.append((shard_id, node_id))
+    async def fun(node: AbstractIndexNode, shard_id: str):
+        nodes.append((shard_id, node.id))
 
     await shard_manager.apply_for_all_shards(kbid, fun, timeout=10)
 

--- a/nucliadb/nucliadb/tests/unit/common/cluster/test_manager.py
+++ b/nucliadb/nucliadb/tests/unit/common/cluster/test_manager.py
@@ -111,7 +111,7 @@ def test_choose_node_with_two_primary_nodes():
     add_index_node("node-0")
     add_index_node("node-1")
 
-    _, _, node_id = manager.choose_node(
+    node, _ = manager.choose_node(
         writer_pb2.ShardObject(
             replicas=[
                 writer_pb2.ShardReplica(
@@ -120,8 +120,8 @@ def test_choose_node_with_two_primary_nodes():
             ]
         )
     )
-    assert node_id == "node-0"
-    _, _, node_id = manager.choose_node(
+    assert node.id == "node-0"
+    node, _ = manager.choose_node(
         writer_pb2.ShardObject(
             replicas=[
                 writer_pb2.ShardReplica(
@@ -130,7 +130,7 @@ def test_choose_node_with_two_primary_nodes():
             ]
         )
     )
-    assert node_id == "node-1"
+    assert node.id == "node-1"
 
     manager.INDEX_NODES.clear()
 
@@ -144,7 +144,7 @@ def test_choose_node_with_two_read_replicas():
     add_read_replica_node("node-replica-0", primary_id="node-0")
     add_read_replica_node("node-replica-1", primary_id="node-1")
 
-    _, _, node_id = manager.choose_node(
+    node, _ = manager.choose_node(
         writer_pb2.ShardObject(
             replicas=[
                 writer_pb2.ShardReplica(
@@ -154,8 +154,8 @@ def test_choose_node_with_two_read_replicas():
         ),
         use_read_replica_nodes=True,
     )
-    assert node_id == "node-replica-0"
-    _, _, node_id = manager.choose_node(
+    assert node.id == "node-replica-0"
+    node, _ = manager.choose_node(
         writer_pb2.ShardObject(
             replicas=[
                 writer_pb2.ShardReplica(
@@ -165,7 +165,7 @@ def test_choose_node_with_two_read_replicas():
         ),
         use_read_replica_nodes=True,
     )
-    assert node_id == "node-replica-1"
+    assert node.id == "node-replica-1"
 
     manager.INDEX_NODES.clear()
 
@@ -201,9 +201,9 @@ def repeated_choose_node(
     node_ids = []
 
     for _ in range(count):
-        _, shard_id, node_id = manager.choose_node(shard, **kwargs)
+        node, shard_id = manager.choose_node(shard, **kwargs)
         shard_ids.append(shard_id)
-        node_ids.append(node_id)
+        node_ids.append(node.id)
 
     return shard_ids, node_ids
 

--- a/nucliadb/nucliadb/train/nodes.py
+++ b/nucliadb/nucliadb/train/nodes.py
@@ -55,7 +55,7 @@ class TrainShardManager(manager.KBShardManager):
         except StopIteration:
             raise KeyError("Shard not found")
 
-        node_obj, shard_id, _ = manager.choose_node(shard_object)
+        node_obj, shard_id = manager.choose_node(shard_object)
         return node_obj, shard_id
 
     async def get_kb_obj(self, txn: Transaction, kbid: str) -> Optional[KnowledgeBox]:

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -244,7 +244,7 @@ class ResourceSearchResults(JsonBaseModel):
     sentences: Optional[Sentences] = None
     paragraphs: Optional[Paragraphs] = None
     relations: Optional[Relations] = None
-    nodes: Optional[List[Tuple[str, str, str]]] = None
+    nodes: Optional[List[Dict[str, str]]] = None
     shards: Optional[List[str]] = None
 
 
@@ -779,7 +779,8 @@ class FieldExtensionStrategy(RagStrategy):
                     ]
                 )
                 raise ValueError(
-                    f"Field '{field}' does not have a valid field type. Valid field types are: {allowed_field_types_part}."
+                    f"Field '{field}' does not have a valid field type. "
+                    f"Valid field types are: {allowed_field_types_part}."
                 )
 
         return values

--- a/nucliadb_models/nucliadb_models/search.py
+++ b/nucliadb_models/nucliadb_models/search.py
@@ -20,7 +20,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 from google.protobuf.json_format import MessageToDict
 from nucliadb_protos.audit_pb2 import ClientType
@@ -256,7 +256,7 @@ class KnowledgeboxSearchResults(JsonBaseModel):
     paragraphs: Optional[Paragraphs] = None
     fulltext: Optional[Resources] = None
     relations: Optional[Relations] = None
-    nodes: Optional[List[Tuple[str, str, str]]] = None
+    nodes: Optional[List[Dict[str, str]]] = None
     shards: Optional[List[str]] = None
     autofilters: List[str] = ModelParamDefaults.applied_autofilters.to_pydantic_field()
 
@@ -1010,7 +1010,7 @@ class KnowledgeboxFindResults(JsonBaseModel):
     page_number: int = 0
     page_size: int = 20
     next_page: bool = False
-    nodes: Optional[List[Tuple[str, str, str]]] = None
+    nodes: Optional[List[Dict[str, str]]] = None
     shards: Optional[List[str]] = None
     autofilters: List[str] = ModelParamDefaults.applied_autofilters.to_pydantic_field()
     min_score: float = ModelParamDefaults.min_score.to_pydantic_field()


### PR DESCRIPTION
### Description
- When querying index nodes, if a secondary fails with an internal error, retry query to a primary

### How was this PR tested?
- Unit tests
