### PR TITLE
GH CI: Set Helm version to v3.15.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v4
       with:
-        version: v3.4.0
+        version: v3.15.3
 
     - name: Push helm package
       run: |-
@@ -145,7 +145,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.4.0
+          version: v3.15.3
 
       - name: Push helm package
         run: |-
@@ -214,7 +214,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.4.0
+          version: v3.15.3
 
       - name: Push helm package
         run: |-

--- a/.github/workflows/public_release.yml
+++ b/.github/workflows/public_release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.4.0
+          version: v3.15.3
 
       - name: Build helm package
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.4.0
+          version: v3.15.3
 
       - name: Push helm package
         run: |-


### PR DESCRIPTION
### Description
Update CI workflows to use most recent version of Helm for lint/package. Original version 3.4.0 is close to 4 years old now and [officially supports](https://helm.sh/docs/topics/version_skew/#supported-version-skew) only archaic versions of Kubernetes (1.19.x - 1.16.x). This also fixes failing CI lints with old versions.

### How was this PR tested?
Describe how you tested this PR.
