### PR TITLE
Overwrite vectorsets key, create vectorsets on shard creation and make new kbs have this key

### DIFF
--- a/nucliadb/migrations/0021_overwrite_vectorsets_key.py
+++ b/nucliadb/migrations/0021_overwrite_vectorsets_key.py
@@ -20,8 +20,9 @@
 
 """Migration #21
 
-Remove the old vectorsets maindb key to be able to reuse it with new data. The
-old key was: "/kbs/{kbid}/vectorsets"
+With the new vectorsets implementation, we need to store some information on
+maindb. As the key "/kbs/{kbid}/vectorsets" was already used at some point, this
+migration will ensure to overwrite the key and set the new value
 
 """
 import logging
@@ -40,6 +41,6 @@ async def migrate(context: ExecutionContext) -> None: ...
 async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
     key = f"/kbs/{kbid}/vectorsets"
     async with context.kv_driver.transaction() as txn:
-        logger.info(f"Removing vectorsets key: {key}")
-        await txn.delete(key)
+        logger.info(f"Overwriting vectorsets key", extra={"kbid": kbid})
+        await datamanagers.vectorsets.initialize(txn, kbid=kbid)
         await txn.commit()

--- a/nucliadb/migrations/0021_remove_deprecated_vectorsets_key.py
+++ b/nucliadb/migrations/0021_remove_deprecated_vectorsets_key.py
@@ -25,7 +25,6 @@ old key was: "/kbs/{kbid}/vectorsets"
 
 """
 import logging
-import re
 
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.kb import KB_SLUGS_BASE
@@ -35,25 +34,12 @@ from nucliadb.migrator.context import ExecutionContext
 logger = logging.getLogger(__name__)
 
 
-DEPRECATED_KEY_REGEX = re.compile(r"^/kbs/[a-zA-Z0-9-]+/vectorsets$")
+async def migrate(context: ExecutionContext) -> None: ...
 
 
-async def migrate(context: ExecutionContext) -> None:
-    keys_to_delete = []
-    async with context.kv_driver.transaction(read_only=True) as txn:
-        async for key in txn.keys("/kbs/", count=-1):
-            if re.fullmatch(DEPRECATED_KEY_REGEX, key):
-                keys_to_delete.append(key)
-
-    batch_size = 50
-    while keys_to_delete:
-        async with context.kv_driver.transaction() as txn:
-            batch = keys_to_delete[:batch_size]
-            for key in batch:
-                logger.info(f"Removing vectorsets key: {key}")
-                await txn.delete(key)
-            await txn.commit()
-            del keys_to_delete[:batch_size]
-
-
-async def migrate_kb(context: ExecutionContext, kbid: str) -> None: ...
+async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
+    key = f"/kbs/{kbid}/vectorsets"
+    async with context.kv_driver.transaction() as txn:
+        logger.info(f"Removing vectorsets key: {key}")
+        await txn.delete(key)
+        await txn.commit()

--- a/nucliadb/nucliadb/common/datamanagers/vectorsets.py
+++ b/nucliadb/nucliadb/common/datamanagers/vectorsets.py
@@ -26,6 +26,13 @@ from nucliadb_protos import knowledgebox_pb2
 KB_VECTORSETS = "/kbs/{kbid}/vectorsets"
 
 
+async def initialize(txn: Transaction, *, kbid: str):
+    key = KB_VECTORSETS.format(kbid=kbid)
+    await txn.set(
+        key, knowledgebox_pb2.KnowledgeBoxVectorSetsConfig().SerializeToString()
+    )
+
+
 async def get(
     txn: Transaction, *, kbid: str, vectorset_id: str
 ) -> Optional[knowledgebox_pb2.VectorSetConfig]:

--- a/nucliadb/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/nucliadb/ingest/orm/knowledgebox.py
@@ -132,6 +132,8 @@ class KnowledgeBox:
         if config is None:
             config = KnowledgeBoxConfig()
 
+        await datamanagers.vectorsets.initialize(txn, kbid=uuid)
+
         config.migration_version = get_latest_version()
         config.slug = slug
         await txn.set(

--- a/nucliadb/nucliadb/tests/migrations/test_migration_0021.py
+++ b/nucliadb/nucliadb/tests/migrations/test_migration_0021.py
@@ -25,6 +25,7 @@ import pytest
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.migrator.models import Migration
 from nucliadb.tests.migrations import get_migration
+from nucliadb_protos import knowledgebox_pb2
 
 migration: Migration = get_migration(21)
 
@@ -52,7 +53,9 @@ async def test_migration_0021(maindb_driver: Driver):
 
     async with maindb_driver.transaction(read_only=True) as txn:
         assert (await txn.get(f"/kbs/{kbid}")) == b"my kb"
-        assert (await txn.get(f"/kbs/{kbid}/vectorsets")) is None
+        assert (
+            await txn.get(f"/kbs/{kbid}/vectorsets")
+        ) == knowledgebox_pb2.KnowledgeBoxVectorSetsConfig().SerializeToString()
         assert (await txn.get(f"/kbs/{kbid}/other")) == b"other data"
 
 
@@ -78,5 +81,7 @@ async def test_migration_0021_kb_without_vectorset_key(maindb_driver: Driver):
 
     async with maindb_driver.transaction(read_only=True) as txn:
         assert (await txn.get(f"/kbs/{kbid}")) == b"my kb"
-        assert (await txn.get(f"/kbs/{kbid}/vectorsets")) is None
+        assert (
+            await txn.get(f"/kbs/{kbid}/vectorsets")
+        ) == knowledgebox_pb2.KnowledgeBoxVectorSetsConfig().SerializeToString()
         assert (await txn.get(f"/kbs/{kbid}/other")) == b"other data"

--- a/nucliadb/nucliadb/tests/migrations/test_migration_0021.py
+++ b/nucliadb/nucliadb/tests/migrations/test_migration_0021.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import uuid
+from unittest.mock import Mock
+
+import pytest
+
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.migrator.models import Migration
+from nucliadb.tests.migrations import get_migration
+
+migration: Migration = get_migration(21)
+
+
+@pytest.mark.asyncio
+async def test_migration_0021(maindb_driver: Driver):
+    execution_context = Mock()
+    execution_context.kv_driver = maindb_driver
+
+    key = "/kbs/{kbid}/vectorsets"
+
+    kv = {}
+    for _ in range(200):
+        kbid = str(uuid.uuid4())
+        kv[f"/kbs/{kbid}"] = b"my kb"
+        kv[f"/kbs/{kbid}/vectorsets"] = b"vectorset data"
+        kv[f"/kbs/{kbid}/other"] = b"other data"
+
+    # Create a bunch of deprecated vectorsets keys and add
+    async with maindb_driver.transaction() as txn:
+        for key, value in kv.items():
+            await txn.set(key, value)
+        await txn.commit()
+
+    async with maindb_driver.transaction(read_only=True) as txn:
+        for key, value in kv.items():
+            stored = await txn.get(key)
+            assert stored == value
+
+    await migration.module.migrate(execution_context)
+
+    async with maindb_driver.transaction(read_only=True) as txn:
+        for key, value in kv.items():
+            stored = await txn.get(key)
+            if key.endswith("/vectorsets"):
+                assert stored is None
+            else:
+                assert stored == value


### PR DESCRIPTION
### Description
As we'll reuse the same maindb key for vectorsets, ensure there's no value in maindb

### How was this PR tested?
Describe how you tested this PR.
