### PR TITLE
remove istio cors policy

### DIFF
--- a/charts/nucliadb_reader/templates/reader.vs.yaml
+++ b/charts/nucliadb_reader/templates/reader.vs.yaml
@@ -58,18 +58,3 @@ spec:
             port:
               number: {{.Values.serving.port}}
             host: "reader.{{ .Release.Namespace }}.svc.cluster.local"
-      corsPolicy:
-        allowOrigins:
-          - exact: "*"
-        allowHeaders:
-          - "*"
-          # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
-          # Browsers already showing deprecation notices, so it needs to be specified explicitly
-          - "Authorization"
-        allowMethods:
-          - GET
-          - OPTIONS
-          - POST
-          - PATCH
-          - PUT
-          - DELETE

--- a/charts/nucliadb_search/templates/search.vs.yaml
+++ b/charts/nucliadb_search/templates/search.vs.yaml
@@ -58,15 +58,3 @@ spec:
             port:
               number: {{.Values.serving.port}}
             host: "search.{{ .Release.Namespace }}.svc.cluster.local"
-      corsPolicy:
-        allowOrigins:
-          - exact: "*"
-        allowHeaders:
-          - "*"
-          # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
-          # Browsers already showing deprecation notices, so it needs to be specified explicitly
-          - "Authorization"
-        allowMethods:
-          - GET
-          - POST
-          - OPTIONS

--- a/charts/nucliadb_train/templates/train.vs.yaml
+++ b/charts/nucliadb_train/templates/train.vs.yaml
@@ -27,16 +27,3 @@ spec:
             port:
               number: {{.Values.serving.port}}
             host: "train.{{ .Release.Namespace }}.svc.cluster.local"
-
-      corsPolicy:
-        allowOrigins:
-          - exact: "*"
-        allowHeaders:
-          - "*"
-          # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
-          # Browsers already showing deprecation notices, so it needs to be specified explicitly
-          - "Authorization"
-        allowMethods:
-          - GET
-          - POST
-          - OPTIONS

--- a/charts/nucliadb_writer/templates/writer.vs.yaml
+++ b/charts/nucliadb_writer/templates/writer.vs.yaml
@@ -27,20 +27,6 @@ spec:
             port:
               number: {{.Values.serving.port}}
             host: "writer.{{ .Release.Namespace }}.svc.cluster.local"
-      corsPolicy:
-        allowOrigins:
-          - exact: "*"
-        allowHeaders:
-          - "*"
-          # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
-          # Browsers already showing deprecation notices, so it needs to be specified explicitly
-          - "Authorization"
-        allowMethods:
-          - PUT
-          - DELETE
-          - POST
-          - PATCH
-          - OPTIONS
     - name: nucliadb_writer_tus
       match:
         - uri:
@@ -59,16 +45,3 @@ spec:
             port:
               number: {{.Values.serving.port}}
             host: "writer.{{ .Release.Namespace }}.svc.cluster.local"
-      corsPolicy:
-        allowOrigins:
-          - exact: "*"
-        allowHeaders:
-          - "*"
-          # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
-          # Browsers already showing deprecation notices, so it needs to be specified explicitly
-          - "Authorization"
-        allowMethods:
-          - POST
-          - PATCH
-          - HEAD
-          - OPTIONS

