### PR TITLE
Revert "Is CPAN really needed?"

### DIFF
--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -20,12 +20,13 @@ if [ "$machine" == "linux" ]; then
 	case $ID in
 	debian | ubuntu | mint)
 		$SUDO apt-get -y update
-		$SUDO apt-get install -y libdw-dev pkg-config libssl-dev
+		$SUDO apt-get install -y libdw-dev pkg-config libssl-dev cpanminus
+		$SUDO cpanm IPC::Cmd
 		;;
 
 	fedora | rhel | centos)
 		$SUDO yum update -y
-		$SUDO yum -y install elfutils-devel pkgconfig openssl-devel
+		$SUDO yum -y install elfutils-devel pkgconfig openssl-devel perl-IPC-Cmd
 		;;
 
 	*)


### PR DESCRIPTION
Reverts nuclia/nucliadb#1829

Needed for compilation of openssl-sys inside the docker image for the node.