### PR TITLE
Query shard replicas as primary-secondary

### DIFF
--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -526,8 +526,8 @@ def choose_node(
         ranked_nodes.setdefault(score, []).append((node, shard_replica_id))
 
     top = ranked_nodes[max(ranked_nodes)]
-    # Sort by shard replica id and choose its node to make
-    # sure we choose in deterministically
+    # As shard replica ids are random numbers, we sort by shard replica id and choose its
+    # node to make sure we choose in deterministically but we don't favour any node in particular
     top.sort(key=lambda x: x[1])
     selected_node, shard_replica_id = top[0]
     return selected_node, shard_replica_id

--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -19,7 +19,6 @@
 #
 import asyncio
 import logging
-import random
 import uuid
 from typing import Any, Awaitable, Callable, Optional
 
@@ -527,7 +526,10 @@ def choose_node(
         ranked_nodes.setdefault(score, []).append((node, shard_replica_id))
 
     top = ranked_nodes[max(ranked_nodes)]
-    selected_node, shard_replica_id = random.choice(top)
+    # Sort by shard replica id and choose its node to make
+    # sure we choose in deterministically
+    top.sort(key=lambda x: x[1])
+    selected_node, shard_replica_id = top[0]
     return selected_node, shard_replica_id
 
 

--- a/nucliadb/nucliadb/tests/integration/common/cluster/test_manager.py
+++ b/nucliadb/nucliadb/tests/integration/common/cluster/test_manager.py
@@ -139,13 +139,15 @@ async def shards(fake_nodes, fake_kbid: str, maindb_driver: Driver):
     ],
 )
 @pytest.mark.asyncio
-async def test_choose_node(shards, shard_index: int, nodes: set):
+async def test_choose_node_always_prefer_the_same_node(
+    shards, shard_index: int, nodes: set
+):
     shard = shards.shards[shard_index]
     node_ids = set()
     for i in range(100):
         node, _ = manager.choose_node(shard)
         node_ids.add(node.id)
-    assert node_ids == nodes, "Random numbers have defeat this test"
+    assert len(node_ids) == 1
 
 
 async def test_choose_node_attempts_target_replicas_but_is_not_imperative(shards):

--- a/nucliadb/nucliadb/tests/unit/common/cluster/test_cluster.py
+++ b/nucliadb/nucliadb/tests/unit/common/cluster/test_cluster.py
@@ -217,8 +217,8 @@ def test_choose_node_with_nodes_and_replicas(standalone_mode_off):
     """Validate how choose node selects between different options depending on
     configuration.
 
-    As some choices can be random between a subset of nodes, choose_node is
-    called multiple times per assert.
+    Choose_node is called multiple times per assert to ensure there
+    is no randomness in the replica/node choice.
 
     """
     TRIES_PER_ASSERT = 10
@@ -247,15 +247,15 @@ def test_choose_node_with_nodes_and_replicas(standalone_mode_off):
     shard_ids, node_ids = repeated_choose_node(
         TRIES_PER_ASSERT, shard, use_read_replica_nodes=False
     )
-    assert set(shard_ids) == {"123", "456"}
-    assert set(node_ids) == {"node-0", "node-1"}
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-0"}
 
     # Secondaries are preferred
     shard_ids, node_ids = repeated_choose_node(
         TRIES_PER_ASSERT, shard, use_read_replica_nodes=True
     )
-    assert set(shard_ids) == {"123", "456"}
-    assert set(node_ids) == {"node-replica-0", "node-replica-1"}
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-replica-0"}
 
     # Target replicas take more preference
     shard_ids, node_ids = repeated_choose_node(
@@ -291,8 +291,8 @@ def test_choose_node_with_nodes_and_replicas(standalone_mode_off):
     shard_ids, node_ids = repeated_choose_node(
         TRIES_PER_ASSERT, shard, use_read_replica_nodes=True
     )
-    assert set(shard_ids) == {"123", "456"}
-    assert set(node_ids) == {"node-replica-0", "node-replica-1"}
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-replica-0"}
 
     # target replicas is ignored but only primaries are used
     shard_ids, node_ids = repeated_choose_node(
@@ -322,8 +322,8 @@ def test_choose_node_with_nodes_and_replicas(standalone_mode_off):
     shard_ids, node_ids = repeated_choose_node(
         TRIES_PER_ASSERT, shard, use_read_replica_nodes=False
     )
-    assert set(shard_ids) == {"123", "456"}
-    assert set(node_ids) == {"node-0", "node-1"}
+    assert set(shard_ids) == {"123"}
+    assert set(node_ids) == {"node-0"}
 
     shard_ids, node_ids = repeated_choose_node(
         TRIES_PER_ASSERT, shard, use_read_replica_nodes=True


### PR DESCRIPTION
### Description
This will reduce the possibility of showing inconsistent results across two consecutive requests, as we'll always be querying the same shard replicas as long as their corresponding node is up. Otherwise we'll fall back to the other replica.

### How was this PR tested?
Existing tests
