### PR TITLE
Add encryption util

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -97,5 +97,4 @@ data:
 
 {{- if .Values.encryption.secret_key }}
   ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key }}
-  ENCRYPTION_THREAD_POOL_SIZE: {{ .Values.encryption.thread_pool_size | quote }}
 {{- end }}

--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -95,7 +95,7 @@ data:
   FLAG_SETTINGS_URL: "{{ .Values.flag_settings_url }}"
 {{- end }}
 
-{{ - if .Values.encryption.secret_key }}
+{{- if .Values.encryption.secret_key }}
   ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key }}
   ENCRYPTION_THREAD_POOL_SIZE: {{ .Values.encryption.thread_pool_size | quote }}
 {{- end }}

--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -94,3 +94,8 @@ data:
 {{- if .Values.flag_settings_url }}
   FLAG_SETTINGS_URL: "{{ .Values.flag_settings_url }}"
 {{- end }}
+
+{{ - if .Values.encryption.secret_key }}
+  ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key }}
+  ENCRYPTION_THREAD_POOL_SIZE: {{ .Values.encryption.thread_pool_size | quote }}
+{{- end }}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -86,3 +86,7 @@ telemetry:
   enabled: True
 
 flag_settings_url: null
+
+encryption:
+  secret_key: XX
+  thread_pool_size: 2

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -89,4 +89,3 @@ flag_settings_url: null
 
 encryption:
   secret_key: XX
-  thread_pool_size: 2

--- a/nucliadb_utils/src/nucliadb_utils/encryption/__init__.py
+++ b/nucliadb_utils/src/nucliadb_utils/encryption/__init__.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import nacl.secret
+import nacl.utils
+
+
+class EndecryptorUtility:
+    """
+    Utility class for encryption and decryption of sensitive data using the nacl library.
+    It uses a thread pool to avoid blocking the event loop.
+    """
+
+    def __init__(self, key: bytes, max_thread_pool_size: int = 1):
+        self.box = nacl.secret.SecretBox(key)
+        self.executor = ThreadPoolExecutor(max_workers=max_thread_pool_size)
+
+    async def encrypt_text(self, message: str) -> str:
+        message_bytes = message.encode()
+        encrypted = await self.encrypt(message_bytes)
+        return encrypted.hex()
+
+    async def encrypt(self, message: bytes) -> nacl.utils.EncryptedMessage:
+        loop = asyncio.get_running_loop()
+        func = self.box.encrypt
+        encrypted = await loop.run_in_executor(self.executor, func, message)
+        return encrypted
+
+    async def decrypt_text(self, encrypted_hex: str) -> str:
+        encrypted = nacl.utils.EncryptedMessage.fromhex(encrypted_hex)
+        decrypted_bytes = await self.decrypt(encrypted)
+        return decrypted_bytes.decode()
+
+    async def decrypt(self, encrypted: nacl.utils.EncryptedMessage) -> bytes:
+        loop = asyncio.get_running_loop()
+        func = self.box.decrypt
+        result_bytes = await loop.run_in_executor(self.executor, func, encrypted)
+        return result_bytes

--- a/nucliadb_utils/src/nucliadb_utils/encryption/__init__.py
+++ b/nucliadb_utils/src/nucliadb_utils/encryption/__init__.py
@@ -18,7 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import base64
+import binascii
 
+import nacl.exceptions
 import nacl.secret
 import nacl.utils
 
