### PR TITLE
Faster get page number

### DIFF
--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -605,9 +605,9 @@ def is_paragraph_repeated_in_field(
 class PagePositions:
     def __init__(self, page_positions: FilePagePositions):
         self.page_positions = page_positions
-        self.materialized = self.materialize_page_numbers(page_positions)
+        self.materialized = self._materialize_page_numbers(page_positions)
 
-    def materialize_page_numbers(self, page_positions: FilePagePositions) -> list[int]:
+    def _materialize_page_numbers(self, page_positions: FilePagePositions) -> list[int]:
         page_numbers_by_index = []
         for page_number, (page_start, page_end) in page_positions.items():
             page_numbers_by_index.extend(
@@ -625,13 +625,6 @@ class PagePositions:
             if len(self.materialized) > 0:
                 return self.materialized[-1]
             return 0
-
-    def get_page_number_slow(self, start_index: int) -> int:
-        page_number = 0
-        for page_number, (page_start, page_end) in self.page_positions.items():
-            if page_start <= start_index <= page_end:
-                return page_number
-        return page_number
 
 
 def extend_unique(a: list, b: list):

--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -620,7 +620,7 @@ class PagePositions:
             return self.materialized[start_index]
         except IndexError:
             logger.error(
-                f"Could not find a page for the given index: {start_index}. Page positions: {self.page_positions}"
+                f"Could not find a page for the given index: {start_index}. Page positions: {self.page_positions}"  # noqa
             )
             if len(self.materialized) > 0:
                 return self.materialized[-1]

--- a/nucliadb/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/nucliadb/ingest/orm/brain.py
@@ -610,9 +610,7 @@ class PagePositions:
     def _materialize_page_numbers(self, page_positions: FilePagePositions) -> list[int]:
         page_numbers_by_index = []
         for page_number, (page_start, page_end) in page_positions.items():
-            page_numbers_by_index.extend(
-                [int(page_number)] * (page_end - page_start + 1)
-            )
+            page_numbers_by_index.extend([page_number] * (page_end - page_start + 1))
         return page_numbers_by_index
 
     def get_page_number(self, start_index: int) -> int:

--- a/nucliadb/nucliadb/ingest/tests/unit/orm/test_brain.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/orm/test_brain.py
@@ -31,8 +31,9 @@ from nucliadb_protos.resources_pb2 import (
     Paragraph,
     Sentence,
 )
+from responses import start
 
-from nucliadb.ingest.orm.brain import ResourceBrain, get_page_number
+from nucliadb.ingest.orm.brain import PagePositions, ResourceBrain
 from nucliadb_protos import resources_pb2
 
 
@@ -121,14 +122,16 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
 
 
 def test_get_page_number():
-    page_positions = {
-        0: (0, 99),
-        1: (100, 199),
-        2: (200, 299),
-    }
-    assert get_page_number(10, page_positions) == 0
-    assert get_page_number(100, page_positions) == 1
-    assert get_page_number(500, page_positions) == 2
+    positions = PagePositions(
+        {
+            0: (0, 99),
+            1: (100, 199),
+            2: (200, 299),
+        }
+    )
+    assert positions.get_page_number(10) == 0
+    assert positions.get_page_number(100) == 1
+    assert positions.get_page_number(500) == 2
 
 
 @pytest.mark.parametrize(

--- a/nucliadb/nucliadb/ingest/tests/unit/orm/test_brain.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/orm/test_brain.py
@@ -31,7 +31,6 @@ from nucliadb_protos.resources_pb2 import (
     Paragraph,
     Sentence,
 )
-from responses import start
 
 from nucliadb.ingest.orm.brain import PagePositions, ResourceBrain
 from nucliadb_protos import resources_pb2

--- a/nucliadb/nucliadb/ingest/tests/unit/orm/test_brain.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/orm/test_brain.py
@@ -32,7 +32,7 @@ from nucliadb_protos.resources_pb2 import (
     Sentence,
 )
 
-from nucliadb.ingest.orm.brain import PagePositions, ResourceBrain
+from nucliadb.ingest.orm.brain import ParagraphPages, ResourceBrain
 from nucliadb_protos import resources_pb2
 
 
@@ -121,16 +121,16 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
 
 
 def test_get_page_number():
-    positions = PagePositions(
+    page_numbers = ParagraphPages(
         {
             0: (0, 99),
             1: (100, 199),
             2: (200, 299),
         }
     )
-    assert positions.get_page_number(10) == 0
-    assert positions.get_page_number(100) == 1
-    assert positions.get_page_number(500) == 2
+    assert page_numbers.get(10) == 0
+    assert page_numbers.get(100) == 1
+    assert page_numbers.get(500) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Getting page numbers is very cpu bound for documents that have a lot of paragraphs.
Materializing page numbers into a list makes it 4x faster for these cases

### How was this PR tested?
Unit tests
