### PR TITLE
Mypy typing party

### DIFF
--- a/nucliadb/src/nucliadb/common/cluster/discovery/base.py
+++ b/nucliadb/src/nucliadb/common/cluster/discovery/base.py
@@ -113,7 +113,7 @@ async def _get_index_node_metadata(
     channel = get_traced_grpc_channel(grpc_address, "discovery", variant="_writer")
     if read_replica:
         # on a read replica, we need to use the replication service
-        stub = replication_pb2_grpc.ReplicationServiceStub(channel)  # type: ignore
+        stub = replication_pb2_grpc.ReplicationServiceStub(channel)
     else:
         stub = nodewriter_pb2_grpc.NodeWriterStub(channel)  # type: ignore
     try:
@@ -152,7 +152,7 @@ async def _get_standalone_index_node_metadata(
     else:
         grpc_address = address
     channel = get_traced_grpc_channel(grpc_address, "standalone_proxy")
-    stub = standalone_pb2_grpc.StandaloneClusterServiceStub(channel)  # type: ignore
+    stub = standalone_pb2_grpc.StandaloneClusterServiceStub(channel)
     resp: standalone_pb2.NodeInfoResponse = await stub.NodeInfo(standalone_pb2.NodeInfoRequest())  # type: ignore
     return IndexNodeMetadata(
         node_id=resp.id,

--- a/nucliadb/src/nucliadb/common/cluster/index_node.py
+++ b/nucliadb/src/nucliadb/common/cluster/index_node.py
@@ -19,15 +19,12 @@
 #
 from typing import Optional
 
-from lru import LRU  # type: ignore
+from lru import LRU
 from nucliadb_protos.nodereader_pb2_grpc import NodeReaderStub
 from nucliadb_protos.nodewriter_pb2_grpc import NodeWriterStub
 
-from nucliadb.common.cluster.base import AbstractIndexNode  # type: ignore
-from nucliadb.common.cluster.grpc_node_dummy import (  # type: ignore
-    DummyReaderStub,
-    DummyWriterStub,
-)
+from nucliadb.common.cluster.base import AbstractIndexNode
+from nucliadb.common.cluster.grpc_node_dummy import DummyReaderStub, DummyWriterStub
 from nucliadb.ingest import SERVICE_NAME
 from nucliadb_utils.grpc import get_traced_grpc_channel
 
@@ -63,7 +60,7 @@ class IndexNode(AbstractIndexNode):
                 channel = get_traced_grpc_channel(
                     grpc_address, SERVICE_NAME, variant="_writer"
                 )
-                WRITE_CONNECTIONS[self.address] = NodeWriterStub(channel)  # type: ignore
+                WRITE_CONNECTIONS[self.address] = NodeWriterStub(channel)
             else:
                 WRITE_CONNECTIONS[self.address] = DummyWriterStub()
             self._writer = WRITE_CONNECTIONS[self.address]
@@ -79,7 +76,7 @@ class IndexNode(AbstractIndexNode):
                 channel = get_traced_grpc_channel(
                     grpc_address, SERVICE_NAME, variant="_reader"
                 )
-                READ_CONNECTIONS[self.address] = NodeReaderStub(channel)  # type: ignore
+                READ_CONNECTIONS[self.address] = NodeReaderStub(channel)
             else:
                 READ_CONNECTIONS[self.address] = DummyReaderStub()
             self._reader = READ_CONNECTIONS[self.address]

--- a/nucliadb/src/nucliadb/common/cluster/manager.py
+++ b/nucliadb/src/nucliadb/common/cluster/manager.py
@@ -159,7 +159,7 @@ class KBShardManager:
 
         try:
             results = await asyncio.wait_for(
-                asyncio.gather(*ops, return_exceptions=True),  # type: ignore
+                asyncio.gather(*ops, return_exceptions=True),
                 timeout=timeout,
             )
         except asyncio.TimeoutError as exc:
@@ -451,7 +451,7 @@ class StandaloneKBShardManager(KBShardManager):
     def __init__(self):
         super().__init__()
         self._lock = asyncio.Lock()
-        self._change_count: dict[tuple[str, str], int] = {}  # type: ignore
+        self._change_count: dict[tuple[str, str], int] = {}
 
     async def _resource_change_event(
         self, kbid: str, node_id: str, shard_id: str
@@ -468,13 +468,15 @@ class StandaloneKBShardManager(KBShardManager):
             if index_node is None:
                 return
             shard_info: noderesources_pb2.Shard = await index_node.reader.GetShard(
-                nodereader_pb2.GetShardRequest(shard_id=noderesources_pb2.ShardId(id=shard_id))  # type: ignore
+                nodereader_pb2.GetShardRequest(
+                    shard_id=noderesources_pb2.ShardId(id=shard_id)
+                )
             )
             await self.maybe_create_new_shard(
                 kbid,
                 shard_info.paragraphs,
             )
-            await index_node.writer.GC(noderesources_pb2.ShardId(id=shard_id))  # type: ignore
+            await index_node.writer.GC(noderesources_pb2.ShardId(id=shard_id))
 
     @backoff.on_exception(
         backoff.expo, NodesUnsync, jitter=backoff.random_jitter, max_tries=5
@@ -626,7 +628,7 @@ def check_enough_nodes():
     if settings.max_node_replicas >= 0:
         available_nodes = list(
             filter(
-                lambda n: n.shard_count < settings.max_node_replicas, available_nodes  # type: ignore
+                lambda n: n.shard_count < settings.max_node_replicas, available_nodes
             )
         )
         if len(available_nodes) < target_replicas:

--- a/nucliadb/src/nucliadb/common/cluster/standalone/grpc_node_binding.py
+++ b/nucliadb/src/nucliadb/common/cluster/standalone/grpc_node_binding.py
@@ -68,8 +68,7 @@ except ImportError:  # pragma: no cover
     IndexNodeException = Exception
 
 try:
-    from nucliadb_node_binding import NodeReader  # type: ignore
-    from nucliadb_node_binding import NodeWriter  # type: ignore
+    from nucliadb_node_binding import NodeReader, NodeWriter
 except ImportError:  # pragma: no cover
     NodeReader = None
     NodeWriter = None

--- a/nucliadb/src/nucliadb/common/cluster/standalone/index_node.py
+++ b/nucliadb/src/nucliadb/common/cluster/standalone/index_node.py
@@ -20,10 +20,7 @@
 from typing import Any, Optional
 
 from nucliadb.common.cluster.base import AbstractIndexNode
-from nucliadb.common.cluster.grpc_node_dummy import (  # type: ignore
-    DummyReaderStub,
-    DummyWriterStub,
-)
+from nucliadb.common.cluster.grpc_node_dummy import DummyReaderStub, DummyWriterStub
 from nucliadb.common.cluster.settings import settings as cluster_settings
 from nucliadb.common.cluster.standalone import grpc_node_binding
 from nucliadb_protos import standalone_pb2, standalone_pb2_grpc
@@ -79,7 +76,7 @@ class ProxyCallerWrapper:
         else:
             grpc_address = address
         self._channel = get_traced_grpc_channel(grpc_address, "standalone_proxy")
-        self._stub = standalone_pb2_grpc.StandaloneClusterServiceStub(self._channel)  # type: ignore
+        self._stub = standalone_pb2_grpc.StandaloneClusterServiceStub(self._channel)
 
     def __getattr__(self, name):
         async def call(request):

--- a/nucliadb/src/nucliadb/common/datamanagers/atomic.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/atomic.py
@@ -51,7 +51,7 @@ from .utils import with_ro_transaction, with_transaction
 
 __python_version = (sys.version_info.major, sys.version_info.minor)
 if __python_version == (3, 9):
-    from typing_extensions import ParamSpec  # type: ignore
+    from typing_extensions import ParamSpec
 else:
     from typing import ParamSpec  # type: ignore
 

--- a/nucliadb/src/nucliadb/common/datamanagers/rollover.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/rollover.py
@@ -106,7 +106,7 @@ async def get_indexed_data(
     val = await txn.get(key)
     if val is not None:
         data = orjson.loads(val)
-        return tuple(data)  # type: ignore
+        return tuple(data)
     return None
 
 
@@ -140,7 +140,7 @@ async def _get_batch_indexed_data(
     results: list[tuple[str, tuple[str, int]]] = []
     for key, val in zip(batch, values):
         if val is not None:
-            data: tuple[str, int] = tuple(orjson.loads(val))  # type: ignore
+            data: tuple[str, int] = tuple(orjson.loads(val))
             results.append((key.split("/")[-1], data))
     return results
 

--- a/nucliadb/src/nucliadb/export_import/importer.py
+++ b/nucliadb/src/nucliadb/export_import/importer.py
@@ -110,6 +110,6 @@ async def import_kb_from_blob_storage(
     async def import_kb_retried(context, kbid, stream, metadata):
         await import_kb(context, kbid, stream, metadata)
 
-    await import_kb_retried(context, kbid, stream, metadata)  # type: ignore
+    await import_kb_retried(context, kbid, stream, metadata)
 
     await dm.try_delete_from_storage("import", kbid, import_id)

--- a/nucliadb/src/nucliadb/export_import/tasks.py
+++ b/nucliadb/src/nucliadb/export_import/tasks.py
@@ -32,7 +32,7 @@ def get_exports_consumer() -> NatsTaskConsumer:
         name="exports_consumer",
         stream=const.Streams.KB_EXPORTS,  # type: ignore
         callback=export_kb_to_blob_storage,  # type: ignore
-        msg_type=NatsTaskMessage,  # type: ignore
+        msg_type=NatsTaskMessage,
         max_concurrent_messages=10,
     )
 
@@ -41,7 +41,7 @@ async def get_exports_producer(context: ApplicationContext) -> NatsTaskProducer:
     producer = create_producer(
         name="exports_producer",
         stream=const.Streams.KB_EXPORTS,  # type: ignore
-        msg_type=NatsTaskMessage,  # type: ignore
+        msg_type=NatsTaskMessage,
     )
     await producer.initialize(context)
     return producer
@@ -52,7 +52,7 @@ def get_imports_consumer() -> NatsTaskConsumer:
         name="imports_consumer",
         stream=const.Streams.KB_IMPORTS,  # type: ignore
         callback=import_kb_from_blob_storage,  # type: ignore
-        msg_type=NatsTaskMessage,  # type: ignore
+        msg_type=NatsTaskMessage,
         max_concurrent_messages=10,
     )
 
@@ -61,7 +61,7 @@ async def get_imports_producer(context: ApplicationContext) -> NatsTaskProducer:
     producer = create_producer(
         name="imports_producer",
         stream=const.Streams.KB_IMPORTS,  # type: ignore
-        msg_type=NatsTaskMessage,  # type: ignore
+        msg_type=NatsTaskMessage,
     )
     await producer.initialize(context)
     return producer

--- a/nucliadb/src/nucliadb/export_import/utils.py
+++ b/nucliadb/src/nucliadb/export_import/utils.py
@@ -417,7 +417,7 @@ class ExportStreamReader:
                     ExportedItemType.ENTITIES: self.read_entities,
                     ExportedItemType.LABELS: self.read_labels,
                 }[item_type]
-                data = await read_data_func()  # type: ignore
+                data = await read_data_func()
                 yield item_type, data
             except ExportStreamExhausted:
                 break

--- a/nucliadb/src/nucliadb/ingest/orm/broker_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/broker_message.py
@@ -136,7 +136,7 @@ class _BrokerMessageBuilder:
     ):
         etw = ExtractedTextWrapper()
         etw.field.field = field_id
-        etw.field.field_type = type_id  # type: ignore
+        etw.field.field_type = type_id
         extracted_text = await field.get_extracted_text()
         if extracted_text is not None:
             etw.body.CopyFrom(extracted_text)
@@ -150,13 +150,13 @@ class _BrokerMessageBuilder:
     ):
         fcmw = FieldComputedMetadataWrapper()
         fcmw.field.field = field_id
-        fcmw.field.field_type = type_id  # type: ignore
+        fcmw.field.field_type = type_id
 
         field_metadata = await field.get_field_metadata()
         if field_metadata is not None:
             fcmw.metadata.CopyFrom(field_metadata)
             fcmw.field.field = field_id
-            fcmw.field.field_type = type_id  # type: ignore
+            fcmw.field.field_type = type_id
             self.bm.field_metadata.append(fcmw)
             # Make sure cloud files are removed for exporting
 
@@ -171,7 +171,7 @@ class _BrokerMessageBuilder:
             return
         evw = ExtractedVectorsWrapper()
         evw.field.field = field_id
-        evw.field.field_type = type_id  # type: ignore
+        evw.field.field_type = type_id
         evw.vectors.CopyFrom(vo)
         self.bm.field_vectors.append(evw)
 
@@ -186,6 +186,6 @@ class _BrokerMessageBuilder:
             return
         lcmw = LargeComputedMetadataWrapper()
         lcmw.field.field = field_id
-        lcmw.field.field_type = type_id  # type: ignore
+        lcmw.field.field_type = type_id
         lcmw.real.CopyFrom(lcm)
         self.bm.field_large_metadata.append(lcmw)

--- a/nucliadb/src/nucliadb/ingest/orm/entities.py
+++ b/nucliadb/src/nucliadb/ingest/orm/entities.py
@@ -199,7 +199,7 @@ class EntitiesManager:
         elif stored is not None and indexed is not None:
             entities_group = self.merge_entities_groups(indexed, stored)
         else:
-            entities_group = stored or indexed  # type: ignore
+            entities_group = stored or indexed
         return entities_group
 
     async def get_stored_entities_group(self, group: str) -> Optional[EntitiesGroup]:

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -247,7 +247,7 @@ class KnowledgeBox:
                 logger.warning(f"Shards not found for kbid={kbid}")
             else:
                 shards_obj = writer_pb2.Shards()
-                shards_obj.ParseFromString(payload)  # type: ignore
+                shards_obj.ParseFromString(payload)
 
                 for shard in shards_obj.shards:
                     # Delete the shard on nodes

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -337,7 +337,7 @@ class Resource:
         await self.compute_global_tags(brain)
         fields = await self.get_fields(force=True)
         for (type_id, field_id), field in fields.items():
-            fieldid = FieldID(field_type=type_id, field=field_id)  # type: ignore
+            fieldid = FieldID(field_type=type_id, field=field_id)
             await self.compute_global_text_field(fieldid, brain)
 
             field_metadata = await field.get_field_metadata()
@@ -505,7 +505,7 @@ class Resource:
             if field in self.all_fields_keys:
                 self.all_fields_keys.remove(field)
 
-        field_key = self.generate_field_id(FieldID(field_type=type, field=key))  # type: ignore
+        field_key = self.generate_field_id(FieldID(field_type=type, field=key))
         vo = await field_obj.get_vectors()
         if vo is not None:
             self.indexer.delete_vectors(field_key=field_key, vo=vo)
@@ -898,7 +898,7 @@ class Resource:
         brain.set_resource_metadata(basic=basic, origin=origin)
         for type, field in await self.get_fields_ids(force=True):
             fieldobj = await self.get_field(field, type, load=False)
-            fieldid = FieldID(field_type=type, field=field)  # type: ignore
+            fieldid = FieldID(field_type=type, field=field)
             fieldkey = self.generate_field_id(fieldid)
             extracted_metadata = await fieldobj.get_field_metadata()
             valid_user_field_metadata = None
@@ -960,7 +960,7 @@ class Resource:
                         )
 
         for (type_id, field_id), field in fields.items():
-            fieldid = FieldID(field_type=type_id, field=field_id)  # type: ignore
+            fieldid = FieldID(field_type=type_id, field=field_id)
             field_key = self.generate_field_id(fieldid)
             fm = await field.get_field_metadata()
             extracted_text = None
@@ -1074,7 +1074,7 @@ class Resource:
                         )
 
         for (type_id, field_id), field in fields.items():
-            fieldid = FieldID(field_type=type_id, field=field_id)  # type: ignore
+            fieldid = FieldID(field_type=type_id, field=field_id)
             field_key = self.generate_field_id(fieldid)
             fm = await field.get_field_metadata()
             extracted_text = None
@@ -1152,7 +1152,7 @@ class Resource:
                 metadata.labels.resource.extend(self.basic.usermetadata.classifications)
 
         for (type_id, field_id), field in fields.items():
-            fieldid = FieldID(field_type=type_id, field=field_id)  # type: ignore
+            fieldid = FieldID(field_type=type_id, field=field_id)
             fm = await field.get_field_metadata()
             extracted_text = None
 

--- a/nucliadb/src/nucliadb/ingest/processing.py
+++ b/nucliadb/src/nucliadb/ingest/processing.py
@@ -473,7 +473,7 @@ class ProcessingEngine:
 
 class DummyProcessingEngine(ProcessingEngine):
     def __init__(self):
-        self.calls: list[list[Any]] = []  # type: ignore
+        self.calls: list[list[Any]] = []
         self.values = defaultdict(list)
         self.onprem = True
 

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -287,10 +287,8 @@ async def managed_serialize(
                     resource.data.files[field.id] = FileFieldData()
                 if include_value:
                     if value is not None:
-                        resource.data.files[
-                            field.id
-                        ].value = models.FieldFile.from_message(
-                            value  # type: ignore
+                        resource.data.files[field.id].value = (
+                            models.FieldFile.from_message(value)
                         )
                     else:
                         resource.data.files[field.id].value = None

--- a/nucliadb/src/nucliadb/ingest/utils.py
+++ b/nucliadb/src/nucliadb/ingest/utils.py
@@ -41,7 +41,7 @@ async def start_ingest(service_name: Optional[str] = None):
             nucliadb_settings.nucliadb_ingest, service_name or "ingest"
         )
         set_utility(Utility.CHANNEL, channel)
-        ingest = WriterStub(channel)  # type: ignore
+        ingest = WriterStub(channel)
         set_utility(Utility.INGEST, ingest)
     else:
         # Its not distributed create a ingest

--- a/nucliadb/src/nucliadb/migrator/migrator.py
+++ b/nucliadb/src/nucliadb/migrator/migrator.py
@@ -62,7 +62,7 @@ async def run_kb_migrations(
                 with migration_observer(
                     {"type": "kb", "target_version": str(migration.version)}
                 ):
-                    await migration.module.migrate_kb(context, kbid)  # type: ignore
+                    await migration.module.migrate_kb(context, kbid)
                 logger.info("Finished KB Migration", extra=migration_info)
                 await context.data_manager.update_kb_info(
                     kbid=kbid, current_version=migration.version
@@ -157,7 +157,7 @@ async def run_global_migrations(context: ExecutionContext, target_version: int) 
             with migration_observer(
                 {"type": "global", "target_version": str(migration.version)}
             ):
-                await migration.module.migrate(context)  # type: ignore
+                await migration.module.migrate(context)
             await context.data_manager.update_global_info(
                 current_version=migration.version
             )

--- a/nucliadb/src/nucliadb/purge/orphan_shards.py
+++ b/nucliadb/src/nucliadb/purge/orphan_shards.py
@@ -23,7 +23,7 @@ import importlib.metadata
 from dataclasses import dataclass
 from typing import Optional
 
-from grpc.aio import AioRpcError  # type: ignore
+from grpc.aio import AioRpcError
 
 from nucliadb.common import datamanagers
 from nucliadb.common.cluster import manager

--- a/nucliadb/src/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/download.py
@@ -35,11 +35,7 @@ from nucliadb.reader.api.models import FIELD_NAMES_TO_PB_TYPE_MAP
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
-from nucliadb_utils.storages.storage import (  # type: ignore
-    ObjectMetadata,
-    Range,
-    StorageField,
-)
+from nucliadb_utils.storages.storage import ObjectMetadata, Range, StorageField
 from nucliadb_utils.utilities import get_storage
 
 from .router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX, api

--- a/nucliadb/src/nucliadb/reader/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/knowledgebox.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from fastapi import HTTPException
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 from starlette.requests import Request
 
 from nucliadb.common import datamanagers
@@ -49,7 +49,7 @@ async def get_kbs(request: Request, prefix: str = "") -> KnowledgeBoxList:
     async with driver.transaction() as txn:
         response = KnowledgeBoxList()
         async for kbid, slug in datamanagers.kb.get_kbs(txn, prefix=prefix):
-            response.kbs.append(KnowledgeBoxObjSummary(slug=slug or None, uuid=kbid))  # type: ignore
+            response.kbs.append(KnowledgeBoxObjSummary(slug=slug or None, uuid=kbid))
         return response
 
 
@@ -71,7 +71,7 @@ async def get_kb(request: Request, kbid: str) -> KnowledgeBoxObj:
 
         return KnowledgeBoxObj(
             uuid=kbid,
-            slug=kb_config.slug,  # type: ignore
+            slug=kb_config.slug,
             config=KnowledgeBoxConfig.from_message(kb_config),
         )
 
@@ -98,6 +98,6 @@ async def get_kb_by_slug(request: Request, slug: str) -> KnowledgeBoxObj:
 
         return KnowledgeBoxObj(
             uuid=kbid,
-            slug=kb_config.slug,  # type: ignore
+            slug=kb_config.slug,
             config=KnowledgeBoxConfig.from_message(kb_config),
         )

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -33,7 +33,7 @@ from nucliadb.ingest.serialize import (
     serialize,
     set_resource_field_extracted_data,
 )
-from nucliadb.reader import SERVICE_NAME  # type: ignore
+from nucliadb.reader import SERVICE_NAME
 from nucliadb.reader.api import DEFAULT_RESOURCE_LIST_PAGE_SIZE
 from nucliadb.reader.api.models import (
     FIELD_NAME_TO_EXTRACTED_DATA_FIELD_MAP,
@@ -360,7 +360,7 @@ async def _get_resource_field(
         if field is None:
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
 
-        resource_field = ResourceField(field_id=field_id, field_type=field_type)  # type: ignore
+        resource_field = ResourceField(field_id=field_id, field_type=field_type)
 
         if ResourceFieldProperties.VALUE in show:
             value = await field.get_value()

--- a/nucliadb/src/nucliadb/reader/api/v1/services.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/services.py
@@ -22,7 +22,7 @@ from typing import Optional, Union
 
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 from google.protobuf.json_format import MessageToDict
 from nucliadb_protos.knowledgebox_pb2 import Synonyms
 from nucliadb_protos.writer_pb2 import (

--- a/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
@@ -121,7 +121,7 @@ async def knowledgebox_counters(
         )
 
     try:
-        results: Optional[list[Shard]] = await asyncio.wait_for(  # type: ignore
+        results: Optional[list[Shard]] = await asyncio.wait_for(
             asyncio.gather(*ops, return_exceptions=True),  # type: ignore
             timeout=settings.search_timeout,
         )

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -295,7 +295,7 @@ async def catalog(
     """
     try:
         sort = item.sort
-        if item.sort is None:
+        if sort is None:
             # By default we sort by creation date (most recent first)
             sort = SortOptions(
                 field=SortField.CREATED,
@@ -479,7 +479,7 @@ async def search(
         show=item.show,
         field_type_filter=item.field_type_filter,
         extracted=item.extracted,
-        sort=query_parser.sort,
+        sort=query_parser.sort,  # type: ignore
         requested_relations=pb_query.relation_subgraph,
         min_score=query_parser.min_score,
         highlight=item.highlight,

--- a/nucliadb/src/nucliadb/search/lifecycle.py
+++ b/nucliadb/src/nucliadb/search/lifecycle.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from nucliadb.common.cluster.utils import setup_cluster, teardown_cluster
-from nucliadb.common.maindb.utils import setup_driver  # type: ignore
+from nucliadb.common.maindb.utils import setup_driver
 from nucliadb.ingest.utils import start_ingest, stop_ingest
 from nucliadb.search import SERVICE_NAME
 from nucliadb.search.predict import start_predict_engine

--- a/nucliadb/src/nucliadb/search/predict.py
+++ b/nucliadb/src/nucliadb/search/predict.py
@@ -514,7 +514,7 @@ class DummyPredictEngine(PredictEngine):
 
     async def chat_query_ndjson(
         self, kbid: str, item: ChatModel
-    ) -> tuple[str, AsyncIterator[bytes]]:
+    ) -> tuple[str, AsyncIterator[GenerativeChunk]]:
         self.calls.append(("chat_query_ndjson", item))
 
         async def generate():

--- a/nucliadb/src/nucliadb/search/requesters/utils.py
+++ b/nucliadb/src/nucliadb/search/requesters/utils.py
@@ -82,7 +82,7 @@ T = TypeVar(
 )
 
 
-@overload  # type: ignore
+@overload
 async def node_query(
     kbid: str,
     method: Method,

--- a/nucliadb/src/nucliadb/search/search/cache.py
+++ b/nucliadb/src/nucliadb/search/search/cache.py
@@ -21,7 +21,7 @@ import asyncio
 from contextvars import ContextVar
 from typing import Optional
 
-from lru import LRU  # type: ignore
+from lru import LRU
 
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -463,7 +463,7 @@ async def ask(
         ask_request=ask_request,
         find_results=find_results,
         nuclia_learning_id=nuclia_learning_id,
-        predict_answer_stream=predict_answer_stream,
+        predict_answer_stream=predict_answer_stream,  # type: ignore
         prompt_context=prompt_context,
         prompt_context_order=prompt_context_order,
         auditor=auditor,

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -519,7 +519,7 @@ async def get_extra_chars(
                 paragraphs=[(paragraph, new_text)],
             )
         else:
-            resources[rid].paragraphs.append((paragraph, new_text))  # type: ignore
+            resources[rid].paragraphs.append((paragraph, new_text))
 
     for values in resources.values():
         title_text = values.title

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -105,7 +105,7 @@ async def find(
             extracted=item.extracted,
             requested_relations=pb_query.relation_subgraph,
             min_score_bm25=query_parser.min_score.bm25,
-            min_score_semantic=query_parser.min_score.semantic,
+            min_score_semantic=query_parser.min_score.semantic,  # type: ignore
             highlight=item.highlight,
         )
 

--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -245,7 +245,7 @@ async def fetch_find_metadata(
 
     FIND_FETCH_OPS_DISTRIBUTION.observe(len(operations))
     if len(operations) > 0:
-        done, _ = await asyncio.wait(operations)  # type: ignore
+        done, _ = await asyncio.wait(operations)
         for task in done:
             if task.exception() is not None:  # pragma: no cover
                 logger.error("Error fetching find metadata", exc_info=task.exception())

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -115,7 +115,7 @@ class QueryParser:
         key_filters: Optional[list[str]] = None,
         security: Optional[RequestSecurity] = None,
         generative_model: Optional[str] = None,
-        rephrase: Optional[bool] = False,
+        rephrase: bool = False,
         max_tokens: Optional[MaxTokens] = None,
     ):
         self.kbid = kbid

--- a/nucliadb/src/nucliadb/tasks/consumer.py
+++ b/nucliadb/src/nucliadb/tasks/consumer.py
@@ -214,7 +214,7 @@ async def start_consumer(
         name=f"{task_name}_consumer",
         stream=task.stream,
         callback=task.callback,  # type: ignore
-        msg_type=task.msg_type,  # type: ignore
+        msg_type=task.msg_type,
         max_concurrent_messages=task.max_concurrent_messages,
     )
     await consumer.initialize(context)

--- a/nucliadb/src/nucliadb/tasks/producer.py
+++ b/nucliadb/src/nucliadb/tasks/producer.py
@@ -48,7 +48,7 @@ class NatsTaskProducer:
         )
         self.initialized = True
 
-    async def __call__(self, msg: MsgType) -> int:  # type: ignore
+    async def __call__(self, msg: MsgType) -> int:
         """
         Publish message to the producer's nats stream.
         Returns the sequence number of the published message.

--- a/nucliadb/src/nucliadb/train/api/v1/check.py
+++ b/nucliadb/src/nucliadb/train/api/v1/check.py
@@ -19,7 +19,7 @@
 #
 
 from fastapi import Request
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 
 from nucliadb.train.api.utils import get_kb_partitions
 from nucliadb.train.api.v1.router import KB_PREFIX, api

--- a/nucliadb/src/nucliadb/train/api/v1/shards.py
+++ b/nucliadb/src/nucliadb/train/api/v1/shards.py
@@ -21,7 +21,7 @@
 
 from fastapi import HTTPException, Request
 from fastapi.responses import StreamingResponse
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 
 from nucliadb.train.api.utils import get_kb_partitions, get_train
 from nucliadb.train.api.v1.router import KB_PREFIX, api

--- a/nucliadb/src/nucliadb/train/api/v1/trainset.py
+++ b/nucliadb/src/nucliadb/train/api/v1/trainset.py
@@ -21,7 +21,7 @@
 from typing import Optional
 
 from fastapi import Request
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 
 from nucliadb.train.api.utils import get_kb_partitions
 from nucliadb.train.api.v1.router import KB_PREFIX, api

--- a/nucliadb/src/nucliadb/train/utils.py
+++ b/nucliadb/src/nucliadb/train/utils.py
@@ -23,7 +23,7 @@ from grpc import aio
 from grpc_health.v1 import health, health_pb2_grpc
 
 from nucliadb.common.maindb.utils import setup_driver, teardown_driver
-from nucliadb.train.nodes import TrainShardManager  # type: ignore
+from nucliadb.train.nodes import TrainShardManager
 from nucliadb.train.settings import settings
 from nucliadb_protos import train_pb2_grpc
 from nucliadb_telemetry.utils import setup_telemetry

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -21,7 +21,7 @@ from inspect import iscoroutinefunction
 from typing import TYPE_CHECKING, Callable, Optional, Type, Union
 
 from fastapi import HTTPException, Response
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 from nucliadb_protos.resources_pb2 import FieldID, Metadata
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from starlette.requests import Request

--- a/nucliadb/src/nucliadb/writer/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/knowledgebox.py
@@ -63,7 +63,7 @@ async def create_kb(request: Request, item: KnowledgeBoxConfig):
     if item.slug != "":
         slug = item.slug
     else:
-        slug = kbobj.uuid  # type: ignore
+        slug = kbobj.uuid
     if kbobj.status == KnowledgeBoxResponseStatus.OK:
         return KnowledgeBoxObj(uuid=kbobj.uuid, slug=slug)
     elif kbobj.status == KnowledgeBoxResponseStatus.CONFLICT:

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -30,7 +30,7 @@ from fastapi import HTTPException
 from fastapi.params import Header
 from fastapi.requests import Request
 from fastapi.responses import Response
-from fastapi_versioning import version  # type: ignore
+from fastapi_versioning import version
 from nucliadb_protos.resources_pb2 import FieldFile, Metadata
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from starlette.requests import Request as StarletteRequest
@@ -58,7 +58,7 @@ from nucliadb.writer.tus.exceptions import (
     InvalidTUSMetadata,
     ResumableURINotAvailable,
 )
-from nucliadb.writer.tus.storage import FileStorageManager  # type: ignore
+from nucliadb.writer.tus.storage import FileStorageManager
 from nucliadb.writer.tus.utils import parse_tus_metadata
 from nucliadb.writer.utilities import get_processing
 from nucliadb_models.resource import NucliaDBRoles

--- a/nucliadb/src/nucliadb/writer/resource/basic.py
+++ b/nucliadb/src/nucliadb/writer/resource/basic.py
@@ -147,7 +147,7 @@ def parse_basic_modify(
                 userfieldmetadata.question_answers.append(qa_annotation_pb)
 
             userfieldmetadata.field.field = fieldmetadata.field.field
-            userfieldmetadata.field.field_type = FIELD_TYPES_MAP_REVERSE[  # type: ignore
+            userfieldmetadata.field.field_type = FIELD_TYPES_MAP_REVERSE[
                 fieldmetadata.field.field_type.value
             ]
 

--- a/nucliadb/src/nucliadb/writer/tus/__init__.py
+++ b/nucliadb/src/nucliadb/writer/tus/__init__.py
@@ -107,7 +107,7 @@ async def finalize():
         REDIS_FILE_DATA_MANAGER_FACTORY = None
 
 
-def get_dm() -> FileDataManager:  # type: ignore
+def get_dm() -> FileDataManager:
     if writer_settings.dm_enabled:
         global REDIS_FILE_DATA_MANAGER_FACTORY
         if REDIS_FILE_DATA_MANAGER_FACTORY is None:

--- a/nucliadb/src/nucliadb/writer/tus/s3.py
+++ b/nucliadb/src/nucliadb/writer/tus/s3.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 import aiobotocore  # type: ignore
 import aiohttp
-import backoff  # type: ignore
+import backoff
 import botocore  # type: ignore
 from aiobotocore.session import AioSession  # type: ignore
 from nucliadb_protos.resources_pb2 import CloudFile

--- a/nucliadb/tests/fixtures.py
+++ b/nucliadb/tests/fixtures.py
@@ -231,13 +231,13 @@ async def knowledgebox(nucliadb_manager: AsyncClient, request):
 
 @pytest.fixture(scope="function")
 async def nucliadb_grpc(nucliadb: Settings):
-    stub = WriterStub(aio.insecure_channel(f"localhost:{nucliadb.ingest_grpc_port}"))  # type: ignore
+    stub = WriterStub(aio.insecure_channel(f"localhost:{nucliadb.ingest_grpc_port}"))
     return stub
 
 
 @pytest.fixture(scope="function")
 async def nucliadb_train(nucliadb: Settings):
-    stub = TrainStub(aio.insecure_channel(f"localhost:{nucliadb.train_grpc_port}"))  # type: ignore
+    stub = TrainStub(aio.insecure_channel(f"localhost:{nucliadb.train_grpc_port}"))
     return stub
 
 
@@ -500,7 +500,7 @@ def predict_mock() -> Mock:  # type: ignore
 
 @pytest.fixture(scope="function")
 def metrics_registry():
-    import prometheus_client.registry  # type: ignore
+    import prometheus_client.registry
 
     for collector in prometheus_client.registry.REGISTRY._names_to_collectors.values():
         if not hasattr(collector, "_metrics"):

--- a/nucliadb/tests/ingest/integration/consumer/test_pull.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_pull.py
@@ -59,7 +59,7 @@ class PullProcessorAPI:
 @pytest.fixture()
 async def pull_processor_api():
     app = FastAPI()
-    messages: list[BrokerMessage] = []  # type: ignore
+    messages: list[BrokerMessage] = []
 
     @app.get("/api/v1/internal/processing/pull")
     async def pull():

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -196,10 +196,10 @@ async def test_ingest_messages_autocommit(kbid: str, processor):
     storage = await get_storage(service_name=SERVICE_NAME)
 
     pb = await storage.get_indexing(index._calls[0][1])
-    assert pb.texts["a/summary"].text == "My summary"  # type: ignore
+    assert pb.texts["a/summary"].text == "My summary"
 
     pb = await storage.get_indexing(index._calls[1][1])
-    assert pb.texts["a/summary"].text == "My summary"  # type: ignore
+    assert pb.texts["a/summary"].text == "My summary"
 
 
 @pytest.mark.asyncio
@@ -478,7 +478,7 @@ async def test_ingest_audit_stream_files_only(
 
     async with maindb_driver.transaction() as txn:
         set_utility(Utility.AUDIT, stream_audit)
-        await KnowledgeBox.delete_kb(txn, knowledgebox_ingest)  # type: ignore
+        await KnowledgeBox.delete_kb(txn, knowledgebox_ingest)
 
         auditreq = await get_audit_messages(psub)
         assert auditreq.kbid == knowledgebox_ingest

--- a/nucliadb/tests/ingest/integration/servicer/test_entities_servicer.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_entities_servicer.py
@@ -30,7 +30,7 @@ from nucliadb_protos import knowledgebox_pb2, writer_pb2, writer_pb2_grpc
 async def test_create_entities_group(
     grpc_servicer: IngestFixture, entities_manager_mock
 ):
-    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)  # type: ignore
+    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
 
     kb_id = str(uuid4())
     pb = knowledgebox_pb2.KnowledgeBoxNew(slug="test", forceuuid=kb_id)

--- a/nucliadb/tests/ingest/integration/servicer/test_knowledgebox_servicer.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_knowledgebox_servicer.py
@@ -32,7 +32,7 @@ async def test_create_knowledgebox(grpc_servicer: IngestFixture, maindb_driver):
     if isinstance(maindb_driver, LocalDriver):
         pytest.skip("There is a bug in the local driver that needs to be fixed")
 
-    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)  # type: ignore
+    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
 
     kbs = await list_all_kb_slugs(maindb_driver)
     assert len(kbs) == 0
@@ -71,7 +71,7 @@ async def list_all_kb_slugs(driver: Driver) -> list[str]:
 async def test_delete_knowledgebox_handles_unexisting_kb(
     grpc_servicer: IngestFixture,
 ) -> None:
-    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)  # type: ignore
+    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
 
     pbid = knowledgebox_pb2.KnowledgeBoxID(slug="idonotexist")
     result = await stub.DeleteKnowledgeBox(pbid)  # type: ignore
@@ -95,7 +95,7 @@ async def test_create_knowledgebox_release_channel(
     grpc_servicer: IngestFixture,
     release_channel,
 ):
-    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)  # type: ignore
+    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
     pb = knowledgebox_pb2.KnowledgeBoxNew(
         slug="test-default", release_channel=release_channel
     )

--- a/nucliadb/tests/ingest/integration/servicer/test_list_members.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_list_members.py
@@ -28,7 +28,7 @@ from nucliadb_protos import writer_pb2_grpc
 
 @pytest.mark.asyncio
 async def test_list_members(grpc_servicer: IngestFixture):
-    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)  # type: ignore
+    stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
 
     response = await stub.ListMembers(ListMembersRequest())  # type: ignore
 

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -62,7 +62,7 @@ async def resource_with_conversation(nucliadb_grpc, nucliadb_writer, knowledgebo
     resp = await nucliadb_writer.post(
         f"/kb/{knowledgebox}/resources",
         headers={"Content-Type": "application/json"},
-        data=CreateResourcePayload(  # type: ignore
+        data=CreateResourcePayload(
             slug="myresource",
             conversations={
                 "faq": InputConversationField(messages=messages),
@@ -76,7 +76,7 @@ async def resource_with_conversation(nucliadb_grpc, nucliadb_writer, knowledgebo
     # add another message using the api to add single message
     resp = await nucliadb_writer.put(
         f"/kb/{knowledgebox}/resource/{rid}/conversation/faq/messages",
-        data="["  # type: ignore
+        data="["
         + InputMessage(
             to=[f"computer"],
             content=InputMessageContent(text="42"),

--- a/nucliadb/tests/nucliadb/integration/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/test_labels.py
@@ -343,7 +343,7 @@ async def test_fieldmetadata_classification_labels(
     )
     payload = CreateResourcePayload(
         title="Foo",
-        texts={"text": TextField(body="my text")},  # type: ignore
+        texts={"text": TextField(body="my text")},
         fieldmetadata=[fieldmetadata],
     )
     resp = await nucliadb_writer.post(

--- a/nucliadb/tests/reader/fixtures.py
+++ b/nucliadb/tests/reader/fixtures.py
@@ -64,7 +64,7 @@ async def reader_api(test_settings_reader: None, local_files):  # type: ignore
         client_base_url = "http://test"
         client_base_url = f"{client_base_url}/{API_PREFIX}/v{version}"
 
-        client = AsyncClient(app=application, base_url=client_base_url)  # type: ignore
+        client = AsyncClient(app=application, base_url=client_base_url)
         client.headers["X-NUCLIADB-ROLES"] = ";".join([role.value for role in roles])
         client.headers["X-NUCLIADB-USER"] = user
 

--- a/nucliadb/tests/reader/integration/api/v1/test_services.py
+++ b/nucliadb/tests/reader/integration/api/v1/test_services.py
@@ -163,7 +163,7 @@ async def test_processing_status(
     processing_client.__aenter__ = AsyncMock(return_value=processing_client)
     processing_client.__aexit__ = AsyncMock(return_value=None)
     processing_client.requests = AsyncMock(
-        return_value=processing.RequestsResults(  # type: ignore
+        return_value=processing.RequestsResults(
             results=[
                 processing.RequestsResult(  # type: ignore
                     processing_id="processing_id",

--- a/nucliadb/tests/search/fixtures.py
+++ b/nucliadb/tests/search/fixtures.py
@@ -126,7 +126,7 @@ async def search_api(test_settings_search, transaction_utility, redis):  # type:
         if root is False:
             client_base_url = f"{client_base_url}/{API_PREFIX}/v{version}"
 
-        client = AsyncClient(app=application, base_url=client_base_url)  # type: ignore
+        client = AsyncClient(app=application, base_url=client_base_url)
         client.headers["X-NUCLIADB-ROLES"] = ";".join([role.value for role in roles])
         client.headers["X-NUCLIADB-USER"] = user
 

--- a/nucliadb/tests/search/integration/requesters/test_utils.py
+++ b/nucliadb/tests/search/integration/requesters/test_utils.py
@@ -44,7 +44,7 @@ async def test_vector_result_metadata(
         kbid=kbid,
         query="own text",
         features=[SearchOptions.VECTOR],
-        filters=[],  # type: ignore
+        filters=[],
         faceted=[],
         page_number=0,
         page_size=20,

--- a/nucliadb/tests/search/node.py
+++ b/nucliadb/tests/search/node.py
@@ -341,7 +341,7 @@ class _NodeRunner:
         for container_id in container_ids:
             for _ in range(5):
                 try:
-                    self.docker_client.containers.get(container_id)  # type: ignore
+                    self.docker_client.containers.get(container_id)
                 except docker.errors.NotFound:
                     break
                 time.sleep(2)

--- a/nucliadb/tests/train/test_field_classification.py
+++ b/nucliadb/tests/train/test_field_classification.py
@@ -65,7 +65,7 @@ async def test_generator_field_classification(
 
     for labels, expected_batches, expected_total in tests:
         trainset.filter.ClearField("labels")
-        trainset.filter.labels.extend(labels)  # type: ignore
+        trainset.filter.labels.extend(labels)
 
         async with train_rest_api.post(
             f"/{API_PREFIX}/v1/{KB_PREFIX}/{kbid}/trainset/{partition_id}",

--- a/nucliadb/tests/writer/fixtures.py
+++ b/nucliadb/tests/writer/fixtures.py
@@ -73,7 +73,7 @@ async def writer_api(
         client_base_url = "http://test"
         client_base_url = f"{client_base_url}/{API_PREFIX}/v{version}"
 
-        client = AsyncClient(app=application, base_url=client_base_url)  # type: ignore
+        client = AsyncClient(app=application, base_url=client_base_url)
         client.headers["X-NUCLIADB-ROLES"] = ";".join(
             map(lambda role: role.value, roles)
         )

--- a/nucliadb/tests/writer/test_resources.py
+++ b/nucliadb/tests/writer/test_resources.py
@@ -19,7 +19,7 @@
 #
 from datetime import datetime
 from typing import Any, Callable, Optional
-from unittest.mock import AsyncMock  # type: ignore
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient

--- a/nucliadb_dataset/Makefile
+++ b/nucliadb_dataset/Makefile
@@ -12,6 +12,7 @@ install-dev:
 format:
 	cd .. && isort --profile black nucliadb_dataset
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_dataset/setup.py
+++ b/nucliadb_dataset/setup.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 _dir = Path(__file__).resolve().parent
 VERSION = _dir.parent.joinpath("VERSION").open().read().strip()

--- a/nucliadb_dataset/src/nucliadb_dataset/dataset.py
+++ b/nucliadb_dataset/src/nucliadb_dataset/dataset.py
@@ -203,7 +203,7 @@ class NucliaDBDataset(NucliaDataset):
                 kbid=self.kbid,
                 content=SearchRequest(
                     features=[SearchOptions.DOCUMENT], faceted=[base_label], page_size=0
-                ),  # type: ignore
+                ),
             )
             if (
                 fsearch_result.fulltext is None
@@ -305,7 +305,7 @@ class NucliaDBDataset(NucliaDataset):
 
 
 def download_all_partitions(
-    task: str,  # type: ignore
+    task: str,
     slug: Optional[str] = None,
     kbid: Optional[str] = None,
     nucliadb_base_url: Optional[str] = "http://localhost:8080",

--- a/nucliadb_dataset/src/nucliadb_dataset/tests/fixtures.py
+++ b/nucliadb_dataset/src/nucliadb_dataset/tests/fixtures.py
@@ -35,10 +35,10 @@ from nucliadb_models.resource import KnowledgeBoxObj
 from nucliadb_models.text import TextField
 from nucliadb_models.utils import FieldIdString, SlugString
 from nucliadb_models.writer import CreateResourcePayload
-from nucliadb_sdk.v2.sdk import NucliaDB  # type: ignore
+from nucliadb_sdk.v2.sdk import NucliaDB
 
 DOCKER_ENV_GROUPS = re.search(r"//([^:]+)", docker.from_env().api.base_url)
-DOCKER_HOST: Optional[str] = DOCKER_ENV_GROUPS.group(1) if DOCKER_ENV_GROUPS else None  # type: ignore
+DOCKER_HOST: Optional[str] = DOCKER_ENV_GROUPS.group(1) if DOCKER_ENV_GROUPS else None
 
 
 @pytest.fixture(scope="function")
@@ -324,7 +324,7 @@ def temp_folder():
 @pytest.mark.asyncio
 async def ingest_stub(nucliadb) -> AsyncIterator[WriterStub]:
     channel = aio.insecure_channel(f"{nucliadb.host}:{nucliadb.grpc}")
-    stub = WriterStub(channel)  # type: ignore
+    stub = WriterStub(channel)
     yield stub
     await channel.close(grace=True)
 
@@ -332,6 +332,6 @@ async def ingest_stub(nucliadb) -> AsyncIterator[WriterStub]:
 @pytest.fixture
 def ingest_stub_sync(nucliadb) -> Iterator[WriterStub]:
     channel = grpc.insecure_channel(f"{nucliadb.host}:{nucliadb.grpc}")
-    stub = WriterStub(channel)  # type: ignore
+    stub = WriterStub(channel)
     yield stub
     channel.close()

--- a/nucliadb_dataset/tests/integration/test_field_classifier.py
+++ b/nucliadb_dataset/tests/integration/test_field_classifier.py
@@ -45,7 +45,7 @@ def test_field_classification_with_labels(
     ]
     for labels, expected in tests:
         trainset.filter.ClearField("labels")
-        trainset.filter.labels.extend(labels)  # type: ignore
+        trainset.filter.labels.extend(labels)
 
         partitions = export_dataset(
             sdk=sdk, trainset=trainset, kb=upload_data_field_classification

--- a/nucliadb_dataset/tests/integration/test_paragraph_classifier.py
+++ b/nucliadb_dataset/tests/integration/test_paragraph_classifier.py
@@ -38,7 +38,7 @@ def test_paragraph_classification_with_labels(
     ]
     for labels, expected in tests:
         trainset.filter.ClearField("labels")
-        trainset.filter.labels.extend(labels)  # type: ignore
+        trainset.filter.labels.extend(labels)
 
         partitions = export_dataset(
             sdk=sdk, trainset=trainset, kb=upload_data_paragraph_classification

--- a/nucliadb_models/Makefile
+++ b/nucliadb_models/Makefile
@@ -11,6 +11,7 @@ install-dev:
 format:
 	cd .. && isort --profile black nucliadb_models
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -256,7 +256,7 @@ FIELD_TYPES_MAP: Dict[resources_pb2.FieldType.ValueType, FieldTypeName] = {
 }
 
 FIELD_TYPES_MAP_REVERSE: Dict[str, resources_pb2.FieldType.ValueType] = {
-    y.value: x for x, y in FIELD_TYPES_MAP.items()  # type: ignore
+    y.value: x for x, y in FIELD_TYPES_MAP.items()
 }
 
 

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -39,7 +39,7 @@ else:
 # Shared classes
 
 
-class MessageFormat(Enum):  # type: ignore
+class MessageFormat(Enum):
     PLAIN = "PLAIN"
     HTML = "HTML"
     RST = "RST"

--- a/nucliadb_models/src/nucliadb_models/layout.py
+++ b/nucliadb_models/src/nucliadb_models/layout.py
@@ -42,7 +42,7 @@ class LayoutFormat(LayoutFormatValue, Enum):  # type: ignore
     NUCLIAv1 = "NUCLIAv1"
 
 
-class TypeBlock(str, Enum):  # type: ignore
+class TypeBlock(str, Enum):
     TITLE = "TITLE"
     DESCRIPTION = "DESCRIPTION"
     RICHTEXT = "RICHTEXT"
@@ -112,7 +112,7 @@ class InputLayoutField(BaseModel):
 # Processing classes (Those used to sent to push endpoints)
 
 
-class PushLayoutFormat(Enum):  # type: ignore
+class PushLayoutFormat(Enum):
     NUCLIAv1 = 0
 
 

--- a/nucliadb_models/src/nucliadb_models/resource.py
+++ b/nucliadb_models/src/nucliadb_models/resource.py
@@ -293,7 +293,7 @@ class ResourceData(BaseModel):
     generics: Optional[Dict[str, GenericFieldData]] = None
 
 
-class QueueType(str, Enum):  # type: ignore
+class QueueType(str, Enum):
     PRIVATE = "private"
     SHARED = "shared"
 

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -736,7 +736,7 @@ class BaseSearchRequest(BaseModel):
         SearchParamDefaults.security.to_pydantic_field()
     )
 
-    rephrase: Optional[bool] = Field(
+    rephrase: bool = Field(
         default=False,
         title="Rephrase the query to improve search",
         description="Consume LLM tokens to rephrase the query so the semantic search is better",
@@ -1064,7 +1064,7 @@ class ChatRequest(BaseModel):
         description="Use to limit the amount of tokens used in the LLM context and/or for generating the answer. If not provided, the default maximum tokens of the generative model will be used. If an integer is provided, it is interpreted as the maximum tokens for the answer.",  # noqa
     )
 
-    rephrase: Optional[bool] = Field(
+    rephrase: bool = Field(
         default=False,
         title="Rephrase the query to improve search",
         description="Consume LLM tokens to rephrase the query so the semantic search is better",

--- a/nucliadb_models/src/nucliadb_models/text.py
+++ b/nucliadb_models/src/nucliadb_models/text.py
@@ -38,7 +38,7 @@ else:
 # Shared classes
 
 
-class TextFormat(Enum):  # type: ignore
+class TextFormat(Enum):
     PLAIN = "PLAIN"
     HTML = "HTML"
     RST = "RST"

--- a/nucliadb_node/Makefile
+++ b/nucliadb_node/Makefile
@@ -16,6 +16,7 @@ check-system:
 format:
 	cd .. && isort --profile black nucliadb_sidecar
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_performance/Makefile
+++ b/nucliadb_performance/Makefile
@@ -54,6 +54,7 @@ install-dev: # Install the package for development
 format: # Format the code
 	cd .. && isort --profile black nucliadb_performance
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint: # Run lint checks

--- a/nucliadb_performance/setup.py
+++ b/nucliadb_performance/setup.py
@@ -1,6 +1,6 @@
 import re
 
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 
 def load_reqs(filename):

--- a/nucliadb_sdk/Makefile
+++ b/nucliadb_sdk/Makefile
@@ -12,6 +12,7 @@ install-dev:
 format:
 	cd .. && isort --profile black nucliadb_sdk
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_sdk/src/nucliadb_sdk/v2/docstrings.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/docstrings.py
@@ -438,7 +438,7 @@ def _inject_signature_and_annotations(
                 path_param, kind=inspect.Parameter.KEYWORD_ONLY, annotation=str
             )
         )
-        annotations[path_param] = str  # type: ignore
+        annotations[path_param] = str
 
     # Body params
     if request_type is not None:

--- a/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
@@ -229,9 +229,9 @@ def _parse_list_of_pydantic(
 def _parse_response(response_type, resp: httpx.Response) -> Any:
     if response_type is not None:
         if isinstance(response_type, type) and issubclass(response_type, BaseModel):
-            return response_type.model_validate_json(resp.content)  # type: ignore
+            return response_type.model_validate_json(resp.content)
         else:
-            return response_type(resp)  # type: ignore
+            return response_type(resp)
     else:
         return resp.content
 

--- a/nucliadb_sidecar/Makefile
+++ b/nucliadb_sidecar/Makefile
@@ -16,6 +16,7 @@ check-system:
 format:
 	cd .. && isort --profile black nucliadb_sidecar
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_sidecar/src/nucliadb_sidecar/writer.py
+++ b/nucliadb_sidecar/src/nucliadb_sidecar/writer.py
@@ -32,7 +32,7 @@ from nucliadb_protos.noderesources_pb2 import (
 from nucliadb_protos.nodewriter_pb2 import IndexMessage, OpStatus
 from nucliadb_protos.nodewriter_pb2_grpc import NodeWriterStub
 
-from nucliadb_sidecar import SERVICE_NAME  # type: ignore
+from nucliadb_sidecar import SERVICE_NAME
 from nucliadb_utils.grpc import get_traced_grpc_channel
 
 
@@ -45,7 +45,7 @@ class Writer:
         self.channel = get_traced_grpc_channel(
             grpc_writer_address, SERVICE_NAME, max_send_message=250
         )
-        self.stub = NodeWriterStub(self.channel)  # type: ignore
+        self.stub = NodeWriterStub(self.channel)
 
     async def set_resource(self, pb: Resource) -> OpStatus:
         return await self.stub.SetResource(pb)  # type: ignore

--- a/nucliadb_sidecar/tests/fixtures.py
+++ b/nucliadb_sidecar/tests/fixtures.py
@@ -199,7 +199,7 @@ def node_single():
 @pytest.fixture(scope="function")
 async def writer_stub(node_single) -> AsyncIterable[NodeWriterStub]:
     channel = aio.insecure_channel(settings.writer_listen_address)
-    stub = NodeWriterStub(channel)  # type: ignore
+    stub = NodeWriterStub(channel)
     yield stub
 
 
@@ -213,7 +213,7 @@ async def writer(node_single) -> AsyncIterable[Writer]:
 class Reader:
     def __init__(self, grpc_reader_address: str):
         self.channel = aio.insecure_channel(grpc_reader_address)
-        self.stub = nodereader_pb2_grpc.NodeReaderStub(self.channel)  # type: ignore
+        self.stub = nodereader_pb2_grpc.NodeReaderStub(self.channel)
 
     async def get_shard(self, pb: ShardId) -> Optional[noderesources_pb2.Shard]:
         req = nodereader_pb2.GetShardRequest()

--- a/nucliadb_sidecar/tests/integration/test_indexing.py
+++ b/nucliadb_sidecar/tests/integration/test_indexing.py
@@ -115,9 +115,9 @@ async def test_prioritary_indexing_on_one_shard(
     mock = AsyncMock(side_effect=side_effect)
     with patch("nucliadb_sidecar.indexer.PriorityIndexer._index_message", new=mock):
         for i in range(3):
-            await send_indexing_message(worker, processor_index, node)  # type: ignore
+            await send_indexing_message(worker, processor_index, node)
         for i in range(3):
-            await send_indexing_message(worker, writer_index, node)  # type: ignore
+            await send_indexing_message(worker, writer_index, node)
 
         processing = True
         start = datetime.now()
@@ -317,7 +317,7 @@ async def test_indexing_publishes_to_sidecar_index_stream(worker, shard: str, na
     waiting_task = asyncio.create_task(wait_for_indexed_message("kb"))
     await asyncio.sleep(0.01)
 
-    await send_indexing_message(worker, indexpb, node_id)  # type: ignore
+    await send_indexing_message(worker, indexpb, node_id)
 
     msg = await waiting_task
     assert msg is not None, "Message has not been received"

--- a/nucliadb_sidecar/tests/unit/test_indexer.py
+++ b/nucliadb_sidecar/tests/unit/test_indexer.py
@@ -294,7 +294,7 @@ class TestPriorityIndexer:
         work.seqid = 10
         await indexer._do_work(work)
 
-        assert writer.set_resource_from_storage.await_count == 1  # type: ignore
+        assert writer.set_resource_from_storage.await_count == 1
         assert successful_indexing.dispatch.await_count == 1
         assert successful_indexing.dispatch.await_args.args[0].seqid == 10
 

--- a/nucliadb_telemetry/Makefile
+++ b/nucliadb_telemetry/Makefile
@@ -17,6 +17,7 @@ install-dev:
 format:
 	cd .. && isort --profile black nucliadb_telemetry
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_telemetry/setup.py
+++ b/nucliadb_telemetry/setup.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 _dir = Path(__file__).resolve().parent
 VERSION = _dir.parent.joinpath("VERSION").open().read().strip()

--- a/nucliadb_telemetry/src/nucliadb_telemetry/batch_span.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/batch_span.py
@@ -28,8 +28,8 @@ from opentelemetry.context import (  # type: ignore
     detach,
     set_value,
 )
-from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor  # type: ignore
-from opentelemetry.sdk.trace.export import SpanExporter  # type: ignore
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.sdk.trace.export import SpanExporter
 
 from nucliadb_telemetry import logger
 

--- a/nucliadb_telemetry/src/nucliadb_telemetry/common.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/common.py
@@ -19,8 +19,8 @@
 
 import traceback
 
-from opentelemetry.sdk.trace import Span  # type: ignore
-from opentelemetry.trace.status import Status, StatusCode  # type: ignore
+from opentelemetry.sdk.trace import Span
+from opentelemetry.trace.status import Status, StatusCode
 
 
 def set_span_exception(span: Span, exception: Exception):

--- a/nucliadb_telemetry/src/nucliadb_telemetry/errors.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/errors.py
@@ -79,7 +79,7 @@ def push_scope(**kwargs: Any) -> ContextManager[Scope]:
     if SENTRY:
         return sentry_sdk.push_scope(**kwargs)
     else:
-        return NoopScope()  # type: ignore
+        return NoopScope()
 
 
 class ErrorHandlingSettings(BaseSettings):

--- a/nucliadb_telemetry/src/nucliadb_telemetry/fastapi/__init__.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/fastapi/__init__.py
@@ -20,7 +20,7 @@
 from typing import Iterable, List
 from urllib.parse import urlparse
 
-import prometheus_client  # type: ignore
+import prometheus_client
 from fastapi import FastAPI
 from opentelemetry.instrumentation.fastapi import (  # type: ignore
     _get_default_span_details,
@@ -51,7 +51,7 @@ async def metrics_endpoint(request):
     )
 
 
-application_metrics = FastAPI(title="Metrics")  # type: ignore
+application_metrics = FastAPI(title="Metrics")
 application_metrics.add_route("/metrics", metrics_endpoint)
 
 
@@ -93,9 +93,9 @@ def instrument_app(
     if tracer_provider is not None:
         app.add_middleware(
             OpenTelemetryMiddleware,
-            excluded_urls=excluded_urls_obj,  # type: ignore
+            excluded_urls=excluded_urls_obj,
             default_span_details=_get_default_span_details,
-            server_request_hook=server_request_hook,  # type: ignore
+            server_request_hook=server_request_hook,
             tracer_provider=tracer_provider,
         )
 

--- a/nucliadb_telemetry/src/nucliadb_telemetry/fastapi/tracing.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/fastapi/tracing.py
@@ -32,8 +32,7 @@ from opentelemetry.instrumentation.utils import (
 )
 from opentelemetry.propagators.textmap import Getter, Setter
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import Span  # type: ignore
-from opentelemetry.trace import format_trace_id, set_span_in_context
+from opentelemetry.trace import Span, format_trace_id, set_span_in_context
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.util.http import (
     OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS,

--- a/nucliadb_telemetry/src/nucliadb_telemetry/grpc.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/grpc.py
@@ -28,13 +28,11 @@ from grpc import ChannelCredentials, ClientCallDetails, aio
 from grpc.experimental import wrap_server_method_handler
 from opentelemetry.context import attach, detach
 from opentelemetry.propagate import extract, inject
-from opentelemetry.propagators.textmap import CarrierT, Setter  # type: ignore
-from opentelemetry.sdk.trace import Span  # type: ignore
-from opentelemetry.sdk.trace import TracerProvider  # type: ignore
-from opentelemetry.semconv.trace import SpanAttributes  # type: ignore
-from opentelemetry.trace import SpanKind  # type: ignore
-from opentelemetry.trace import Tracer  # type: ignore
-from opentelemetry.trace.status import Status, StatusCode  # type: ignore
+from opentelemetry.propagators.textmap import CarrierT, Setter
+from opentelemetry.sdk.trace import Span, TracerProvider
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import SpanKind, Tracer
+from opentelemetry.trace.status import Status, StatusCode
 
 from nucliadb_telemetry import grpc_metrics, logger
 from nucliadb_telemetry.common import set_span_exception
@@ -96,10 +94,10 @@ def start_span_client(
         for key, value in mutable_metadata.items():
             client_call_details.metadata.add(key=key, value=value)  # type: ignore
 
-    span = tracer.start_span(  # type: ignore
+    span = tracer.start_span(
         name=method_name,
         kind=SpanKind.CLIENT,
-        attributes=attributes,  # type: ignore
+        attributes=attributes,
         set_status_on_exception=set_status_on_exception,
     )
     return span
@@ -127,7 +125,7 @@ class OpenTelemetryServerInterceptor(aio.ServerInterceptor):
         context: grpc.ServicerContext,
         set_status_on_exception=False,
     ):
-        service, meth = handler_call_details.method.lstrip("/").split("/", 1)  # type: ignore
+        service, meth = handler_call_details.method.lstrip("/").split("/", 1)
 
         attributes = {
             SpanAttributes.RPC_SYSTEM: "grpc",
@@ -160,8 +158,8 @@ class OpenTelemetryServerInterceptor(aio.ServerInterceptor):
         except IndexError:
             logger.warning("Failed to parse peer address '%s'", context.peer())
 
-        return self.tracer.start_as_current_span(  # type: ignore
-            name=handler_call_details.method,  # type: ignore
+        return self.tracer.start_as_current_span(
+            name=handler_call_details.method,
             kind=SpanKind.SERVER,
             attributes=attributes,
             set_status_on_exception=set_status_on_exception,
@@ -239,7 +237,7 @@ class OpenTelemetryServerInterceptor(aio.ServerInterceptor):
 
             return wrapper
 
-        if "grpc.health.v1.Health" in handler_call_details.method:  # type: ignore
+        if "grpc.health.v1.Health" in handler_call_details.method:
             return handler
 
         return wrap_server_method_handler(wrapper, handler)

--- a/nucliadb_telemetry/src/nucliadb_telemetry/grpc_metrics.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/grpc_metrics.py
@@ -74,7 +74,7 @@ class MetricsServerInterceptor(aio.ServerInterceptor):
             @functools.wraps(behavior)
             async def wrapper(request: Any, context: aio.ServicerContext) -> Any:
                 with grpc_server_observer(
-                    labels={"method": handler_call_details.method}  # type: ignore
+                    labels={"method": handler_call_details.method}
                 ) as observer:
                     value = await behavior(request, context)
                     observer.set_status(str(context.code()))

--- a/nucliadb_telemetry/src/nucliadb_telemetry/jaeger.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/jaeger.py
@@ -24,16 +24,13 @@ from asyncio import Future
 from functools import partial
 from typing import List
 
-from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore
-from opentelemetry.exporter.jaeger.thrift.gen.agent import Agent  # type: ignore
-from opentelemetry.exporter.jaeger.thrift.gen.jaeger import Collector  # type: ignore
-from opentelemetry.exporter.jaeger.thrift.translate import Translate  # type: ignore
-from opentelemetry.exporter.jaeger.thrift.translate import (  # type: ignore
-    ThriftTranslator,
-)
-from opentelemetry.sdk.resources import SERVICE_NAME  # type: ignore
-from opentelemetry.sdk.trace import Span  # type: ignore
-from opentelemetry.sdk.trace.export import SpanExportResult  # type: ignore
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.exporter.jaeger.thrift.gen.agent import Agent
+from opentelemetry.exporter.jaeger.thrift.gen.jaeger import Collector
+from opentelemetry.exporter.jaeger.thrift.translate import ThriftTranslator, Translate
+from opentelemetry.sdk.resources import SERVICE_NAME
+from opentelemetry.sdk.trace import Span
+from opentelemetry.sdk.trace.export import SpanExportResult
 from thrift.protocol import TCompactProtocol  # type: ignore
 from thrift.transport import TTransport  # type: ignore
 

--- a/nucliadb_telemetry/src/nucliadb_telemetry/jetstream.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/jetstream.py
@@ -26,10 +26,9 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 from opentelemetry.context import attach
 from opentelemetry.propagate import extract, inject
-from opentelemetry.sdk.trace import TracerProvider  # type: ignore
-from opentelemetry.semconv.trace import SpanAttributes  # type: ignore
-from opentelemetry.trace import SpanKind  # type: ignore
-from opentelemetry.trace import Tracer  # type: ignore
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import SpanKind, Tracer
 
 from nucliadb_telemetry import logger, metrics
 from nucliadb_telemetry.common import set_span_exception
@@ -276,7 +275,7 @@ class NatsClientTelemetry:
         with start_span_message_publisher(tracer, subject) as span:
             try:
                 result = await self.nc.request(
-                    subject, payload, timeout, old_style, headers  # type: ignore
+                    subject, payload, timeout, old_style, headers
                 )
             except Exception as error:
                 set_span_exception(span, error)

--- a/nucliadb_telemetry/src/nucliadb_telemetry/logs.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/logs.py
@@ -43,7 +43,7 @@ from . import context
 try:
     from uvicorn.logging import AccessFormatter  # type: ignore
 except ImportError:  # pragma: no cover
-    AccessFormatter = logging.Formatter  # type: ignore
+    AccessFormatter = logging.Formatter
 
 _BUILTIN_ATTRS = set(
     [

--- a/nucliadb_telemetry/src/nucliadb_telemetry/metrics.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/metrics.py
@@ -21,7 +21,17 @@ import os
 import time
 from functools import wraps
 from inspect import isasyncgenfunction, isgeneratorfunction
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import prometheus_client
 
@@ -37,6 +47,9 @@ INF = float("inf")
 _STATUS_METRIC = "status"
 _VERSION_METRIC = "version"
 _VERSION_ENV_VAR_NAME = "VERSION"
+
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
 class Observer:
@@ -77,7 +90,7 @@ class Observer:
             **hist_kwargs,  # type: ignore
         )
 
-    def wrap(self, labels: Optional[Dict[str, str]] = None):
+    def wrap(self, labels: Optional[Dict[str, str]] = None) -> Callable[[F], F]:
         def decorator(func):
             if asyncio.iscoroutinefunction(func):
 

--- a/nucliadb_telemetry/src/nucliadb_telemetry/tests/telemetry.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/tests/telemetry.py
@@ -319,7 +319,7 @@ async def http_service(
 ):
     tracer_provider = get_telemetry("HTTP_SERVICE")
     await init_telemetry(tracer_provider)
-    app = FastAPI(title="Test API")  # type: ignore
+    app = FastAPI(title="Test API")
     set_global_textmap(B3MultiFormat())
     instrument_app(
         app,
@@ -353,6 +353,6 @@ async def http_service(
         return response.message
 
     client_base_url = "http://test"
-    client = AsyncClient(app=app, base_url=client_base_url)  # type: ignore
+    client = AsyncClient(app=app, base_url=client_base_url)
     yield client
     await clean_telemetry("HTTP_SERVICE")

--- a/nucliadb_telemetry/src/nucliadb_telemetry/tracerprovider.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/tracerprovider.py
@@ -22,8 +22,7 @@ import time
 from typing import Optional
 
 from opentelemetry.context import Context  # type: ignore
-from opentelemetry.sdk.trace import TracerProvider  # type: ignore
-from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor  # type: ignore
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerProvider
 
 
 class AsyncMultiSpanProcessor(SpanProcessor):
@@ -62,7 +61,7 @@ class AsyncMultiSpanProcessor(SpanProcessor):
         for sp in self._span_processors:
             sp.shutdown()
 
-    async def async_force_flush(self, timeout_millis: int = 30000) -> bool:  # type: ignore
+    async def async_force_flush(self, timeout_millis: int = 30000) -> bool:
         """Sequentially calls async_force_flush on all underlying
         :class:`SpanProcessor`
 

--- a/nucliadb_telemetry/src/nucliadb_telemetry/utils.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/utils.py
@@ -23,8 +23,7 @@ from typing import Dict, Optional
 
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.b3 import B3MultiFormat
-from opentelemetry.sdk.resources import SERVICE_NAME  # type: ignore
-from opentelemetry.sdk.resources import Resource  # type: ignore
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
 from nucliadb_telemetry.batch_span import BatchSpanProcessor
 from nucliadb_telemetry.jaeger import JaegerExporterAsync
@@ -128,7 +127,7 @@ async def setup_telemetry(service_name: str) -> Optional[AsyncTracerProvider]:
         except ImportError:  # pragma: no cover
             pass
         try:
-            from opentelemetry.instrumentation.aiohttp_client import (  # type: ignore
+            from opentelemetry.instrumentation.aiohttp_client import (
                 AioHttpClientInstrumentor,
             )
 

--- a/nucliadb_utils/Makefile
+++ b/nucliadb_utils/Makefile
@@ -11,6 +11,7 @@ install-dev:
 format:
 	cd .. && isort --profile black nucliadb_utils
 	black .
+	ruff check --fix --config=../ruff.toml .
 
 .PHONY: lint
 lint:

--- a/nucliadb_utils/src/nucliadb_utils/audit/audit.py
+++ b/nucliadb_utils/src/nucliadb_utils/audit/audit.py
@@ -43,7 +43,7 @@ class AuditStorage:
         field_metadata: Optional[List[FieldID]] = None,
         audit_fields: Optional[List[AuditField]] = None,
         kb_counter: Optional[AuditKBCounter] = None,
-    ):  # type: ignore
+    ):
         raise NotImplementedError
 
     def report_resources(

--- a/nucliadb_utils/src/nucliadb_utils/audit/basic.py
+++ b/nucliadb_utils/src/nucliadb_utils/audit/basic.py
@@ -50,7 +50,7 @@ class BasicAuditStorage(AuditStorage):
         field_metadata: Optional[List[FieldID]] = None,
         audit_fields: Optional[List[AuditField]] = None,
         kb_counter: Optional[AuditKBCounter] = None,
-    ):  # type: ignore
+    ):
         logger.debug(
             f"AUDIT {audit_type} {kbid} {user} {origin} {rid} {audit_fields} {kb_counter}"
         )

--- a/nucliadb_utils/src/nucliadb_utils/audit/stream.py
+++ b/nucliadb_utils/src/nucliadb_utils/audit/stream.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from typing import List, Optional
 
 import backoff
-import mmh3  # type: ignore
+import mmh3
 import nats
 from google.protobuf.timestamp_pb2 import Timestamp
 from nucliadb_protos.audit_pb2 import (

--- a/nucliadb_utils/src/nucliadb_utils/cache/nats.py
+++ b/nucliadb_utils/src/nucliadb_utils/cache/nats.py
@@ -31,7 +31,7 @@ from nats.aio.client import Client
 from nats.aio.errors import ErrConnectionClosed, ErrNoServers, ErrTimeout
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
-from nats.js.client import JetStreamContext  # type: ignore
+from nats.js.client import JetStreamContext
 from nats.js.manager import JetStreamManager
 
 from nucliadb_utils import logger

--- a/nucliadb_utils/src/nucliadb_utils/indexing.py
+++ b/nucliadb_utils/src/nucliadb_utils/indexing.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import nats
 from nats.aio.client import Client
 from nats.js.client import JetStreamContext
-from nucliadb_protos.nodewriter_pb2 import IndexMessage  # type: ignore
+from nucliadb_protos.nodewriter_pb2 import IndexMessage
 
 from nucliadb_telemetry.jetstream import JetStreamContextTelemetry
 from nucliadb_utils import const, logger

--- a/nucliadb_utils/src/nucliadb_utils/partition.py
+++ b/nucliadb_utils/src/nucliadb_utils/partition.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import mmh3  # type: ignore
+import mmh3
 
 
 class PartitionUtility:

--- a/nucliadb_utils/src/nucliadb_utils/storages/gcs.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/gcs.py
@@ -31,7 +31,7 @@ from urllib.parse import quote_plus
 
 import aiohttp
 import aiohttp.client_exceptions
-import backoff  # type: ignore
+import backoff
 import google.auth.transport.requests  # type: ignore
 import yarl
 from google.oauth2 import service_account  # type: ignore

--- a/nucliadb_utils/src/nucliadb_utils/storages/s3.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/s3.py
@@ -25,7 +25,7 @@ from typing import AsyncGenerator, AsyncIterator, Optional
 
 import aiobotocore  # type: ignore
 import aiohttp
-import backoff  # type: ignore
+import backoff
 import botocore  # type: ignore
 from aiobotocore.client import AioBaseClient  # type: ignore
 from aiobotocore.session import AioSession, get_session  # type: ignore

--- a/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
+++ b/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
@@ -30,12 +30,12 @@ from pytest_docker_fixtures.containers._base import BaseImage  # type: ignore
 from nucliadb_utils.storages.gcs import GCSStorage
 from nucliadb_utils.store import MAIN
 from nucliadb_utils.tests import free_port
-from nucliadb_utils.utilities import Utility  # type: ignore
+from nucliadb_utils.utilities import Utility
 
 # IMPORTANT!
 # Without this, tests running in a remote docker host won't work
 DOCKER_ENV_GROUPS = re.search(r"//([^:]+)", docker.from_env().api.base_url)
-DOCKER_HOST: Optional[str] = DOCKER_ENV_GROUPS.group(1) if DOCKER_ENV_GROUPS else None  # type: ignore
+DOCKER_HOST: Optional[str] = DOCKER_ENV_GROUPS.group(1) if DOCKER_ENV_GROUPS else None
 
 images.settings["gcs"] = {
     "image": "fsouza/fake-gcs-server",

--- a/nucliadb_utils/src/nucliadb_utils/utilities.py
+++ b/nucliadb_utils/src/nucliadb_utils/utilities.py
@@ -266,7 +266,7 @@ async def start_transaction_utility(
         )
         await transaction_utility.initialize(service_name)
     set_utility(Utility.TRANSACTION, transaction_utility)
-    return transaction_utility  # type: ignore
+    return transaction_utility
 
 
 def get_transaction_utility() -> TransactionUtility:

--- a/nucliadb_utils/tests/unit/storages/test_aws.py
+++ b/nucliadb_utils/tests/unit/storages/test_aws.py
@@ -55,6 +55,6 @@ def response_generator():
                     "Code": error_code,
                 }
             }
-            super().__init__(error_response=response, operation_name="TEST")  # type: ignore
+            super().__init__(error_response=response, operation_name="TEST")
 
     yield TestError


### PR DESCRIPTION
### Description
- Remove unused `type: ignore` annotations
- Properly type metrics decorator, which was causing all decorated functions to not be type checked
- (bonus) Add `ruff check --fix` where missing

### How was this PR tested?
Describe how you tested this PR.
