### PR TITLE
Always x synchronous 

### DIFF
--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -52,7 +52,6 @@ def resource_id(kbid: str):
         headers={
             "content-type": "application/json",
             "X-NUCLIADB-ROLES": "WRITER",
-            "x-synchronous": "true",
             "x-ndb-client": "web",
         },
         json={

--- a/nucliadb/nucliadb/standalone/tests/integration/test_basic.py
+++ b/nucliadb/nucliadb/standalone/tests/integration/test_basic.py
@@ -34,7 +34,6 @@ async def test_basic_patch_thumbnail_sc_2390(
             "summary": "A simple summary",
             "thumbnail": "thumbnail-on-creation",
         },
-        headers={"X-Synchronous": "true"},
     )
     assert resp.status_code == 201
     rid = resp.json()["uuid"]
@@ -50,7 +49,6 @@ async def test_basic_patch_thumbnail_sc_2390(
     resp = await nucliadb_writer.patch(
         f"/{KB_PREFIX}/{knowledgebox_one}/resource/{rid}",
         json={"thumbnail": "thumbnail-modified"},
-        headers={"X-Synchronous": "true"},
     )
     assert resp.status_code == 200
 

--- a/nucliadb/nucliadb/standalone/tests/integration/test_delete_field.py
+++ b/nucliadb/nucliadb/standalone/tests/integration/test_delete_field.py
@@ -32,7 +32,6 @@ async def test_delete_field(
 ) -> None:
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox_one}/resources",
-        headers={"X-SYNCHRONOUS": "True"},
         json={
             "slug": "resource1",
             "title": "Resource 1",
@@ -51,7 +50,6 @@ async def test_delete_field(
 
     resp = await nucliadb_writer.delete(
         f"/{KB_PREFIX}/{knowledgebox_one}/resource/{uuid}/text/text1",
-        headers={"X-SYNCHRONOUS": "True"},
     )
     assert resp.status_code == 204
 

--- a/nucliadb/nucliadb/standalone/tests/integration/test_fieldmetadata.py
+++ b/nucliadb/nucliadb/standalone/tests/integration/test_fieldmetadata.py
@@ -120,7 +120,6 @@ async def test_fieldmetadata_crud(
 
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox_one}/resources",
-        headers={"X-SYNCHRONOUS": "True"},
         json={
             "texts": {
                 "textfield1": {"body": "Some text", "format": "PLAIN"},
@@ -141,7 +140,6 @@ async def test_fieldmetadata_crud(
 
     resp = await nucliadb_writer.patch(
         f"/{KB_PREFIX}/{knowledgebox_one}/resource/{rid}",
-        headers={"X-SYNCHRONOUS": "True"},
         json={"fieldmetadata": [fieldmetadata_1]},
     )
     assert resp.status_code == 200
@@ -162,7 +160,6 @@ async def test_fieldmetadata_crud(
 
     resp = await nucliadb_writer.patch(
         f"/{KB_PREFIX}/{knowledgebox_one}/resource/{rid}",
-        headers={"X-SYNCHRONOUS": "True"},
         json={"fieldmetadata": [fieldmetadata_2]},
     )
     assert resp.status_code == 200

--- a/nucliadb/nucliadb/standalone/tests/integration/test_upload_download.py
+++ b/nucliadb/nucliadb/standalone/tests/integration/test_upload_download.py
@@ -47,7 +47,6 @@ async def test_file_tus_upload_and_download(
     kb_path = f"/{KB_PREFIX}/{knowledgebox_one}"
     resp = await nucliadb_writer.post(
         f"{kb_path}/{RESOURCES_PREFIX}",
-        headers={"X-SYNCHRONOUS": "True"},
         json={
             "slug": "resource1",
             "title": "Resource 1",
@@ -84,7 +83,6 @@ async def test_file_tus_upload_and_download(
             headers = {
                 "upload-offset": f"{offset}",
                 "content-length": f"{len(data)}",
-                "X-SYNCHRONOUS": "True",
             }
             if len(data) < 10000:
                 headers["upload-length"] = f"{offset + len(data)}"

--- a/nucliadb/nucliadb/tests/fixtures.py
+++ b/nucliadb/nucliadb/tests/fixtures.py
@@ -241,7 +241,6 @@ async def knowledge_graph(
 ):
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"X-SYNCHRONOUS": "True"},
         json={
             "title": "Knowledge graph",
             "slug": "knowledgegraph",

--- a/nucliadb/nucliadb/tests/integration/search/test_filters_expression.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_filters_expression.py
@@ -42,7 +42,6 @@ async def test_filtering_expression(nucliadb_reader, nucliadb_writer, knowledgeb
                     "tags": [tag],
                 },
             },
-            headers={"x-synchronous": "true"},
         )
         assert resp.status_code == 201
         slug_to_uuid[slug] = resp.json()["uuid"]

--- a/nucliadb/nucliadb/tests/integration/search/test_search.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search.py
@@ -328,7 +328,6 @@ async def test_paragraph_search_with_filters(
             "title": "Mushrooms",
             "summary": "A very good book about mushrooms (aka funghi)",
         },
-        headers={"X-SYNCHRONOUS": "True"},
     )
     assert resp.status_code == 201
     rid = resp.json()["uuid"]
@@ -712,7 +711,6 @@ async def test_processing_status_doesnt_change_on_search_after_processed(
             json={
                 "title": "My new title",
             },
-            headers={"X-SYNCHRONOUS": "True"},
             timeout=None,
         )
     ).status_code == 200
@@ -755,7 +753,6 @@ async def test_search_automatic_relations(
 
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"X-Synchronous": "true"},
         json={
             "title": "My resource",
             "slug": "myresource",
@@ -1110,7 +1107,6 @@ async def test_resource_search_pagination(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"X-Synchronous": "true"},
         json={
             "title": "Resource with ",
             "slug": "resource-with-texts",
@@ -1230,7 +1226,6 @@ async def create_dummy_resources(
     for payload in payloads:
         resp = await nucliadb_writer.post(
             f"/kb/{kbid}/resources",
-            headers={"X-Synchronous": "true"},
             json=payload,
         )
         assert resp.status_code == 201
@@ -1512,7 +1507,6 @@ async def test_search_by_path_filter(
     for path in paths:
         resp = await nucliadb_writer.post(
             f"/kb/{knowledgebox}/resources",
-            headers={"X-Synchronous": "true"},
             json={
                 "title": f"My resource: {path}",
                 "summary": "Some summary",

--- a/nucliadb/nucliadb/tests/integration/search/test_search_date_ranges_filter.py
+++ b/nucliadb/nucliadb/tests/integration/search/test_search_date_ranges_filter.py
@@ -164,7 +164,6 @@ async def test_search_with_date_range_filters_origin_dates(
                 "modified": ORIGIN_MODIFICATION.isoformat(),
             },
         },
-        headers={"X-Synchronous": "true"},
     )
     assert resp.status_code == 200
 

--- a/nucliadb/nucliadb/tests/integration/test_api.py
+++ b/nucliadb/nucliadb/tests/integration/test_api.py
@@ -524,7 +524,6 @@ async def test_extra(
             "title": "Foo",
             "extra": extra,
         },
-        headers={"X-SYNCHRONOUS": "true"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -575,7 +574,6 @@ async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
         json={"title": "Foo", "icon": "application/pdf"},
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -590,7 +588,6 @@ async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
         json={
             "usermetadata": {"classifications": [{"labelset": "foo", "label": "bar"}]}
         },
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 200
@@ -649,7 +646,6 @@ async def test_icon_doesnt_change_after_adding_file_field_sc_2388(
             "icon": "text/plain",
             "texts": {"text": {"body": "my text"}},
         },
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -662,7 +658,6 @@ async def test_icon_doesnt_change_after_adding_file_field_sc_2388(
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resource/{uuid}/file/file/upload",
         content=b"foo" * 200,
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -683,7 +678,6 @@ async def test_language_metadata(
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
         json={"title": "My resource"},
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -725,7 +719,6 @@ async def test_language_metadata(
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
         json={"metadata": {"language": "en"}},
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -742,7 +735,6 @@ async def test_language_metadata(
     resp = await nucliadb_writer.patch(
         f"/kb/{kbid}/resource/{uuid}",
         json={"metadata": {"language": "de"}},
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 200

--- a/nucliadb/nucliadb/tests/integration/test_ask.py
+++ b/nucliadb/nucliadb/tests/integration/test_ask.py
@@ -46,7 +46,6 @@ async def test_ask_document(
             "summary": "The summary",
             "texts": {"text_field": {"body": "The body of the text field"}},
         },
-        headers={"X-Synchronous": "True"},
     )
     assert resp.status_code in (200, 201)
     rid = resp.json()["uuid"]

--- a/nucliadb/nucliadb/tests/integration/test_chat.py
+++ b/nucliadb/nucliadb/tests/integration/test_chat.py
@@ -92,7 +92,6 @@ async def resource(nucliadb_writer, knowledgebox):
             "summary": "The summary",
             "texts": {"text_field": {"body": "The body of the text field"}},
         },
-        headers={"X-Synchronous": "True"},
     )
     assert resp.status_code in (200, 201)
     rid = resp.json()["uuid"]
@@ -313,7 +312,6 @@ async def resources(nucliadb_writer, knowledgebox):
                 "summary": f"The summary {i}",
                 "texts": {"text_field": {"body": "The body of the text field"}},
             },
-            headers={"X-Synchronous": "True"},
         )
         assert resp.status_code in (200, 201)
         rid = resp.json()["uuid"]

--- a/nucliadb/nucliadb/tests/integration/test_conversation.py
+++ b/nucliadb/nucliadb/tests/integration/test_conversation.py
@@ -61,7 +61,7 @@ async def resource_with_conversation(nucliadb_grpc, nucliadb_writer, knowledgebo
         )
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"Content-Type": "application/json", "X-Synchronous": "true"},
+        headers={"Content-Type": "application/json"},
         data=CreateResourcePayload(  # type: ignore
             slug="myresource",
             conversations={

--- a/nucliadb/nucliadb/tests/integration/test_entities.py
+++ b/nucliadb/nucliadb/tests/integration/test_entities.py
@@ -73,7 +73,6 @@ async def text_field(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"X-Synchronous": "true"},
         json={
             "slug": "entities-test-resource",
             "title": "E2E entities test resource",
@@ -134,7 +133,6 @@ async def annotated_entities(
 
     resp = await nucliadb_writer.patch(
         f"/kb/{kbid}/resource/{rid}",
-        headers={"X-Synchronous": "true"},
         json={
             "fieldmetadata": [
                 {

--- a/nucliadb/nucliadb/tests/integration/test_export_import.py
+++ b/nucliadb/nucliadb/tests/integration/test_export_import.py
@@ -48,7 +48,6 @@ async def src_kb(nucliadb_writer, nucliadb_manager):
                 "icon": "application/pdf",
                 "slug": f"test-{i}",
             },
-            headers={"X-SYNCHRONOUS": "true"},
             timeout=None,
         )
         assert resp.status_code == 201
@@ -60,7 +59,6 @@ async def src_kb(nucliadb_writer, nucliadb_manager):
             f"/kb/{kbid}/resource/{rid}/file/file/upload",
             headers={
                 "X-Filename": base64.b64encode(b"testfile").decode("utf-8"),
-                "X-Synchronous": "true",
                 "Content-Type": "text/plain",
             },
             content=base64.b64encode(content),

--- a/nucliadb/nucliadb/tests/integration/test_field_external_file.py
+++ b/nucliadb/nucliadb/tests/integration/test_field_external_file.py
@@ -52,7 +52,6 @@ async def test_external_file_field(
     kb_path = f"/{KB_PREFIX}/{knowledgebox}"
     resp = await nucliadb_writer.post(
         f"{kb_path}/{RESOURCES_PREFIX}",
-        headers={"X-SYNCHRONOUS": "True"},
         json={
             "slug": "resource1",
             "title": "Resource 1",
@@ -65,7 +64,6 @@ async def test_external_file_field(
     # Create the external file field to the resource
     resp = await nucliadb_writer.put(
         f"{kb_path}/{RESOURCE_PREFIX}/{resource}/file/field2",
-        headers={"X-SYNCHRONOUS": "True"},
         json=TEST_EXTERNAL_FILE_FIELD_PAYLOAD,
     )
     assert resp.status_code == 201
@@ -88,7 +86,6 @@ async def test_external_file_field(
     # Try the patch
     resp = await nucliadb_writer.patch(
         f"{kb_path}/{RESOURCE_PREFIX}/{resource}",
-        headers={"X-SYNCHRONOUS": "True"},
         json={"files": {"field3": TEST_EXTERNAL_FILE_FIELD_PAYLOAD}},
     )
     assert resp.status_code == 200

--- a/nucliadb/nucliadb/tests/integration/test_find.py
+++ b/nucliadb/nucliadb/tests/integration/test_find.py
@@ -86,7 +86,6 @@ async def test_find_with_label_changes(
                 "relations": [],
             }
         },
-        headers={"X-SYNCHRONOUS": "True"},
         timeout=None,
     )
     assert resp.status_code == 200
@@ -137,7 +136,6 @@ async def test_find_resource_filters(
             "summary": "My summary",
             "icon": "text/plain",
         },
-        headers={"X-SYNCHRONOUS": "True"},
     )
     assert resp.status_code == 201
     rid1 = resp.json()["uuid"]
@@ -149,7 +147,6 @@ async def test_find_resource_filters(
             "summary": "My summary",
             "icon": "text/plain",
         },
-        headers={"X-SYNCHRONOUS": "True"},
     )
     assert resp.status_code == 201
     rid2 = resp.json()["uuid"]

--- a/nucliadb/nucliadb/tests/integration/test_labels.py
+++ b/nucliadb/nucliadb/tests/integration/test_labels.py
@@ -209,7 +209,6 @@ async def test_classification_labels_cancelled_by_the_user(
     }
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"X-SYNCHRONOUS": "TRUE"},
         json={
             "title": "My Resource",
             "summary": "My summary",
@@ -350,7 +349,6 @@ async def test_fieldmetadata_classification_labels(
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
         data=payload.json(),  # type: ignore
-        headers={"X-SYNCHRONOUS": "True"},
     )
     assert resp.status_code == 201
     rid = resp.json()["uuid"]

--- a/nucliadb/nucliadb/tests/integration/test_purge.py
+++ b/nucliadb/nucliadb/tests/integration/test_purge.py
@@ -68,7 +68,6 @@ async def test_purge_deletes_everything_from_maindb(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"x-synchronous": "true"},
         json={
             "title": "My title",
             "slug": "myresource",
@@ -132,7 +131,6 @@ async def test_purge_orphan_shards(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"x-synchronous": "true"},
         json={
             "title": "My title",
             "slug": "myresource",

--- a/nucliadb/nucliadb/tests/integration/test_resources.py
+++ b/nucliadb/nucliadb/tests/integration/test_resources.py
@@ -35,7 +35,6 @@ async def test_last_seqid_is_stored_in_resource(
 ):
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-        headers={"X-SYNCHRONOUS": "True"},
         json={
             "texts": {
                 "textfield1": {"body": "Some text", "format": "PLAIN"},
@@ -68,7 +67,6 @@ async def test_resource_crud(
 ):
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-        headers={"X-Synchronous": "true"},
         json={
             "slug": "mykb",
             "title": "My KB",
@@ -83,7 +81,6 @@ async def test_resource_crud(
 
     resp = await nucliadb_writer.patch(
         f"/{KB_PREFIX}/{knowledgebox}/resource/{rid}",
-        headers={"X-Synchronous": "true"},
         json={
             "title": "My updated KB",
         },
@@ -96,7 +93,6 @@ async def test_resource_crud(
 
     resp = await nucliadb_writer.delete(
         f"/{KB_PREFIX}/{knowledgebox}/resource/{rid}",
-        headers={"X-Synchronous": "true"},
     )
     assert resp.status_code == 204
 
@@ -120,7 +116,6 @@ async def test_list_resources(
     for _ in range(20):
         resp = await nucliadb_writer.post(
             f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-            headers={"X-Synchronous": "true"},
             json={
                 "title": "My resource",
             },
@@ -158,7 +153,6 @@ async def test_get_resource_field(
 
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-        headers={"X-Synchronous": "true"},
         json={
             "slug": slug,
             "title": "My Resource",
@@ -193,7 +187,6 @@ async def test_resource_creation_slug_conflicts(
     resources_path = f"/{KB_PREFIX}/{{knowledgebox}}/{RESOURCES_PREFIX}"
     resp = await nucliadb_writer.post(
         resources_path.format(knowledgebox=knowledgebox),
-        headers={"X-Synchronous": "true"},
         json={
             "slug": slug,
         },
@@ -202,7 +195,6 @@ async def test_resource_creation_slug_conflicts(
 
     resp = await nucliadb_writer.post(
         resources_path.format(knowledgebox=knowledgebox),
-        headers={"X-Synchronous": "true"},
         json={
             "slug": slug,
         },
@@ -212,7 +204,6 @@ async def test_resource_creation_slug_conflicts(
     # Creating it in another KB should not raise conflict error
     resp = await nucliadb_writer.post(
         resources_path.format(knowledgebox=philosophy_books_kb),
-        headers={"X-Synchronous": "true"},
         json={
             "slug": slug,
         },
@@ -229,7 +220,6 @@ async def test_title_is_set_automatically_if_not_provided(
 ):
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-        headers={"X-Synchronous": "true"},
         json={
             "texts": {"text-field": {"body": "test1", "format": "PLAIN"}},
         },
@@ -246,18 +236,15 @@ async def test_title_is_set_automatically_if_not_provided(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
 @pytest.mark.parametrize("update_by", ["slug", "uuid"])
-@pytest.mark.parametrize("x_synchronous", [True, False])
 async def test_resource_slug_modification(
     nucliadb_reader,
     nucliadb_writer,
     knowledgebox,
     update_by,
-    x_synchronous,
 ):
     old_slug = "my-resource"
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-        headers={"X-Synchronous": "true"},
         json={
             "title": "My Resource",
             "slug": old_slug,
@@ -276,7 +263,6 @@ async def test_resource_slug_modification(
         path = f"/{KB_PREFIX}/{knowledgebox}/resource/{rid}"
     resp = await nucliadb_writer.patch(
         path,
-        headers={"X-Synchronous": str(x_synchronous).lower()},
         json={
             "slug": new_slug,
             "title": "New title",
@@ -313,7 +299,6 @@ async def test_resource_slug_modification_rollbacks(
     old_slug = "my-resource"
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-        headers={"X-Synchronous": "true"},
         json={
             "title": "Old title",
             "slug": old_slug,
@@ -331,7 +316,6 @@ async def test_resource_slug_modification_rollbacks(
     ):
         resp = await nucliadb_writer.patch(
             f"/{KB_PREFIX}/{knowledgebox}/resource/{rid}",
-            headers={"X-Synchronous": "true"},
             json={
                 "slug": "my-resource-2",
                 "title": "New title",
@@ -358,7 +342,6 @@ async def test_resource_slug_modification_handles_conflicts(
         slugs.append(slug)
         resp = await nucliadb_writer.post(
             f"/{KB_PREFIX}/{knowledgebox}/{RESOURCES_PREFIX}",
-            headers={"X-Synchronous": "true"},
             json={
                 "title": "My Resource",
                 "slug": slug,
@@ -372,7 +355,6 @@ async def test_resource_slug_modification_handles_conflicts(
     path = f"/{KB_PREFIX}/{knowledgebox}/resource/{rids[0]}"
     resp = await nucliadb_writer.patch(
         path,
-        headers={"X-Synchronous": "true"},
         json={
             "slug": slugs[1],
         },
@@ -388,7 +370,6 @@ async def test_resource_slug_modification_handles_unknown_resources(
 ):
     resp = await nucliadb_writer.patch(
         f"/{KB_PREFIX}/{knowledgebox}/resource/foobar",
-        headers={"X-Synchronous": "true"},
         json={
             "slug": "foo",
         },

--- a/nucliadb/nucliadb/tests/integration/test_security.py
+++ b/nucliadb/nucliadb/tests/integration/test_security.py
@@ -162,7 +162,6 @@ async def test_resource_security_search(
                 "access_groups": [],
             },
         },
-        headers={"x-synchronous": "true"},
     )
     assert resp.status_code == 200, resp.text
 

--- a/nucliadb/nucliadb/tests/integration/test_suggest.py
+++ b/nucliadb/nucliadb/tests/integration/test_suggest.py
@@ -193,7 +193,6 @@ async def test_suggest_related_entities(
     ]
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"X-Synchronous": "True"},
         json={
             "title": "People and places",
             "slug": "pap",
@@ -286,7 +285,6 @@ async def test_suggestion_on_link_computed_titles_sc6088(
                 }
             },
         },
-        headers={"X-Synchronous": "True"},
         timeout=None,
     )
     assert resp.status_code == 201
@@ -468,7 +466,6 @@ async def entities(nucliadb_writer: AsyncClient, knowledgebox: str):
     ]
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"X-Synchronous": "True"},
         json={
             "title": "People and places",
             "slug": "pap",

--- a/nucliadb/nucliadb/tests/integration/test_text_field_json.py
+++ b/nucliadb/nucliadb/tests/integration/test_text_field_json.py
@@ -38,7 +38,6 @@ async def test_text_field_in_json_format(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"x-synchronous": "true"},
         json={
             "title": "JSON text field",
             "texts": {
@@ -72,7 +71,6 @@ async def test_text_field_with_invalid_json(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"x-synchronous": "true"},
         json={
             "title": "JSON text field",
             "texts": {

--- a/nucliadb/nucliadb/tests/integration/test_tokens.py
+++ b/nucliadb/nucliadb/tests/integration/test_tokens.py
@@ -38,7 +38,6 @@ async def test_metadata_tokens_cancelled_by_the_user_sc_3775(
     }
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
-        headers={"X-Synchronous": "true"},
         json={
             "title": "My Resource",
             "summary": "My summary",

--- a/nucliadb/nucliadb/tests/integration/test_upload.py
+++ b/nucliadb/nucliadb/tests/integration/test_upload.py
@@ -37,7 +37,6 @@ async def test_upload(
         f"/kb/{knowledgebox}/{UPLOAD}",
         headers={
             "X-Filename": base64.b64encode(b"testfile").decode("utf-8"),
-            "X-Synchronous": "true",
             "Content-Type": "text/plain",
             "Content-Length": str(len(content)),
         },
@@ -83,7 +82,6 @@ async def test_upload_guesses_content_type(
         f"/kb/{knowledgebox}/{UPLOAD}",
         headers={
             "X-Filename": base64.b64encode(filename.encode()).decode("utf-8"),
-            "X-Synchronous": "true",
         },
         content=base64.b64encode(content),
     )

--- a/nucliadb/nucliadb/tests/integration/test_visual_selections.py
+++ b/nucliadb/nucliadb/tests/integration/test_visual_selections.py
@@ -65,7 +65,6 @@ async def annotated_file_field(
 
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
-        headers={"x-synchronous": "true"},
         json={
             "title": "My invoice",
             "files": {

--- a/nucliadb/nucliadb/tests/knowledgeboxes/philosophy_books.py
+++ b/nucliadb/nucliadb/tests/knowledgeboxes/philosophy_books.py
@@ -192,7 +192,6 @@ async def philosophy_books_kb(
     for payload in payloads:
         resp = await nucliadb_writer.post(
             f"/kb/{kbid}/resources",
-            headers={"X-Synchronous": "true"},
             json=payload,
         )
         assert resp.status_code == 201

--- a/nucliadb/nucliadb/tests/knowledgeboxes/ten_dummy_resources.py
+++ b/nucliadb/nucliadb/tests/knowledgeboxes/ten_dummy_resources.py
@@ -47,7 +47,6 @@ async def ten_dummy_resources_kb(
     for payload in payloads:
         resp = await nucliadb_writer.post(
             f"/kb/{kbid}/resources",
-            headers={"X-Synchronous": "true"},
             json=payload,
         )
         assert resp.status_code == 201
@@ -91,7 +90,6 @@ async def ten_quick_dummy_resources_kb(
     for payload in payloads:
         resp = await nucliadb_writer.post(
             f"/kb/{kbid}/resources",
-            headers={"X-Synchronous": "true"},
             json=payload,
         )
         assert resp.status_code == 201

--- a/nucliadb/nucliadb/train/tests/test_image_classification.py
+++ b/nucliadb/nucliadb/train/tests/test_image_classification.py
@@ -110,7 +110,6 @@ async def image_classification_resource(
 
     resp = await writer_rest_api.post(
         f"/{API_PREFIX}/v1/{KB_PREFIX}/{knowledgebox}/resources",
-        headers={"x-synchronous": "true"},
         json={
             "title": "My invoice",
             "files": {

--- a/nucliadb/nucliadb/writer/api/constants.py
+++ b/nucliadb/nucliadb/writer/api/constants.py
@@ -23,17 +23,12 @@ from fastapi.params import Header
 
 if TYPE_CHECKING:  # pragma: no cover
     SKIP_STORE_DEFAULT = False
-    SYNC_CALL = False
     X_NUCLIADB_USER = ""
     X_FILE_PASSWORD = None
 else:
     SKIP_STORE_DEFAULT = Header(
         False,
         description="If set to true, file fields will not be saved in the blob storage. They will only be sent to process.",  # noqa
-    )
-    SYNC_CALL = Header(
-        False,
-        description="If set to true, the request will return when the changes to be commited to the database.",
     )
     X_NUCLIADB_USER = Header("")
     X_FILE_PASSWORD = Header(

--- a/nucliadb/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/nucliadb/writer/api/v1/field.py
@@ -116,7 +116,8 @@ async def finish_field_put(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
@@ -657,7 +658,8 @@ async def _append_messages_to_conversation_field(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     try:
@@ -755,7 +757,8 @@ async def _append_blocks_to_layout_field(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
@@ -840,7 +843,8 @@ async def _delete_resource_field(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     return Response(status_code=204)
@@ -915,7 +919,8 @@ async def reprocess_file_field(
         await transaction.commit(writer, partition, wait=False)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
     # Send current resource to reprocess.
     try:

--- a/nucliadb/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/nucliadb/writer/api/v1/field.py
@@ -125,7 +125,10 @@ async def finish_field_put(
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
-        raise HTTPException(status_code=500, detail="Error while sending to process")
+        raise HTTPException(
+            status_code=500,
+            detail="Error while sending to process. Try calling /reprocess",
+        )
 
 
 @api.put(
@@ -661,13 +664,15 @@ async def _append_messages_to_conversation_field(
             status_code=501,
             detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
-
     try:
         processing_info = await processing.send_to_process(toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
-        raise HTTPException(status_code=500, detail="Error while sending to process")
+        raise HTTPException(
+            status_code=500,
+            detail="Error while sending to process. Try calling /reprocess",
+        )
 
     return ResourceFieldAdded(seqid=processing_info.seqid)
 
@@ -765,7 +770,10 @@ async def _append_blocks_to_layout_field(
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
-        raise HTTPException(status_code=500, detail="Error while sending to process")
+        raise HTTPException(
+            status_code=500,
+            detail="Error while sending to process. Try calling /reprocess",
+        )
     return ResourceFieldAdded(seqid=processing_info.seqid)
 
 
@@ -928,6 +936,9 @@ async def reprocess_file_field(
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
-        raise HTTPException(status_code=500, detail="Error while sending to process")
+        raise HTTPException(
+            status_code=500,
+            detail="Error while sending to process. Try calling /reprocess",
+        )
 
     return ResourceUpdated(seqid=processing_info.seqid)

--- a/nucliadb/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/nucliadb/writer/api/v1/field.py
@@ -32,7 +32,6 @@ from nucliadb.ingest.processing import PushPayload, Source
 from nucliadb.writer import SERVICE_NAME
 from nucliadb.writer.api.constants import (
     SKIP_STORE_DEFAULT,
-    SYNC_CALL,
     X_FILE_PASSWORD,
     X_NUCLIADB_USER,
 )
@@ -108,7 +107,6 @@ async def finish_field_put(
     writer: BrokerMessage,
     toprocess: PushPayload,
     partition: int,
-    wait_on_commit: bool,
 ) -> Optional[int]:
     # Create processing message
     transaction = get_transaction_utility()
@@ -118,7 +116,7 @@ async def finish_field_put(
 
     writer.source = BrokerMessage.MessageSource.WRITER
     set_processing_info(writer, processing_info)
-    await transaction.commit(writer, partition, wait=wait_on_commit)
+    await transaction.commit(writer, partition, wait=True)
 
     return processing_info.seqid
 
@@ -138,14 +136,12 @@ async def add_resource_field_text_rslug_prefix(
     rslug: str,
     field_id: str,
     field_payload: models.TextField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_text(
         request,
         kbid,
         field_id,
         field_payload,
-        x_synchronous,
         rslug=rslug,
     )
 
@@ -165,14 +161,12 @@ async def add_resource_field_text_rid_prefix(
     rid: str,
     field_id: str,
     field_payload: models.TextField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_text(
         request,
         kbid,
         field_id,
         field_payload,
-        x_synchronous,
         rid=rid,
     )
 
@@ -182,7 +176,6 @@ async def _add_resource_field_text(
     kbid: str,
     field_id: str,
     field_payload: models.TextField,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -193,7 +186,7 @@ async def _add_resource_field_text(
     writer, toprocess, partition = prepare_field_put(kbid, rid, request)
     parse_text_field(field_id, field_payload, writer, toprocess)
     try:
-        seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -217,10 +210,9 @@ async def add_resource_field_link_rslug_prefix(
     rslug: str,
     field_id: str,
     field_payload: models.LinkField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_link(
-        request, kbid, field_id, field_payload, x_synchronous, rslug=rslug
+        request, kbid, field_id, field_payload, rslug=rslug
     )
 
 
@@ -239,10 +231,9 @@ async def add_resource_field_link_rid_prefix(
     rid: str,
     field_id: str,
     field_payload: models.LinkField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_link(
-        request, kbid, field_id, field_payload, x_synchronous, rid=rid
+        request, kbid, field_id, field_payload, rid=rid
     )
 
 
@@ -251,7 +242,6 @@ async def _add_resource_field_link(
     kbid: str,
     field_id: str,
     field_payload: models.LinkField,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -262,7 +252,7 @@ async def _add_resource_field_link(
     writer, toprocess, partition = prepare_field_put(kbid, rid, request)
     parse_link_field(field_id, field_payload, writer, toprocess)
     try:
-        seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -286,10 +276,9 @@ async def add_resource_field_keywordset_rslug_prefix(
     rslug: str,
     field_id: str,
     field_payload: models.FieldKeywordset,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_keywordset(
-        request, kbid, field_id, field_payload, x_synchronous, rslug=rslug
+        request, kbid, field_id, field_payload, rslug=rslug
     )
 
 
@@ -308,10 +297,9 @@ async def add_resource_field_keywordset_rid_prefix(
     rid: str,
     field_id: str,
     field_payload: models.FieldKeywordset,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_keywordset(
-        request, kbid, field_id, field_payload, x_synchronous, rid=rid
+        request, kbid, field_id, field_payload, rid=rid
     )
 
 
@@ -320,7 +308,6 @@ async def _add_resource_field_keywordset(
     kbid: str,
     field_id: str,
     field_payload: models.FieldKeywordset,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -331,7 +318,7 @@ async def _add_resource_field_keywordset(
     writer, toprocess, partition = prepare_field_put(kbid, rid, request)
     parse_keywordset_field(field_id, field_payload, writer, toprocess)
     try:
-        seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -355,10 +342,9 @@ async def add_resource_field_datetime_rslug_prefix(
     rslug: str,
     field_id: str,
     field_payload: models.FieldDatetime,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_datetime(
-        request, kbid, field_id, field_payload, x_synchronous, rslug=rslug
+        request, kbid, field_id, field_payload, rslug=rslug
     )
 
 
@@ -377,10 +363,9 @@ async def add_resource_field_datetime_rid_prefix(
     rid: str,
     field_id: str,
     field_payload: models.FieldDatetime,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_datetime(
-        request, kbid, field_id, field_payload, x_synchronous, rid=rid
+        request, kbid, field_id, field_payload, rid=rid
     )
 
 
@@ -389,7 +374,6 @@ async def _add_resource_field_datetime(
     kbid: str,
     field_id: str,
     field_payload: models.FieldDatetime,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -400,7 +384,7 @@ async def _add_resource_field_datetime(
     writer, toprocess, partition = prepare_field_put(kbid, rid, request)
     parse_datetime_field(field_id, field_payload, writer, toprocess)
     try:
-        seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -424,14 +408,12 @@ async def add_resource_field_layout_rslug_prefix(
     rslug: str,
     field_id: str,
     field_payload: models.InputLayoutField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_layout(
         request,
         kbid,
         field_id,
         field_payload,
-        x_synchronous,
         rslug=rslug,
     )
 
@@ -451,10 +433,9 @@ async def add_resource_field_layout_rid_prefix(
     rid: str,
     field_id: str,
     field_payload: models.InputLayoutField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_layout(
-        request, kbid, field_id, field_payload, x_synchronous, rid=rid
+        request, kbid, field_id, field_payload, rid=rid
     )
 
 
@@ -463,7 +444,6 @@ async def _add_resource_field_layout(
     kbid: str,
     field_id: str,
     field_payload: models.InputLayoutField,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -474,7 +454,7 @@ async def _add_resource_field_layout(
     writer, toprocess, partition = prepare_field_put(kbid, rid, request)
     await parse_layout_field(field_id, field_payload, writer, toprocess, kbid, rid)
     try:
-        seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -498,10 +478,9 @@ async def add_resource_field_conversation_rslug_prefix(
     rslug: str,
     field_id: str,
     field_payload: models.InputConversationField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_conversation(
-        request, kbid, field_id, field_payload, x_synchronous, rslug=rslug
+        request, kbid, field_id, field_payload, rslug=rslug
     )
 
 
@@ -520,10 +499,9 @@ async def add_resource_field_conversation_rid_prefix(
     rid: str,
     field_id: str,
     field_payload: models.InputConversationField,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_conversation(
-        request, kbid, field_id, field_payload, x_synchronous, rid=rid
+        request, kbid, field_id, field_payload, rid=rid
     )
 
 
@@ -532,7 +510,6 @@ async def _add_resource_field_conversation(
     kbid: str,
     field_id: str,
     field_payload: models.InputConversationField,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -545,7 +522,7 @@ async def _add_resource_field_conversation(
         field_id, field_payload, writer, toprocess, kbid, rid
     )
     try:
-        seqid = await finish_field_put(writer, toprocess, partition, x_synchronous)
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -570,7 +547,6 @@ async def add_resource_field_file_rslug_prefix(
     field_id: str,
     field_payload: models.FileField,
     x_skip_store: bool = SKIP_STORE_DEFAULT,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_file(
         request,
@@ -578,7 +554,6 @@ async def add_resource_field_file_rslug_prefix(
         field_id,
         field_payload,
         x_skip_store,
-        x_synchronous,
         rslug=rslug,
     )
 
@@ -599,10 +574,9 @@ async def add_resource_field_file_rid_prefix(
     field_id: str,
     field_payload: models.FileField,
     x_skip_store: bool = SKIP_STORE_DEFAULT,
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _add_resource_field_file(
-        request, kbid, field_id, field_payload, x_skip_store, x_synchronous, rid=rid
+        request, kbid, field_id, field_payload, x_skip_store, rid=rid
     )
 
 
@@ -612,7 +586,6 @@ async def _add_resource_field_file(
     field_id: str,
     field_payload: models.FileField,
     x_skip_store: bool,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -626,9 +599,7 @@ async def _add_resource_field_file(
     )
 
     try:
-        seqid = await finish_field_put(
-            writer, toprocess, partition, wait_on_commit=x_synchronous
-        )
+        seqid = await finish_field_put(writer, toprocess, partition)
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
@@ -652,10 +623,9 @@ async def append_messages_to_conversation_field_rslug_prefix(
     rslug: str,
     field_id: str,
     messages: list[models.InputMessage],
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _append_messages_to_conversation_field(
-        request, kbid, field_id, messages, x_synchronous, rslug=rslug
+        request, kbid, field_id, messages, rslug=rslug
     )
 
 
@@ -674,10 +644,9 @@ async def append_messages_to_conversation_field_rid_prefix(
     rid: str,
     field_id: str,
     messages: list[models.InputMessage],
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _append_messages_to_conversation_field(
-        request, kbid, field_id, messages, x_synchronous, rid=rid
+        request, kbid, field_id, messages, rid=rid
     )
 
 
@@ -686,7 +655,6 @@ async def _append_messages_to_conversation_field(
     kbid: str,
     field_id: str,
     messages: list[models.InputMessage],
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -730,7 +698,7 @@ async def _append_messages_to_conversation_field(
 
     writer.source = BrokerMessage.MessageSource.WRITER
     set_processing_info(writer, processing_info)
-    await transaction.commit(writer, partition, wait=x_synchronous)
+    await transaction.commit(writer, partition, wait=True)
 
     return ResourceFieldAdded(seqid=processing_info.seqid)
 
@@ -750,10 +718,9 @@ async def append_blocks_to_layout_field_rslug_prefix(
     rslug: str,
     field_id: str,
     blocks: dict[str, models.InputBlock],
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _append_blocks_to_layout_field(
-        request, kbid, field_id, blocks, x_synchronous, rslug=rslug
+        request, kbid, field_id, blocks, rslug=rslug
     )
 
 
@@ -772,10 +739,9 @@ async def append_blocks_to_layout_field_rid_prefix(
     rid: str,
     field_id: str,
     blocks: dict[str, models.InputBlock],
-    x_synchronous: bool = SYNC_CALL,
 ) -> ResourceFieldAdded:
     return await _append_blocks_to_layout_field(
-        request, kbid, field_id, blocks, x_synchronous, rid=rid
+        request, kbid, field_id, blocks, rid=rid
     )
 
 
@@ -784,7 +750,6 @@ async def _append_blocks_to_layout_field(
     kbid: str,
     field_id: str,
     blocks: dict[str, models.InputBlock],
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ) -> ResourceFieldAdded:
@@ -827,7 +792,7 @@ async def _append_blocks_to_layout_field(
 
     writer.source = BrokerMessage.MessageSource.WRITER
     set_processing_info(writer, processing_info)
-    await transaction.commit(writer, partition, wait=x_synchronous)
+    await transaction.commit(writer, partition, wait=True)
 
     return ResourceFieldAdded(seqid=processing_info.seqid)
 
@@ -847,14 +812,12 @@ async def delete_resource_field_rslug_prefix(
     rslug: str,
     field_type: models.FieldTypeName,
     field_id: str,
-    x_synchronous: bool = SYNC_CALL,
 ):
     return await _delete_resource_field(
         request,
         kbid,
         field_type,
         field_id,
-        x_synchronous,
         rslug=rslug,
     )
 
@@ -874,11 +837,8 @@ async def delete_resource_field_rid_prefix(
     rid: str,
     field_type: models.FieldTypeName,
     field_id: str,
-    x_synchronous: bool = SYNC_CALL,
 ):
-    return await _delete_resource_field(
-        request, kbid, field_type, field_id, x_synchronous, rid=rid
-    )
+    return await _delete_resource_field(request, kbid, field_type, field_id, rid=rid)
 
 
 async def _delete_resource_field(
@@ -886,7 +846,6 @@ async def _delete_resource_field(
     kbid: str,
     field_type: models.FieldTypeName,
     field_id: str,
-    x_synchronous: bool,
     rid: Optional[str] = None,
     rslug: Optional[str] = None,
 ):
@@ -908,7 +867,7 @@ async def _delete_resource_field(
     writer.delete_fields.append(pb_field_id)
     parse_audit(writer.audit, request)
 
-    await transaction.commit(writer, partition, wait=x_synchronous)
+    await transaction.commit(writer, partition, wait=True)
 
     return Response(status_code=204)
 

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -714,7 +714,10 @@ async def send_to_process(toprocess: PushPayload, partition) -> ProcessingInfo:
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
-        raise HTTPException(status_code=500, detail="Error while sending to process")
+        raise HTTPException(
+            status_code=500,
+            detail="Error while sending to process. Try calling /reprocess",
+        )
 
 
 def needs_reprocess(processing_payload: PushPayload) -> bool:

--- a/nucliadb/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/nucliadb/writer/api/v1/resource.py
@@ -192,7 +192,8 @@ async def create_resource(
         txn_time = time() - t0
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     seqid = await maybe_send_to_process(toprocess, partition)
@@ -353,7 +354,8 @@ async def modify_resource(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     seqid = await maybe_send_to_process(toprocess, partition)
@@ -492,7 +494,8 @@ async def _reprocess_resource(
         await transaction.commit(writer, partition, wait=False)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     processing_info = await send_to_process(toprocess, partition)
@@ -557,7 +560,8 @@ async def _delete_resource(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     processing = get_processing()

--- a/nucliadb/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/nucliadb/writer/api/v1/upload.py
@@ -944,7 +944,8 @@ async def store_file_on_nuclia_db(
         await transaction.commit(writer, partition, wait=True)
     except TransactionCommitTimeoutError:
         raise HTTPException(
-            status_code=501, detail="Inconsistent write. Commit timeout"
+            status_code=501,
+            detail="Inconsistent write. This resource will not be processed and may not be stored.",
         )
 
     try:

--- a/nucliadb/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/nucliadb/writer/api/v1/upload.py
@@ -953,7 +953,10 @@ async def store_file_on_nuclia_db(
     except LimitsExceededError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
     except SendToProcessError:
-        raise HTTPException(status_code=500, detail="Error while sending to process")
+        raise HTTPException(
+            status_code=500,
+            detail="Error while sending to process. Try calling /reprocess",
+        )
 
     return processing_info.seqid
 

--- a/nucliadb/nucliadb/writer/resource/basic.py
+++ b/nucliadb/nucliadb/writer/resource/basic.py
@@ -40,7 +40,7 @@ from nucliadb_protos.utils_pb2 import Relation, RelationNode
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
 from nucliadb.ingest.orm.utils import set_title
-from nucliadb.ingest.processing import ProcessingInfo, PushPayload
+from nucliadb.ingest.processing import PushPayload
 from nucliadb_models.common import FIELD_TYPES_MAP_REVERSE
 from nucliadb_models.file import FileField
 from nucliadb_models.link import LinkField
@@ -222,22 +222,6 @@ def set_status(basic: Basic, item: CreateResourcePayload):
 
 def set_status_modify(basic: Basic, item: UpdateResourcePayload):
     basic.metadata.status = Metadata.Status.PENDING
-
-
-def set_processing_info(bm: BrokerMessage, processing_info: ProcessingInfo):
-    """
-    Processing V2 does not have this awkward processing info data field and storage
-    but keeping for b/w compatibility.
-
-    Once V1 is removed, this code can be removed because status checking will be done
-    in a separate API that is not part of NucliaDB.
-    """
-    if processing_info.seqid is not None:
-        bm.basic.last_seqid = processing_info.seqid
-    if processing_info.account_seq is not None:
-        bm.basic.last_account_seq = processing_info.account_seq
-    if processing_info.queue is not None:
-        bm.basic.queue = bm.basic.QueueType.Value(processing_info.queue.name)
 
 
 def validate_classifications(paragraph: ParagraphAnnotation):

--- a/nucliadb/nucliadb/writer/tests/fixtures.py
+++ b/nucliadb/nucliadb/writer/tests/fixtures.py
@@ -166,7 +166,6 @@ async def resource(redis, writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_writer}/resources",
-            headers={"X-Synchronous": "true"},
             json={
                 "slug": "resource1",
                 "title": "Resource 1",

--- a/nucliadb/nucliadb/writer/tests/test_fields.py
+++ b/nucliadb/nucliadb/writer/tests/test_fields.py
@@ -132,7 +132,6 @@ async def test_resource_field_add(writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={"slug": "resource1", "title": "My resource"},
         )
         assert resp.status_code == 201
@@ -221,7 +220,6 @@ async def test_resource_field_add(writer_api, knowledgebox_writer):
         resp = await client.put(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/{rid}/file/externalfile",
             json=TEST_EXTERNAL_FILE_PAYLOAD,
-            headers={"X-SYNCHRONOUS": "True"},
         )
         assert resp.status_code == 201
         data = resp.json()
@@ -234,7 +232,6 @@ async def test_resource_field_append_extra(writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "slug": "resource1",
                 "title": "My resource",
@@ -274,7 +271,6 @@ async def test_resource_field_delete(writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "slug": "resource1",
                 "title": "My resource",
@@ -353,11 +349,9 @@ async def test_resource_field_delete(writer_api, knowledgebox_writer):
 async def test_sync_ops(writer_api, knowledgebox_writer, endpoint, payload):
     knowledgebox_id = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
-        HEADERS = {"X-SYNCHRONOUS": "True"}
         # Create a resource
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
-            headers=HEADERS,
             json={
                 "slug": "resource1",
                 "title": "My resource",
@@ -372,7 +366,6 @@ async def test_sync_ops(writer_api, knowledgebox_writer, endpoint, payload):
         resource_path = f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/{rid}"
         resp = await client.put(
             f"{resource_path}/{endpoint}",
-            headers={"X-SYNCHRONOUS": "True"},
             json=payload,
         )
         assert resp.status_code in (201, 200)
@@ -385,7 +378,6 @@ async def test_external_file_field(writer_api, knowledgebox_writer):
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
             json={"slug": "resource1", "title": "My resource"},
-            headers={"X-SYNCHRONOUS": "True"},
         )
         assert resp.status_code == 201
         rid = resp.json()["uuid"]
@@ -394,7 +386,6 @@ async def test_external_file_field(writer_api, knowledgebox_writer):
         resp = await client.put(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/{rid}/file/externalfile",
             json=TEST_EXTERNAL_FILE_PAYLOAD,
-            headers={"X-SYNCHRONOUS": "True"},
         )
         assert resp.status_code == 201
 
@@ -406,7 +397,6 @@ async def test_file_field_validation(writer_api, knowledgebox_writer):
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
             json={"slug": "resource1", "title": "My resource"},
-            headers={"X-SYNCHRONOUS": "True"},
         )
         assert resp.status_code == 201
         rid = resp.json()["uuid"]
@@ -418,7 +408,6 @@ async def test_file_field_validation(writer_api, knowledgebox_writer):
         resp = await client.put(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/{rid}/file/file1",
             json=payload,
-            headers={"X-SYNCHRONOUS": "True"},
         )
         assert resp.status_code == 201
 
@@ -451,7 +440,6 @@ async def test_field_endpoints_by_slug(
 
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_ingest}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={"slug": slug},
         )
         assert resp.status_code == 201

--- a/nucliadb/nucliadb/writer/tests/test_files.py
+++ b/nucliadb/nucliadb/writer/tests/test_files.py
@@ -427,7 +427,6 @@ async def test_knowledgebox_file_upload_field_sync(
                     "X-LANGUAGE": "ca",
                     "X-MD5": "7af0916dba8b70e29d99e72941923529",
                     "content-type": "image/jpg",
-                    "X-SYNCHRONOUS": "True",
                 },
             )
             assert resp.status_code == 201
@@ -644,9 +643,6 @@ async def test_file_upload_by_slug(writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         resp = await client.post(
             f"/{KB_PREFIX}/{kb}/resources",
-            headers={
-                "X-Synchronous": "True",
-            },
             json={
                 "slug": rslug,
             },

--- a/nucliadb/nucliadb/writer/tests/test_reprocess_file_field.py
+++ b/nucliadb/nucliadb/writer/tests/test_reprocess_file_field.py
@@ -55,7 +55,6 @@ async def file_field(
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         resp = await client.post(
             f"/{KB_PREFIX}/{kbid}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "slug": "resource",
                 "title": "My resource",

--- a/nucliadb/nucliadb/writer/tests/test_resources.py
+++ b/nucliadb/nucliadb/writer/tests/test_resources.py
@@ -120,7 +120,6 @@ async def test_resource_crud(
         # Test create resource
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "slug": "resource1",
                 "title": "My resource",
@@ -216,7 +215,6 @@ async def test_resource_crud_sync(
         # Test create resource
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "slug": "resource1",
                 "title": "My resource",
@@ -294,7 +292,6 @@ async def test_resource_crud_sync(
         # Test update resource
         resp = await client.patch(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/{rid}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={},
         )
         assert resp.status_code == 200
@@ -303,14 +300,12 @@ async def test_resource_crud_sync(
 
         resp = await client.delete(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/resource1",
-            headers={"X-SYNCHRONOUS": "True"},
         )
 
         assert resp.status_code == 404
 
         resp = await client.delete(
             f"/{KB_PREFIX}/{knowledgebox_id}/{RESOURCE_PREFIX}/{rid}",
-            headers={"X-SYNCHRONOUS": "True"},
         )
         assert resp.status_code == 204
 
@@ -397,7 +392,6 @@ async def test_resource_endpoints_by_slug(
         slug = "my-resource"
         resp = await client.post(
             f"/{KB_PREFIX}/{knowledgebox_ingest}/{RESOURCES_PREFIX}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "slug": slug,
                 "texts": {"text1": {"body": "test1", "format": "PLAIN"}},
@@ -480,7 +474,6 @@ async def test_paragraph_annotations(writer_api, knowledgebox_writer):
         # Must have at least one classification
         resp = await client.post(
             f"/{KB_PREFIX}/{kbid}/resources",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "texts": {"text1": TEST_TEXT_PAYLOAD},
                 "fieldmetadata": [
@@ -504,7 +497,6 @@ async def test_paragraph_annotations(writer_api, knowledgebox_writer):
 
         resp = await client.post(
             f"/{KB_PREFIX}/{kbid}/resources",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "texts": {"text1": TEST_TEXT_PAYLOAD},
                 "fieldmetadata": [
@@ -526,7 +518,6 @@ async def test_paragraph_annotations(writer_api, knowledgebox_writer):
         # Classifications need to be unique
         resp = await client.patch(
             f"/{KB_PREFIX}/{kbid}/resource/{rid}",
-            headers={"X-SYNCHRONOUS": "True"},
             json={
                 "fieldmetadata": [
                     {

--- a/nucliadb_utils/nucliadb_utils/settings.py
+++ b/nucliadb_utils/nucliadb_utils/settings.py
@@ -166,6 +166,9 @@ class TransactionSettings(BaseSettings):
     transaction_jetstream_auth: Optional[str] = None
     transaction_jetstream_servers: List[str] = ["nats://localhost:4222"]
     transaction_local: bool = False
+    transaction_commit_timeout: int = Field(
+        default=60, description="Transaction commit timeout in seconds"
+    )
 
 
 transaction_settings = TransactionSettings()

--- a/nucliadb_utils/nucliadb_utils/transaction.py
+++ b/nucliadb_utils/nucliadb_utils/transaction.py
@@ -89,9 +89,11 @@ class TransactionUtility:
         self,
         nats_servers: list[str],
         nats_creds: Optional[str] = None,
+        commit_timeout: int = 60,
     ):
         self.nats_creds = nats_creds
         self.nats_servers = nats_servers
+        self.commit_timeout = commit_timeout
 
     async def disconnected_cb(self):
         logger.info("Got disconnected from NATS!")
@@ -205,7 +207,9 @@ class TransactionUtility:
 
         if wait and waiting_event is not None:
             try:
-                await asyncio.wait_for(waiting_event.wait(), timeout=30.0)
+                await asyncio.wait_for(
+                    waiting_event.wait(), timeout=self.commit_timeout
+                )
             except asyncio.TimeoutError:
                 logger.warning("Took too much to commit")
                 raise TransactionCommitTimeoutError()

--- a/nucliadb_utils/nucliadb_utils/transaction.py
+++ b/nucliadb_utils/nucliadb_utils/transaction.py
@@ -49,6 +49,10 @@ class WaitFor:
         self.seq = seq
 
 
+class TransactionCommitTimeoutError(Exception):
+    pass
+
+
 class LocalTransactionUtility:
     async def commit(
         self,
@@ -204,6 +208,7 @@ class TransactionUtility:
                 await asyncio.wait_for(waiting_event.wait(), timeout=30.0)
             except asyncio.TimeoutError:
                 logger.warning("Took too much to commit")
+                raise TransactionCommitTimeoutError()
             finally:
                 await self.stop_waiting(writer.kbid, request_id=request_id)
 

--- a/nucliadb_utils/nucliadb_utils/utilities.py
+++ b/nucliadb_utils/nucliadb_utils/utilities.py
@@ -265,6 +265,7 @@ async def start_transaction_utility(
         transaction_utility = TransactionUtility(
             nats_creds=transaction_settings.transaction_jetstream_auth,
             nats_servers=transaction_settings.transaction_jetstream_servers,
+            commit_timeout=transaction_settings.transaction_commit_timeout,
         )
         await transaction_utility.initialize(service_name)
     set_utility(Utility.TRANSACTION, transaction_utility)


### PR DESCRIPTION
### Description

Not having synchronous writes is not an API we want anymore, as it is very easy to flood the ingestion system.
This PR makes all write operations synchronous.

### How was this PR tested?
Existing tests cover it
- [ ] add unit test on transaction class
