### PR TITLE
Do not do custom validations for datetimes on output fields

### DIFF
--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -987,7 +987,7 @@ async def test_dates_are_properly_validated(
             },
         },
     )
-    assert resp.status_code == 422
+    assert resp.status_code == 422, print(resp.text)
     detail = resp.json()["detail"][0]
     assert detail["loc"] == ["body", "origin", "created"]
 
@@ -1000,10 +1000,10 @@ async def test_dates_are_properly_validated(
             },
         },
     )
-    assert resp.status_code == 201
+    assert resp.status_code == 201, print(resp.text)
     rid = resp.json()["uuid"]
 
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid}?show=origin")
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
 
     assert resp.json()["origin"]["created"] == "0001-01-01T00:00:00Z"

--- a/nucliadb_models/src/nucliadb_models/metadata.py
+++ b/nucliadb_models/src/nucliadb_models/metadata.py
@@ -347,6 +347,11 @@ class InputOrigin(BaseModel):
 
 
 class Origin(InputOrigin):
+    # Created and modified are redefined to
+    # use native datetime objects and skip validation
+    created: Optional[datetime] = None
+    modified: Optional[datetime] = None
+
     class Source(Enum):
         WEB = "WEB"
         DESKTOP = "DESKTOP"

--- a/nucliadb_models/src/nucliadb_models/writer.py
+++ b/nucliadb_models/src/nucliadb_models/writer.py
@@ -28,6 +28,7 @@ from nucliadb_models.link import LinkField
 from nucliadb_models.metadata import (
     Extra,
     InputMetadata,
+    InputOrigin,
     Origin,
     UserFieldMetadata,
     UserMetadata,
@@ -85,7 +86,7 @@ class CreateResourcePayload(BaseModel):
     metadata: Optional[InputMetadata] = None
     usermetadata: Optional[UserMetadata] = None
     fieldmetadata: Optional[List[UserFieldMetadata]] = None
-    origin: Optional[Origin] = None
+    origin: Optional[InputOrigin] = None
     extra: Optional[Extra] = None
 
     files: Dict[FieldIdString, FileField] = FieldDefaults.files

--- a/nucliadb_models/src/nucliadb_models/writer.py
+++ b/nucliadb_models/src/nucliadb_models/writer.py
@@ -29,7 +29,6 @@ from nucliadb_models.metadata import (
     Extra,
     InputMetadata,
     InputOrigin,
-    Origin,
     UserFieldMetadata,
     UserMetadata,
 )
@@ -131,7 +130,7 @@ class UpdateResourcePayload(BaseModel):
     metadata: Optional[InputMetadata] = None
     usermetadata: Optional[UserMetadata] = None
     fieldmetadata: Optional[List[UserFieldMetadata]] = None
-    origin: Optional[Origin] = None
+    origin: Optional[InputOrigin] = None
     extra: Optional[Extra] = None
     files: Dict[FieldIdString, FileField] = FieldDefaults.files
     links: Dict[FieldIdString, LinkField] = FieldDefaults.links


### PR DESCRIPTION
### Description
Since this was inherited from InputOrigin, we were validating when we didn't need to

### How was this PR tested?
Local tests
