### PR TITLE
Catch all errors on purge and rebalance commands

### DIFF
--- a/nucliadb/src/nucliadb/common/cluster/rebalance.py
+++ b/nucliadb/src/nucliadb/common/cluster/rebalance.py
@@ -221,8 +221,8 @@ async def run_command(context: ApplicationContext) -> None:
         errors.capture_exception(ex)
     finally:
         try:
-            await context.finalize()
             await metrics_server.shutdown()
+            await context.finalize()
         except Exception:  # pragma: no cover
             logger.exception("Error tearing down utilities on rebalance command")
             pass

--- a/nucliadb/src/nucliadb/purge/__init__.py
+++ b/nucliadb/src/nucliadb/purge/__init__.py
@@ -191,15 +191,20 @@ async def main():
         await purge_kb(driver)
         await purge_kb_storage(driver, storage)
         await purge_kb_vectorsets(driver, storage)
+    except Exception as ex:  # pragma: no cover
+        logger.exception("Unhandled exception on purge command")
+        errors.capture_exception(ex)
     finally:
-        await storage.finalize()
-        await teardown_driver()
-        await teardown_cluster()
+        try:
+            await storage.finalize()
+            await teardown_driver()
+            await teardown_cluster()
+        except Exception:  # pragma: no cover
+            logger.exception("Error tearing down utilities on purge command")
+            pass
 
 
 def run() -> int:  # pragma: no cover
     setup_logging()
-
     errors.setup_error_handling(importlib.metadata.distribution("nucliadb").version)
-
     return asyncio.run(main())


### PR DESCRIPTION
### Description
And send the error events to sentry. Don't let the command finish on an error state, as right now the k8s jobs alerts we have are very noisy and tedious to resolve.

### How was this PR tested?
Describe how you tested this PR.
