### PR TITLE
Skip arm build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,6 @@ jobs:
         with:
           context: .
           file: Dockerfile.withbinding
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             nuclia/nucliadb:latest


### PR DESCRIPTION
It's quite slow (~3 hours) and low priority, so disabling for now.