### PR TITLE
Validate that export is compatible when importing

### DIFF
--- a/nucliadb/nucliadb/export_import/exceptions.py
+++ b/nucliadb/nucliadb/export_import/exceptions.py
@@ -70,3 +70,11 @@ class WrongExportStreamFormat(Exception):
     """
 
     pass
+
+
+class IncompatibleExport(Exception):
+    """
+    Raised when trying to import an export file that is incompatible with the destination knowledgebox.
+    """
+
+    pass

--- a/nucliadb/nucliadb/export_import/importer.py
+++ b/nucliadb/nucliadb/export_import/importer.py
@@ -28,9 +28,7 @@ from nucliadb.export_import.models import (
     NatsTaskMessage,
 )
 from nucliadb.export_import.utils import (
-    ExportStream,
     ExportStreamReader,
-    IteratorExportStream,
     TaskRetryHandler,
     import_binary,
     import_broker_message,
@@ -47,7 +45,7 @@ BinaryStreamGenerator = Callable[[int], BinaryStream]
 async def import_kb(
     context: ApplicationContext,
     kbid: str,
-    stream: ExportStream,
+    stream: AsyncGenerator[bytes, None],
     metadata: Optional[ImportMetadata] = None,
 ) -> None:
     """
@@ -104,8 +102,7 @@ async def import_kb_from_blob_storage(
     kbid, import_id = msg.kbid, msg.id
     dm = ExportImportDataManager(context.kv_driver, context.blob_storage)
     metadata = await dm.get_metadata(type="import", kbid=kbid, id=import_id)
-    iterator = dm.download_import(kbid, import_id)
-    stream = IteratorExportStream(iterator)
+    stream = dm.download_import(kbid, import_id)
 
     retry_handler = TaskRetryHandler("import", dm, metadata)
 

--- a/nucliadb/nucliadb/export_import/models.py
+++ b/nucliadb/nucliadb/export_import/models.py
@@ -36,6 +36,7 @@ class ExportedItemType(str, Enum):
     LABELS = "LAB"
     ENTITIES = "ENT"
     BINARY = "BIN"
+    LEARNING_CONFIG = "LEA"
 
 
 ExportItem = tuple[ExportedItemType, Any]

--- a/nucliadb/nucliadb/export_import/utils.py
+++ b/nucliadb/nucliadb/export_import/utils.py
@@ -18,18 +18,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import functools
-from io import BytesIO
 from typing import AsyncGenerator, AsyncIterator, Callable, Optional
 
 import nats.errors
 from google.protobuf.message import DecodeError as ProtobufDecodeError
 
+from nucliadb import learning_proxy
 from nucliadb.common import datamanagers
 from nucliadb.common.context import ApplicationContext
 from nucliadb.export_import import logger
 from nucliadb.export_import.datamanager import ExportImportDataManager
 from nucliadb.export_import.exceptions import (
     ExportStreamExhausted,
+    IncompatibleExport,
     WrongExportStreamFormat,
 )
 from nucliadb.export_import.models import ExportedItemType, ExportItem, Metadata
@@ -258,27 +259,6 @@ class EndOfStream(Exception): ...
 class ExportStream:
     """
     Models a stream of export bytes that can be read from asynchronously.
-    """
-
-    def __init__(self, export: BytesIO):
-        self.export = export
-        self.read_bytes = 0
-        self._length = len(export.getvalue())
-
-    async def read(self, n_bytes):
-        """
-        Reads n_bytes from the export stream.
-        Raises ExportStreamExhausted if there are no more bytes to read.
-        """
-        if self.read_bytes == self._length:
-            raise ExportStreamExhausted()
-        chunk = self.export.read(n_bytes)
-        self.read_bytes += len(chunk)
-        return chunk
-
-
-class IteratorExportStream(ExportStream):
-    """
     Adapts the parent class to be able to read bytes yielded from an async iterator.
     """
 
@@ -286,6 +266,10 @@ class IteratorExportStream(ExportStream):
         self.iterator = iterator
         self.buffer = b""
         self.read_bytes = 0
+
+    @classmethod
+    def from_generator(cls, generator: AsyncGenerator[bytes, None]):
+        return cls(iterator=generator.__aiter__())
 
     def _read_from_buffer(self, n_bytes: int) -> bytes:
         value = self.buffer[:n_bytes]
@@ -323,8 +307,8 @@ class ExportStreamReader:
     yields the deserialized export items ready to be imported.
     """
 
-    def __init__(self, export_stream: ExportStream):
-        self.stream = export_stream
+    def __init__(self, stream: AsyncGenerator[bytes, None]):
+        self.stream = ExportStream(stream)
 
     @property
     def read_bytes(self) -> int:
@@ -398,6 +382,23 @@ class ExportStreamReader:
         except ProtobufDecodeError as ex:
             raise WrongExportStreamFormat() from ex
         return labels
+
+    async def maybe_read_learning_config(
+        self,
+    ) -> tuple[Optional[learning_proxy.LearningConfiguration], bytes]:
+        """
+        Tries to read a learning config from the stream.
+        Returs the learning config, if found, and the leftover bytes that
+        were read from the stream to memory.
+        """
+        type_bytes = await self.stream.read(3)
+        if type_bytes != ExportedItemType.LEARNING_CONFIG.value.encode():
+            # Backward compatible code for exports that don't have a learning config.
+            return None, type_bytes + self.stream.buffer
+
+        data = await self.read_item()
+        lconfig = learning_proxy.LearningConfiguration.parse_raw(data)
+        return lconfig, self.stream.buffer
 
     async def iter_items(self) -> AsyncGenerator[ExportItem, None]:
         while True:
@@ -474,3 +475,55 @@ class TaskRetryHandler:
                 await self.dm.set_metadata(self.type, metadata)
 
         return wrapper
+
+
+async def get_learning_config(
+    kbid: str,
+) -> Optional[learning_proxy.LearningConfiguration]:
+    return await learning_proxy.get_configuration(kbid)
+
+
+def stream_compatible_with_kb(
+    kbid: str, stream: AsyncGenerator[bytes, None]
+) -> AsyncGenerator[bytes, None]:
+    """
+    Wrapper around an export stream that checks if the export is compatible with the destination knowledge box.
+    """
+
+    async def wrapped() -> AsyncGenerator[bytes, None]:
+        # Read the a few bytes from the beginning of the stream to check the semantic model.
+        # If the semantic model is not compatible, raise an exception.
+        # If there are leftover bytes, yield them.
+        leftover_bytes = await _check_semantic_model_compatibility(kbid, stream)
+        if len(leftover_bytes) > 0:
+            yield leftover_bytes
+
+        # Now yield the rest of the stream
+        async for chunk in stream:
+            yield chunk
+
+    return wrapped()
+
+
+async def _check_semantic_model_compatibility(
+    kbid: str, stream: AsyncGenerator[bytes, None]
+) -> bytes:
+    stream_reader = ExportStreamReader(stream)
+    lconfig, leftover_bytes = await stream_reader.maybe_read_learning_config()
+    if lconfig is None:
+        logger.warning(
+            "Learning config not found on the export stream. Export may be incompatible."
+        )
+        return leftover_bytes
+    kb_lconfig = await get_learning_config(kbid)
+    if kb_lconfig is None:
+        logger.warning(
+            "No learning config found on the knowledge box. Export may be incompatible."
+        )
+        return leftover_bytes
+    if kb_lconfig.semantic_model == lconfig.semantic_model:
+        logger.info(f"Semantic model match: {kb_lconfig.semantic_model}")
+        return leftover_bytes
+    raise IncompatibleExport(
+        f"Cannot import. Semantic model mismatch: {kb_lconfig.semantic_model} != {lconfig.semantic_model}"
+    )

--- a/nucliadb/nucliadb/writer/api/v1/export_import.py
+++ b/nucliadb/nucliadb/writer/api/v1/export_import.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+from typing import AsyncGenerator
 from uuid import uuid4
 
 from fastapi_versioning import version
@@ -28,13 +29,14 @@ from nucliadb.common.context import ApplicationContext
 from nucliadb.common.context.fastapi import get_app_context
 from nucliadb.export_import import importer
 from nucliadb.export_import.datamanager import ExportImportDataManager
+from nucliadb.export_import.exceptions import IncompatibleExport
 from nucliadb.export_import.models import (
     ExportMetadata,
     ImportMetadata,
     NatsTaskMessage,
 )
 from nucliadb.export_import.tasks import get_exports_producer, get_imports_producer
-from nucliadb.export_import.utils import IteratorExportStream
+from nucliadb.export_import.utils import stream_compatible_with_kb
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.writer import logger
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
@@ -91,34 +93,40 @@ async def start_kb_import_endpoint(request: Request, kbid: str):
 
     await maybe_back_pressure(request, kbid)
 
-    import_id = uuid4().hex
-    if in_standalone_mode():
-        # In standalone mode, we import directly from the request content stream.
-        # Note that we return an import_id simply to keep the API consistent with hosted nucliadb.
-        stream = FastAPIExportStream(request)
-        await importer.import_kb(
-            context=context,
-            kbid=kbid,
-            stream=stream,
-        )
-        return CreateImportResponse(import_id=import_id)
-    else:
-        import_size = await upload_import_to_blob_storage(
-            context=context,
-            request=request,
-            kbid=kbid,
-            import_id=import_id,
-        )
-        await start_import_task(context, kbid, import_id, import_size)
-        return CreateImportResponse(import_id=import_id)
+    stream = stream_compatible_with_kb(kbid, request.stream())
+    try:
+        import_id = uuid4().hex
+        if in_standalone_mode():
+            # In standalone mode, we import directly from the request content stream.
+            # Note that we return an import_id simply to keep the API consistent with hosted nucliadb.
+            await importer.import_kb(
+                context=context,
+                kbid=kbid,
+                stream=stream,
+            )
+            return CreateImportResponse(import_id=import_id)
+        else:
+            import_size = await upload_import_to_blob_storage(
+                context=context,
+                stream=stream,
+                kbid=kbid,
+                import_id=import_id,
+            )
+            await start_import_task(context, kbid, import_id, import_size)
+            return CreateImportResponse(import_id=import_id)
+    except IncompatibleExport as exc:
+        return HTTPClientError(status_code=400, detail=str(exc))
 
 
 async def upload_import_to_blob_storage(
-    context: ApplicationContext, request: Request, kbid: str, import_id: str
+    context: ApplicationContext,
+    stream: AsyncGenerator[bytes, None],
+    kbid: str,
+    import_id: str,
 ) -> int:
     dm = ExportImportDataManager(context.kv_driver, context.blob_storage)
     return await dm.upload_import(
-        import_bytes=request.stream(),
+        import_bytes=stream,
         kbid=kbid,
         import_id=import_id,
     )
@@ -161,9 +169,3 @@ async def start_import_task(
         errors.capture_exception(e)
         await dm.delete_metadata("import", metadata)
         raise
-
-
-class FastAPIExportStream(IteratorExportStream):
-    def __init__(self, request: Request):
-        iterator = request.stream().__aiter__()
-        super().__init__(iterator)


### PR DESCRIPTION
### Description
Right now, if you export a KB with semantic model A and import it into a KB with semantic model B, the import process will run smoothly but effectively the KB will not work because the model does not match with the imported data.

This PR aims to validate compatibility at the beginning of an import

### How was this PR tested?
Integration tests
