### PR TITLE
Helm Node: fix Helm chart env values

### DIFF
--- a/charts/nucliadb_ingest/templates/_cronjob_purge.tpl
+++ b/charts/nucliadb_ingest/templates/_cronjob_purge.tpl
@@ -58,6 +58,12 @@ spec:
               {{- if .Values.envFrom }}
               {{- toYaml .Values.envFrom | nindent 14 }}
               {{- end }}
+            env:
+              - name: VERSION
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['version']
+              {{- include "toEnv" .Values.env | indent 14 }}
             imagePullPolicy: Always
             command: ["{{ .command }}"]
 {{ end }}

--- a/charts/nucliadb_node/templates/node.replicas.deploy.yaml
+++ b/charts/nucliadb_node/templates/node.replicas.deploy.yaml
@@ -167,10 +167,7 @@ spec:
             value: secondary
           - name: METRICS_PORT
             value: "3031"
-        {{- range $key, $value := $values.env }}
-          - name: "{{ $key }}"
-            value: {{ tpl $value $ | toJson }}
-        {{- end }}
+          {{- include "toEnv" $values.env | indent 10 }}
         ports:
         - name: grpc-reader
           containerPort: {{ $values.serving.grpc_reader }}

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -124,10 +124,7 @@ spec:
         env:
           - name: METRICS_PORT
             value: "3032"
-          {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: {{ tpl $value $ | toJson }}
-          {{- end }}
+          {{- include "toEnv" .Values.env | indent 10 }}
         ports:
         - name: grpc-writer
           containerPort: {{ .Values.serving.grpc_writer }}
@@ -164,10 +161,7 @@ spec:
         env:
           - name: METRICS_PORT
             value: "3031"
-        {{- range $key, $value := .Values.env }}
-          - name: "{{ $key }}"
-            value: {{ tpl $value $ | toJson }}
-        {{- end }}
+          {{- include "toEnv" .Values.env | indent 10 }}
         ports:
         - name: grpc-reader
           containerPort: {{ .Values.serving.grpc_reader }}


### PR DESCRIPTION
### Description
* Replaces remaining references to the original way of env management.
* Introduces env section as in all other nucliadb node components

### How was this PR tested?
Describe how you tested this PR.
