### PR TITLE
Add nuclia zone as context for feature flags

### DIFF
--- a/nucliadb_utils/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/nucliadb_utils/featureflagging.py
@@ -24,12 +24,10 @@ import mrflagly
 import pydantic
 
 from nucliadb_utils import const
+from nucliadb_utils.settings import nuclia_settings, running_settings
 
 
 class Settings(pydantic.BaseSettings):
-    environment: str = pydantic.Field(
-        "local", env=["environment", "running_environment"]
-    )
     flag_settings_url: Optional[str]
 
 
@@ -64,18 +62,17 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
 
 class FlagService:
     def __init__(self):
-        self.settings = Settings()
-        if self.settings.flag_settings_url is None:
+        settings = Settings()
+        if settings.flag_settings_url is None:
             self.flag_service = mrflagly.FlagService(data=json.dumps(DEFAULT_FLAG_DATA))
         else:
-            self.flag_service = mrflagly.FlagService(
-                url=self.settings.flag_settings_url
-            )
+            self.flag_service = mrflagly.FlagService(url=settings.flag_settings_url)
 
     def enabled(
         self, flag_key: str, default: bool = False, context: Optional[dict] = None
     ) -> bool:
         if context is None:
             context = {}
-        context["environment"] = self.settings.environment
+        context["environment"] = running_settings.running_environment
+        context["zone"] = nuclia_settings.nuclia_zone
         return self.flag_service.enabled(flag_key, default=default, context=context)


### PR DESCRIPTION
### Description
- Remove duplicated env var setting
- Always pass nuclia zone as context for feature flags
