### PR TITLE
Use deprecated pointer to current shard in case of error

### DIFF
--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -176,7 +176,7 @@ class KBShardManager:
         active_shards = [shard for shard in kb_shards.shards if not shard.read_only]
 
         # B/c with Shards.actual
-        if len(active_shards) == 0:
+        if len(active_shards) == len(kb_shards.shards):
             # already not migrated
             shard = kb_shards.shards[kb_shards.actual]
         elif len(active_shards) == 1:

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -189,7 +189,9 @@ class KBShardManager:
                 errors.capture_message(
                     "KB with more than one active shard!", "error", scope
                 )
-            shard = active_shards[0]
+            # we keep being B/c with actual, if something is weird, use the
+            # shard pointed by actual
+            shard = kb_shards.shards[kb_shards.actual]
 
         return shard
 


### PR DESCRIPTION
### Description
Finding multiple open shards right now is a bug. As we maintain `actual` (the deprecated pointer) for B/c, use it instead of getting one of the possibly wrong active shards denoted by the new field

### How was this PR tested?
Describe how you tested this PR.
