### PR TITLE
Chat with a resource (without retrieval)

### DIFF
--- a/nucliadb/nucliadb/search/api/v1/chat.py
+++ b/nucliadb/nucliadb/search/api/v1/chat.py
@@ -153,6 +153,7 @@ async def create_chat_response(
     client_type: NucliaDBClientType,
     origin: str,
     x_synchronous: bool,
+    resource: Optional[str] = None,
 ) -> Response:
     chat_result = await chat(
         kbid,
@@ -160,6 +161,7 @@ async def create_chat_response(
         user_id,
         client_type,
         origin,
+        resource=resource,
     )
     if x_synchronous:
         streamed_answer = b""

--- a/nucliadb/nucliadb/search/api/v1/resource/chat.py
+++ b/nucliadb/nucliadb/search/api/v1/resource/chat.py
@@ -64,9 +64,14 @@ async def resource_chat_endpoint(
     ),
 ) -> Union[StreamingResponse, HTTPClientError, Response]:
     try:
-        item.resource_filters = [rid]
         return await create_chat_response(
-            kbid, item, x_nucliadb_user, x_ndb_client, x_forwarded_for, x_synchronous
+            kbid,
+            item,
+            x_nucliadb_user,
+            x_ndb_client,
+            x_forwarded_for,
+            x_synchronous,
+            resource=rid,
         )
     except LimitsExceededError as exc:
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)

--- a/nucliadb/nucliadb/search/search/chat/query.py
+++ b/nucliadb/nucliadb/search/search/chat/query.py
@@ -277,6 +277,7 @@ async def chat(
                 prompt_context_order=prompt_context_order,
             )
     else:
+        status_code = FoundStatusCode()
         find_results = KnowledgeboxFindResults(resources={}, min_score=None)
         query_parser = QueryParser(
             kbid=kbid,

--- a/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
+++ b/nucliadb/nucliadb/search/tests/unit/search/test_chat_prompt.py
@@ -174,24 +174,26 @@ async def test_default_prompt_context(kb):
         "nucliadb.search.search.chat.prompt.get_storage"
     ), patch("nucliadb.search.search.chat.prompt.KnowledgeBoxORM", return_value=kb):
         context = chat_prompt.CappedPromptContext(max_size=int(1e6))
+        find_results = KnowledgeboxFindResults(
+            facets={},
+            resources={
+                "bmid": _create_find_result(
+                    "bmid/c/conv/ident", result_text, SCORE_TYPE.BM25, order=1
+                ),
+                "vecid": _create_find_result(
+                    "vecid/c/conv/ident", result_text, SCORE_TYPE.VECTOR, order=2
+                ),
+                "both_id": _create_find_result(
+                    "both_id/c/conv/ident", result_text, SCORE_TYPE.BOTH, order=0
+                ),
+            },
+        )
+        ordered_paragraphs = chat_prompt.get_ordered_paragraphs(find_results)
+
         await chat_prompt.default_prompt_context(
             context,
             "kbid",
-            KnowledgeboxFindResults(
-                facets={},
-                resources={
-                    "bmid": _create_find_result(
-                        "bmid/c/conv/ident", result_text, SCORE_TYPE.BM25, order=1
-                    ),
-                    "vecid": _create_find_result(
-                        "vecid/c/conv/ident", result_text, SCORE_TYPE.VECTOR, order=2
-                    ),
-                    "both_id": _create_find_result(
-                        "both_id/c/conv/ident", result_text, SCORE_TYPE.BOTH, order=0
-                    ),
-                },
-                min_score=MinScore(semantic=-1),
-            ),
+            ordered_paragraphs,
         )
         prompt_result = context.output
         # Check that the results are sorted by increasing order and that the extra

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
@@ -54,13 +54,12 @@ def test_chat_on_kb_no_context_found(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
 
 def test_chat_on_resource(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
     rid = sdk.list_resources(kbid=docs_dataset).resources[0].id
+    # With retrieval
     _ = sdk.chat_on_resource(
         kbid=docs_dataset, rid=rid, query="Nuclia loves Semantic Search"
     )
-    # Commenting this out as this test depends on some docs dataset
-    # that has changed and now the query does not return any results
 
-    # assert result.learning_id == "00"
-    # assert result.answer == "valid answer  to"
-    # assert len(result.result.resources) == 1
-    # assert result.result.resources[rid]
+    # Check chatting with the whole resource (no retrieval)
+    _ = sdk.chat_on_resource(
+        kbid=docs_dataset, rid=rid, query="Nuclia loves Semantic Search", rag_strategies=[{"name": "full_resource"}]
+    )

--- a/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
+++ b/nucliadb_sdk/nucliadb_sdk/tests/test_chat.py
@@ -61,5 +61,8 @@ def test_chat_on_resource(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
 
     # Check chatting with the whole resource (no retrieval)
     _ = sdk.chat_on_resource(
-        kbid=docs_dataset, rid=rid, query="Nuclia loves Semantic Search", rag_strategies=[{"name": "full_resource"}]
+        kbid=docs_dataset,
+        rid=rid,
+        query="Nuclia loves Semantic Search",
+        rag_strategies=[{"name": "full_resource"}],
     )


### PR DESCRIPTION
### Description
When calling the chat endpoint on a particular resource, if the full_resource strategy is used, we skip the retrieval and simply send the whole extracted text to the LLM

### How was this PR tested?
Integration and local tests
