### PR TITLE
Rollover uses resource date, not origin date

### DIFF
--- a/nucliadb/src/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/src/nucliadb/common/cluster/rollover.py
@@ -231,8 +231,8 @@ async def index_rollover_shards(app_context: ApplicationContext, kbid: str) -> N
                 f"Shard {shard_id} not found. Was a new one created during migration?"
             )
 
-        resource_index_message = await index_resource_to_shard(app_context, kbid, resource_id, shard)
-        if resource_index_message is None:
+        resource = await index_resource_to_shard(app_context, kbid, resource_id, shard)
+        if resource is None:
             # resource no longer existing, remove indexing and carry on
             async with datamanagers.with_transaction() as txn:
                 await datamanagers.rollover.remove_to_index(txn, kbid=kbid, resource=resource_id)
@@ -245,7 +245,7 @@ async def index_rollover_shards(app_context: ApplicationContext, kbid: str) -> N
                 kbid=kbid,
                 resource_id=resource_id,
                 shard_id=shard_id,
-                modification_time=_to_ts(resource_index_message.metadata.modified.ToDatetime()),
+                modification_time=_to_ts(resource.basic.modified.ToDatetime()),
             )
             await txn.commit()
         wait_index_batch.append(shard)
@@ -370,8 +370,8 @@ async def validate_indexed_data(app_context: ApplicationContext, kbid: str) -> l
             continue
 
         # resource was modified or added during rollover, reindex
-        resource_index_message = await index_resource_to_shard(app_context, kbid, resource_id, shard)
-        if resource_index_message is not None:
+        resource = await index_resource_to_shard(app_context, kbid, resource_id, shard)
+        if resource is not None:
             repaired_resources.append(resource_id)
         async with datamanagers.with_transaction() as txn:
             await datamanagers.rollover.add_indexed(

--- a/nucliadb/src/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/src/nucliadb/common/cluster/rollover.py
@@ -245,7 +245,7 @@ async def index_rollover_shards(app_context: ApplicationContext, kbid: str) -> N
                 kbid=kbid,
                 resource_id=resource_id,
                 shard_id=shard_id,
-                modification_time=_to_ts(resource.basic.modified.ToDatetime()),
+                modification_time=_to_ts(resource.basic.modified.ToDatetime()),  # type: ignore
             )
             await txn.commit()
         wait_index_batch.append(shard)

--- a/nucliadb/src/nucliadb/common/cluster/utils.py
+++ b/nucliadb/src/nucliadb/common/cluster/utils.py
@@ -37,7 +37,8 @@ from nucliadb.common.cluster.standalone.service import (
     start_grpc as start_standalone_grpc,
 )
 from nucliadb.common.cluster.standalone.utils import is_index_node
-from nucliadb_protos import noderesources_pb2, writer_pb2
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb_protos import writer_pb2
 from nucliadb_utils import const
 from nucliadb_utils.settings import is_onprem_nucliadb
 from nucliadb_utils.utilities import Utility, clean_utility, get_utility, set_utility
@@ -125,7 +126,7 @@ async def index_resource_to_shard(
     kbid: str,
     resource_id: str,
     shard: writer_pb2.ShardObject,
-) -> Optional[noderesources_pb2.Resource]:
+) -> Optional[Resource]:
     logger.info("Indexing resource", extra={"kbid": kbid, "resource_id": resource_id})
     sm = app_context.shard_manager
     partitioning = app_context.partitioning

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -27,7 +27,7 @@ from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 
 # These should be refactored
 from nucliadb.ingest.settings import settings as ingest_settings
-from nucliadb_protos import noderesources_pb2, resources_pb2
+from nucliadb_protos import resources_pb2
 from nucliadb_utils.utilities import get_storage
 
 from .utils import with_ro_transaction
@@ -316,21 +316,3 @@ async def get_resource(txn: Transaction, *, kbid: str, rid: str) -> Optional["Re
 
     kb_orm = KnowledgeBoxORM(txn, await get_storage(), kbid)
     return await kb_orm.get(rid)
-
-
-@backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
-async def get_resource_index_message(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-    reindex: bool = False,
-) -> Optional[noderesources_pb2.Resource]:
-    # prevent circulat imports -- this is not ideal that we have the ORM mix here.
-    from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
-
-    kb_orm = KnowledgeBoxORM(txn, await get_storage(), kbid)
-    res = await kb_orm.get(rid)
-    if res is None:
-        return None
-    return (await res.generate_index_message(reindex=reindex)).brain


### PR DESCRIPTION
Rollover read the resource date from the index message, which can be the origin date or the resource date. This date is used to detect when a resource changed so we want the actual resource date. After this PR, we always read it from the resource itself.