### PR TITLE
Parallelize KB migrations 

### DIFF
--- a/nucliadb/nucliadb/migrator/migrator.py
+++ b/nucliadb/nucliadb/migrator/migrator.py
@@ -126,9 +126,16 @@ async def run_kb_migrations_in_parallel(
     async with max_concurrent:
         try:
             await run_kb_migrations(context, kbid, target_version)
+            logger.info(
+                f"Finished KB migration",
+                extra={"kbid": kbid, "target_version": target_version},
+            )
         except Exception as exc:
             errors.capture_exception(exc)
-            logger.exception("Failed to migrate KB", extra={"kbid": kbid})
+            logger.exception(
+                "Failed to migrate KB",
+                extra={"kbid": kbid, "target_version": target_version},
+            )
             raise
 
 

--- a/nucliadb/nucliadb/migrator/settings.py
+++ b/nucliadb/nucliadb/migrator/settings.py
@@ -26,5 +26,5 @@ class Settings(pydantic.BaseSettings):
     redis_url: Optional[str] = None
     max_concurrent_migrations: int = pydantic.Field(
         default=5,
-        description="Maximum number of concurrent migrations allowed. Default is 5.",
+        description="Maximum number of concurrent KB migrations allowed.",
     )

--- a/nucliadb/nucliadb/migrator/settings.py
+++ b/nucliadb/nucliadb/migrator/settings.py
@@ -24,3 +24,7 @@ import pydantic
 
 class Settings(pydantic.BaseSettings):
     redis_url: Optional[str] = None
+    max_concurrent_migrations: int = pydantic.Field(
+        default=5,
+        description="Maximum number of concurrent migrations allowed. Default is 5.",
+    )

--- a/nucliadb/nucliadb/tests/integration/migrator/test_migrator.py
+++ b/nucliadb/nucliadb/tests/integration/migrator/test_migrator.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import uuid
+
 import pytest
 
 from nucliadb.migrator import migrator
@@ -63,5 +65,45 @@ async def test_migrate_kb(execution_context: ExecutionContext, knowledgebox):
     assert global_info.current_version == 1
 
 
-async def test_run_all_kb_migrations(execution_context: ExecutionContext):
-    pass
+@pytest.fixture(scope="function")
+async def two_knowledgeboxes(nucliadb_manager):
+    kbs = []
+    for _ in range(2):
+        resp = await nucliadb_manager.post("/kbs", json={"slug": uuid.uuid4().hex})
+        assert resp.status_code == 201
+        kbs.append(resp.json().get("uuid"))
+
+    yield kbs
+
+    for kb in kbs:
+        resp = await nucliadb_manager.delete(f"/kb/{kb}")
+        assert resp.status_code == 200
+
+
+async def test_run_all_kb_migrations(
+    execution_context: ExecutionContext, two_knowledgeboxes
+):
+    # Set migration version to -1 for all knowledgeboxes
+    for kbid in two_knowledgeboxes:
+        await execution_context.data_manager.update_kb_info(
+            kbid=kbid, current_version=-1
+        )
+        await execution_context.data_manager.update_global_info(current_version=0)
+
+        kb_info = await execution_context.data_manager.get_kb_info(kbid=kbid)
+        assert kb_info is not None
+        assert kb_info.current_version == -1
+        global_info = await execution_context.data_manager.get_global_info()
+        assert global_info.current_version == 0
+
+    # only run first noop migration
+    # other tests can be so slow and cumbersome to maintain
+    await migrator.run(execution_context, target_version=1)
+
+    # Assert that all knowledgeboxes are now at version 1
+    for kbid in two_knowledgeboxes:
+        kb_info = await execution_context.data_manager.get_kb_info(kbid=kbid)
+        assert kb_info is not None
+        assert kb_info.current_version == 1
+        global_info = await execution_context.data_manager.get_global_info()
+        assert global_info.current_version == 1

--- a/nucliadb/nucliadb/tests/integration/migrator/test_migrator.py
+++ b/nucliadb/nucliadb/tests/integration/migrator/test_migrator.py
@@ -61,3 +61,7 @@ async def test_migrate_kb(execution_context: ExecutionContext, knowledgebox):
     assert kb_info.current_version == 1
     global_info = await execution_context.data_manager.get_global_info()
     assert global_info.current_version == 1
+
+
+async def test_run_all_kb_migrations(execution_context: ExecutionContext):
+    pass

--- a/nucliadb/nucliadb/tests/unit/migrator/test_migrator.py
+++ b/nucliadb/nucliadb/tests/unit/migrator/test_migrator.py
@@ -54,7 +54,7 @@ async def test_run_all_kb_migrations_raises_on_failure():
     )
     execution_context.settings = Mock(max_concurrent_migrations=1)
     with patch(
-        "nucliadb.migrator.migrator.run_kb_migrations_in_parallel",
+        "nucliadb.migrator.migrator.run_kb_migrations",
         side_effect=[None, Exception("Boom")],
     ) as mock:
         with pytest.raises(Exception) as exc_info:


### PR DESCRIPTION
### Description
Right now we're running only one at a time. This is a pain in production as we have very big KBs that have been running a shard rollover migration for weeks now.

### How was this PR tested?
Unit and integration tests
