### PR TITLE
Cleanup optionals from metadata file

### DIFF
--- a/nucliadb_core/src/lib.rs
+++ b/nucliadb_core/src/lib.rs
@@ -72,6 +72,15 @@ impl From<i32> for Channel {
     }
 }
 
+impl From<Channel> for i32 {
+    fn from(value: Channel) -> Self {
+        match value {
+            Channel::STABLE => 0,
+            Channel::EXPERIMENTAL => 1,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct RawReplicaState {
     pub metadata_files: HashMap<String, Vec<u8>>,

--- a/nucliadb_core/src/lib.rs
+++ b/nucliadb_core/src/lib.rs
@@ -51,6 +51,7 @@ use std::collections::HashMap;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub use anyhow::{anyhow as node_error, Context, Error};
+use nucliadb_protos::utils::ReleaseChannel;
 use serde::{Deserialize, Serialize};
 
 use crate::tantivy_replica::TantivyReplicaState;
@@ -75,8 +76,8 @@ impl From<i32> for Channel {
 impl From<Channel> for i32 {
     fn from(value: Channel) -> Self {
         match value {
-            Channel::STABLE => 0,
-            Channel::EXPERIMENTAL => 1,
+            Channel::STABLE => ReleaseChannel::Stable as i32,
+            Channel::EXPERIMENTAL => ReleaseChannel::Experimental as i32,
         }
     }
 }

--- a/nucliadb_node/src/cache/writer_cache.rs
+++ b/nucliadb_node/src/cache/writer_cache.rs
@@ -235,6 +235,7 @@ mod tests {
     use std::time::Duration;
 
     use crossbeam_utils::thread::scope;
+    use nucliadb_core::Channel;
     use tempfile::tempdir;
 
     use super::ShardWriterCache;
@@ -256,8 +257,14 @@ mod tests {
         let shard_0_path = settings.shards_path().join(shard_id_0.clone());
         fs::create_dir(settings.shards_path()).unwrap();
 
-        let shard_meta =
-            ShardMetadata::new(shard_0_path.clone(), shard_id_0.clone(), None, Similarity::Cosine, None, false);
+        let shard_meta = ShardMetadata::new(
+            shard_0_path.clone(),
+            shard_id_0.clone(),
+            "kbid".to_string(),
+            Similarity::Cosine,
+            Channel::EXPERIMENTAL,
+            false,
+        );
         cache.create(shard_meta).unwrap();
 
         let shard_0 = cache.get(&shard_id_0).unwrap();
@@ -297,8 +304,14 @@ mod tests {
         assert!(cache.get(&shard_id_0).is_err());
 
         // Recreating the shard should work (i.e: it's not stuck in the deletion state)
-        let shard_meta =
-            ShardMetadata::new(shard_0_path.clone(), shard_id_0.clone(), None, Similarity::Cosine, None, false);
+        let shard_meta = ShardMetadata::new(
+            shard_0_path.clone(),
+            shard_id_0.clone(),
+            "kbid".to_string(),
+            Similarity::Cosine,
+            Channel::EXPERIMENTAL,
+            false,
+        );
         cache.create(shard_meta).unwrap();
 
         assert!(cache.get(&shard_id_0).is_ok());

--- a/nucliadb_node/src/grpc/grpc_writer.rs
+++ b/nucliadb_node/src/grpc/grpc_writer.rs
@@ -120,9 +120,9 @@ impl NodeWriter for NodeWriterGRPCDriver {
         let metadata = ShardMetadata::new(
             self.shards.shards_path.join(shard_id.clone()),
             shard_id,
-            Some(kbid),
+            kbid,
             request.similarity().into(),
-            Some(Channel::from(request.release_channel)),
+            Channel::from(request.release_channel),
             request.normalize_vectors,
         );
 

--- a/nucliadb_node/src/replication/replicator.rs
+++ b/nucliadb_node/src/replication/replicator.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use futures::Future;
 use nucliadb_core::metrics::replication as replication_metrics;
 use nucliadb_core::tracing::{debug, error, info, warn};
-use nucliadb_core::{metrics, Error, NodeResult};
+use nucliadb_core::{metrics, Channel, Error, NodeResult};
 use nucliadb_protos::prelude::EmptyQuery;
 use nucliadb_protos::replication;
 use tokio::io::AsyncWriteExt;
@@ -264,9 +264,9 @@ pub async fn connect_to_primary_and_replicate(
                 let metadata = ShardMetadata::new(
                     shards_path.join(shard_id.clone()),
                     shard_state.shard_id.clone(),
-                    Some(shard_state.kbid.clone()),
+                    shard_state.kbid.clone(),
                     shard_state.similarity.clone().into(),
-                    None,
+                    Channel::from(shard_state.release_channel),
                     shard_state.normalize_vectors,
                 );
                 let shard_cache_clone = Arc::clone(&shard_cache);

--- a/nucliadb_node/src/replication/service.rs
+++ b/nucliadb_node/src/replication/service.rs
@@ -227,9 +227,10 @@ impl replication::replication_service_server::ReplicationService for Replication
                     resp_shard_states.push(replication::PrimaryShardReplicationState {
                         shard_id,
                         generation_id: gen_id,
-                        kbid: metadata.kbid().unwrap_or_default(),
+                        kbid: metadata.kbid(),
                         similarity: similarity.to_string(),
                         normalize_vectors: metadata.normalize_vectors(),
+                        release_channel: metadata.channel().into(),
                     });
                 }
             } else {

--- a/nucliadb_node/src/shards/shard_reader.rs
+++ b/nucliadb_node/src/shards/shard_reader.rs
@@ -220,7 +220,7 @@ impl ShardReader {
 
         Ok(Shard {
             metadata: Some(protos::ShardMetadata {
-                kbid: self.metadata.kbid().unwrap_or_default(),
+                kbid: self.metadata.kbid(),
                 release_channel: self.metadata.channel() as i32,
             }),
             shard_id: self.id.clone(),

--- a/nucliadb_node_binding/src/writer.rs
+++ b/nucliadb_node_binding/src/writer.rs
@@ -100,9 +100,9 @@ impl NodeWriter {
         let metadata = ShardMetadata::new(
             self.shards_path.join(shard_id.clone()),
             shard_id,
-            Some(request.kbid),
+            request.kbid,
             similarity.into(),
-            Some(Channel::from(request.release_channel)),
+            Channel::from(request.release_channel),
             request.normalize_vectors,
         );
         let new_shard = self.shards.create(metadata);

--- a/nucliadb_protos/python/nucliadb_protos/replication_pb2.py
+++ b/nucliadb_protos/python/nucliadb_protos/replication_pb2.py
@@ -20,7 +20,7 @@ except AttributeError:
 
 from nucliadb_protos.noderesources_pb2 import *
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!nucliadb_protos/replication.proto\x12\x0breplication\x1a#nucliadb_protos/noderesources.proto\"\x84\x01\n\x1cPrimaryShardReplicationState\x12\x10\n\x08shard_id\x18\x01 \x01(\t\x12\x15\n\rgeneration_id\x18\x02 \x01(\t\x12\x0c\n\x04kbid\x18\x03 \x01(\t\x12\x12\n\nsimilarity\x18\x04 \x01(\t\x12\x19\n\x11normalize_vectors\x18\x05 \x01(\x08\"I\n\x1eSecondaryShardReplicationState\x12\x10\n\x08shard_id\x18\x01 \x01(\t\x12\x15\n\rgeneration_id\x18\x02 \x01(\t\"\x80\x01\n%SecondaryCheckReplicationStateRequest\x12\x14\n\x0csecondary_id\x18\x01 \x01(\t\x12\x41\n\x0cshard_states\x18\x02 \x03(\x0b\x32+.replication.SecondaryShardReplicationState\"\x95\x01\n$PrimaryCheckReplicationStateResponse\x12?\n\x0cshard_states\x18\x01 \x03(\x0b\x32).replication.PrimaryShardReplicationState\x12\x18\n\x10shards_to_remove\x18\x02 \x03(\t\x12\x12\n\nprimary_id\x18\x03 \x01(\t\"\x1b\n\nSegmentIds\x12\r\n\x05items\x18\x01 \x03(\t\"\xeb\x01\n\x15ReplicateShardRequest\x12\x10\n\x08shard_id\x18\x01 \x01(\t\x12X\n\x14\x65xisting_segment_ids\x18\x02 \x03(\x0b\x32:.replication.ReplicateShardRequest.ExistingSegmentIdsEntry\x12\x12\n\nchunk_size\x18\x03 \x01(\x04\x1aR\n\x17\x45xistingSegmentIdsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.replication.SegmentIds:\x02\x38\x01\"\x89\x01\n\x16ReplicateShardResponse\x12\x15\n\rgeneration_id\x18\x01 \x01(\t\x12\x10\n\x08\x66ilepath\x18\x02 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\x12\r\n\x05\x63hunk\x18\x04 \x01(\r\x12\x15\n\rread_position\x18\x05 \x01(\x04\x12\x12\n\ntotal_size\x18\x06 \x01(\x04\x32\xbf\x02\n\x12ReplicationService\x12\x80\x01\n\x15\x43heckReplicationState\x12\x32.replication.SecondaryCheckReplicationStateRequest\x1a\x31.replication.PrimaryCheckReplicationStateResponse\"\x00\x12]\n\x0eReplicateShard\x12\".replication.ReplicateShardRequest\x1a#.replication.ReplicateShardResponse\"\x00\x30\x01\x12G\n\x0bGetMetadata\x12\x19.noderesources.EmptyQuery\x1a\x1b.noderesources.NodeMetadata\"\x00P\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!nucliadb_protos/replication.proto\x12\x0breplication\x1a#nucliadb_protos/noderesources.proto\"\xb4\x01\n\x1cPrimaryShardReplicationState\x12\x10\n\x08shard_id\x18\x01 \x01(\t\x12\x15\n\rgeneration_id\x18\x02 \x01(\t\x12\x0c\n\x04kbid\x18\x03 \x01(\t\x12\x12\n\nsimilarity\x18\x04 \x01(\t\x12\x19\n\x11normalize_vectors\x18\x05 \x01(\x08\x12.\n\x0frelease_channel\x18\x06 \x01(\x0e\x32\x15.utils.ReleaseChannel\"I\n\x1eSecondaryShardReplicationState\x12\x10\n\x08shard_id\x18\x01 \x01(\t\x12\x15\n\rgeneration_id\x18\x02 \x01(\t\"\x80\x01\n%SecondaryCheckReplicationStateRequest\x12\x14\n\x0csecondary_id\x18\x01 \x01(\t\x12\x41\n\x0cshard_states\x18\x02 \x03(\x0b\x32+.replication.SecondaryShardReplicationState\"\x95\x01\n$PrimaryCheckReplicationStateResponse\x12?\n\x0cshard_states\x18\x01 \x03(\x0b\x32).replication.PrimaryShardReplicationState\x12\x18\n\x10shards_to_remove\x18\x02 \x03(\t\x12\x12\n\nprimary_id\x18\x03 \x01(\t\"\x1b\n\nSegmentIds\x12\r\n\x05items\x18\x01 \x03(\t\"\xeb\x01\n\x15ReplicateShardRequest\x12\x10\n\x08shard_id\x18\x01 \x01(\t\x12X\n\x14\x65xisting_segment_ids\x18\x02 \x03(\x0b\x32:.replication.ReplicateShardRequest.ExistingSegmentIdsEntry\x12\x12\n\nchunk_size\x18\x03 \x01(\x04\x1aR\n\x17\x45xistingSegmentIdsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.replication.SegmentIds:\x02\x38\x01\"\x89\x01\n\x16ReplicateShardResponse\x12\x15\n\rgeneration_id\x18\x01 \x01(\t\x12\x10\n\x08\x66ilepath\x18\x02 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\x12\r\n\x05\x63hunk\x18\x04 \x01(\r\x12\x15\n\rread_position\x18\x05 \x01(\x04\x12\x12\n\ntotal_size\x18\x06 \x01(\x04\x32\xbf\x02\n\x12ReplicationService\x12\x80\x01\n\x15\x43heckReplicationState\x12\x32.replication.SecondaryCheckReplicationStateRequest\x1a\x31.replication.PrimaryCheckReplicationStateResponse\"\x00\x12]\n\x0eReplicateShard\x12\".replication.ReplicateShardRequest\x1a#.replication.ReplicateShardResponse\"\x00\x30\x01\x12G\n\x0bGetMetadata\x12\x19.noderesources.EmptyQuery\x1a\x1b.noderesources.NodeMetadata\"\x00P\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -30,21 +30,21 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_REPLICATESHARDREQUEST_EXISTINGSEGMENTIDSENTRY']._options = None
   _globals['_REPLICATESHARDREQUEST_EXISTINGSEGMENTIDSENTRY']._serialized_options = b'8\001'
   _globals['_PRIMARYSHARDREPLICATIONSTATE']._serialized_start=88
-  _globals['_PRIMARYSHARDREPLICATIONSTATE']._serialized_end=220
-  _globals['_SECONDARYSHARDREPLICATIONSTATE']._serialized_start=222
-  _globals['_SECONDARYSHARDREPLICATIONSTATE']._serialized_end=295
-  _globals['_SECONDARYCHECKREPLICATIONSTATEREQUEST']._serialized_start=298
-  _globals['_SECONDARYCHECKREPLICATIONSTATEREQUEST']._serialized_end=426
-  _globals['_PRIMARYCHECKREPLICATIONSTATERESPONSE']._serialized_start=429
-  _globals['_PRIMARYCHECKREPLICATIONSTATERESPONSE']._serialized_end=578
-  _globals['_SEGMENTIDS']._serialized_start=580
-  _globals['_SEGMENTIDS']._serialized_end=607
-  _globals['_REPLICATESHARDREQUEST']._serialized_start=610
-  _globals['_REPLICATESHARDREQUEST']._serialized_end=845
-  _globals['_REPLICATESHARDREQUEST_EXISTINGSEGMENTIDSENTRY']._serialized_start=763
-  _globals['_REPLICATESHARDREQUEST_EXISTINGSEGMENTIDSENTRY']._serialized_end=845
-  _globals['_REPLICATESHARDRESPONSE']._serialized_start=848
-  _globals['_REPLICATESHARDRESPONSE']._serialized_end=985
-  _globals['_REPLICATIONSERVICE']._serialized_start=988
-  _globals['_REPLICATIONSERVICE']._serialized_end=1307
+  _globals['_PRIMARYSHARDREPLICATIONSTATE']._serialized_end=268
+  _globals['_SECONDARYSHARDREPLICATIONSTATE']._serialized_start=270
+  _globals['_SECONDARYSHARDREPLICATIONSTATE']._serialized_end=343
+  _globals['_SECONDARYCHECKREPLICATIONSTATEREQUEST']._serialized_start=346
+  _globals['_SECONDARYCHECKREPLICATIONSTATEREQUEST']._serialized_end=474
+  _globals['_PRIMARYCHECKREPLICATIONSTATERESPONSE']._serialized_start=477
+  _globals['_PRIMARYCHECKREPLICATIONSTATERESPONSE']._serialized_end=626
+  _globals['_SEGMENTIDS']._serialized_start=628
+  _globals['_SEGMENTIDS']._serialized_end=655
+  _globals['_REPLICATESHARDREQUEST']._serialized_start=658
+  _globals['_REPLICATESHARDREQUEST']._serialized_end=893
+  _globals['_REPLICATESHARDREQUEST_EXISTINGSEGMENTIDSENTRY']._serialized_start=811
+  _globals['_REPLICATESHARDREQUEST_EXISTINGSEGMENTIDSENTRY']._serialized_end=893
+  _globals['_REPLICATESHARDRESPONSE']._serialized_start=896
+  _globals['_REPLICATESHARDRESPONSE']._serialized_end=1033
+  _globals['_REPLICATIONSERVICE']._serialized_start=1036
+  _globals['_REPLICATIONSERVICE']._serialized_end=1355
 # @@protoc_insertion_point(module_scope)

--- a/nucliadb_protos/python/nucliadb_protos/replication_pb2.pyi
+++ b/nucliadb_protos/python/nucliadb_protos/replication_pb2.pyi
@@ -7,6 +7,7 @@ import collections.abc
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
+import nucliadb_protos.utils_pb2
 import sys
 
 if sys.version_info >= (3, 8):
@@ -48,6 +49,7 @@ class PrimaryShardReplicationState(google.protobuf.message.Message):
     KBID_FIELD_NUMBER: builtins.int
     SIMILARITY_FIELD_NUMBER: builtins.int
     NORMALIZE_VECTORS_FIELD_NUMBER: builtins.int
+    RELEASE_CHANNEL_FIELD_NUMBER: builtins.int
     shard_id: builtins.str
     generation_id: builtins.str
     """ID to identify the generation of the shard to know
@@ -56,6 +58,7 @@ class PrimaryShardReplicationState(google.protobuf.message.Message):
     kbid: builtins.str
     similarity: builtins.str
     normalize_vectors: builtins.bool
+    release_channel: nucliadb_protos.utils_pb2.ReleaseChannel.ValueType
     def __init__(
         self,
         *,
@@ -64,8 +67,9 @@ class PrimaryShardReplicationState(google.protobuf.message.Message):
         kbid: builtins.str = ...,
         similarity: builtins.str = ...,
         normalize_vectors: builtins.bool = ...,
+        release_channel: nucliadb_protos.utils_pb2.ReleaseChannel.ValueType = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["generation_id", b"generation_id", "kbid", b"kbid", "normalize_vectors", b"normalize_vectors", "shard_id", b"shard_id", "similarity", b"similarity"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["generation_id", b"generation_id", "kbid", b"kbid", "normalize_vectors", b"normalize_vectors", "release_channel", b"release_channel", "shard_id", b"shard_id", "similarity", b"similarity"]) -> None: ...
 
 global___PrimaryShardReplicationState = PrimaryShardReplicationState
 

--- a/nucliadb_protos/replication.proto
+++ b/nucliadb_protos/replication.proto
@@ -13,6 +13,7 @@ message PrimaryShardReplicationState {
     string kbid = 3;
     string similarity = 4;
     bool normalize_vectors = 5;
+    utils.ReleaseChannel release_channel = 6;
 }
 
 message SecondaryShardReplicationState {

--- a/nucliadb_protos/rust/src/replication.rs
+++ b/nucliadb_protos/rust/src/replication.rs
@@ -12,6 +12,8 @@ pub struct PrimaryShardReplicationState {
     pub similarity: ::prost::alloc::string::String,
     #[prost(bool, tag="5")]
     pub normalize_vectors: bool,
+    #[prost(enumeration="super::utils::ReleaseChannel", tag="6")]
+    pub release_channel: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SecondaryShardReplicationState {


### PR DESCRIPTION
### Description
- Pass release channel to secondaries (it was always passing None)
- Remove `Option` from all fields in shards metadata file. As all shards are in the same migration version, this change is safe

### How was this PR tested?
Describe how you tested this PR.
