### PR TITLE
Better observability for kb creation

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/metrics.py
+++ b/nucliadb/nucliadb/ingest/orm/metrics.py
@@ -17,6 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+from nucliadb.ingest.orm.exceptions import KnowledgeBoxConflict
 from nucliadb_telemetry import metrics
 
-processor_observer = metrics.Observer("nucliadb_ingest_processor", labels={"type": ""})
+processor_observer = metrics.Observer(
+    "nucliadb_ingest_processor",
+    labels={"type": ""},
+    error_mappings={"kb_conflict": KnowledgeBoxConflict},
+)

--- a/nucliadb/nucliadb/ingest/service/writer.py
+++ b/nucliadb/nucliadb/ingest/service/writer.py
@@ -214,12 +214,14 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
             )
             logger.info("KB created successfully", extra={"kbid": kbid})
         except KnowledgeBoxConflict:
-            logger.warning(f"KB with slug already exists", extra={"slug": request.slug})
+            logger.warning("KB already exists", extra={"slug": request.slug})
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.CONFLICT)
         except Exception as exc:
             errors.capture_exception(exc)
             logger.exception(
-                "Could not create KB", exc_info=True, extra={"slug": request.slug}
+                "Unexpected error creating KB",
+                exc_info=True,
+                extra={"slug": request.slug},
             )
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.ERROR)
         return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.OK, uuid=kbid)

--- a/nucliadb/nucliadb/ingest/service/writer.py
+++ b/nucliadb/nucliadb/ingest/service/writer.py
@@ -212,10 +212,13 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
                 forceuuid=request.forceuuid,
                 release_channel=release_channel,
             )
+            logger.info("KB created successfully", extra={"kbid": kbid})
         except KnowledgeBoxConflict:
+            logger.warning(f"KB with slug already exists", extra={"slug": request.slug})
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.CONFLICT)
-        except Exception:
-            logger.exception("Could not create KB", exc_info=True)
+        except Exception as exc:
+            errors.capture_exception(exc)
+            logger.exception("Could not create KB", exc_info=True, extra={"slug": request.slug})
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.ERROR)
         return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.OK, uuid=kbid)
 

--- a/nucliadb/nucliadb/ingest/service/writer.py
+++ b/nucliadb/nucliadb/ingest/service/writer.py
@@ -218,7 +218,9 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.CONFLICT)
         except Exception as exc:
             errors.capture_exception(exc)
-            logger.exception("Could not create KB", exc_info=True, extra={"slug": request.slug})
+            logger.exception(
+                "Could not create KB", exc_info=True, extra={"slug": request.slug}
+            )
             return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.ERROR)
         return NewKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.OK, uuid=kbid)
 


### PR DESCRIPTION
### Description
- Right now we are getting alarms trigger when there is a conflict error. This PR fixes the metric recording.
- Have a senrty alert if there is an error creating the KB.
- Log info/warning on happy path/handled exception

### How was this PR tested?
Existing tests cover the changes
