### PR TITLE
Do not use default full_jitter

### DIFF
--- a/nucliadb/nucliadb/common/cluster/discovery/base.py
+++ b/nucliadb/nucliadb/common/cluster/discovery/base.py
@@ -137,7 +137,7 @@ async def _get_index_node_metadata(
     )
 
 
-@backoff.on_exception(backoff.expo, (Exception,), max_tries=4)
+@backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=4)
 async def _get_standalone_index_node_metadata(
     settings: Settings, address: str
 ) -> IndexNodeMetadata:

--- a/nucliadb/nucliadb/common/cluster/discovery/base.py
+++ b/nucliadb/nucliadb/common/cluster/discovery/base.py
@@ -137,7 +137,9 @@ async def _get_index_node_metadata(
     )
 
 
-@backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=4)
+@backoff.on_exception(
+    backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=4
+)
 async def _get_standalone_index_node_metadata(
     settings: Settings, address: str
 ) -> IndexNodeMetadata:

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -427,7 +427,9 @@ class StandaloneKBShardManager(KBShardManager):
             )
             await index_node.writer.GC(noderesources_pb2.ShardId(id=shard_id))  # type: ignore
 
-    @backoff.on_exception(backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5)
+    @backoff.on_exception(
+        backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5
+    )
     async def delete_resource(
         self,
         shard: writer_pb2.ShardObject,
@@ -453,7 +455,9 @@ class StandaloneKBShardManager(KBShardManager):
                 )
             )
 
-    @backoff.on_exception(backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5)
+    @backoff.on_exception(
+        backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5
+    )
     async def add_resource(
         self,
         shard: writer_pb2.ShardObject,

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -427,7 +427,7 @@ class StandaloneKBShardManager(KBShardManager):
             )
             await index_node.writer.GC(noderesources_pb2.ShardId(id=shard_id))  # type: ignore
 
-    @backoff.on_exception(backoff.expo, NodesUnsync, max_tries=5)
+    @backoff.on_exception(backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5)
     async def delete_resource(
         self,
         shard: writer_pb2.ShardObject,
@@ -453,7 +453,7 @@ class StandaloneKBShardManager(KBShardManager):
                 )
             )
 
-    @backoff.on_exception(backoff.expo, NodesUnsync, max_tries=5)
+    @backoff.on_exception(backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5)
     async def add_resource(
         self,
         shard: writer_pb2.ShardObject,

--- a/nucliadb/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/nucliadb/common/cluster/rollover.py
@@ -156,7 +156,9 @@ async def wait_for_node(app_context: ApplicationContext, node_id: str) -> None:
         await asyncio.sleep(2)
 
 
-@backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=8)
+@backoff.on_exception(
+    backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=8
+)
 async def index_resource(
     app_context: ApplicationContext,
     kbid: str,

--- a/nucliadb/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/nucliadb/common/cluster/rollover.py
@@ -156,7 +156,7 @@ async def wait_for_node(app_context: ApplicationContext, node_id: str) -> None:
         await asyncio.sleep(2)
 
 
-@backoff.on_exception(backoff.expo, (Exception,), max_tries=8)
+@backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=8)
 async def index_resource(
     app_context: ApplicationContext,
     kbid: str,

--- a/nucliadb/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/nucliadb/common/datamanagers/resources.py
@@ -42,7 +42,7 @@ class ResourcesDataManager:
         self.driver = driver
         self.storage = storage
 
-    @backoff.on_exception(backoff.expo, (Exception,), max_tries=3)
+    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
     async def iter_resource_slugs(self, kbid: str) -> AsyncGenerator[str, None]:
         async with self.driver.transaction() as txn:
             async for key in txn.keys(
@@ -50,7 +50,7 @@ class ResourcesDataManager:
             ):
                 yield key.split("/")[-1]
 
-    @backoff.on_exception(backoff.expo, (Exception,), max_tries=3)
+    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
     async def get_resource_ids_from_slugs(
         self, kbid: str, slugs: list[str]
     ) -> list[str]:
@@ -77,7 +77,7 @@ class ResourcesDataManager:
             for rid in await self.get_resource_ids_from_slugs(kbid, batch):
                 yield rid
 
-    @backoff.on_exception(backoff.expo, (Exception,), max_tries=3)
+    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
     async def get_resource_shard_id(self, kbid: str, rid: str) -> Optional[str]:
         async with self.driver.transaction() as txn:
             shard = await txn.get(KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid))
