### PR TITLE
Better file page position

### DIFF
--- a/nucliadb/nucliadb/ingest/tests/unit/orm/test_resource.py
+++ b/nucliadb/nucliadb/ingest/tests/unit/orm/test_resource.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from nucliadb_protos.resources_pb2 import (
@@ -32,10 +32,11 @@ from nucliadb_protos.resources_pb2 import (
 )
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
+from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.orm.resource import (
     Resource,
-    get_file_page_positions,
     get_text_field_mimetype,
+    maybe_get_file_page_positions,
     maybe_update_basic_icon,
     maybe_update_basic_summary,
     maybe_update_basic_thumbnail,
@@ -44,15 +45,16 @@ from nucliadb.ingest.orm.resource import (
 
 
 @pytest.mark.asyncio
-async def test_get_file_page_positions():
+async def test_maybe_get_file_page_positions():
     extracted_data = FileExtractedData()
     extracted_data.file_pages_previews.positions.extend(
         [PagePositions(start=0, end=10), PagePositions(start=11, end=20)]
     )
-    file_field = AsyncMock(
-        get_file_extracted_data=AsyncMock(return_value=extracted_data)
-    )
-    assert await get_file_page_positions(file_field) == {0: (0, 10), 1: (11, 20)}
+    file_field = File(id="foo", resource=Mock())
+    file_field.get_file_extracted_data = AsyncMock(return_value=extracted_data)
+    page_positions = await maybe_get_file_page_positions(file_field)
+    assert page_positions.get(1) == 0
+    assert page_positions.get(11) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Right now processing includes the page metadata at the paragraph level, so we don't need to calculate it from the extracted page start/end positions metadata.

However, we still need the later for backward compatibility for broker messages that didn't have it yet. 

### How was this PR tested?
Unit tests and local testing