--- a/nucliadb/nucliadb/reader/app.py
+++ b/nucliadb/nucliadb/reader/app.py
@@ -41,8 +41,10 @@ middleware = [
     Middleware(
         CORSMiddleware,
         allow_origins=http_settings.cors_origins,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "OPTIONS", "POST", "PATCH", "PUT", "DELETE"],
+        # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
+        # Browsers already showing deprecation notices, so it needs to be specified explicitly
+        allow_headers=["*", "Authorization"],
     ),
     Middleware(
         AuthenticationMiddleware,

--- a/nucliadb/nucliadb/search/app.py
+++ b/nucliadb/nucliadb/search/app.py
@@ -43,8 +43,10 @@ middleware = [
     Middleware(
         CORSMiddleware,
         allow_origins=http_settings.cors_origins,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "OPTIONS"],
+        # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
+        # Browsers already showing deprecation notices, so it needs to be specified explicitly
+        allow_headers=["*", "Authorization"],
     ),
     Middleware(
         AuthenticationMiddleware,

--- a/nucliadb/nucliadb/train/app.py
+++ b/nucliadb/nucliadb/train/app.py
@@ -40,8 +40,10 @@ middleware = [
     Middleware(
         CORSMiddleware,
         allow_origins=http_settings.cors_origins,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "OPTIONS"],
+        # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
+        # Browsers already showing deprecation notices, so it needs to be specified explicitly
+        allow_headers=["*", "Authorization"],
     ),
     Middleware(
         AuthenticationMiddleware,

--- a/nucliadb/nucliadb/writer/app.py
+++ b/nucliadb/nucliadb/writer/app.py
@@ -41,8 +41,10 @@ middleware = [
     Middleware(
         CORSMiddleware,
         allow_origins=http_settings.cors_origins,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["PUT", "DELETE", "POST", "PATCH", "HEAD", "OPTIONS"],
+        # Authorization will be exluded from * in the future, (CORS non-wildcard request-header).
+        # Browsers already showing deprecation notices, so it needs to be specified explicitly
+        allow_headers=["*", "Authorization"],
     ),
     Middleware(
         AuthenticationMiddleware,

--- a/nucliadb_utils/nucliadb_utils/cors.py
+++ b/nucliadb_utils/nucliadb_utils/cors.py
@@ -133,7 +133,7 @@ class CORSMiddleware:
         headers = dict(self.preflight_headers)
         failures = []
 
-        allowed_domains = request_headers.get("x-nucliadb-cors-allowed-domains")
+        allowed_domains = request_headers.get("x-nucliadb-cors-allowed-origins")
         if self.is_allowed_origin(
             origin=requested_origin, allowed_domains=allowed_domains
         ):
@@ -194,7 +194,7 @@ class CORSMiddleware:
         # the Origin header in the response.
         elif not self.allow_all_origins and self.is_allowed_origin(
             origin=origin,
-            allowed_domains=headers.get("x-nucliadb-cors-allowed-domains"),
+            allowed_domains=headers.get("x-nucliadb-cors-allowed-origins"),
         ):
             self.allow_explicit_origin(headers, origin)
 

--- a/nucliadb_utils/nucliadb_utils/cors.py
+++ b/nucliadb_utils/nucliadb_utils/cors.py
@@ -110,10 +110,10 @@ class CORSMiddleware:
         await self.simple_response(scope, receive, send, request_headers=headers)
 
     def is_allowed_origin(
-        self, origin: str, allowed_domains: typing.Optional[str]
+        self, origin: str, allowed_origins: typing.Optional[str]
     ) -> bool:
-        if allowed_domains:
-            return origin in allowed_domains.split(",")
+        if allowed_origins:
+            return origin in allowed_origins.split(",")
 
         if self.allow_all_origins:
             return True
@@ -133,9 +133,9 @@ class CORSMiddleware:
         headers = dict(self.preflight_headers)
         failures = []
 
-        allowed_domains = request_headers.get("x-nucliadb-cors-allowed-origins")
+        allowed_origins = request_headers.get("x-nucliadb-cors-allowed-origins")
         if self.is_allowed_origin(
-            origin=requested_origin, allowed_domains=allowed_domains
+            origin=requested_origin, allowed_origins=allowed_origins
         ):
             if self.preflight_explicit_allow_origin:
                 # The "else" case is already accounted for in self.preflight_headers
@@ -194,7 +194,7 @@ class CORSMiddleware:
         # the Origin header in the response.
         elif not self.allow_all_origins and self.is_allowed_origin(
             origin=origin,
-            allowed_domains=headers.get("x-nucliadb-cors-allowed-origins"),
+            allowed_origins=headers.get("x-nucliadb-cors-allowed-origins"),
         ):
             self.allow_explicit_origin(headers, origin)
 

--- a/nucliadb_utils/nucliadb_utils/tests/unit/test_cors.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/test_cors.py
@@ -604,7 +604,7 @@ def test_cors_x_nucliadb_cors_allowed_domains(
             status_code=200,
             headers={
                 "Vary": "Accept-Encoding",
-                "x-nucliadb-cors-allowed-domains": "https://example-a.org,https://example-b.org",
+                "x-nucliadb-cors-allowed-origins": "https://example-a.org,https://example-b.org",
             },
         )
 

--- a/nucliadb_utils/nucliadb_utils/tests/unit/test_cors.py
+++ b/nucliadb_utils/nucliadb_utils/tests/unit/test_cors.py
@@ -595,7 +595,7 @@ def test_cors_allowed_origin_does_not_leak_between_credentialed_requests(
     assert "access-control-allow-credentials" not in response.headers
 
 
-def test_cors_x_nucliadb_cors_allowed_domains(
+def test_cors_x_nucliadb_cors_allowed_origins(
     test_client_factory: TestClientFactory,
 ) -> None:
     def homepage(request: Request) -> PlainTextResponse:


### PR DESCRIPTION
### Description
The CORS Middleware by Starlette was never used because istio cors policy was resolved before. By removing this policy from the yaml template we make sure we only have a single cors configuration.

### How was this PR tested?
We tested it by disabling this istio cors policy temporaly and doing some requests with different Origins and configurations.