@@ -86,7 +86,7 @@ class ResourcesDataManager:
             else:
                 return None
 
-    @backoff.on_exception(backoff.expo, (Exception,), max_tries=3)
+    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
     async def get_resource(self, kbid: str, rid: str) -> Optional[ResourceORM]:
         """
         Not ideal to return Resource type here but refactoring would
@@ -98,7 +98,7 @@ class ResourcesDataManager:
             kb_orm = KnowledgeBoxORM(txn, self.storage, kbid)
             return await kb_orm.get(rid)
 
-    @backoff.on_exception(backoff.expo, (Exception,), max_tries=3)
+    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
     async def get_resource_index_message(
         self, kbid: str, rid: str
     ) -> Optional[noderesources_pb2.Resource]:

--- a/nucliadb/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/nucliadb/common/datamanagers/resources.py
@@ -42,7 +42,9 @@ class ResourcesDataManager:
         self.driver = driver
         self.storage = storage
 
-    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3
+    )
     async def iter_resource_slugs(self, kbid: str) -> AsyncGenerator[str, None]:
         async with self.driver.transaction() as txn:
             async for key in txn.keys(
@@ -50,7 +52,9 @@ class ResourcesDataManager:
             ):
                 yield key.split("/")[-1]
 
-    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3
+    )
     async def get_resource_ids_from_slugs(
         self, kbid: str, slugs: list[str]
     ) -> list[str]:
@@ -77,7 +81,9 @@ class ResourcesDataManager:
             for rid in await self.get_resource_ids_from_slugs(kbid, batch):
                 yield rid
 
-    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3
+    )
     async def get_resource_shard_id(self, kbid: str, rid: str) -> Optional[str]:
         async with self.driver.transaction() as txn:
             shard = await txn.get(KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid))
@@ -86,7 +92,9 @@ class ResourcesDataManager:
             else:
                 return None
 
-    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3
+    )
     async def get_resource(self, kbid: str, rid: str) -> Optional[ResourceORM]:
         """
         Not ideal to return Resource type here but refactoring would
@@ -98,7 +106,9 @@ class ResourcesDataManager:
             kb_orm = KnowledgeBoxORM(txn, self.storage, kbid)
             return await kb_orm.get(rid)
 
-    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3
+    )
     async def get_resource_index_message(
         self, kbid: str, rid: str
     ) -> Optional[noderesources_pb2.Resource]:

--- a/nucliadb/nucliadb/common/maindb/pg.py
+++ b/nucliadb/nucliadb/common/maindb/pg.py
@@ -158,7 +158,7 @@ class PGTransaction(Transaction):
     async def delete(self, key: str):
         await self.data_layer.delete(key)
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=2)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=2)
     async def keys(
         self,
         match: str,
@@ -248,7 +248,7 @@ class PGDriver(Driver):
             await self.pool.close()
             self.initialized = False
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
     async def begin(
         self, read_only: bool = False
     ) -> Union[PGTransaction, ReadOnlyPGTransaction]:

--- a/nucliadb/nucliadb/common/maindb/pg.py
+++ b/nucliadb/nucliadb/common/maindb/pg.py
@@ -158,7 +158,9 @@ class PGTransaction(Transaction):
     async def delete(self, key: str):
         await self.data_layer.delete(key)
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=2)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=2
+    )
     async def keys(
         self,
         match: str,
@@ -248,7 +250,9 @@ class PGDriver(Driver):
             await self.pool.close()
             self.initialized = False
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3
+    )
     async def begin(
         self, read_only: bool = False
     ) -> Union[PGTransaction, ReadOnlyPGTransaction]:

--- a/nucliadb/nucliadb/common/maindb/tikv.py
+++ b/nucliadb/nucliadb/common/maindb/tikv.py
@@ -82,7 +82,9 @@ class TiKVDataLayer:
                 output[key.decode()] = value
         return [output.get(key) for key in keys]
 
-    @backoff.on_exception(backoff.expo, (TimeoutError,), jitter=backoff.random_jitter, max_tries=2)
+    @backoff.on_exception(
+        backoff.expo, (TimeoutError,), jitter=backoff.random_jitter, max_tries=2
+    )
     async def get(self, key: str) -> Optional[bytes]:
         try:
             with tikv_observer({"type": "get"}):
@@ -226,7 +228,9 @@ class TiKVTransaction(Transaction):
         assert self.open
         return await self.data_layer.batch_get(keys)
 
-    @backoff.on_exception(backoff.expo, (TimeoutError,), jitter=backoff.random_jitter, max_tries=2)
+    @backoff.on_exception(
+        backoff.expo, (TimeoutError,), jitter=backoff.random_jitter, max_tries=2
+    )
     async def get(self, key: str) -> Optional[bytes]:
         assert self.open
         return await self.data_layer.get(key)

--- a/nucliadb/nucliadb/common/maindb/tikv.py
+++ b/nucliadb/nucliadb/common/maindb/tikv.py
@@ -82,7 +82,7 @@ class TiKVDataLayer:
                 output[key.decode()] = value
         return [output.get(key) for key in keys]
 
-    @backoff.on_exception(backoff.expo, (TimeoutError,), max_tries=2)
+    @backoff.on_exception(backoff.expo, (TimeoutError,), jitter=backoff.random_jitter, max_tries=2)
     async def get(self, key: str) -> Optional[bytes]:
         try:
             with tikv_observer({"type": "get"}):
@@ -226,7 +226,7 @@ class TiKVTransaction(Transaction):
         assert self.open
         return await self.data_layer.batch_get(keys)
 
-    @backoff.on_exception(backoff.expo, (TimeoutError,), max_tries=2)
+    @backoff.on_exception(backoff.expo, (TimeoutError,), jitter=backoff.random_jitter, max_tries=2)
     async def get(self, key: str) -> Optional[bytes]:
         assert self.open
         return await self.data_layer.get(key)

--- a/nucliadb/nucliadb/ingest/consumer/consumer.py
+++ b/nucliadb/nucliadb/ingest/consumer/consumer.py
@@ -114,7 +114,9 @@ class IngestConsumer:
             f"Subscribed to {subject} on stream {const.Streams.INGEST.name} from {last_seqid}"
         )
 
-    @backoff.on_exception(backoff.expo, (ConflictError,), jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, (ConflictError,), jitter=backoff.random_jitter, max_tries=4
+    )
     async def _process(self, pb: BrokerMessage, seqid: int):
         await self.processor.process(pb, seqid, self.partition)
 
@@ -267,7 +269,9 @@ class IngestProcessedConsumer(IngestConsumer):
             f"Subscribed to {subject} on stream {const.Streams.INGEST_PROCESSED.name}"
         )
 
-    @backoff.on_exception(backoff.expo, (ConflictError,), jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, (ConflictError,), jitter=backoff.random_jitter, max_tries=4
+    )
     async def _process(self, pb: BrokerMessage, seqid: int):
         """
         We are setting `transaction_check` to False here because we can not mix

--- a/nucliadb/nucliadb/ingest/consumer/consumer.py
+++ b/nucliadb/nucliadb/ingest/consumer/consumer.py
@@ -114,7 +114,7 @@ class IngestConsumer:
             f"Subscribed to {subject} on stream {const.Streams.INGEST.name} from {last_seqid}"
         )
 
-    @backoff.on_exception(backoff.expo, (ConflictError,), max_tries=4)
+    @backoff.on_exception(backoff.expo, (ConflictError,), jitter=backoff.random_jitter, max_tries=4)
     async def _process(self, pb: BrokerMessage, seqid: int):
         await self.processor.process(pb, seqid, self.partition)
 
@@ -267,7 +267,7 @@ class IngestProcessedConsumer(IngestConsumer):
             f"Subscribed to {subject} on stream {const.Streams.INGEST_PROCESSED.name}"
         )
 
-    @backoff.on_exception(backoff.expo, (ConflictError,), max_tries=4)
+    @backoff.on_exception(backoff.expo, (ConflictError,), jitter=backoff.random_jitter, max_tries=4)
     async def _process(self, pb: BrokerMessage, seqid: int):
         """
         We are setting `transaction_check` to False here because we can not mix

--- a/nucliadb/nucliadb/ingest/processing.py
+++ b/nucliadb/nucliadb/ingest/processing.py
@@ -252,7 +252,7 @@ class ProcessingEngine:
         }
         return jwt.encode(payload, self.nuclia_jwt_key, algorithm="HS256")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @processing_observer.wrap({"type": "file_field_upload"})
     async def convert_filefield_to_str(self, file: models.FileField) -> str:
         # Upload file without storing on Nuclia DB
@@ -303,7 +303,7 @@ class ProcessingEngine:
         }
         return jwt.encode(payload, self.nuclia_jwt_key, algorithm="HS256")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @processing_observer.wrap({"type": "file_field_upload_internal"})
     async def convert_internal_filefield_to_str(
         self, file: FieldFilePB, storage: Storage
@@ -341,7 +341,7 @@ class ProcessingEngine:
                     raise Exception(f"STATUS: {resp.status} - {text}")
         return jwttoken
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @processing_observer.wrap({"type": "cloud_file_upload"})
     async def convert_internal_cf_to_str(self, cf: CloudFile, storage: Storage) -> str:
         if self.onprem is False:
@@ -373,7 +373,7 @@ class ProcessingEngine:
 
         return jwttoken
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     async def send_to_process(
         self, item: PushPayload, partition: int
     ) -> ProcessingInfo:

--- a/nucliadb/nucliadb/ingest/processing.py
+++ b/nucliadb/nucliadb/ingest/processing.py
@@ -252,7 +252,12 @@ class ProcessingEngine:
         }
         return jwt.encode(payload, self.nuclia_jwt_key, algorithm="HS256")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @processing_observer.wrap({"type": "file_field_upload"})
     async def convert_filefield_to_str(self, file: models.FileField) -> str:
         # Upload file without storing on Nuclia DB
@@ -303,7 +308,12 @@ class ProcessingEngine:
         }
         return jwt.encode(payload, self.nuclia_jwt_key, algorithm="HS256")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @processing_observer.wrap({"type": "file_field_upload_internal"})
     async def convert_internal_filefield_to_str(
         self, file: FieldFilePB, storage: Storage
@@ -341,7 +351,12 @@ class ProcessingEngine:
                     raise Exception(f"STATUS: {resp.status} - {text}")
         return jwttoken
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @processing_observer.wrap({"type": "cloud_file_upload"})
     async def convert_internal_cf_to_str(self, cf: CloudFile, storage: Storage) -> str:
         if self.onprem is False:
@@ -373,7 +388,12 @@ class ProcessingEngine:
 
         return jwttoken
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     async def send_to_process(
         self, item: PushPayload, partition: int
     ) -> ProcessingInfo:

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -223,7 +223,7 @@ class PredictEngine:
         logger.error(f"Predict API error at {resp.url}: {detail}")
         raise ProxiedPredictAPIError(status=resp.status, detail=detail)
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     async def make_request(self, method: str, **request_args):
         func = getattr(self.session, method.lower())
         return await func(**request_args)

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -223,7 +223,12 @@ class PredictEngine:
         logger.error(f"Predict API error at {resp.url}: {detail}")
         raise ProxiedPredictAPIError(status=resp.status, detail=detail)
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     async def make_request(self, method: str, **request_args):
         func = getattr(self.session, method.lower())
         return await func(**request_args)

--- a/nucliadb/nucliadb/search/tests/node.py
+++ b/nucliadb/nucliadb/search/tests/node.py
@@ -457,7 +457,7 @@ def node(_node, request):
     yield _node
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=5)
+@backoff.on_exception(backoff.expo, Exception, jitter=backoff.random_jitter, max_tries=5)
 def cleanup_node(writer: NodeWriterStub):
     for shard in writer.ListShards(EmptyQuery()).ids:
         writer.DeleteShard(ShardId(id=shard.id))

--- a/nucliadb/nucliadb/search/tests/node.py
+++ b/nucliadb/nucliadb/search/tests/node.py
@@ -457,7 +457,9 @@ def node(_node, request):
     yield _node
 
 
-@backoff.on_exception(backoff.expo, Exception, jitter=backoff.random_jitter, max_tries=5)
+@backoff.on_exception(
+    backoff.expo, Exception, jitter=backoff.random_jitter, max_tries=5
+)
 def cleanup_node(writer: NodeWriterStub):
     for shard in writer.ListShards(EmptyQuery()).ids:
         writer.DeleteShard(ShardId(id=shard.id))

--- a/nucliadb/nucliadb/writer/tus/gcs.py
+++ b/nucliadb/nucliadb/writer/tus/gcs.py
@@ -170,7 +170,7 @@ class GCloudFileStorageManager(FileStorageManager):
     chunk_size = CHUNK_SIZE
     min_upload_size = MIN_UPLOAD_SIZE
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=4)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
     async def start(self, dm: FileDataManager, path: str, kbid: str):
         """Init an upload.
 
@@ -232,7 +232,7 @@ class GCloudFileStorageManager(FileStorageManager):
             resumable_uri=resumable_uri, upload_file_id=upload_file_id, path=path
         )
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=4)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
     async def delete_upload(self, uri, kbid):
         bucket = self.storage.get_bucket_name(kbid)
 
@@ -264,7 +264,7 @@ class GCloudFileStorageManager(FileStorageManager):
         else:
             raise AttributeError("No valid uri")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=4)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
     async def _append(self, dm: FileDataManager, data, offset):
         if self.storage.session is None:
             raise AttributeError()
@@ -329,7 +329,7 @@ class GCloudFileStorageManager(FileStorageManager):
                 break
         return count
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=4)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
     async def finish(self, dm: FileDataManager):
         if dm.size == 0:
             if self.storage.session is None:

--- a/nucliadb/nucliadb/writer/tus/gcs.py
+++ b/nucliadb/nucliadb/writer/tus/gcs.py
@@ -170,7 +170,9 @@ class GCloudFileStorageManager(FileStorageManager):
     chunk_size = CHUNK_SIZE
     min_upload_size = MIN_UPLOAD_SIZE
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4
+    )
     async def start(self, dm: FileDataManager, path: str, kbid: str):
         """Init an upload.
 
@@ -232,7 +234,9 @@ class GCloudFileStorageManager(FileStorageManager):
             resumable_uri=resumable_uri, upload_file_id=upload_file_id, path=path
         )
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4
+    )
     async def delete_upload(self, uri, kbid):
         bucket = self.storage.get_bucket_name(kbid)
 
@@ -264,7 +268,9 @@ class GCloudFileStorageManager(FileStorageManager):
         else:
             raise AttributeError("No valid uri")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4
+    )
     async def _append(self, dm: FileDataManager, data, offset):
         if self.storage.session is None:
             raise AttributeError()
@@ -329,7 +335,9 @@ class GCloudFileStorageManager(FileStorageManager):
                 break
         return count
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=4
+    )
     async def finish(self, dm: FileDataManager):
         if dm.size == 0:
             if self.storage.session is None:

--- a/nucliadb/nucliadb/writer/tus/s3.py
+++ b/nucliadb/nucliadb/writer/tus/s3.py
@@ -53,7 +53,7 @@ class S3FileStorageManager(FileStorageManager):
     chunk_size = CHUNK_SIZE
     min_upload_size = MIN_UPLOAD_SIZE
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
     async def _abort_multipart(self, dm: FileDataManager):
         try:
             mpu = dm.get("mpu")
@@ -79,7 +79,7 @@ class S3FileStorageManager(FileStorageManager):
             bucket=bucket,
         )
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
     async def _create_multipart(self, path, bucket):
         return await self.storage._s3aioclient.create_multipart_upload(
             Bucket=bucket, Key=path
@@ -99,7 +99,7 @@ class S3FileStorageManager(FileStorageManager):
 
         return size
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
     async def _upload_part(self, dm: FileDataManager, data):
         return await self.storage._s3aioclient.upload_part(
             Bucket=dm.get("bucket"),
@@ -116,7 +116,7 @@ class S3FileStorageManager(FileStorageManager):
         await dm.finish()
         return path
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
     async def _complete_multipart_upload(self, dm: FileDataManager):
         # if blocks is 0, it means the file is of zero length so we need to
         # trick it to finish a multiple part with no data.
@@ -134,7 +134,7 @@ class S3FileStorageManager(FileStorageManager):
             MultipartUpload=dm.get("multipart"),
         )
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
     async def _download(self, uri: str, kbid: str, **kwargs):
         bucket = self.storage.get_bucket_name(kbid)
         return await self.storage._s3aioclient.get_object(

--- a/nucliadb/nucliadb/writer/tus/s3.py
+++ b/nucliadb/nucliadb/writer/tus/s3.py
@@ -53,7 +53,9 @@ class S3FileStorageManager(FileStorageManager):
     chunk_size = CHUNK_SIZE
     min_upload_size = MIN_UPLOAD_SIZE
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3
+    )
     async def _abort_multipart(self, dm: FileDataManager):
         try:
             mpu = dm.get("mpu")
@@ -79,7 +81,9 @@ class S3FileStorageManager(FileStorageManager):
             bucket=bucket,
         )
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3
+    )
     async def _create_multipart(self, path, bucket):
         return await self.storage._s3aioclient.create_multipart_upload(
             Bucket=bucket, Key=path
@@ -99,7 +103,9 @@ class S3FileStorageManager(FileStorageManager):
 
         return size
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3
+    )
     async def _upload_part(self, dm: FileDataManager, data):
         return await self.storage._s3aioclient.upload_part(
             Bucket=dm.get("bucket"),
@@ -116,7 +122,9 @@ class S3FileStorageManager(FileStorageManager):
         await dm.finish()
         return path
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3
+    )
     async def _complete_multipart_upload(self, dm: FileDataManager):
         # if blocks is 0, it means the file is of zero length so we need to
         # trick it to finish a multiple part with no data.
@@ -134,7 +142,9 @@ class S3FileStorageManager(FileStorageManager):
             MultipartUpload=dm.get("multipart"),
         )
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3)
+    @backoff.on_exception(
+        backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=3
+    )
     async def _download(self, uri: str, kbid: str, **kwargs):
         bucket = self.storage.get_bucket_name(kbid)
         return await self.storage._s3aioclient.get_object(

--- a/nucliadb_node/nucliadb_node/writer.py
+++ b/nucliadb_node/nucliadb_node/writer.py
@@ -56,7 +56,7 @@ class Writer:
     async def garbage_collector(self, shard_id: str):
         return await self.stub.GC(ShardId(id=shard_id))  # type: ignore
 
-    @backoff.on_exception(backoff.expo, (AioRpcError,), max_tries=4)
+    @backoff.on_exception(backoff.expo, (AioRpcError,), jitter=backoff.random_jitter, max_tries=4)
     async def shards(self) -> ShardIds:
         pb = EmptyQuery()
         return await self.stub.ListShards(pb)  # type: ignore

--- a/nucliadb_node/nucliadb_node/writer.py
+++ b/nucliadb_node/nucliadb_node/writer.py
@@ -56,7 +56,9 @@ class Writer:
     async def garbage_collector(self, shard_id: str):
         return await self.stub.GC(ShardId(id=shard_id))  # type: ignore
 
-    @backoff.on_exception(backoff.expo, (AioRpcError,), jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, (AioRpcError,), jitter=backoff.random_jitter, max_tries=4
+    )
     async def shards(self) -> ShardIds:
         pb = EmptyQuery()
         return await self.stub.ListShards(pb)  # type: ignore

--- a/nucliadb_utils/nucliadb_utils/audit/stream.py
+++ b/nucliadb_utils/nucliadb_utils/audit/stream.py
@@ -127,7 +127,7 @@ class StreamAuditStorage(AuditStorage):
     async def send(self, message: AuditRequest):
         self.queue.put_nowait(message)
 
-    @backoff.on_exception(backoff.expo, (Exception,), max_tries=4)
+    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=4)
     async def _send(self, message: AuditRequest):
         if self.js is None:  # pragma: no cover
             raise AttributeError()

--- a/nucliadb_utils/nucliadb_utils/audit/stream.py
+++ b/nucliadb_utils/nucliadb_utils/audit/stream.py
@@ -127,7 +127,9 @@ class StreamAuditStorage(AuditStorage):
     async def send(self, message: AuditRequest):
         self.queue.put_nowait(message)
 
-    @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=4)
+    @backoff.on_exception(
+        backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=4
+    )
     async def _send(self, message: AuditRequest):
         if self.js is None:  # pragma: no cover
             raise AttributeError()

--- a/nucliadb_utils/nucliadb_utils/storages/gcs.py
+++ b/nucliadb_utils/nucliadb_utils/storages/gcs.py
@@ -116,7 +116,12 @@ class GCSStorageField(StorageField):
         )
         await self.storage.delete_upload(origin_uri, origin_bucket_name)
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @storage_ops_observer.wrap({"type": "copy"})
     async def copy(
         self,
@@ -225,7 +230,12 @@ class GCSStorageField(StorageField):
         ):
             yield chunk
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @storage_ops_observer.wrap({"type": "start_upload"})
     async def start(self, cf: CloudFile) -> CloudFile:
         """Init an upload.
@@ -394,7 +404,12 @@ class GCSStorageField(StorageField):
         self.field.ClearField("upload_uri")
         self.field.ClearField("parts")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @storage_ops_observer.wrap({"type": "exists"})
     async def exists(self) -> Optional[Dict[str, str]]:
         """
@@ -535,7 +550,12 @@ class GCSStorage(Storage):
         token = await loop.run_in_executor(self._executor, self._get_access_token)
         return {"AUTHORIZATION": f"Bearer {token}"}
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     @storage_ops_observer.wrap({"type": "delete"})
     async def delete_upload(self, uri: str, bucket_name: str):
         if self.session is None:

--- a/nucliadb_utils/nucliadb_utils/storages/gcs.py
+++ b/nucliadb_utils/nucliadb_utils/storages/gcs.py
@@ -116,7 +116,7 @@ class GCSStorageField(StorageField):
         )
         await self.storage.delete_upload(origin_uri, origin_bucket_name)
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @storage_ops_observer.wrap({"type": "copy"})
     async def copy(
         self,
@@ -225,7 +225,7 @@ class GCSStorageField(StorageField):
         ):
             yield chunk
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @storage_ops_observer.wrap({"type": "start_upload"})
     async def start(self, cf: CloudFile) -> CloudFile:
         """Init an upload.
@@ -394,7 +394,7 @@ class GCSStorageField(StorageField):
         self.field.ClearField("upload_uri")
         self.field.ClearField("parts")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @storage_ops_observer.wrap({"type": "exists"})
     async def exists(self) -> Optional[Dict[str, str]]:
         """
@@ -535,7 +535,7 @@ class GCSStorage(Storage):
         token = await loop.run_in_executor(self._executor, self._get_access_token)
         return {"AUTHORIZATION": f"Bearer {token}"}
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     @storage_ops_observer.wrap({"type": "delete"})
     async def delete_upload(self, uri: str, bucket_name: str):
         if self.session is None:

--- a/nucliadb_utils/nucliadb_utils/storages/s3.py
+++ b/nucliadb_utils/nucliadb_utils/storages/s3.py
@@ -67,7 +67,7 @@ POLICY_DELETE = {
 class S3StorageField(StorageField):
     storage: S3Storage
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     async def _download(self, uri, bucket, **kwargs):
         if "headers" in kwargs:
             for key, value in kwargs["headers"].items():
@@ -156,7 +156,7 @@ class S3StorageField(StorageField):
         field.upload_uri = upload_uri
         return field
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     async def _create_multipart(self, bucket_name: str, upload_id: str, cf: CloudFile):
         return await self.storage._s3aioclient.create_multipart_upload(
             Bucket=bucket_name,
@@ -189,7 +189,7 @@ class S3StorageField(StorageField):
 
         return size
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     async def _upload_part(self, cf: CloudFile, data: bytes):
         if self.field is None:
             raise AttributeError("No field configured")
@@ -227,7 +227,7 @@ class S3StorageField(StorageField):
         self.field.ClearField("upload_uri")
         self.field.ClearField("parts")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, max_tries=MAX_TRIES)
+    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
     async def _complete_multipart_upload(self):
         # if blocks is 0, it means the file is of zero length so we need to
         # trick it to finish a multiple part with no data.

--- a/nucliadb_utils/nucliadb_utils/storages/s3.py
+++ b/nucliadb_utils/nucliadb_utils/storages/s3.py
@@ -67,7 +67,12 @@ POLICY_DELETE = {
 class S3StorageField(StorageField):
     storage: S3Storage
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     async def _download(self, uri, bucket, **kwargs):
         if "headers" in kwargs:
             for key, value in kwargs["headers"].items():
@@ -156,7 +161,12 @@ class S3StorageField(StorageField):
         field.upload_uri = upload_uri
         return field
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     async def _create_multipart(self, bucket_name: str, upload_id: str, cf: CloudFile):
         return await self.storage._s3aioclient.create_multipart_upload(
             Bucket=bucket_name,
@@ -189,7 +199,12 @@ class S3StorageField(StorageField):
 
         return size
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     async def _upload_part(self, cf: CloudFile, data: bytes):
         if self.field is None:
             raise AttributeError("No field configured")
@@ -227,7 +242,12 @@ class S3StorageField(StorageField):
         self.field.ClearField("upload_uri")
         self.field.ClearField("parts")
 
-    @backoff.on_exception(backoff.expo, RETRIABLE_EXCEPTIONS, jitter=backoff.random_jitter, max_tries=MAX_TRIES)
+    @backoff.on_exception(
+        backoff.expo,
+        RETRIABLE_EXCEPTIONS,
+        jitter=backoff.random_jitter,
+        max_tries=MAX_TRIES,
+    )
     async def _complete_multipart_upload(self):
         # if blocks is 0, it means the file is of zero length so we need to
         # trick it to finish a multiple part with no data.


### PR DESCRIPTION
### Description

Default backoff jitter may produce lower backoff times than we expect, switch to random_jitter which is slower and matches better what we expect. Docs: https://github.com/litl/backoff/tree/master?tab=readme-ov-file#jitter

### How was this PR tested?
Describe how you tested this PR.
