### PR TITLE
Merge to prune delete tree when too many deletions

### DIFF
--- a/nucliadb_core/src/vectors.rs
+++ b/nucliadb_core/src/vectors.rs
@@ -39,6 +39,7 @@ pub type ProtosResponse = VectorSearchResponse;
 pub struct MergeParameters {
     pub max_nodes_in_merge: usize,
     pub segments_before_merge: usize,
+    pub maximum_deleted_entries: usize,
 }
 
 pub struct MergeContext {

--- a/nucliadb_node/src/settings.rs
+++ b/nucliadb_node/src/settings.rs
@@ -228,6 +228,7 @@ pub struct EnvSettings {
     pub merge_scheduler_segments_before_merge: usize,
     pub merge_on_commit_max_nodes_in_merge: usize,
     pub merge_on_commit_segments_before_merge: usize,
+    pub merge_maximum_deleted_entries: usize,
 
     pub max_open_shards: Option<NonZeroUsize>,
 
@@ -311,6 +312,7 @@ impl Default for EnvSettings {
             merge_scheduler_segments_before_merge: 2,
             merge_on_commit_max_nodes_in_merge: 10_000,
             merge_on_commit_segments_before_merge: 100,
+            merge_maximum_deleted_entries: 15_000,
             max_open_shards: None,
             file_backend: ObjectStoreType::NOTSET,
             gcs_indexing_bucket: Default::default(),

--- a/nucliadb_vectors/src/data_types/dtrie_ram.rs
+++ b/nucliadb_vectors/src/data_types/dtrie_ram.rs
@@ -69,6 +69,17 @@ impl DTrie {
     pub fn prune(&mut self, time: SystemTime) {
         self.inner_prune(time);
     }
+    pub fn size(&self) -> usize {
+        if self.go_table.is_empty() {
+            if self.value.is_some() {
+                1
+            } else {
+                0
+            }
+        } else {
+            self.go_table.values().map(|v| v.size()).sum()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/nucliadb_vectors/tests/test_merge.rs
+++ b/nucliadb_vectors/tests/test_merge.rs
@@ -62,6 +62,7 @@ fn test_concurrent_merge_delete() -> NodeResult<()> {
         .prepare_merge(MergeParameters {
             max_nodes_in_merge: 1000,
             segments_before_merge: 2,
+            maximum_deleted_entries: 25_000,
         })?
         .unwrap();
 


### PR DESCRIPTION
If there are too many deletions, the prune log can become too full and becomes slow, can create problems with replication due to a large state.bincode.

In this case, we will allow a merge of a single segment with the sole purpose of applying deletions to the segment so we can prune the delete log.