### PR TITLE
Fix autofilter + filter bug

### DIFF
--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -670,6 +670,8 @@ def parse_entities_to_filters(
 
     # We need to expand the filter expression with the automatically detected entities.
     if len(added_filters) > 0:
+        # So far, autofilters feature will only yield 'and' expressions with the detected entities.
+        # More complex autofilters can be added here if we leverage the query endpoint.
         expanded_expression = {"and": [{"literal": entity} for entity in added_filters]}
         if request.filter.expression:
             expression = json.loads(request.filter.expression)

--- a/nucliadb/nucliadb/search/search/query.py
+++ b/nucliadb/nucliadb/search/search/query.py
@@ -667,12 +667,13 @@ def parse_entities_to_filters(
         if entity_filter not in request.filter.field_labels:
             request.filter.field_labels.append(entity_filter)
             added_filters.append(entity_filter)
+
     # We need to expand the filter expression with the automatically detected entities.
     if len(added_filters) > 0:
         expanded_expression = {"and": [{"literal": entity} for entity in added_filters]}
         if request.filter.expression:
             expression = json.loads(request.filter.expression)
-            expanded_expression["and"].extend(expression)
+            expanded_expression["and"].append(expression)
         request.filter.expression = json.dumps(expanded_expression)
     return added_filters
 

--- a/nucliadb/nucliadb/search/tests/unit/search/test_query.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_query.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import unittest
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -44,11 +45,19 @@ def test_parse_entities_to_filters():
     ]
 
     request = SearchRequest()
+    request.filter.field_labels.append("/e/person/Austin")
+    request.filter.expression = json.dumps({"and": [{"literal": "/e/person/Austin"}]})
     assert parse_entities_to_filters(request, detected_entities) == ["/e/person/John"]
-    assert request.filter.field_labels == ["/e/person/John"]
+    assert request.filter.field_labels == ["/e/person/Austin", "/e/person/John"]
+    assert json.loads(request.filter.expression) == {
+        "and": [
+            {"literal": "/e/person/John"},
+            {"and": [{"literal": "/e/person/Austin"}]},
+        ]
+    }
 
     assert parse_entities_to_filters(request, detected_entities) == []
-    assert request.filter.field_labels == ["/e/person/John"]
+    assert request.filter.field_labels == ["/e/person/Austin", "/e/person/John"]
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Description
When using autofilters, if a filter was added to the request payload, the request would fail because the filter expression was not properly crafted and was unable to be json decoded

### How was this PR tested?
Unit tests
