### PR TITLE
Fix error code parsing for AWS S3 responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
         files: (^nucliadb_utils/)|(^nucliadb_node/)|(^nucliadb_telemetry/)|(^nucliadb_dataset/)|(^nucliadb_sdk/)|(^nucliadb_models/)|(^nucliadb/)(^nucliadb_performace/)
         types: ["python"]
 
+      - id: mypy_nucliadb
+        name: mypy
+        entry: env MYPYPATH=mypy_stubs/ mypy --config-file=mypy.ini --show-traceback
+        language: system
+        files: (^nucliadb_utils/)|(^nucliadb_node/)|(^nucliadb_telemetry/)|(^nucliadb_dataset/)|(^nucliadb_sdk/)|(^nucliadb_models/)|(^nucliadb/)(^nucliadb_performace/)
+        types: ["python"]
+
       - id: rustfmt_nucliadb
         name: fmt
         entry: cargo +nightly fmt --check

--- a/nucliadb_utils/nucliadb_utils/storages/exceptions.py
+++ b/nucliadb_utils/nucliadb_utils/storages/exceptions.py
@@ -70,3 +70,10 @@ class IndexDataNotFound(Exception):
     """
     Raised when the index data is not found in storage
     """
+
+
+class UnparsableResponse(Exception):
+    """
+    Raised when trying to parse a response from a storage API and it's not
+    possible
+    """

--- a/nucliadb_utils/nucliadb_utils/tests/s3.py
+++ b/nucliadb_utils/nucliadb_utils/tests/s3.py
@@ -28,7 +28,7 @@ from nucliadb_utils.utilities import Utility
 
 images.settings["s3"] = {
     "image": "localstack/localstack",
-    "version": "3.1",
+    "version": "0.12.18",
     "env": {"SERVICES": "s3"},
     "options": {
         "ports": {"4566": None, "4571": None},
@@ -43,7 +43,7 @@ class S3(BaseImage):
     def check(self):
         try:
             response = requests.get(f"http://{self.host}:{self.get_port()}")
-            return response.status_code == 200
+            return response.status_code == 404
         except Exception:
             return False
 

--- a/nucliadb_utils/nucliadb_utils/tests/s3.py
+++ b/nucliadb_utils/nucliadb_utils/tests/s3.py
@@ -28,7 +28,7 @@ from nucliadb_utils.utilities import Utility
 
 images.settings["s3"] = {
     "image": "localstack/localstack",
-    "version": "0.12.18",
+    "version": "3.1",
     "env": {"SERVICES": "s3"},
     "options": {
         "ports": {"4566": None, "4571": None},
@@ -43,7 +43,7 @@ class S3(BaseImage):
     def check(self):
         try:
             response = requests.get(f"http://{self.host}:{self.get_port()}")
-            return response.status_code == 404
+            return response.status_code == 200
         except Exception:
             return False
 

--- a/nucliadb_utils/nucliadb_utils/tests/unit/storages/test_aws.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/storages/test_aws.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import botocore
+import botocore  # type: ignore
 import pytest
 
 from nucliadb_utils.storages import s3

--- a/nucliadb_utils/nucliadb_utils/tests/unit/storages/test_aws.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/storages/test_aws.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import botocore
+import pytest
+
+from nucliadb_utils.storages import s3
+from nucliadb_utils.storages.exceptions import UnparsableResponse
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("200", 200),
+        ("404", 404),
+        ("NoSuchBucket", 404),
+        ("NoSuchKey", 404),
+    ],
+)
+def test_parse_status_code(response_generator, code: str, expected: int):
+    resp = response_generator(code)
+    assert s3.parse_status_code(resp) == expected
+
+
+def test_unparsable_status_code(response_generator):
+    resp = response_generator("Unknown")
+    with pytest.raises(UnparsableResponse):
+        s3.parse_status_code(resp)
+
+
+@pytest.fixture
+def response_generator():
+    class TestError(botocore.exceptions.ClientError):
+        def __init__(self, error_code: str):
+            response = {
+                "Error": {
+                    "Code": error_code,
+                }
+            }
+            super().__init__(error_response=response, operation_name="TEST")  # type: ignore
+
+    yield TestError


### PR DESCRIPTION
### Description
Error status is sometimes a number and sometimes a string with a special code. I've created a simple function to parse it and return a number always. More mappings can be added if needed

### How was this PR tested?
Describe how you tested this PR.