@@ -47,11 +49,17 @@ class EndecryptorUtility:
     """
 
     def __init__(self, secret_key: bytes):
-        self.box = nacl.secret.SecretBox(secret_key)
+        try:
+            self.box = nacl.secret.SecretBox(secret_key)
+        except nacl.exceptions.TypeError as ex:
+            raise ValueError("Invalid secret key") from ex
 
     @classmethod
     def from_b64_encoded_secret_key(cls, encoded_secret_key: str):
-        secret_key = base64.b64decode(encoded_secret_key)
+        try:
+            secret_key = base64.b64decode(encoded_secret_key)
+        except binascii.Error as ex:
+            raise ValueError("Invalid base64 encoding") from ex
         return cls(secret_key=secret_key)
 
     @endecryptor_observer.wrap({"operation": "encrypt"})

--- a/nucliadb_utils/src/nucliadb_utils/encryption/settings.py
+++ b/nucliadb_utils/src/nucliadb_utils/encryption/settings.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from typing import Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class EncryptionSettings(BaseSettings):
+    encryption_secret_key: Optional[str] = Field(
+        default=None,
+        title="Encryption Secret Key",
+        description="Secret key used for encryption and decryption of sensitive data in the database. The key must be a 32-byte string, base64 encoded.",
+    )
+    encryption_thread_pool_size: int = Field(
+        default=1,
+        title="Encryption Thread Pool Size",
+        description="Number of threads used for encryption and decryption of sensitive data in the database.",
+    )
+
+
+settings = EncryptionSettings()

--- a/nucliadb_utils/src/nucliadb_utils/encryption/settings.py
+++ b/nucliadb_utils/src/nucliadb_utils/encryption/settings.py
@@ -26,12 +26,13 @@ class EncryptionSettings(BaseSettings):
     encryption_secret_key: Optional[str] = Field(
         default=None,
         title="Encryption Secret Key",
-        description="Secret key used for encryption and decryption of sensitive data in the database. The key must be a 32-byte string, base64 encoded.",
-    )
-    encryption_thread_pool_size: int = Field(
-        default=1,
-        title="Encryption Thread Pool Size",
-        description="Number of threads used for encryption and decryption of sensitive data in the database.",
+        description="""Secret key used for encryption and decryption of sensitive data in the database.
+The key must be a 32-byte string, base64 encoded. You can generate a new key with the following unix command:
+head -c 32 /dev/urandom | base64
+""",
+        examples=[
+            "6TGjSkvX6qkFOo/BJKl5OY1fwJoWnMaSVI7VOJjU07Y=",
+        ],
     )
 
 

--- a/nucliadb_utils/src/nucliadb_utils/utilities.py
+++ b/nucliadb_utils/src/nucliadb_utils/utilities.py
@@ -20,14 +20,11 @@
 from __future__ import annotations
 
 import asyncio
-import binascii
 import hashlib
 import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
-
-import nacl
 
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from nucliadb_utils import featureflagging
@@ -422,7 +419,9 @@ def get_endecryptor() -> EndecryptorUtility:
         raise ConfigurationError("Encryption secret key not configured")
     try:
         util = EndecryptorUtility.from_b64_encoded_secret_key(encryption_settings.encryption_secret_key)
-    except (nacl.exceptions.TypeError, binascii.Error):
-        raise ConfigurationError("Invalid encryption key. Must be a base64 encoded 32-byte string")
+    except ValueError as ex:
+        raise ConfigurationError(
+            "Invalid encryption key. Must be a base64 encoded 32-byte string"
+        ) from ex
     set_utility(Utility.ENDECRYPTOR, util)
     return util

--- a/nucliadb_utils/tests/unit/encryption/test_encryption.py
+++ b/nucliadb_utils/tests/unit/encryption/test_encryption.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import base64
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.fixture()
+def encryption_settings():
+    from nucliadb_utils.encryption.settings import settings
+
+    # Get a 32-bytes random string
+    secret_key = uuid4().hex[:32]
+    # Encode the secret key in base64
+    b64_encoded_secret_key = base64.b64encode(secret_key.encode()).decode()
+    settings.encryption_secret_key = b64_encoded_secret_key
+
+    yield settings
+
+
+async def test_endecryptor(encryption_settings):
+    import nacl.utils
+
+    from nucliadb_utils.encryption import EndecryptorUtility
+
+    endecryptor = EndecryptorUtility(key=base64.b64decode(encryption_settings.encryption_secret_key))
+    message = b"This is a test message"
+    encrypted = await endecryptor.encrypt(message)
+    assert isinstance(encrypted, nacl.utils.EncryptedMessage)
+    decrypted = await endecryptor.decrypt(encrypted)
+    assert decrypted == message
+
+    text = "This is some other text"
+    encrypted_text = await endecryptor.encrypt_text(text)
+    assert isinstance(encrypted_text, str)
+    decrypted_text = await endecryptor.decrypt_text(encrypted_text)
+    assert decrypted_text == text

--- a/nucliadb_utils/tests/unit/encryption/test_encryption.py
+++ b/nucliadb_utils/tests/unit/encryption/test_encryption.py
@@ -33,7 +33,10 @@ def get_encoded_secret_key():
 
 
 def test_endecryptor():
-    endecryptor = EndecryptorUtility.from_b64_encoded_secret_key(get_encoded_secret_key())
+    # Key generated with: head -c 32 /dev/urandom | base64
+    key = "gXGebeyXDimP2qXsSdQ+W1GoQKIjbBmrZBxQHiks7I0="
+    endecryptor = EndecryptorUtility.from_b64_encoded_secret_key(key)
+
     text = "This is some other text"
     encrypted_text = endecryptor.encrypt(text)
     assert isinstance(encrypted_text, str)

--- a/nucliadb_utils/tests/unit/test_utilities.py
+++ b/nucliadb_utils/tests/unit/test_utilities.py
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import hashlib
+import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -89,6 +91,9 @@ async def test_get_nuclia_storage():
 
 @pytest.mark.asyncio
 async def test_get_pubsub():
+    from nucliadb_utils.cache.settings import settings
+
+    settings.cache_pubsub_nats_url = ["nats://localhost:4222"]
     with patch("nucliadb_utils.utilities.NatsPubsub", return_value=AsyncMock()):
         assert await utilities.get_pubsub() is not None
 
@@ -153,3 +158,19 @@ def test_has_feature():
                 "account_type": "account-type",
             },
         )
+
+
+def test_get_endecryptor():
+    from nucliadb_utils.encryption.settings import settings
+
+    secret_key = uuid.uuid4().hex[:32]
+    b64_secret_key = base64.b64encode(secret_key.encode()).decode()
+    settings.encryption_secret_key = b64_secret_key
+
+    endecryptor = utilities.get_endecryptor()
+    assert endecryptor is not None
+    assert isinstance(endecryptor, utilities.EndecryptorUtility)
+    utilities.MAIN.get(utilities.Utility.ENDECRYPTOR) is not None
+
+    settings.encryption_secret_key = None
+    utilities.clean_utility(utilities.Utility.ENDECRYPTOR)

--- a/nucliadb_utils/tests/unit/test_utilities.py
+++ b/nucliadb_utils/tests/unit/test_utilities.py
@@ -174,3 +174,14 @@ def test_get_endecryptor():
 
     settings.encryption_secret_key = None
     utilities.clean_utility(utilities.Utility.ENDECRYPTOR)
+
+
+def test_get_endecryptor_errors():
+    with pytest.raises(ConfigurationError):
+        utilities.get_endecryptor()
+
+    from nucliadb_utils.encryption.settings import settings
+
+    settings.encryption_secret_key = "foobar"
+    with pytest.raises(ConfigurationError):
+        utilities.get_endecryptor()

--- a/nucliadb_utils/tests/unit/test_utilities.py
+++ b/nucliadb_utils/tests/unit/test_utilities.py
@@ -167,11 +167,16 @@ def test_get_endecryptor():
     b64_secret_key = base64.b64encode(secret_key.encode()).decode()
     settings.encryption_secret_key = b64_secret_key
 
+    # Check that it returns an instance of EndecryptorUtility
     endecryptor = utilities.get_endecryptor()
     assert endecryptor is not None
     assert isinstance(endecryptor, utilities.EndecryptorUtility)
     utilities.MAIN.get(utilities.Utility.ENDECRYPTOR) is not None
 
+    # Check that utility is cached
+    assert utilities.get_endecryptor() is endecryptor
+
+    # Clean the utility
     settings.encryption_secret_key = None
     utilities.clean_utility(utilities.Utility.ENDECRYPTOR)
 


### PR DESCRIPTION
### Description
This utility allows to encrypt/decrypt text and bytes via a shared secret key.
It uses the PyNacl library, which was already a dependency from nucliadb.
The first use-case will be to encrypt the pinecone api keys before storing them in pg.

### How was this PR tested?
Describe how you tested this PR.
