### PR TITLE
Open grpc-stubs test requirement

### DIFF
--- a/nucliadb/nucliadb/common/cluster/discovery/base.py
+++ b/nucliadb/nucliadb/common/cluster/discovery/base.py
@@ -22,7 +22,7 @@ import asyncio
 import logging
 
 import backoff
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 
 from nucliadb.common.cluster import manager
 from nucliadb.common.cluster.discovery.types import IndexNodeMetadata

--- a/nucliadb/nucliadb/common/cluster/standalone/service.py
+++ b/nucliadb/nucliadb/common/cluster/standalone/service.py
@@ -19,7 +19,7 @@
 #
 import os
 
-from grpc import aio  # type: ignore
+from grpc import aio
 
 from nucliadb.common.cluster.settings import settings
 from nucliadb.common.cluster.settings import settings as cluster_settings

--- a/nucliadb/nucliadb/health.py
+++ b/nucliadb/nucliadb/health.py
@@ -21,8 +21,8 @@ import asyncio
 import logging
 from typing import Awaitable, Callable, Optional
 
-from grpc import aio  # type: ignore
-from grpc_health.v1 import health, health_pb2, health_pb2_grpc  # type: ignore
+from grpc import aio
+from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
 from nucliadb_utils.cache.nats import NatsPubsub
 from nucliadb_utils.cache.pubsub import PubSubDriver

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -22,7 +22,7 @@ from typing import AsyncGenerator, AsyncIterator, Optional, Sequence
 from uuid import uuid4
 
 from grpc import StatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.knowledgebox_pb2 import (
     KnowledgeBoxConfig,
     Labels,

--- a/nucliadb/nucliadb/ingest/service/__init__.py
+++ b/nucliadb/nucliadb/ingest/service/__init__.py
@@ -19,7 +19,7 @@
 #
 from typing import Optional
 
-from grpc import aio  # type: ignore
+from grpc import aio
 
 from nucliadb import health
 from nucliadb.ingest import logger

--- a/nucliadb/nucliadb/ingest/tests/fixtures.py
+++ b/nucliadb/nucliadb/ingest/tests/fixtures.py
@@ -27,7 +27,7 @@ from unittest.mock import AsyncMock, patch
 
 import nats
 import pytest
-from grpc import aio  # type: ignore
+from grpc import aio
 from nucliadb_protos.knowledgebox_pb2 import SemanticModelMetadata
 from nucliadb_protos.writer_pb2 import BrokerMessage
 

--- a/nucliadb/nucliadb/search/api/v1/knowledgebox.py
+++ b/nucliadb/nucliadb/search/api/v1/knowledgebox.py
@@ -23,7 +23,7 @@ from typing import Optional
 from fastapi import HTTPException, Request
 from fastapi_versioning import version
 from grpc import StatusCode as GrpcStatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.noderesources_pb2 import Shard
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from nucliadb_protos.writer_pb2 import Shards

--- a/nucliadb/nucliadb/search/requesters/utils.py
+++ b/nucliadb/nucliadb/search/requesters/utils.py
@@ -23,7 +23,7 @@ from typing import Any, Optional, TypeVar, Union, overload
 
 from fastapi import HTTPException
 from grpc import StatusCode as GrpcStatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.nodereader_pb2 import (
     ParagraphSearchRequest,
     ParagraphSearchResponse,

--- a/nucliadb/nucliadb/search/tests/node.py
+++ b/nucliadb/nucliadb/search/tests/node.py
@@ -26,9 +26,9 @@ from typing import Union
 import backoff
 import docker  # type: ignore
 import pytest
-from grpc import insecure_channel  # type: ignore
-from grpc_health.v1 import health_pb2_grpc  # type: ignore
-from grpc_health.v1.health_pb2 import HealthCheckRequest  # type: ignore
+from grpc import insecure_channel
+from grpc_health.v1 import health_pb2_grpc
+from grpc_health.v1.health_pb2 import HealthCheckRequest
 from nucliadb_protos.nodewriter_pb2 import EmptyQuery, ShardId
 from nucliadb_protos.nodewriter_pb2_grpc import NodeWriterStub
 from pytest_docker_fixtures import images  # type: ignore

--- a/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/requesters/test_utils.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from fastapi import HTTPException
 from grpc import StatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 
 from nucliadb.common.cluster.base import AbstractIndexNode
 from nucliadb.search.requesters import utils

--- a/nucliadb/nucliadb/tests/fixtures.py
+++ b/nucliadb/nucliadb/tests/fixtures.py
@@ -27,7 +27,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import asyncpg
 import pytest
 import tikv_client  # type: ignore
-from grpc import aio  # type: ignore
+from grpc import aio
 from httpx import AsyncClient
 from nucliadb_protos.train_pb2_grpc import TrainStub
 from nucliadb_protos.utils_pb2 import Relation, RelationNode

--- a/nucliadb/nucliadb/train/utils.py
+++ b/nucliadb/nucliadb/train/utils.py
@@ -19,7 +19,7 @@
 #
 from typing import Optional
 
-from grpc import aio  # type: ignore
+from grpc import aio
 from grpc_health.v1 import health, health_pb2_grpc
 
 from nucliadb.common.maindb.utils import setup_driver, teardown_driver

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -26,7 +26,7 @@ from uuid import uuid4
 from fastapi import HTTPException, Query, Response
 from fastapi_versioning import version
 from grpc import StatusCode as GrpcStatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.resources_pb2 import Metadata
 from nucliadb_protos.writer_pb2 import (
     BrokerMessage,

--- a/nucliadb/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/nucliadb/writer/api/v1/upload.py
@@ -32,7 +32,7 @@ from fastapi.requests import Request
 from fastapi.responses import Response
 from fastapi_versioning import version  # type: ignore
 from grpc import StatusCode as GrpcStatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.resources_pb2 import FieldFile
 from nucliadb_protos.writer_pb2 import (
     BrokerMessage,

--- a/nucliadb_dataset/nucliadb_dataset/nuclia.py
+++ b/nucliadb_dataset/nucliadb_dataset/nuclia.py
@@ -19,7 +19,7 @@
 
 from typing import Iterator, List
 
-import grpc  # type: ignore
+import grpc
 from nucliadb_protos.train_pb2 import (
     GetFieldsRequest,
     GetInfoRequest,

--- a/nucliadb_dataset/nucliadb_dataset/tests/fixtures.py
+++ b/nucliadb_dataset/nucliadb_dataset/tests/fixtures.py
@@ -22,9 +22,9 @@ import tempfile
 from typing import AsyncIterator, Iterator, Optional
 
 import docker  # type: ignore
-import grpc  # type: ignore
+import grpc
 import pytest
-from grpc import aio  # type: ignore
+from grpc import aio
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 
 from nucliadb_models.common import FieldID, UserClassification

--- a/nucliadb_node/nucliadb_node/indexer.py
+++ b/nucliadb_node/nucliadb_node/indexer.py
@@ -24,7 +24,7 @@ from functools import cached_property, partial, total_ordering
 from typing import Optional
 
 from grpc import StatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nats.aio.client import Msg
 from nucliadb_protos.noderesources_pb2 import ResourceID
 from nucliadb_protos.nodewriter_pb2 import (

--- a/nucliadb_node/nucliadb_node/listeners/gc_scheduler.py
+++ b/nucliadb_node/nucliadb_node/listeners/gc_scheduler.py
@@ -22,7 +22,7 @@ from functools import partial
 from typing import Optional
 
 from grpc import StatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.nodewriter_pb2 import GarbageCollectorResponse
 
 from nucliadb_node import logger, signals

--- a/nucliadb_node/nucliadb_node/service.py
+++ b/nucliadb_node/nucliadb_node/service.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from grpc import aio  # type: ignore
+from grpc import aio
 from grpc_health.v1 import health, health_pb2_grpc
 
 from nucliadb_node import SERVICE_NAME

--- a/nucliadb_node/nucliadb_node/tests/fixtures.py
+++ b/nucliadb_node/nucliadb_node/tests/fixtures.py
@@ -22,9 +22,9 @@ from typing import AsyncIterable, Optional
 
 import docker  # type: ignore
 import pytest
-from grpc import aio, insecure_channel  # type: ignore
-from grpc_health.v1 import health_pb2_grpc  # type: ignore
-from grpc_health.v1.health_pb2 import HealthCheckRequest  # type: ignore
+from grpc import aio, insecure_channel
+from grpc_health.v1 import health_pb2_grpc
+from grpc_health.v1.health_pb2 import HealthCheckRequest
 from nucliadb_protos.noderesources_pb2 import EmptyQuery, ShardCreated, ShardId
 from nucliadb_protos.nodewriter_pb2 import NewShardRequest
 from nucliadb_protos.nodewriter_pb2_grpc import NodeWriterStub

--- a/nucliadb_node/nucliadb_node/tests/integration/test_indexing.py
+++ b/nucliadb_node/nucliadb_node/tests/integration/test_indexing.py
@@ -27,7 +27,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.noderesources_pb2 import Resource, Shard, ShardId
 from nucliadb_protos.nodewriter_pb2 import IndexMessage, IndexMessageSource, TypeMessage
 from nucliadb_protos.writer_pb2 import Notification

--- a/nucliadb_node/nucliadb_node/tests/unit/test_indexer.py
+++ b/nucliadb_node/nucliadb_node/tests/unit/test_indexer.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from grpc import StatusCode
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.nodewriter_pb2 import (
     IndexMessage,
     IndexMessageSource,

--- a/nucliadb_node/nucliadb_node/writer.py
+++ b/nucliadb_node/nucliadb_node/writer.py
@@ -21,7 +21,7 @@ import asyncio
 from typing import Optional
 
 import backoff
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 from nucliadb_protos.noderesources_pb2 import (
     EmptyQuery,
     Resource,

--- a/nucliadb_telemetry/nucliadb_telemetry/grpc.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/grpc.py
@@ -24,8 +24,8 @@ from contextlib import contextmanager
 from typing import Any, Awaitable, Callable, List, Optional, Tuple
 
 import grpc
-from grpc import ChannelCredentials, ClientCallDetails, aio  # type: ignore
-from grpc.experimental import wrap_server_method_handler  # type: ignore
+from grpc import ChannelCredentials, ClientCallDetails, aio
+from grpc.experimental import wrap_server_method_handler
 from opentelemetry.context import attach, detach
 from opentelemetry.propagate import extract, inject
 from opentelemetry.propagators.textmap import CarrierT, Setter  # type: ignore

--- a/nucliadb_telemetry/nucliadb_telemetry/grpc_metrics.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/grpc_metrics.py
@@ -21,8 +21,8 @@ import functools
 from typing import Any, Awaitable, Callable, Union
 
 import grpc
-from grpc import ClientCallDetails, aio  # type: ignore
-from grpc.experimental import wrap_server_method_handler  # type: ignore
+from grpc import ClientCallDetails, aio
+from grpc.experimental import wrap_server_method_handler
 
 from nucliadb_telemetry import metrics
 

--- a/nucliadb_telemetry/nucliadb_telemetry/grpc_sentry.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/grpc_sentry.py
@@ -22,7 +22,7 @@ from typing import Any, Awaitable, Callable
 
 from grpc import HandlerCallDetails, RpcMethodHandler
 from grpc.experimental import aio  # type: ignore
-from grpc.experimental import wrap_server_method_handler  # type: ignore
+from grpc.experimental import wrap_server_method_handler
 
 from nucliadb_telemetry.errors import capture_exception
 

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/telemetry.py
@@ -25,7 +25,7 @@ import nats
 import pytest
 import requests
 from fastapi import FastAPI
-from grpc import aio  # type: ignore
+from grpc import aio
 from httpx import AsyncClient
 from nats.aio.msg import Msg
 from nats.js import api

--- a/nucliadb_telemetry/nucliadb_telemetry/tests/test_sentry_interceptor.py
+++ b/nucliadb_telemetry/nucliadb_telemetry/tests/test_sentry_interceptor.py
@@ -20,7 +20,7 @@
 from unittest.mock import patch
 
 import pytest
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 
 from nucliadb_telemetry.grpc import GRPCTelemetry
 from nucliadb_telemetry.grpc_sentry import SentryInterceptor

--- a/nucliadb_utils/nucliadb_utils/grpc.py
+++ b/nucliadb_utils/nucliadb_utils/grpc.py
@@ -21,8 +21,7 @@ import json
 import logging
 from typing import Optional
 
-from grpc import aio  # type: ignore
-from grpc import ChannelCredentials
+from grpc import ChannelCredentials, aio
 
 from nucliadb_telemetry.grpc import GRPCTelemetry
 from nucliadb_telemetry.grpc_sentry import SentryInterceptor

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@ requests
 maturin
 pytest-lazy-fixtures
 pytest-mock
-grpc-stubs==1.24.7
+grpc-stubs>=1.24.7
 aioresponses==0.7.5
 asyncpg>=0.27.0
 # required for pytest-docker-fixtures


### PR DESCRIPTION
### Description
`grpc-stubs` was pinned in our test-requirements but not in our normal requirements. Upgrading this package allows us to remove most `type: ignore` while importing grpc

### How was this PR tested?
Running mypy
