### PR TITLE
NDB Shared: Create Kubernetes secret for sensitive values

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -1,7 +1,9 @@
+---
+{{- if .Values.configMap.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nucliadb-config
+  name: {{ .Values.configMapName | default "nucliadb-config" }}
   labels:
     app: writer
     version: "{{ .Chart.Version | replace "+" "_" }}"
@@ -97,4 +99,5 @@ data:
 
 {{- if .Values.encryption.secret_key }}
   ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key }}
+{{- end }}
 {{- end }}

--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.configMapName | default "nucliadb-config" }}
   labels:
-    app: writer
+    app: shared
     version: "{{ .Chart.Version | replace "+" "_" }}"
     chart: "{{ .Chart.Name }}"
     release: "{{ .Release.Name }}"

--- a/charts/nucliadb_shared/templates/nucliadb.secret.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.secret.yaml
@@ -1,7 +1,9 @@
+---
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nucliadb-config
+  name: {{ .Values.secretName | default "nucliadb-config" }}
   labels:
     app: nucliadb
     version: "{{ .Chart.Version | replace "+" "_" }}"
@@ -23,4 +25,5 @@ data:
 {{- end }}
 {{- if .Values.encryption.secret_key }}
   ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key | default "" }}
+{{- end }}
 {{- end }}

--- a/charts/nucliadb_shared/templates/nucliadb.secret.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nucliadb-config
+  labels:
+    app: nucliadb
+    version: "{{ .Chart.Version | replace "+" "_" }}"
+    chart: "{{ .Chart.Name }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- if eq .Values.storage.file_backend "gcs" }}
+  GCS_BASE64_CREDS: {{ .Values.storage.gcs_base64_creds | default "" }}
+{{- else if eq .Values.storage.file_backend "s3" }}
+{{- if eq .Values.storage.s3_irsa "disabled" }}
+  S3_CLIENT_ID: {{ .Values.storage.s3_client_id | default "" }}
+  S3_CLIENT_SECRET: {{ .Values.storage.s3_client_secret | default "" }}
+{{- end }}
+{{- end }}
+  NUCLIA_JWT_KEY: {{ .Values.nuclia.nuclia_jwt_key | default "" }}
+{{- if eq .Values.maindb.driver "pg" }}
+  DRIVER_PG_URL: {{ .Values.maindb.driver_pg_url | default "" }}
+{{- end }}
+{{- if .Values.encryption.secret_key }}
+  ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key | default "" }}
+{{- end }}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -1,3 +1,12 @@
+# Chart configuration
+
+configMap:
+  create: true
+  # name: nucliadb-config
+secret:
+  create: true
+  # name: nucliadb-config
+
 # NucliaDB Settings
 
 running:


### PR DESCRIPTION
### Description
The chart now creates a Kubernetes secret in addition to the configMap already created. This is an effort to be a good citizen and store sensitive values in Kubernetes secrets.

Additionally: 
* Secret and configMap names are configurable (default = original name(s))
* secret/configMap.create(bool) determines whether to create secret/configMap

### How was this PR tested?
Note: At this stage the original configmap still contains all values hence no change to current configuration was done, these are to be removed at a later date. 
