### PR TITLE
Replicate shards using descriptor

### DIFF
--- a/nucliadb_core/Cargo.toml
+++ b/nucliadb_core/Cargo.toml
@@ -31,4 +31,4 @@ serde_json = "1.0.111"
 uuid = { version = "1.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
-tokio = { version = "1.32.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.32.0", features = ["rt-multi-thread", "macros"] }

--- a/nucliadb_core/src/lib.rs
+++ b/nucliadb_core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod prelude {
 }
 
 use std::collections::HashMap;
+use std::fs::File;
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub use anyhow::{anyhow as node_error, Context, Error};
@@ -85,7 +86,7 @@ impl From<Channel> for ReleaseChannel {
 #[derive(Debug, Default)]
 pub struct RawReplicaState {
     pub metadata_files: HashMap<String, Vec<u8>>,
-    pub files: Vec<String>,
+    pub files: Vec<(String, File)>,
 }
 
 impl RawReplicaState {

--- a/nucliadb_vectors/src/data_point_provider/replication.rs
+++ b/nucliadb_vectors/src/data_point_provider/replication.rs
@@ -56,9 +56,18 @@ pub(crate) fn get_index_files(
         if ignored_segment_ids.contains(&segment_id) {
             continue;
         }
-        files.push(format!("{relative_path}/{segment_id}/index.hnsw"));
-        files.push(format!("{relative_path}/{segment_id}/journal.json"));
-        files.push(format!("{relative_path}/{segment_id}/nodes.kv"));
+        files.push((
+            format!("{relative_path}/{segment_id}/index.hnsw"),
+            File::open(location.join(format!("{segment_id}/index.hnsw")))?,
+        ));
+        files.push((
+            format!("{relative_path}/{segment_id}/journal.json"),
+            File::open(location.join(format!("{segment_id}/journal.json")))?,
+        ));
+        files.push((
+            format!("{relative_path}/{segment_id}/nodes.kv"),
+            File::open(location.join(format!("{segment_id}/nodes.kv")))?,
+        ));
     }
 
     Ok(RawReplicaState {

--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -405,7 +405,7 @@ mod tests {
             expected_files.push(format!("vectors/{}/journal.json", segment));
             expected_files.push(format!("vectors/{}/nodes.kv", segment));
         }
-        assert_eq!(index_files.files, expected_files);
+        assert_eq!(index_files.files.into_iter().map(|x| x.0).collect::<Vec<_>>(), expected_files);
         assert_eq!(index_files.metadata_files.len(), 2);
     }
 }


### PR DESCRIPTION
### Description
Replicate shard files from a descriptor instead of a filename, so if the files are deleted (GC'ed) after getting the list of files, replication still works.