### PR TITLE
Cleanup index nodes from global state on teardown

### DIFF
--- a/nucliadb/nucliadb/common/cluster/manager.py
+++ b/nucliadb/nucliadb/common/cluster/manager.py
@@ -68,6 +68,11 @@ def get_index_node(node_id: str) -> Optional[AbstractIndexNode]:
     return INDEX_NODES.get(node_id)
 
 
+def clear_index_nodes():
+    INDEX_NODES.clear()
+    READ_REPLICA_INDEX_NODES.clear()
+
+
 def get_read_replica_node_ids(node_id: str) -> list[str]:
     return list(READ_REPLICA_INDEX_NODES.get(node_id, set()))
 

--- a/nucliadb/nucliadb/common/cluster/utils.py
+++ b/nucliadb/nucliadb/common/cluster/utils.py
@@ -27,7 +27,11 @@ from nucliadb.common.cluster.discovery.utils import (
     setup_cluster_discovery,
     teardown_cluster_discovery,
 )
-from nucliadb.common.cluster.manager import KBShardManager, StandaloneKBShardManager
+from nucliadb.common.cluster.manager import (
+    KBShardManager,
+    StandaloneKBShardManager,
+    clear_index_nodes,
+)
 from nucliadb.common.cluster.settings import settings
 from nucliadb.common.cluster.standalone.service import (
     start_grpc as start_standalone_grpc,
@@ -79,6 +83,8 @@ async def teardown_cluster():
     if std_server is not None:
         await std_server.stop(None)
         clean_utility(_STANDALONE_SERVER)
+
+    clear_index_nodes()
 
 
 def get_shard_manager() -> KBShardManager:


### PR DESCRIPTION
### Description
This fixes the event loop errors we've been seeing in standalone mode: https://github.com/nuclia/nucliadb/actions/runs/9032421397/job/24820582849#step:13:739

### How was this PR tested?
Describe how you tested this PR.
