### PR TITLE
Add running environment to nucliadb chart

### DIFF
--- a/charts/nucliadb/values.yaml
+++ b/charts/nucliadb/values.yaml
@@ -14,7 +14,7 @@ podAnnotations: {}
 # App settings: These are the settings that are passed to the NucliaDB application via environment variables.
 # See https://docs.nuclia.dev/docs/guides/nucliadb/configuration for a complete list of settings.
 env:
-  environment: prod
+  running_environment: prod
   NUCLIA_ZONE: "europe-1"
   CORS_ORIGINS: '["http://localhost:8080"]'
   #NUA_API_KEY: "..."

--- a/charts/nucliadb/values.yaml
+++ b/charts/nucliadb/values.yaml
@@ -14,6 +14,7 @@ podAnnotations: {}
 # App settings: These are the settings that are passed to the NucliaDB application via environment variables.
 # See https://docs.nuclia.dev/docs/guides/nucliadb/configuration for a complete list of settings.
 env:
+  environment: prod
   NUCLIA_ZONE: "europe-1"
   CORS_ORIGINS: '["http://localhost:8080"]'
   #NUA_API_KEY: "..."

--- a/nucliadb_utils/nucliadb_utils/settings.py
+++ b/nucliadb_utils/nucliadb_utils/settings.py
@@ -28,7 +28,9 @@ class RunningSettings(BaseSettings):
     debug: bool = True
     sentry_url: Optional[str] = None
     running_environment: str = Field(
-        default="local", env=["environment", "running_environment"]
+        default="local",
+        env=["environment", "running_environment"],
+        description="Running environment. One of: local, test, stage, prod",
     )
     metrics_port: int = 3030
     metrics_host: str = "0.0.0.0"


### PR DESCRIPTION
### Description
We need to set the value for the nucliadb onprem chart to "prod", otherwise it gets the default "local".
This was a problem as some featureflag are enabled by default on the "local" enviromnent.

### How was this PR tested?
I tested it in http://onprem.stashify.nuclia.com/
