### PR TITLE
Use system openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,15 +2075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.2.3+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,7 +2082,6 @@ checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/nucliadb_node/Cargo.toml
+++ b/nucliadb_node/Cargo.toml
@@ -135,6 +135,6 @@ uuid = { version = "1.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
 serial_test = "2.0.0"
 tempfile = "3.2.0"
 regex = "1.5.5"
-openssl = { version = "0.10.57", features = ["vendored"] }
+openssl = { version = "0.10.57" }
 
 rstest = "0.18.2"

--- a/nucliadb_node_binding/Cargo.toml
+++ b/nucliadb_node_binding/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 bincode = "1.3.3"
 cargo-llvm-cov = "0.5.24"
 
-openssl = { version = "0.10.57", features = ["vendored"] }
+openssl = { version = "0.10.57" }
 prost = "0.10"
 prost-types = "0.10"
 tracing = { version = "0.1.29" }

--- a/scripts/install-system-deps.sh
+++ b/scripts/install-system-deps.sh
@@ -20,13 +20,12 @@ if [ "$machine" == "linux" ]; then
 	case $ID in
 	debian | ubuntu | mint)
 		$SUDO apt-get -y update
-		$SUDO apt-get install -y libdw-dev pkg-config libssl-dev cpanminus
-		$SUDO cpanm IPC::Cmd
+		$SUDO apt-get install -y libdw-dev pkg-config libssl-dev
 		;;
 
 	fedora | rhel | centos)
 		$SUDO yum update -y
-		$SUDO yum -y install elfutils-devel pkgconfig openssl-devel perl-IPC-Cmd
+		$SUDO yum -y install elfutils-devel pkgconfig openssl-devel
 		;;
 
 	*)


### PR DESCRIPTION
### Description

Use system openssl, instead of vendored version. Avoids compiling openssl when building images.
