### PR TITLE
Use new public Predict API

### DIFF
--- a/nucliadb/nucliadb/learning_config.py
+++ b/nucliadb/nucliadb/learning_config.py
@@ -68,6 +68,9 @@ async def proxy(
     If the response is chunked, a StreamingResponse is returned.
     """
     proxied_headers = headers or {}
+    proxied_headers.update({k.lower(): v for k, v in request.headers.items()})
+    proxied_headers.pop("host", None)
+
     async with learning_config_client() as client:
         try:
             response = await client.request(

--- a/nucliadb/nucliadb/reader/api/v1/learning_config.py
+++ b/nucliadb/nucliadb/reader/api/v1/learning_config.py
@@ -61,7 +61,12 @@ async def get_configuration(
     request: Request,
     kbid: str,
 ):
-    return await learning_config.proxy(request, "GET", f"/config/{kbid}")
+    return await learning_config.proxy(
+        request,
+        "GET",
+        f"/config/{kbid}",
+        headers={"X-STF-USER": request.headers.get("X-NUCLIADB-USER", "")},
+    )
 
 
 @api.get(

--- a/nucliadb/nucliadb/reader/tests/integration/api/v1/test_learning_config.py
+++ b/nucliadb/nucliadb/reader/tests/integration/api/v1/test_learning_config.py
@@ -56,9 +56,15 @@ async def test_api(reader_api, knowledgebox_ingest, learning_config_proxy):
     kbid = knowledgebox_ingest
     async with reader_api(roles=[NucliaDBRoles.READER]) as client:
         # Get configuration
-        resp = await client.get(f"/kb/{kbid}/configuration")
+        resp = await client.get(
+            f"/kb/{kbid}/configuration", headers={"x-nucliadb-user": "userfoo"}
+        )
         assert resp.status_code == 200
-        assert learning_config_proxy.calls[-1][1:] == ("GET", f"/config/{kbid}", None)
+        assert learning_config_proxy.calls[-1][1:] == (
+            "GET",
+            f"/config/{kbid}",
+            {"X-STF-USER": "userfoo"},
+        )
 
         # Download model
         resp = await client.get(f"/kb/{kbid}/models/model1/path")

--- a/nucliadb/nucliadb/search/predict.py
+++ b/nucliadb/nucliadb/search/predict.py
@@ -179,11 +179,14 @@ class PredictEngine:
         ):
             raise NUAKeyMissingError()
 
-    def get_predict_url(self, endpoint: str) -> str:
+    def get_predict_url(self, endpoint: str, kbid: str) -> str:
         if not endpoint.startswith("/"):
             endpoint = "/" + endpoint
         if self.onprem:
-            return f"{self.public_url}{PUBLIC_PREDICT}{endpoint}"
+            # On-prem NucliaDB uses the public URL for the predict API. Examples:
+            # /api/v1/predict/chat/{kbid}
+            # /api/v1/predict/rephrase/{kbid}
+            return f"{self.public_url}{PUBLIC_PREDICT}{endpoint}/{kbid}"
         else:
             if has_feature(const.Features.VERSIONED_PRIVATE_PREDICT):
                 return f"{self.cluster_url}{VERSIONED_PRIVATE_PREDICT}{endpoint}"
@@ -257,7 +260,7 @@ class PredictEngine:
 
         resp = await self.make_request(
             "POST",
-            url=self.get_predict_url(FEEDBACK),
+            url=self.get_predict_url(FEEDBACK, kbid),
             json=data,
             headers=self.get_predict_headers(kbid),
         )
@@ -274,7 +277,7 @@ class PredictEngine:
 
         resp = await self.make_request(
             "POST",
-            url=self.get_predict_url(REPHRASE),
+            url=self.get_predict_url(REPHRASE, kbid),
             json=item.dict(),
             headers=self.get_predict_headers(kbid),
         )
@@ -294,7 +297,7 @@ class PredictEngine:
 
         resp = await self.make_request(
             "POST",
-            url=self.get_predict_url(CHAT),
+            url=self.get_predict_url(CHAT, kbid),
             json=item.dict(),
             headers=self.get_predict_headers(kbid),
             timeout=None,
@@ -317,7 +320,7 @@ class PredictEngine:
         item = AskDocumentModel(question=question, blocks=blocks, user_id=user_id)
         resp = await self.make_request(
             "POST",
-            url=self.get_predict_url(ASK_DOCUMENT),
+            url=self.get_predict_url(ASK_DOCUMENT, kbid),
             json=item.dict(),
             headers=self.get_predict_headers(kbid),
             timeout=None,
@@ -337,7 +340,7 @@ class PredictEngine:
 
         resp = await self.make_request(
             "GET",
-            url=self.get_predict_url(SENTENCE),
+            url=self.get_predict_url(SENTENCE, kbid),
             params={"text": sentence},
             headers=self.get_predict_headers(kbid),
         )
@@ -359,7 +362,7 @@ class PredictEngine:
 
         resp = await self.make_request(
             "GET",
-            url=self.get_predict_url(TOKENS),
+            url=self.get_predict_url(TOKENS, kbid),
             params={"text": sentence},
             headers=self.get_predict_headers(kbid),
         )
@@ -377,7 +380,7 @@ class PredictEngine:
             raise SendToPredictError(error)
         resp = await self.make_request(
             "POST",
-            url=self.get_predict_url(SUMMARIZE),
+            url=self.get_predict_url(SUMMARIZE, kbid),
             json=item.dict(),
             headers=self.get_predict_headers(kbid),
             timeout=None,

--- a/nucliadb/nucliadb/search/search/predict_proxy.py
+++ b/nucliadb/nucliadb/search/search/predict_proxy.py
@@ -58,7 +58,7 @@ async def predict_proxy(
     # Proxy the request to predict API
     predict_response = await predict.make_request(
         method=method,
-        url=predict.get_predict_url(endpoint),
+        url=predict.get_predict_url(endpoint, kbid),
         json=json,
         params=params,
         headers=headers,

--- a/nucliadb/nucliadb/tests/unit/test_learning_config.py
+++ b/nucliadb/nucliadb/tests/unit/test_learning_config.py
@@ -130,7 +130,7 @@ async def test_proxy(async_client):
         url="url",
         params={"some": "data"},
         content=b"some data",
-        headers={"foo": "bar"},
+        headers={"foo": "bar", "x-nucliadb-user": "user", "x-nucliadb-roles": "roles"},
     )
 
 
@@ -156,7 +156,7 @@ async def test_proxy_stream_response(async_client, config_stream_response):
         url="url",
         params={"some": "data"},
         content=b"some data",
-        headers={},
+        headers={"x-nucliadb-user": "user", "x-nucliadb-roles": "roles"},
     )
 
 
@@ -183,4 +183,27 @@ async def test_proxy_error(async_client):
         params={"some": "data"},
         content=b"some data",
         headers={},
+    )
+
+
+async def test_proxy_headers(async_client):
+    request = mock.Mock(
+        query_params={},
+        body=mock.AsyncMock(return_value=b""),
+        headers={
+            "x-nucliadb-user": "user",
+            "x-nucliadb-roles": "roles",
+            "host": "localhost",
+        },
+    )
+    response = await proxy(request, "GET", "url")
+
+    assert response.status_code == 200
+
+    async_client.request.assert_called_once_with(
+        method="GET",
+        url="url",
+        params={},
+        content=b"",
+        headers={"x-nucliadb-user": "user", "x-nucliadb-roles": "roles"},
     )

--- a/nucliadb_sdk/README.md
+++ b/nucliadb_sdk/README.md
@@ -2,9 +2,9 @@
 
 The NucliaDB SDK is a Python library designed as a thin wrapper around the [NucliaDB HTTP API](https://docs.nuclia.dev/docs/api). It is tailored for developers who wish to create low-level scripts to interact with NucliaDB.
 
-## :warning: WARNING :warning:
+## WARNING
 
-If it's your first time using Nuclia or you want a simple way to push your unstructured data to Nuclia with a script or a CLI, we highly recommend using the [Nuclia CLI/SDK](https://github.com/nuclia/nuclia.py) instead, as it is much more user-friendly and use-case focused.
+:warning: If it's your first time using Nuclia or you want a simple way to push your unstructured data to Nuclia with a script or a CLI, we highly recommend using the [Nuclia CLI/SDK](https://github.com/nuclia/nuclia.py) instead, as it is much more user-friendly and use-case focused. :warning:
 
 ## Installation
 


### PR DESCRIPTION
### Description

Predict has a new external API that we need to start using.
Additionally, for learning config endpoints that are proxied, we need to pass along all headers of the request (except the host)

### How was this PR tested?
Integration and unit tests 
