### PR TITLE
Fix NATS timeouts by actually asking for the proper consumer

### DIFF
--- a/nucliadb/nucliadb/writer/back_pressure.py
+++ b/nucliadb/nucliadb/writer/back_pressure.py
@@ -231,21 +231,21 @@ class Materializer:
     async def _get_indexing_pending_task(self):
         try:
             while True:
-                for node_id in get_index_nodes():
+                for node in get_index_nodes():
                     try:
                         with back_pressure_observer({"type": "get_indexing_pending"}):
                             self.indexing_pending[
-                                node_id
+                                node.id
                             ] = await get_nats_consumer_pending_messages(
                                 self.nats_manager,
                                 stream=const.Streams.INDEX.name,
-                                consumer=const.Streams.INDEX.group.format(node=node_id),
+                                consumer=const.Streams.INDEX.group.format(node=node.id),
                             )
                     except Exception:
                         logger.exception(
                             "Error getting pending messages to index",
                             exc_info=True,
-                            extra={"node_id": node_id},
+                            extra={"node_id": node.id},
                         )
                 await asyncio.sleep(self.indexing_check_interval)
         except asyncio.CancelledError:

--- a/nucliadb/nucliadb/writer/tests/unit/test_back_pressure.py
+++ b/nucliadb/nucliadb/writer/tests/unit/test_back_pressure.py
@@ -279,7 +279,7 @@ def nats_conn(js):
 @pytest.fixture(scope="function")
 def get_index_nodes():
     with mock.patch(
-        f"{MODULE}.get_index_nodes", return_value=["node1", "node2"]
+        f"{MODULE}.get_index_nodes", return_value=[mock.Mock(id="node1"), mock.Mock(id="node2")]
     ) as mock_:
         yield mock_
 
@@ -310,6 +310,7 @@ async def test_materializer(nats_conn, get_index_nodes, js, processing_client):
 
     await asyncio.sleep(0.1)
 
+    # two index nodes and ingest streams are queried
     assert len(js.consumer_info.call_args_list) == 3
 
     # Wait for the next check

--- a/nucliadb/nucliadb/writer/tests/unit/test_back_pressure.py
+++ b/nucliadb/nucliadb/writer/tests/unit/test_back_pressure.py
@@ -279,7 +279,8 @@ def nats_conn(js):
 @pytest.fixture(scope="function")
 def get_index_nodes():
     with mock.patch(
-        f"{MODULE}.get_index_nodes", return_value=[mock.Mock(id="node1"), mock.Mock(id="node2")]
+        f"{MODULE}.get_index_nodes",
+        return_value=[mock.Mock(id="node1"), mock.Mock(id="node2")],
     ) as mock_:
         yield mock_
 


### PR DESCRIPTION
### Description
We were sending the string representation of the `AbstractIndexNode` instead of the actual index node id and NATS was responding with timeouts.

Send the proper node id

### How was this PR tested?
Describe how you tested this PR.
