### PR TITLE
Refactor rollover state persistence

### DIFF
--- a/nucliadb/src/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/src/nucliadb/common/cluster/rollover.py
@@ -56,7 +56,13 @@ async def create_rollover_shards(
             state = await datamanagers.rollover.get_rollover_state(txn, kbid=kbid)
         except RolloverStateNotFoundError:
             # State is not set yet, create it
-            state = RolloverState()
+            state = RolloverState(
+                rollover_shards_created=False,
+                resources_scheduled=False,
+                resources_indexed=False,
+                cutover=False,
+                resources_validated=False,
+            )
 
         kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
         if kb_shards is None:

--- a/nucliadb/src/nucliadb/common/cluster/rollover.py
+++ b/nucliadb/src/nucliadb/common/cluster/rollover.py
@@ -55,7 +55,7 @@ async def create_rollover_shards(
         try:
             state = await datamanagers.rollover.get_rollover_state(txn, kbid=kbid)
         except RolloverStateNotFoundError:
-            # First time we are creating shards
+            # State is not set yet, create it
             state = RolloverState()
 
         kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)

--- a/nucliadb/src/nucliadb/common/datamanagers/rollover.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/rollover.py
@@ -40,8 +40,8 @@ class RolloverState(BaseModel):
     rollover_shards_created: bool = False
     resources_scheduled: bool = False
     resources_indexed: bool = False
-    resources_validated: bool = False
     cutover: bool = False
+    resources_validated: bool = False
 
 
 class RolloverStateNotFoundError(Exception):

--- a/nucliadb/src/nucliadb/common/datamanagers/rollover.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/rollover.py
@@ -21,6 +21,7 @@ import logging
 from typing import AsyncGenerator, Optional
 
 import orjson
+from pydantic import BaseModel
 
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import writer_pb2
@@ -29,9 +30,18 @@ from .utils import get_kv_pb, with_ro_transaction
 
 logger = logging.getLogger(__name__)
 
+KB_ROLLOVER_STATE = "/kbs/{kbid}/rollover/state"
 KB_ROLLOVER_SHARDS = "/kbs/{kbid}/rollover/shards"
 KB_ROLLOVER_RESOURCES_TO_INDEX = "/kbs/{kbid}/rollover/to-index/{resource}"
 KB_ROLLOVER_RESOURCES_INDEXED = "/kbs/{kbid}/rollover/indexed/{resource}"
+
+
+class RolloverState(BaseModel):
+    rollover_shards_created: bool = False
+    resources_scheduled: bool = False
+    resources_indexed: bool = False
+    resources_validated: bool = False
+    cutover: bool = False
 
 
 async def get_kb_rollover_shards(txn: Transaction, *, kbid: str) -> Optional[writer_pb2.Shards]:
@@ -163,3 +173,21 @@ async def iterate_indexed_data(*, kbid: str) -> AsyncGenerator[tuple[str, tuple[
     if len(batch) > 0:
         for key, val in await _get_batch_indexed_data(kbid=kbid, batch=batch):
             yield key, val
+
+
+async def get_rollover_state(txn: Transaction, kbid: str) -> Optional[RolloverState]:
+    key = KB_ROLLOVER_STATE.format(kbid=kbid)
+    val = await txn.get(key)
+    if not val:
+        return None
+    return RolloverState.model_validate_json(val)
+
+
+async def set_rollover_state(txn: Transaction, kbid: str, state: RolloverState) -> None:
+    key = KB_ROLLOVER_STATE.format(kbid=kbid)
+    await txn.set(key, state.model_dump_json().encode())
+
+
+async def clear_rollover_state(txn: Transaction, kbid: str) -> None:
+    key = KB_ROLLOVER_STATE.format(kbid=kbid)
+    await txn.delete(key)

--- a/nucliadb/src/nucliadb/writer/tus/gcs.py
+++ b/nucliadb/src/nucliadb/writer/tus/gcs.py
@@ -127,9 +127,7 @@ class GCloudBlobStore(BlobStore):
         if self.json_credentials is not None and self.json_credentials.strip() != "":
             self.json_credentials_file = os.path.join(tempfile.mkdtemp(), "gcs_credentials.json")
             with open(self.json_credentials_file, "w") as file:
-                file.write(
-                    base64.b64decode(self.json_credentials).decode("utf-8")
-                )
+                file.write(base64.b64decode(self.json_credentials).decode("utf-8"))
             self._credentials = ServiceAccountCredentials.from_json_keyfile_name(
                 self.json_credentials_file, SCOPES
             )


### PR DESCRIPTION
### Description
Before, the rollover state was kept in the `extra` parameter of the `Shards` protobuf.
Now that we want to rollover not only internal index node shards, but also external indexes, we need to decouple this logic from the shards object.

### How was this PR tested?
Integration, unit and local tests.
