### PR TITLE
Ingest - use defined SA name in purgeCron RBAC

### DIFF
--- a/charts/nucliadb_ingest/templates/ingest.rbac.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.rbac.yaml
@@ -41,5 +41,5 @@ roleRef:
   name: statefulset-viewer
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ ((.Values.purgeCron).serviceAccount) | default "default" }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
### Description
Uses K8s service account defined in the values in purge cron role binding
