### PR TITLE
Proxy predict API errors to nucliadb response

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/chat.py
+++ b/nucliadb/nucliadb/search/api/v1/chat.py
@@ -124,8 +124,8 @@ async def chat_knowledgebox_endpoint(
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)
     except predict.ProxiedPredictAPIError as err:
         return HTTPClientError(
-            status_code=503,
-            detail=f"Chat service unavailable. {err.status}: {err.detail}",
+            status_code=err.status,
+            detail=err.detail,
         )
     except IncompleteFindResultsError:
         return HTTPClientError(

--- a/nucliadb/nucliadb/search/api/v1/feedback.py
+++ b/nucliadb/nucliadb/search/api/v1/feedback.py
@@ -56,8 +56,8 @@ async def send_feedback_endpoint(
         )
     except predict.ProxiedPredictAPIError as err:
         return HTTPClientError(
-            status_code=503,
-            detail=f"Feedback service unavailable. {err.status}: {err.detail}",
+            status_code=err.status,
+            detail=err.detail,
         )
     except Exception as ex:
         errors.capture_exception(ex)

--- a/nucliadb/nucliadb/search/api/v1/find.py
+++ b/nucliadb/nucliadb/search/api/v1/find.py
@@ -214,6 +214,6 @@ async def _find_endpoint(
         return HTTPClientError(status_code=412, detail=str(exc))
     except predict.ProxiedPredictAPIError as err:
         return HTTPClientError(
-            status_code=503,
-            detail=f"Inference service unavailable. {err.status}: {err.detail}",
+            status_code=err.status,
+            detail=err.detail,
         )

--- a/nucliadb/nucliadb/search/api/v1/resource/chat.py
+++ b/nucliadb/nucliadb/search/api/v1/resource/chat.py
@@ -72,8 +72,8 @@ async def resource_chat_endpoint(
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)
     except predict.ProxiedPredictAPIError as err:
         return HTTPClientError(
-            status_code=503,
-            detail=f"Chat service unavailable. {err.status}: {err.detail}",
+            status_code=err.status,
+            detail=err.detail,
         )
     except IncompleteFindResultsError:
         return HTTPClientError(

--- a/nucliadb/nucliadb/search/api/v1/search.py
+++ b/nucliadb/nucliadb/search/api/v1/search.py
@@ -392,8 +392,8 @@ async def _search_endpoint(
         return HTTPClientError(status_code=412, detail=str(exc))
     except predict.ProxiedPredictAPIError as err:
         return HTTPClientError(
-            status_code=503,
-            detail=f"Inference service unavailable. {err.status}: {err.detail}",
+            status_code=err.status,
+            detail=err.detail,
         )
 
 

--- a/nucliadb/nucliadb/search/api/v1/summarize.py
+++ b/nucliadb/nucliadb/search/api/v1/summarize.py
@@ -57,6 +57,6 @@ async def summarize_endpoint(
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)
     except predict.ProxiedPredictAPIError as err:
         return HTTPClientError(
-            status_code=503,
-            detail=f"Summarize service unavailable. {err.status}: {err.detail}",
+            status_code=err.status,
+            detail=err.detail,
         )

--- a/nucliadb/nucliadb/search/tests/unit/api/v1/test_summarize.py
+++ b/nucliadb/nucliadb/search/tests/unit/api/v1/test_summarize.py
@@ -87,7 +87,5 @@ async def test_summarize_endpoint_handles_errors(
         kbid="kbid",
         item=Mock(),
     )
-    if isinstance(predict_error, LimitsExceededError):
-        assert response.status_code == 402
-    else:
-        assert response.status_code == 503
+    assert response.status_code == http_error_response.status_code
+    assert response.body == http_error_response.body


### PR DESCRIPTION
### Description
Before, we were catching all errors with predict api and returning a HTTP 503 to the nucliadb response, with the details of the error in the response body.

It seems that it may be better to proxy those errors so the client can handle them properly, for instance on too many tokens exceeded errors

### How was this PR tested?
Describe how you tested this PR.
