### PR TITLE
PGCatalog: Metrics & Fix paging

### DIFF
--- a/nucliadb/src/nucliadb/ingest/orm/processor/pgcatalog.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/pgcatalog.py
@@ -23,10 +23,13 @@ from typing import cast
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.pg import PGDriver, PGTransaction
 from nucliadb.common.maindb.utils import get_driver
+from nucliadb_telemetry import metrics
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
 from ..resource import Resource
+
+observer = metrics.Observer("pg_catalog_write", labels={"type": ""})
 
 
 def _pg_transaction(txn: Transaction) -> PGTransaction:
@@ -39,6 +42,7 @@ def pgcatalog_enabled(kbid):
     )
 
 
+@observer.wrap({"type": "update"})
 async def pgcatalog_update(txn: Transaction, kbid: str, resource: Resource):
     if not pgcatalog_enabled(kbid):
         return
@@ -69,6 +73,7 @@ async def pgcatalog_update(txn: Transaction, kbid: str, resource: Resource):
         )
 
 
+@observer.wrap({"type": "delete"})
 async def pgcatalog_delete(txn: Transaction, kbid: str, rid: str):
     if not pgcatalog_enabled(kbid):
         return

--- a/nucliadb/src/nucliadb/search/search/pgcatalog.py
+++ b/nucliadb/src/nucliadb/search/search/pgcatalog.py
@@ -32,6 +32,7 @@ from nucliadb_models.search import (
     SortField,
     SortOrder,
 )
+from nucliadb_telemetry import metrics
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
@@ -149,6 +150,7 @@ def pgcatalog_enabled(kbid):
     )
 
 
+@metrics.Observer("pg_catalog_search").wrap()
 async def pgcatalog_search(query_parser: QueryParser) -> Resources:
     # Prepare SQL query
     query, query_params = _prepare_query(query_parser)

--- a/nucliadb/tests/nucliadb/integration/search/test_search.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search.py
@@ -1618,6 +1618,7 @@ async def test_catalog_pagination(
         assert resp.status_code == 200
         body = resp.json()
         assert len(body["resources"]) <= page_size
+        assert body["fulltext"]["page_number"] == page_number
         for resource_id, resource_data in body["resources"].items():
             resource_created_date = datetime.fromisoformat(resource_data["created"]).timestamp()
             if resource_id in resource_uuids:


### PR DESCRIPTION
Fix PGCatalog paging: stop using `merge_results` and work directly with the models. This is also a bit faster, we skip a query per resource (to fetch labels, we get them from the catalog directly).