### PR TITLE
Fix local storage file movement

### DIFF
--- a/nucliadb_utils/nucliadb_utils/storages/local.py
+++ b/nucliadb_utils/nucliadb_utils/storages/local.py
@@ -57,7 +57,7 @@ class LocalStorageField(StorageField):
         destination_bucket_path = self.storage.get_bucket_path(destination_bucket_name)
         origin_path = f"{origin_bucket_path}/{origin_uri}"
         destination_path = f"{destination_bucket_path}/{destination_uri}"
-        os.rename(origin_path, destination_path)
+        os.renames(origin_path, destination_path)
 
     async def copy(
         self,


### PR DESCRIPTION
### Description
When using the tesbed I noticed that storing extracted images failed, because moving the generated images to the local bucket with the other resource data resulted in an Exception.

This was because the previous code used `os.rename` which does not create intermediate directories and since images are stored under `.../generated` it failed.

Changed it to the alternative `os.renames`, which does create those directories if missing.

### How was this PR tested?
Tested in testbed