### PR TITLE
Relax read replicas readiness probe times

### DIFF
--- a/charts/nucliadb_node/templates/node.replicas.deploy.yaml
+++ b/charts/nucliadb_node/templates/node.replicas.deploy.yaml
@@ -119,8 +119,9 @@ spec:
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:{{ $values.serving.grpc_reader }}", "-service=nodereader.NodeReader"]
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
           failureThreshold: 10
         # Disable livenessProbe for now since
         # we need a different livenessProbe than readinessProbe


### PR DESCRIPTION
Info about modified parameters:
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes