### PR TITLE
Update rust version

### DIFF
--- a/Dockerfile.basenode
+++ b/Dockerfile.basenode
@@ -1,4 +1,4 @@
-FROM rust:1.72.1-bullseye
+FROM rust:1.76.0-bullseye
 
 LABEL maintainer="info@nuclia.com"
 LABEL org.opencontainers.image.vendor="Nuclia Inc."

--- a/nucliadb_core/src/metrics/meters/mod.rs
+++ b/nucliadb_core/src/metrics/meters/mod.rs
@@ -21,6 +21,7 @@ mod noop;
 mod prometheus;
 
 pub use noop::NoOpMeter;
+#[cfg(any(prometheus_metrics, test))]
 pub use prometheus::PrometheusMeter;
 
 use crate::metrics::metric::grpc_ops::{GrpcOpKey, GrpcOpValue};

--- a/nucliadb_core/src/tantivy_replica.rs
+++ b/nucliadb_core/src/tantivy_replica.rs
@@ -227,8 +227,8 @@ mod tests {
         let replica_index = Index::open_in_dir(replica_workspace.path()).unwrap();
         let reader = replica_index.reader().unwrap();
         let searcher = reader.searcher();
-        let mut collector = tantivy::collector::DocSetCollector;
-        let docs = searcher.search(&tantivy::query::AllQuery, &mut collector).unwrap();
+        let collector = tantivy::collector::DocSetCollector;
+        let docs = searcher.search(&tantivy::query::AllQuery, &collector).unwrap();
 
         assert_eq!(docs.len(), 1);
     }

--- a/nucliadb_node/src/analytics/blocking.rs
+++ b/nucliadb_node/src/analytics/blocking.rs
@@ -53,7 +53,7 @@ lazy_static::lazy_static! {
     static ref SYNC_ANALYTICS: Option<Mutex<Sender<AnalyticsEvent>>> = {
         if is_analytics_enabled() {
             let (stxn, rtxn) = channel();
-            let Some(analytics_loop) = SyncAnalyticsLoop::new(rtxn) else { return None };
+            let analytics_loop = SyncAnalyticsLoop::new(rtxn)?;
             std::thread::spawn(move || analytics_loop.run());
             Some(Mutex::new(stxn))
         } else {

--- a/nucliadb_node/tests/test_search_relations.rs
+++ b/nucliadb_node/tests/test_search_relations.rs
@@ -377,7 +377,6 @@ async fn test_search_relations_prefixed(
                     node_subtype: None,
                     node_type: NodeType::Entity as i32,
                 }],
-                ..Default::default()
             }),
             ..Default::default()
         })

--- a/nucliadb_paragraphs/src/search_query.rs
+++ b/nucliadb_paragraphs/src/search_query.rs
@@ -56,7 +56,7 @@ impl TermCollector {
         self.eterms.insert(term);
     }
     pub fn log_fterm(&mut self, doc: DocId, data: (Arc<InvertedIndexReader>, u64)) {
-        self.fterms.entry(doc).or_insert_with(Vec::new).push(data);
+        self.fterms.entry(doc).or_default().push(data);
     }
     pub fn get_fterms(&self, doc: DocId) -> Vec<String> {
         let mut terms = Vec::new();

--- a/nucliadb_procs/tests/dont_compile/wrong_actor.stderr
+++ b/nucliadb_procs/tests/dont_compile/wrong_actor.stderr
@@ -4,4 +4,23 @@ error[E0599]: no function or associated item named `wrong` found for struct `Req
 23 | #[measure(actor = "wrong", metric = "my-test")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `RequestTimeKey`
    |
+note: if you're trying to build a new `RequestTimeKey` consider using one of the following associated functions:
+      RequestTimeKey::new
+      RequestTimeKey::shard
+      RequestTimeKey::vectors
+      RequestTimeKey::paragraphs
+      and $N others
+  --> $WORKSPACE/nucliadb_core/src/metrics/metric/request_time.rs
+   |
+   |     fn new(actor: RequestActor, request: String) -> RequestTimeKey {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub fn shard(request: String) -> RequestTimeKey {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub fn vectors(request: String) -> RequestTimeKey {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+   |     pub fn paragraphs(request: String) -> RequestTimeKey {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `measure` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/nucliadb_protos/rust/src/fdbwriter.rs
+++ b/nucliadb_protos/rust/src/fdbwriter.rs
@@ -500,7 +500,7 @@ pub mod notification {
         Deleted = 3,
     }
 }
-//// The member information.
+/// The member information.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Member {
     //// Member ID.　A string of the UUID.

--- a/nucliadb_protos/writer.proto
+++ b/nucliadb_protos/writer.proto
@@ -364,7 +364,7 @@ message Notification {
 }
 
 
-/// The member information.
+// The member information.
 message Member {
     enum Type {
         IO = 0;

--- a/nucliadb_relations/src/graph_db.rs
+++ b/nucliadb_relations/src/graph_db.rs
@@ -126,7 +126,7 @@ pub struct GraphDB {
 
 macro_rules! database_name {
     (const $l:ident) => {
-        const $l: &str = stringify!($l);
+        const $l: &'static str = stringify!($l);
     };
 }
 impl GraphDB {

--- a/nucliadb_relations/src/index.rs
+++ b/nucliadb_relations/src/index.rs
@@ -36,8 +36,8 @@ pub struct Index {
     dictionary: NodeDictionary,
 }
 impl Index {
-    const DICTIONARY_PATH: &str = "NodeDictionary";
-    const GRAPH_PATH: &str = "GraphDB";
+    const DICTIONARY_PATH: &'static str = "NodeDictionary";
+    const GRAPH_PATH: &'static str = "GraphDB";
     const GRAPH_SIZE: usize = 1048576 * 100000;
     fn connect(
         &self,

--- a/nucliadb_relations/src/node_dictionary.rs
+++ b/nucliadb_relations/src/node_dictionary.rs
@@ -39,8 +39,8 @@ pub struct NodeDictionary {
     index: Index,
 }
 impl NodeDictionary {
-    const NODE_VALUE: &str = "value";
-    const NODE_HASH: &str = "hash";
+    const NODE_VALUE: &'static str = "value";
+    const NODE_HASH: &'static str = "hash";
     const NUM_THREADS: usize = 1;
     const MEM_LIMIT: usize = 6_000_000;
 

--- a/nucliadb_vectors/src/data_point/mod.rs
+++ b/nucliadb_vectors/src/data_point/mod.rs
@@ -359,7 +359,7 @@ impl Ord for Neighbour {
 }
 impl PartialOrd for Neighbour {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.node.partial_cmp(&other.node)
+        Some(self.cmp(other))
     }
 }
 impl PartialEq for Neighbour {

--- a/nucliadb_vectors/src/data_point/ops_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ops_hnsw.rs
@@ -61,7 +61,7 @@ struct Cnx(Address, f32);
 impl Eq for Cnx {}
 impl Ord for Cnx {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        f32::total_cmp(&self.1, &other.1)
     }
 }
 impl PartialEq for Cnx {

--- a/nucliadb_vectors/src/data_point/ops_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ops_hnsw.rs
@@ -71,7 +71,7 @@ impl PartialEq for Cnx {
 }
 impl PartialOrd for Cnx {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        f32::partial_cmp(&self.1, &other.1)
+        Some(self.cmp(other))
     }
 }
 

--- a/nucliadb_vectors/src/data_point/ram_hnsw.rs
+++ b/nucliadb_vectors/src/data_point/ram_hnsw.rs
@@ -48,7 +48,7 @@ impl RAMLayer {
         RAMLayer::default()
     }
     pub fn add_node(&mut self, node: Address) {
-        self.out.entry(node).or_insert_with(Vec::new);
+        self.out.entry(node).or_default();
     }
     pub fn add_edge(&mut self, from: Address, edge: Edge, to: Address) {
         if let Some(edges) = self.out.get_mut(&from) {

--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -20,7 +20,7 @@
 
 mod merge_worker;
 mod merger;
-mod state;
+pub mod state;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
@@ -335,18 +335,8 @@ mod test {
         let data_point = DataPoint::new(
             &vectors_path,
             vec![
-                Elem::new(
-                    "key_0".to_string(),
-                    vec![1.0],
-                    LabelDictionary::default(),
-                    None,
-                ),
-                Elem::new(
-                    "key_1".to_string(),
-                    vec![1.0],
-                    LabelDictionary::default(),
-                    None,
-                ),
+                Elem::new("key_0".to_string(), vec![1.0], LabelDictionary::default(), None),
+                Elem::new("key_1".to_string(), vec![1.0], LabelDictionary::default(), None),
             ],
             None,
             Similarity::Cosine,
@@ -356,10 +346,7 @@ mod test {
         index.add(data_point, &lock).unwrap();
         index.commit(&lock).unwrap();
 
-        assert_eq!(
-            index.get_keys(&lock).unwrap(),
-            vec!["key_0".to_string(), "key_1".to_string()]
-        );
+        assert_eq!(index.get_keys(&lock).unwrap(), vec!["key_0".to_string(), "key_1".to_string()]);
 
         index.delete("key_0", SystemTime::now(), &lock);
         assert_eq!(index.get_keys(&lock).unwrap(), vec!["key_1".to_string()]);

--- a/nucliadb_vectors/src/data_point_provider/mod.rs
+++ b/nucliadb_vectors/src/data_point_provider/mod.rs
@@ -20,7 +20,7 @@
 
 mod merge_worker;
 mod merger;
-pub mod state;
+mod state;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};

--- a/nucliadb_vectors/src/data_point_provider/state.rs
+++ b/nucliadb_vectors/src/data_point_provider/state.rs
@@ -158,7 +158,7 @@ pub struct State {
     resources: HashMap<String, usize>,
 }
 impl State {
-    pub fn data_point_iterator(&self) -> impl Iterator<Item = &Journal> {
+    fn data_point_iterator(&self) -> impl Iterator<Item = &Journal> {
         self.work_stack.iter().flat_map(|u| u.load.iter()).chain(self.current.load.iter())
     }
     fn close_work_unit(&mut self) {

--- a/nucliadb_vectors/src/data_point_provider/state.rs
+++ b/nucliadb_vectors/src/data_point_provider/state.rs
@@ -158,7 +158,7 @@ pub struct State {
     resources: HashMap<String, usize>,
 }
 impl State {
-    fn data_point_iterator(&self) -> impl Iterator<Item = &Journal> {
+    pub fn data_point_iterator(&self) -> impl Iterator<Item = &Journal> {
         self.work_stack.iter().flat_map(|u| u.load.iter()).chain(self.current.load.iter())
     }
     fn close_work_unit(&mut self) {
@@ -271,6 +271,12 @@ impl State {
         };
         let data_point = DataPoint::open(location, journal.id())?;
         Ok(data_point.stored_len())
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/nucliadb_vectors/src/fst_index/mod.rs
+++ b/nucliadb_vectors/src/fst_index/mod.rs
@@ -72,8 +72,8 @@ pub struct LabelIndex {
 /// LabelIndex manages an FST file along with an index file.
 /// They are created by iterating on Label objects.
 impl LabelIndex {
-    const LABELS_FST: &str = "labels.fst";
-    const LABELS_IDX: &str = "labels.idx";
+    const LABELS_FST: &'static str = "labels.fst";
+    const LABELS_IDX: &'static str = "labels.idx";
 
     /// Returns true if FST files are present
     pub fn exists(path: &Path) -> bool {
@@ -175,7 +175,7 @@ pub struct KeyIndex {
 
 /// KeyIndex stores a (key, doc_id) tuple used to speed up lookups.
 impl KeyIndex {
-    const KEYS_FST: &str = "keys.fst";
+    const KEYS_FST: &'static str = "keys.fst";
 
     /// Returns true if the FST file is present
     pub fn exists(path: &Path) -> bool {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # if this changes, also change the version in the Dockerfile.basenode
-channel = "1.72.1"
+channel = "1.76.0"

--- a/vectors_benchmark/src/downloader.rs
+++ b/vectors_benchmark/src/downloader.rs
@@ -132,7 +132,7 @@ pub fn download_shard(
     let mut downloaded_bytes = 0;
     if Path::new(&download_path).exists() {
         // Open the file for appending and get the current file size
-        let mut file = OpenOptions::new().write(true).append(true).open(&download_path)?;
+        let mut file = OpenOptions::new().append(true).open(&download_path)?;
 
         // Seek to the end to continue the download
         downloaded_bytes = file.seek(SeekFrom::End(0))?;
@@ -145,7 +145,7 @@ pub fn download_shard(
     let content_length = get_content_length(url);
 
     if downloaded_bytes < content_length {
-        let mut file = OpenOptions::new().write(true).append(true).open(&download_path)?;
+        let mut file = OpenOptions::new().append(true).open(&download_path)?;
 
         println!("Downloading {}", Byte::from_bytes(content_length as u128).get_appropriate_unit(true),);
 


### PR DESCRIPTION
### Description

Some of our dependencies start mandating newer Rust versions. For now, we locked the versions we need (https://github.com/nuclia/nucliadb/pull/1817) which is good practice anyway. This PR updates to the latest Rust version to facilitate future updates.

### How was this PR tested?
Describe how you tested this PR.
