### PR TITLE
Add back pressure feature flag for non-disturbing testing

### DIFF
--- a/nucliadb/nucliadb/writer/back_pressure.py
+++ b/nucliadb/nucliadb/writer/back_pressure.py
@@ -41,6 +41,7 @@ from nucliadb_telemetry import metrics
 from nucliadb_utils import const
 from nucliadb_utils.nats import NatsConnectionManager
 from nucliadb_utils.settings import is_onprem_nucliadb
+from nucliadb_utils.utilities import has_feature
 
 __all__ = ["maybe_back_pressure"]
 
@@ -327,9 +328,10 @@ async def maybe_back_pressure(
     This function does system checks to see if we need to put back pressure on writes.
     In that case, a HTTP 429 will be raised with the estimated time to try again.
     """
-    if not is_back_pressure_enabled() or is_onprem_nucliadb():
-        return
-    await back_pressure_checks(request, kbid, resource_uuid)
+    if has_feature(const.Features.BACK_PRESSURE, context={"kbid": kbid}):
+        if not is_back_pressure_enabled() or is_onprem_nucliadb():
+            return
+        await back_pressure_checks(request, kbid, resource_uuid)
 
 
 async def back_pressure_checks(

--- a/nucliadb_utils/nucliadb_utils/const.py
+++ b/nucliadb_utils/nucliadb_utils/const.py
@@ -76,3 +76,4 @@ class Features:
     EXPERIMENTAL_KB = "nucliadb_experimental_kb"
     READ_REPLICA_SEARCHES = "nucliadb_read_replica_searches"
     VERSIONED_PRIVATE_PREDICT = "nucliadb_versioned_private_predict"
+    BACK_PRESSURE = "nucliadb_back_pressure"

--- a/nucliadb_utils/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/nucliadb_utils/featureflagging.py
@@ -53,6 +53,10 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },
+    const.Features.BACK_PRESSURE: {
+        "rollout": 0,
+        "variants": {"environment": ["local"]},
+    },
 }
 
 


### PR DESCRIPTION
### Description
Add feature flag for back pressure to test back pressure with strict values without disturbing other stage users

### How was this PR tested?
Describe how you tested this PR.
