### PR TITLE
Neighbouring Paragraphs RAG Strategy

### DIFF
--- a/nucliadb/src/nucliadb/common/external_index_providers/pinecone.py
+++ b/nucliadb/src/nucliadb/common/external_index_providers/pinecone.py
@@ -76,6 +76,7 @@ class PineconeQueryResults(QueryResults):
     def iter_matching_text_blocks(self) -> Iterator[TextBlockMatch]:
         for order, matching_vector in enumerate(self.results.matches):
             try:
+                paragraph_id = ParagraphId.from_vector_key(matching_vector.id)
                 vector_id = VectorId.from_string(matching_vector.id)
             except ValueError:  # pragma: no cover
                 logger.error(f"Invalid Pinecone vector id: {matching_vector.id}")
@@ -83,14 +84,14 @@ class PineconeQueryResults(QueryResults):
             vector_metadata = VectorMetadata.model_validate(matching_vector.metadata)  # noqa
             yield TextBlockMatch(
                 text=None,  # To be filled by the results hydrator
-                id=matching_vector.id,
-                resource_id=vector_id.field_id.rid,
-                field_id=vector_id.field_id.full(),
+                id=paragraph_id.full(),
+                resource_id=paragraph_id.field_id.rid,
+                field_id=paragraph_id.field_id.full(),
                 score=matching_vector.score,
                 order=order,
-                position_start=vector_id.vector_start,
-                position_end=vector_id.vector_end,
-                subfield_id=vector_id.field_id.subfield_id,
+                position_start=paragraph_id.paragraph_start,
+                position_end=paragraph_id.paragraph_end,
+                subfield_id=paragraph_id.field_id.subfield_id,
                 index=vector_id.index,
                 position_start_seconds=list(map(int, vector_metadata.position_start_seconds or [])),
                 position_end_seconds=list(map(int, vector_metadata.position_end_seconds or [])),

--- a/nucliadb/src/nucliadb/common/external_index_providers/pinecone.py
+++ b/nucliadb/src/nucliadb/common/external_index_providers/pinecone.py
@@ -76,8 +76,8 @@ class PineconeQueryResults(QueryResults):
     def iter_matching_text_blocks(self) -> Iterator[TextBlockMatch]:
         for order, matching_vector in enumerate(self.results.matches):
             try:
-                paragraph_id = ParagraphId.from_vector_key(matching_vector.id)
                 vector_id = VectorId.from_string(matching_vector.id)
+                paragraph_id = ParagraphId.from_vector_id(vector_id)
             except ValueError:  # pragma: no cover
                 logger.error(f"Invalid Pinecone vector id: {matching_vector.id}")
                 continue

--- a/nucliadb/src/nucliadb/common/ids.py
+++ b/nucliadb/src/nucliadb/common/ids.py
@@ -41,8 +41,30 @@ FIELD_TYPE_PB_TO_STR = {v: k for k, v in FIELD_TYPE_STR_TO_PB.items()}
 
 @dataclass
 class FieldId:
+    """
+    Field ids are used to identify fields in resources. They usually have the following format:
+
+        `rid/field_type/field_key`
+
+    where field type is one of: `t`, `f`, `u`, `a`, `c` (text, file, link, generic, conversation)
+    and field_key is an identifier for that field type on the resource, usually chosen by the user.
+
+    In some cases, fields can have subfields, for example, in conversations, where each part of the
+    conversation is a subfield. In those cases, the id has the following format:
+
+        `rid/field_type/field_key/subfield_id`
+
+    Examples:
+
+    >>> FieldId(rid="rid", type="u", key="/my-link")
+    FieldID("rid/u/my-link")
+    >>> FieldId.from_string("rid/u/my-link")
+    FieldID("rid/u/my-link")
+    """
+
     rid: str
-    field_id: str
+    type: str
+    key: str
     # also knwon as `split`, this indicates a part of a field in, for example, conversations
     subfield_id: Optional[str] = None
 
@@ -51,40 +73,46 @@ class FieldId:
 
     def full(self) -> str:
         if self.subfield_id is None:
-            return f"{self.rid}/{self.field_id}"
+            return f"{self.rid}/{self.type}/{self.key}"
         else:
-            return f"{self.rid}/{self.field_id}/{self.subfield_id}"
-
-    @property
-    def field_type(self) -> str:
-        return self.field_id.split("/")[0]
+            return f"{self.rid}/{self.type}/{self.key}/{self.subfield_id}"
 
     def __hash__(self) -> int:
         return hash(self.full())
 
     @property
     def pb_type(self) -> FieldType.ValueType:
-        return FIELD_TYPE_STR_TO_PB[self.field_type]
+        return FIELD_TYPE_STR_TO_PB[self.type]
 
     @classmethod
     def from_string(cls, value: str) -> "FieldId":
         """
         Parse a FieldId from a string
         Example:
-        >>> FieldId.from_string("rid/u/field_id")
-        FieldId(rid="rid", field_id="u/field_id")
-        >>> FieldId.from_string("rid/u/field_id/subfield_id")
-        FieldId(rid="rid", field_id="u/field_id", subfield_id="subfield_id")
+        >>> fid = FieldId.from_string("rid/u/foo")
+        >>> fid
+        FieldId("rid/u/foo")
+        >>> fid.type
+        'u'
+        >>> fid.key
+        'foo'
+        >>> FieldId.from_string("rid/u/foo/subfield_id").subfield_id
+        'subfield_id'
         """
         parts = value.split("/")
         if len(parts) == 3:
-            rid, field_type, field_id = parts
-            return cls(rid=rid, field_id=f"{field_type}/{field_id}")
+            rid, _type, key = parts
+            if _type not in FIELD_TYPE_STR_TO_PB:
+                raise ValueError(f"Invalid FieldId: {value}")
+            return cls(rid=rid, type=_type, key=key)
         elif len(parts) == 4:
-            rid, field_type, field_id, subfield_id = parts
+            rid, _type, key, subfield_id = parts
+            if _type not in FIELD_TYPE_STR_TO_PB:
+                raise ValueError(f"Invalid FieldId: {value}")
             return cls(
                 rid=rid,
-                field_id=f"{field_type}/{field_id}",
+                type=_type,
+                key=key,
                 subfield_id=subfield_id,
             )
         else:
@@ -133,6 +161,18 @@ class VectorId:
     """
     Ids of vectors are very similar to ParagraphIds, but for legacy reasons, they have an index
     indicating the position of the corresponding text block in the list of text blocks for the field.
+
+    Examples:
+
+    >>> VectorId.from_string("rid/u/field_id/0/0-10")
+    VectorId("rid/u/field_id/0/0-10")
+    >>> VectorId(
+    ...    field_id=FieldId.from_string("rid/u/field_id"),
+    ...    index=0,
+    ...    vector_start=0,
+    ...    vector_end=10,
+    ... )
+    VectorId("rid/u/field_id/0/0-10")
     """
 
     field_id: FieldId

--- a/nucliadb/src/nucliadb/common/ids.py
+++ b/nucliadb/src/nucliadb/common/ids.py
@@ -143,17 +143,18 @@ class ParagraphId:
         return cls(field_id=field_id, paragraph_start=start, paragraph_end=end)
 
     @classmethod
-    def from_vector_key(cls, vector_key: str) -> "ParagraphId":
+    def from_vector_id(cls, vid: "VectorId") -> "ParagraphId":
         """
         Returns a ParagraphId from a vector_key (the index part of the vector_key is ignored).
-        >>> ParagraphId.from_vector_key("rid/u/field_id/0/0-1")
+        >>> vid = VectorId.from_string("rid/u/field_id/0/0-1")
+        >>> ParagraphId.from_vector_id(vid)
         ParagraphId("rid/u/field_id/0-1")
         """
-        parts = vector_key.split("/")
-        vector_range = parts[-1]
-        start, end = map(int, vector_range.split("-"))
-        field_id = FieldId.from_string("/".join(parts[:-2]))
-        return cls(field_id=field_id, paragraph_start=start, paragraph_end=end)
+        return cls(
+            field_id=vid.field_id,
+            paragraph_start=vid.vector_start,
+            paragraph_end=vid.vector_end,
+        )
 
 
 @dataclass

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -228,9 +228,10 @@ class ResourceBrain:
             self.brain.paragraphs_to_delete.append(f"{self.rid}/{field_key}/{paragraph_to_delete}")
 
     def delete_metadata(self, field_key: str, metadata: FieldComputedMetadata):
+        ftype, fkey = field_key.split("/")
         for subfield, metadata_split in metadata.split_metadata.items():
             self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, field_id=field_key, subfield_id=subfield).full()
+                ids.FieldId(rid=self.rid, type=ftype, key=fkey, subfield_id=subfield).full()
             )
             # TODO: Bw/c, remove this when paragraph deletion by field_id gets
             # promoted
@@ -240,7 +241,9 @@ class ResourceBrain:
                 )
 
         for paragraph in metadata.metadata.paragraphs:
-            self.brain.paragraphs_to_delete.append(ids.FieldId(rid=self.rid, field_id=field_key).full())
+            self.brain.paragraphs_to_delete.append(
+                ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
+            )
             # TODO: Bw/c, remove this when paragraph deletion by field_id gets
             # promoted
             self.brain.paragraphs_to_delete.append(
@@ -258,11 +261,12 @@ class ResourceBrain:
         matryoshka_vector_dimension: Optional[int] = None,
     ):
         replace_splits = replace_splits or []
-
+        ftype, fkey = field_id.split("/")
         for subfield, vectors in vo.split_vectors.items():
             _field_id = ids.FieldId(
                 rid=self.rid,
-                field_id=field_id,
+                type=ftype,
+                key=fkey,
                 subfield_id=subfield,
             )
             # For each split of this field
@@ -289,7 +293,8 @@ class ResourceBrain:
 
         _field_id = ids.FieldId(
             rid=self.rid,
-            field_id=field_id,
+            type=ftype,
+            key=fkey,
         )
         for index, vector in enumerate(vo.vectors.vectors):
             paragraph_key = ids.ParagraphId(
@@ -314,15 +319,17 @@ class ResourceBrain:
 
         for split in replace_splits:
             self.brain.sentences_to_delete.append(
-                ids.FieldId(rid=self.rid, field_id=field_id, subfield_id=split).full()
+                ids.FieldId(rid=self.rid, type=ftype, key=fkey, subfield_id=split).full()
             )
             self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, field_id=field_id, subfield_id=split).full()
+                ids.FieldId(rid=self.rid, type=ftype, key=fkey, subfield_id=split).full()
             )
 
         if replace_field:
-            self.brain.sentences_to_delete.append(ids.FieldId(rid=self.rid, field_id=field_id).full())
-            self.brain.paragraphs_to_delete.append(ids.FieldId(rid=self.rid, field_id=field_id).full())
+            self.brain.sentences_to_delete.append(ids.FieldId(rid=self.rid, type=ftype, key=fkey).full())
+            self.brain.paragraphs_to_delete.append(
+                ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
+            )
 
     def _apply_field_vector(
         self,

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -261,12 +261,12 @@ class ResourceBrain:
         matryoshka_vector_dimension: Optional[int] = None,
     ):
         replace_splits = replace_splits or []
-        ftype, fkey = field_id.split("/")
+        fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():
             _field_id = ids.FieldId(
-                rid=self.rid,
-                type=ftype,
-                key=fkey,
+                rid=fid.rid,
+                type=fid.type,
+                key=fid.key,
                 subfield_id=subfield,
             )
             # For each split of this field
@@ -292,9 +292,9 @@ class ResourceBrain:
                 )
 
         _field_id = ids.FieldId(
-            rid=self.rid,
-            type=ftype,
-            key=fkey,
+            rid=fid.rid,
+            type=fid.type,
+            key=fid.key,
         )
         for index, vector in enumerate(vo.vectors.vectors):
             paragraph_key = ids.ParagraphId(
@@ -319,16 +319,18 @@ class ResourceBrain:
 
         for split in replace_splits:
             self.brain.sentences_to_delete.append(
-                ids.FieldId(rid=self.rid, type=ftype, key=fkey, subfield_id=split).full()
+                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key, subfield_id=split).full()
             )
             self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, type=ftype, key=fkey, subfield_id=split).full()
+                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key, subfield_id=split).full()
             )
 
         if replace_field:
-            self.brain.sentences_to_delete.append(ids.FieldId(rid=self.rid, type=ftype, key=fkey).full())
+            self.brain.sentences_to_delete.append(
+                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key).full()
+            )
             self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
+                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key).full()
             )
 
     def _apply_field_vector(

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Type
 
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.resources import KB_RESOURCE_FIELDS, KB_RESOURCE_SLUG
+from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR, FIELD_TYPE_STR_TO_PB
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.fields.conversation import Conversation
@@ -91,16 +92,6 @@ KB_FIELDS: dict[int, Type] = {
     FieldType.GENERIC: Generic,
     FieldType.CONVERSATION: Conversation,
 }
-
-KB_REVERSE: dict[str, FieldType.ValueType] = {
-    "t": FieldType.TEXT,
-    "f": FieldType.FILE,
-    "u": FieldType.LINK,
-    "a": FieldType.GENERIC,
-    "c": FieldType.CONVERSATION,
-}
-
-FIELD_TYPE_TO_ID = {v: k for k, v in KB_REVERSE.items()}
 
 _executor = ThreadPoolExecutor(10)
 
@@ -407,7 +398,7 @@ class Resource:
             # The [6:8] `slicing purpose is to match exactly the two
             # splitted parts corresponding to type and field, and nothing else!
             type, field = key.split("/")[6:8]
-            type_id = KB_REVERSE.get(type)
+            type_id = FIELD_TYPE_STR_TO_PB.get(type)
             if type_id is None:
                 raise AttributeError("Invalid field type")
             result = (type_id, field)
@@ -823,7 +814,7 @@ class Resource:
         await field_obj.set_large_field_metadata(field_large_metadata)
 
     def generate_field_id(self, field: FieldID) -> str:
-        return f"{FIELD_TYPE_TO_ID[field.field_type]}/{field.field}"
+        return f"{FIELD_TYPE_PB_TO_STR[field.field_type]}/{field.field}"
 
     async def compute_security(self, brain: ResourceBrain):
         security = await self.get_security()

--- a/nucliadb/src/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/download.py
@@ -28,7 +28,7 @@ from fastapi_versioning import version
 from starlette.datastructures import Headers
 from starlette.responses import StreamingResponse
 
-from nucliadb.ingest.orm.resource import FIELD_TYPE_TO_ID
+from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.ingest.serialize import get_resource_uuid_by_slug
 from nucliadb.reader import SERVICE_NAME, logger
 from nucliadb.reader.api.models import FIELD_NAMES_TO_PB_TYPE_MAP
@@ -98,7 +98,7 @@ async def _download_extract_file(
     storage = await get_storage(service_name=SERVICE_NAME)
 
     pb_field_type = FIELD_NAMES_TO_PB_TYPE_MAP[field_type]
-    field_type_letter = FIELD_TYPE_TO_ID[pb_field_type]
+    field_type_letter = FIELD_TYPE_PB_TO_STR[pb_field_type]
 
     sf = storage.file_extracted(kbid, rid, field_type_letter, field_id, download_field)
 

--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -25,6 +25,7 @@ from starlette.responses import StreamingResponse
 
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, api
+from nucliadb.search.search import cache
 from nucliadb.search.search.chat.ask import AskResult, ask, handled_ask_exceptions
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (
@@ -75,14 +76,15 @@ async def create_ask_response(
     resource: Optional[str] = None,
 ) -> Response:
     ask_request.max_tokens = parse_max_tokens(ask_request.max_tokens)
-    ask_result: AskResult = await ask(
-        kbid=kbid,
-        ask_request=ask_request,
-        user_id=user_id,
-        client_type=client_type,
-        origin=origin,
-        resource=resource,
-    )
+    with cache.request_caches():
+        ask_result: AskResult = await ask(
+            kbid=kbid,
+            ask_request=ask_request,
+            user_id=user_id,
+            client_type=client_type,
+            origin=origin,
+            resource=resource,
+        )
     headers = {
         "NUCLIA-LEARNING-ID": ask_result.nuclia_learning_id or "unknown",
         "Access-Control-Expose-Headers": "NUCLIA-LEARNING-ID",

--- a/nucliadb/src/nucliadb/search/api/v1/resource/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/search.py
@@ -26,6 +26,7 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.requesters.utils import Method, debug_nodes_info, node_query
+from nucliadb.search.search import cache
 from nucliadb.search.search.exceptions import InvalidQueryError
 from nucliadb.search.search.merge import merge_paragraphs_results
 from nucliadb.search.search.query import paragraph_query_to_pb
@@ -88,49 +89,49 @@ async def resource_search(
     debug: bool = fastapi_query(SearchParamDefaults.debug),
     shards: list[str] = fastapi_query(SearchParamDefaults.shards),
 ) -> Union[ResourceSearchResults, HTTPClientError]:
-    # We need to query all nodes
-    try:
-        pb_query = await paragraph_query_to_pb(
-            kbid,
-            [SearchOptions.KEYWORD],
-            rid,
-            query,
-            fields,
-            filters,
-            faceted,
-            page_number,
-            page_size,
-            range_creation_start,
-            range_creation_end,
-            range_modification_start,
-            range_modification_end,
-            sort=sort.value if sort else None,
-            sort_ord=sort_order.value,
+    with cache.request_caches():
+        try:
+            pb_query = await paragraph_query_to_pb(
+                kbid,
+                [SearchOptions.KEYWORD],
+                rid,
+                query,
+                fields,
+                filters,
+                faceted,
+                page_number,
+                page_size,
+                range_creation_start,
+                range_creation_end,
+                range_modification_start,
+                range_modification_end,
+                sort=sort.value if sort else None,
+                sort_ord=sort_order.value,
+            )
+        except InvalidQueryError as exc:
+            return HTTPClientError(status_code=412, detail=str(exc))
+
+        results, incomplete_results, queried_nodes = await node_query(
+            kbid, Method.PARAGRAPH, pb_query, shards
         )
-    except InvalidQueryError as exc:
-        return HTTPClientError(status_code=412, detail=str(exc))
 
-    results, incomplete_results, queried_nodes = await node_query(
-        kbid, Method.PARAGRAPH, pb_query, shards
-    )
+        # We need to merge
+        search_results = await merge_paragraphs_results(
+            results,
+            count=page_size,
+            page=page_number,
+            kbid=kbid,
+            show=show,
+            field_type_filter=field_type_filter,
+            extracted=extracted,
+            highlight_split=highlight,
+            min_score=0.0,
+        )
 
-    # We need to merge
-    search_results = await merge_paragraphs_results(
-        results,
-        count=page_size,
-        page=page_number,
-        kbid=kbid,
-        show=show,
-        field_type_filter=field_type_filter,
-        extracted=extracted,
-        highlight_split=highlight,
-        min_score=0.0,
-    )
+        response.status_code = 206 if incomplete_results else 200
+        if debug:
+            search_results.nodes = debug_nodes_info(queried_nodes)
 
-    response.status_code = 206 if incomplete_results else 200
-    if debug:
-        search_results.nodes = debug_nodes_info(queried_nodes)
-
-    queried_shards = [shard_id for _, shard_id in queried_nodes]
-    search_results.shards = queried_shards
-    return search_results
+        queried_shards = [shard_id for _, shard_id in queried_nodes]
+        search_results.shards = queried_shards
+        return search_results

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -32,6 +32,7 @@ from nucliadb.search import logger, predict
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.requesters.utils import Method, debug_nodes_info, node_query
+from nucliadb.search.search import cache
 from nucliadb.search.search.exceptions import InvalidQueryError
 from nucliadb.search.search.merge import fetch_resources, merge_results
 from nucliadb.search.search.pgcatalog import pgcatalog_enabled, pgcatalog_search
@@ -409,13 +410,13 @@ async def _search_endpoint(
     x_forwarded_for: str,
     **kwargs,
 ) -> Union[KnowledgeboxSearchResults, HTTPClientError]:
-    # All endpoint logic should be here
     try:
-        results, incomplete = await search(
-            kbid, item, x_ndb_client, x_nucliadb_user, x_forwarded_for, **kwargs
-        )
-        response.status_code = 206 if incomplete else 200
-        return results
+        with cache.request_caches():
+            results, incomplete = await search(
+                kbid, item, x_ndb_client, x_nucliadb_user, x_forwarded_for, **kwargs
+            )
+            response.status_code = 206 if incomplete else 200
+            return results
     except KnowledgeBoxNotFound:
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")
     except LimitsExceededError as exc:

--- a/nucliadb/src/nucliadb/search/search/cache.py
+++ b/nucliadb/src/nucliadb/search/search/cache.py
@@ -18,37 +18,74 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import contextlib
+import logging
 from contextvars import ContextVar
 from typing import Optional
 
 from lru import LRU
 
+from nucliadb.common.ids import FieldId
 from nucliadb.common.maindb.utils import get_driver
+from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.search import SERVICE_NAME
+from nucliadb_protos.utils_pb2 import ExtractedText
 from nucliadb_telemetry import metrics
 from nucliadb_utils.utilities import get_storage
 
+logger = logging.getLogger(__name__)
+
 rcache: ContextVar[Optional[dict[str, ResourceORM]]] = ContextVar("rcache", default=None)
+etcache: ContextVar[Optional["ExtractedTextCache"]] = ContextVar("etcache", default=None)
 
 
 RESOURCE_LOCKS: dict[str, asyncio.Lock] = LRU(1000)  # type: ignore
 RESOURCE_CACHE_OPS = metrics.Counter("nucliadb_resource_cache_ops", labels={"type": ""})
+EXTRACTED_CACHE_OPS = metrics.Counter("nucliadb_extracted_text_cache_ops", labels={"type": ""})
 
 
-def get_resource_cache(clear: bool = False) -> dict[str, ResourceORM]:
-    value: Optional[dict[str, ResourceORM]] = rcache.get()
-    if value is None or clear:
-        value = {}
-        rcache.set(value)
-    return value
+def set_extracted_text_cache() -> None:
+    value = ExtractedTextCache()
+    etcache.set(value)
+
+
+def get_extracted_text_cache() -> Optional["ExtractedTextCache"]:
+    return etcache.get()
+
+
+def clear_extracted_text_cache() -> None:
+    value = etcache.get()
+    if value is not None:
+        value.clear()
+        etcache.set(None)
+
+
+def set_resource_cache() -> None:
+    value: dict[str, ResourceORM] = {}
+    rcache.set(value)
+
+
+def get_resource_cache() -> Optional[dict[str, ResourceORM]]:
+    return rcache.get()
+
+
+def clear_resource_cache() -> None:
+    value = rcache.get()
+    if value is not None:
+        value.clear()
+        rcache.set(None)
 
 
 async def get_resource_from_cache(kbid: str, uuid: str) -> Optional[ResourceORM]:
     orm_resource: Optional[ResourceORM] = None
 
     resource_cache = get_resource_cache()
+    if resource_cache is None:
+        RESOURCE_CACHE_OPS.inc({"type": "miss"})
+        logger.warning("Resource cache not set")
+        return await _orm_get_resource(kbid, uuid)
 
     if uuid not in RESOURCE_LOCKS:
         RESOURCE_LOCKS[uuid] = asyncio.Lock()
@@ -56,10 +93,7 @@ async def get_resource_from_cache(kbid: str, uuid: str) -> Optional[ResourceORM]
     async with RESOURCE_LOCKS[uuid]:
         if uuid not in resource_cache:
             RESOURCE_CACHE_OPS.inc({"type": "miss"})
-            async with get_driver().transaction(read_only=True) as txn:
-                storage = await get_storage(service_name=SERVICE_NAME)
-                kb = KnowledgeBoxORM(txn, storage, kbid)
-                orm_resource = await kb.get(uuid)
+            orm_resource = await _orm_get_resource(kbid, uuid)
         else:
             RESOURCE_CACHE_OPS.inc({"type": "hit"})
 
@@ -69,3 +103,101 @@ async def get_resource_from_cache(kbid: str, uuid: str) -> Optional[ResourceORM]
             orm_resource = resource_cache.get(uuid)
 
     return orm_resource
+
+
+async def _orm_get_resource(kbid: str, uuid: str) -> Optional[ResourceORM]:
+    async with get_driver().transaction(read_only=True) as txn:
+        storage = await get_storage(service_name=SERVICE_NAME)
+        kb = KnowledgeBoxORM(txn, storage, kbid)
+        return await kb.get(uuid)
+
+
+class ExtractedTextCache:
+    """
+    Used to cache extracted text from a resource in memory during the process
+    of search results hydration.
+
+    This is needed to avoid fetching the same extracted text multiple times,
+    as matching text blocks are processed in parallel and the extracted text is
+    fetched for each field where the text block is found.
+    """
+
+    def __init__(self):
+        self.locks = {}
+        self.values = {}
+
+    def get_value(self, key: str) -> Optional[ExtractedText]:
+        return self.values.get(key)
+
+    def get_lock(self, key: str) -> asyncio.Lock:
+        return self.locks.setdefault(key, asyncio.Lock())
+
+    def set_value(self, key: str, value: ExtractedText) -> None:
+        self.values[key] = value
+
+    def clear(self):
+        self.values.clear()
+        self.locks.clear()
+
+
+async def get_field_extracted_text(field: Field) -> Optional[ExtractedText]:
+    cache = get_extracted_text_cache()
+    if cache is None:
+        logger.warning("Extracted text cache not set")
+        EXTRACTED_CACHE_OPS.inc({"type": "miss"})
+        return await field.get_extracted_text()
+
+    key = f"{field.kbid}/{field.uuid}/{field.id}"
+    extracted_text = cache.get_value(key)
+    if extracted_text is not None:
+        EXTRACTED_CACHE_OPS.inc({"type": "hit"})
+        return extracted_text
+
+    async with cache.get_lock(key):
+        # Check again in case another task already fetched it
+        extracted_text = cache.get_value(key)
+        if extracted_text is not None:
+            EXTRACTED_CACHE_OPS.inc({"type": "hit"})
+            return extracted_text
+
+        EXTRACTED_CACHE_OPS.inc({"type": "miss"})
+        extracted_text = await field.get_extracted_text()
+        if extracted_text is not None:
+            # Only cache if we actually have extracted text
+            cache.set_value(key, extracted_text)
+        return extracted_text
+
+
+async def get_field_extracted_text_from_cache(kbid: str, field: FieldId) -> Optional[ExtractedText]:
+    rid = field.rid
+    orm_resource = await get_resource_from_cache(kbid, rid)
+    if orm_resource is None:
+        return None
+    field_obj = await orm_resource.get_field(
+        key=field.key,
+        type=field.pb_type,
+        load=False,
+    )
+    return await get_field_extracted_text(field_obj)
+
+
+@contextlib.contextmanager
+def request_caches():
+    """
+    This context manager sets the caches for extracted text and resources for a request.
+
+    It should used at the beginning of a request handler to avoid fetching the same
+    resources and extracted text multiple times.
+
+    Makes sure to clean the caches at the end of the context manager.
+    >>> with request_caches():
+    ...     resource = await get_resource_from_cache(kbid, uuid)
+    ...     extracted_text = await get_field_extracted_text_from_cache(kbid, rid, field_id)
+    """
+    set_resource_cache()
+    set_extracted_text_cache()
+    try:
+        yield
+    finally:
+        clear_resource_cache()
+        clear_extracted_text_cache()

--- a/nucliadb/src/nucliadb/search/search/cache.py
+++ b/nucliadb/src/nucliadb/search/search/cache.py
@@ -78,7 +78,10 @@ def clear_resource_cache() -> None:
         rcache.set(None)
 
 
-async def get_resource_from_cache(kbid: str, uuid: str) -> Optional[ResourceORM]:
+async def get_resource(kbid: str, uuid: str) -> Optional[ResourceORM]:
+    """
+    Will try to get the resource from the cache, if it's not there it will fetch it from the ORM and cache it.
+    """
     orm_resource: Optional[ResourceORM] = None
 
     resource_cache = get_resource_cache()
@@ -168,9 +171,9 @@ async def get_field_extracted_text(field: Field) -> Optional[ExtractedText]:
         return extracted_text
 
 
-async def get_field_extracted_text_from_cache(kbid: str, field: FieldId) -> Optional[ExtractedText]:
+async def get_extracted_text_from_field_id(kbid: str, field: FieldId) -> Optional[ExtractedText]:
     rid = field.rid
-    orm_resource = await get_resource_from_cache(kbid, rid)
+    orm_resource = await get_resource(kbid, rid)
     if orm_resource is None:
         return None
     field_obj = await orm_resource.get_field(
@@ -191,8 +194,8 @@ def request_caches():
 
     Makes sure to clean the caches at the end of the context manager.
     >>> with request_caches():
-    ...     resource = await get_resource_from_cache(kbid, uuid)
-    ...     extracted_text = await get_field_extracted_text_from_cache(kbid, rid, field_id)
+    ...     resource = await get_resource(kbid, uuid)
+    ...     extracted_text = await get_extracted_text_from_field_id(kbid, rid, field_id)
     """
     set_resource_cache()
     set_extracted_text_cache()

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -287,9 +287,10 @@ async def full_resource_prompt_context(
     for extracted_texts in resource_extracted_texts:
         if extracted_texts is None:
             continue
+        field: FieldId
         for field, extracted_text in extracted_texts:
             # Add the extracted text of each field to the context.
-            context[field.resource_unique_id] = extracted_text
+            context[field.full()] = extracted_text
 
 
 async def composed_prompt_context(
@@ -330,7 +331,7 @@ async def composed_prompt_context(
             continue
         # Add the extracted text of each field to the beginning of the context.
         field, extracted_text = result
-        context[field.resource_unique_id] = extracted_text
+        context[field.full()] = extracted_text
 
     # Add the extracted text of each paragraph to the end of the context.
     for paragraph in ordered_paragraphs:

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -211,7 +211,7 @@ async def get_field_extracted_text(field: Field) -> Optional[tuple[Field, str]]:
 async def get_resource_field_extracted_text(
     kbid: str, field_id: FieldId
 ) -> Optional[tuple[FieldId, str]]:
-    extracted_text = await cache.get_field_extracted_text_from_cache(kbid, field_id)
+    extracted_text = await cache.get_extracted_text_from_field_id(kbid, field_id)
     if extracted_text is None:
         return None
     return field_id, extracted_text.text
@@ -221,7 +221,7 @@ async def get_resource_extracted_texts(
     kbid: str,
     resource_uuid: str,
 ) -> list[tuple[Field, str]]:
-    resource = await cache.get_resource_from_cache(kbid, resource_uuid)
+    resource = await cache.get_resource(kbid, resource_uuid)
     if resource is None:
         return []
 
@@ -399,7 +399,7 @@ async def get_field_paragraphs_list(
     """
     Modifies the paragraphs list by adding the paragraph ids of the field, sorted by position.
     """
-    resource = await cache.get_resource_from_cache(kbid, field.rid)
+    resource = await cache.get_resource(kbid, field.rid)
     if resource is None:
         return
     field_obj: Field = await resource.get_field(key=field.key, type=field.pb_type, load=False)

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -31,8 +31,9 @@ from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
 from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.search import logger
+from nucliadb.search.search import cache
 from nucliadb.search.search.chat.images import get_page_image, get_paragraph_image
-from nucliadb.search.search.paragraphs import ExtractedTextCache, get_paragraph_text
+from nucliadb.search.search.paragraphs import get_paragraph_text
 from nucliadb_models.search import (
     SCORE_TYPE,
     FieldExtensionStrategy,
@@ -203,37 +204,19 @@ async def default_prompt_context(
 
 
 async def get_field_extracted_text(field: Field) -> Optional[tuple[Field, str]]:
-    extracted_text_pb = await field.get_extracted_text(force=True)
+    extracted_text_pb = await cache.get_field_extracted_text(field)
     if extracted_text_pb is None:
         return None
     return field, extracted_text_pb.text
 
 
 async def get_resource_field_extracted_text(
-    kb_obj: KnowledgeBoxORM,
-    resource_uuid,
-    field_id: str,
-) -> Optional[tuple[Field, str]]:
-    resource = await kb_obj.get(resource_uuid)
-    if resource is None:
+    kbid: str, field_id: FieldId
+) -> Optional[tuple[FieldId, str]]:
+    extracted_text = await cache.get_field_extracted_text_from_cache(kbid, field_id)
+    if extracted_text is None:
         return None
-
-    try:
-        field_type, field_key = field_id.strip("/").split("/")
-    except ValueError:
-        logger.info(
-            f"Invalid field id: {field_id}. Skipping getting extracted text.",
-            extra={"kbid": kb_obj.kbid},
-        )
-        return None
-    field = await resource.get_field(field_key, FIELD_TYPE_STR_TO_PB[field_type], load=False)
-    if field is None:
-        return None
-    result = await get_field_extracted_text(field)
-    if result is None:
-        return None
-    _, extracted_text = result
-    return field, extracted_text
+    return field_id, extracted_text.text
 
 
 async def get_resource_extracted_texts(
@@ -329,32 +312,34 @@ async def composed_prompt_context(
             ordered_resources.append(resource_uuid)
 
     # Fetch the extracted texts of the specified fields for each resource
-    async with get_driver().transaction(read_only=True) as txn:
-        kb_obj = KnowledgeBoxORM(txn, await get_storage(), kbid)
-
-        tasks = [
-            get_resource_field_extracted_text(kb_obj, resource_uuid, field_id)
-            for resource_uuid in ordered_resources
-            for field_id in extend_with_fields
-        ]
-        field_extracted_texts = await run_concurrently(tasks)
-
-        for result in field_extracted_texts:
-            if result is None:
+    extend_field_ids = []
+    for resource_uuid in ordered_resources:
+        for field_id in extend_with_fields:
+            try:
+                fid = FieldId.from_string(f"{resource_uuid}/{field_id}")
+                extend_field_ids.append(fid)
+            except ValueError:
+                logger.info("Invalid field id to extend", extra={"field_id": field_id, "kbid": kbid})
                 continue
-            # Add the extracted text of each field to the beginning of the context.
-            field, extracted_text = result
-            context[field.resource_unique_id] = extracted_text
 
-        # Add the extracted text of each paragraph to the end of the context.
-        for paragraph in ordered_paragraphs:
-            context[paragraph.id] = _clean_paragraph_text(paragraph)
+    tasks = [get_resource_field_extracted_text(kbid, fid) for fid in extend_field_ids]
+    field_extracted_texts = await run_concurrently(tasks)
+
+    for result in field_extracted_texts:
+        if result is None:
+            continue
+        # Add the extracted text of each field to the beginning of the context.
+        field, extracted_text = result
+        context[field.resource_unique_id] = extracted_text
+
+    # Add the extracted text of each paragraph to the end of the context.
+    for paragraph in ordered_paragraphs:
+        context[paragraph.id] = _clean_paragraph_text(paragraph)
 
 
 async def get_paragraph_text_with_neighbours(
     kbid: str,
     pid: ParagraphId,
-    etcache: ExtractedTextCache,
     field_paragraphs: list[ParagraphId],
     before: int = 0,
     after: int = 0,
@@ -362,7 +347,6 @@ async def get_paragraph_text_with_neighbours(
     async def _get_paragraph_text(
         kbid: str,
         pid: ParagraphId,
-        etcache: ExtractedTextCache,
     ) -> tuple[ParagraphId, str]:
         return pid, await get_paragraph_text(
             kbid=kbid,
@@ -370,8 +354,7 @@ async def get_paragraph_text_with_neighbours(
             field=pid.field_id.full(),
             start=pid.paragraph_start,
             end=pid.paragraph_end,
-            extracted_text_cache=etcache,
-            log_on_missing_field=False,
+            log_on_missing_field=True,
         )
 
     ops = []
@@ -387,7 +370,6 @@ async def get_paragraph_text_with_neighbours(
                 _get_paragraph_text(
                     kbid=kbid,
                     pid=neighbour_pid,
-                    etcache=etcache,
                 )
             )
         )
@@ -417,8 +399,7 @@ async def get_field_paragraphs_list(
         resource = await datamanagers.resources.get_resource(txn, kbid=kbid, rid=field.rid)
         if resource is None:
             return
-    field_key = field.field_id.split("/")[-1]
-    field_obj: Field = await resource.get_field(key=field_key, type=field.pb_type, load=False)
+    field_obj: Field = await resource.get_field(key=field.key, type=field.pb_type, load=False)
     field_metadata: Optional[resources_pb2.FieldComputedMetadata] = await field_obj.get_field_metadata(
         force=True
     )
@@ -462,8 +443,6 @@ async def neighbouring_paragraphs_prompt_context(
     if field_ops:
         await asyncio.gather(*field_ops)
 
-    etcache = ExtractedTextCache()
-
     paragraph_ops = []
     for text_block in ordered_text_blocks:
         pid = ParagraphId.from_string(text_block.id)
@@ -472,7 +451,6 @@ async def neighbouring_paragraphs_prompt_context(
                 get_paragraph_text_with_neighbours(
                     kbid=kbid,
                     pid=pid,
-                    etcache=etcache,
                     before=before,
                     after=after,
                     field_paragraphs=paragraphs_by_field.get(pid.field_id, []),
@@ -504,7 +482,6 @@ async def hierarchy_prompt_context(
     # Make a copy of the ordered paragraphs to avoid modifying the original list, which is returned
     # in the response to the user
     ordered_paragraphs_copy = copy.deepcopy(ordered_paragraphs)
-    etcache = ExtractedTextCache()
     resources: Dict[str, ExtraCharsParagraph] = {}
 
     # Iterate paragraphs to get extended text
@@ -523,7 +500,6 @@ async def hierarchy_prompt_context(
                 field=field_path,
                 start=int_start,
                 end=int_end,
-                extracted_text_cache=etcache,
                 log_on_missing_field=True,
             )
         if rid not in resources:
@@ -534,7 +510,6 @@ async def hierarchy_prompt_context(
                 field="/a/title",
                 start=0,
                 end=500,
-                extracted_text_cache=etcache,
                 log_on_missing_field=False,
             )
             summary_text = await get_paragraph_text(
@@ -543,7 +518,6 @@ async def hierarchy_prompt_context(
                 field="/a/summary",
                 start=0,
                 end=1000,
-                extracted_text_cache=etcache,
                 log_on_missing_field=False,
             )
             resources[rid] = ExtraCharsParagraph(

--- a/nucliadb/src/nucliadb/search/search/fetch.py
+++ b/nucliadb/src/nucliadb/search/search/fetch.py
@@ -25,13 +25,12 @@ from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.ingest.serialize import managed_serialize
 from nucliadb.search import SERVICE_NAME, logger
+from nucliadb.search.search import cache
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName, Resource
 from nucliadb_models.search import ResourceProperties
 from nucliadb_protos.nodereader_pb2 import DocumentResult, ParagraphResult
 from nucliadb_protos.resources_pb2 import Paragraph
-
-from .cache import get_resource_from_cache
 
 rcache: ContextVar[Optional[dict[str, ResourceORM]]] = ContextVar("rcache", default=None)
 
@@ -79,7 +78,7 @@ async def get_paragraph_from_resource(
 
 
 async def get_labels_resource(result: DocumentResult, kbid: str) -> list[str]:
-    orm_resource = await get_resource_from_cache(kbid, result.uuid)
+    orm_resource = await cache.get_resource(kbid, result.uuid)
 
     if orm_resource is None:
         logger.error(f"{result.uuid} does not exist on DB")
@@ -95,7 +94,7 @@ async def get_labels_resource(result: DocumentResult, kbid: str) -> list[str]:
 
 
 async def get_labels_paragraph(result: ParagraphResult, kbid: str) -> list[str]:
-    orm_resource = await get_resource_from_cache(kbid, result.uuid)
+    orm_resource = await cache.get_resource(kbid, result.uuid)
 
     if orm_resource is None:
         logger.error(f"{result.uuid} does not exist on DB")
@@ -129,7 +128,7 @@ async def get_labels_paragraph(result: ParagraphResult, kbid: str) -> list[str]:
 async def get_seconds_paragraph(
     result: ParagraphResult, kbid: str
 ) -> Optional[tuple[list[int], list[int]]]:
-    orm_resource = await get_resource_from_cache(kbid, result.uuid)
+    orm_resource = await cache.get_resource(kbid, result.uuid)
 
     if orm_resource is None:
         logger.error(f"{result.uuid} does not exist on DB")

--- a/nucliadb/src/nucliadb/search/search/fetch.py
+++ b/nucliadb/src/nucliadb/search/search/fetch.py
@@ -21,7 +21,7 @@ from contextvars import ContextVar
 from typing import Optional
 
 from nucliadb.common.maindb.utils import get_driver
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.ingest.serialize import managed_serialize
 from nucliadb.search import SERVICE_NAME, logger
@@ -65,7 +65,7 @@ async def get_paragraph_from_resource(
     orm_resource: ResourceORM, result: ParagraphResult
 ) -> Optional[Paragraph]:
     _, field_type, field = result.field.split("/")
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     field_metadata = await field_obj.get_field_metadata()
     paragraph = None
@@ -108,7 +108,7 @@ async def get_labels_paragraph(result: ParagraphResult, kbid: str) -> list[str]:
             labels.append(f"{classification.labelset}/{classification.label}")
 
     _, field_type, field = result.field.split("/")
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     field_metadata = await field_obj.get_field_metadata()
     if field_metadata:

--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -24,7 +24,6 @@ from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.serialize import managed_serialize
 from nucliadb.search import SERVICE_NAME, logger
-from nucliadb.search.search.cache import get_resource_cache
 from nucliadb.search.search.merge import merge_relations_results
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName
@@ -69,7 +68,6 @@ async def set_text_value(
     max_operations: asyncio.Semaphore,
     highlight: bool = False,
     ematches: Optional[list[str]] = None,
-    extracted_text_cache: Optional[paragraphs.ExtractedTextCache] = None,
 ):
     async with max_operations:
         assert result_paragraph.paragraph
@@ -84,7 +82,6 @@ async def set_text_value(
             highlight=highlight,
             ematches=ematches,
             matches=[],  # TODO
-            extracted_text_cache=extracted_text_cache,
         )
 
 
@@ -162,7 +159,6 @@ async def fetch_find_metadata(
     operations = []
     max_operations = asyncio.Semaphore(50)
     orderer = Orderer()
-    etcache = paragraphs.ExtractedTextCache()
     for result_paragraph in result_paragraphs:
         if result_paragraph.paragraph is not None:
             find_resource = find_resources.setdefault(
@@ -212,12 +208,10 @@ async def fetch_find_metadata(
                         highlight=highlight,
                         ematches=ematches,
                         max_operations=max_operations,
-                        extracted_text_cache=etcache,
                     )
                 )
             )
             resources.add(result_paragraph.rid)
-    etcache.clear()
 
     for order, (rid, field_id, paragraph_id, _) in enumerate(orderer.sorted_by_score()):
         find_resources[rid].fields[field_id].paragraphs[paragraph_id].order = order
@@ -401,7 +395,6 @@ async def find_merge_results(
     total_paragraphs = 0
     for response in search_responses:
         # Iterate over answers from different logic shards
-
         ematches.extend(response.paragraph.ematches)
         real_query = response.paragraph.query
         next_page = next_page and response.paragraph.next_page
@@ -412,38 +405,33 @@ async def find_merge_results(
 
         relations.append(response.relation)
 
-    rcache = get_resource_cache(clear=True)
+    result_paragraphs, merged_next_page = merge_paragraphs_vectors(
+        paragraphs, vectors, count, page, min_score_semantic, kbid
+    )
+    next_page = next_page or merged_next_page
 
-    try:
-        result_paragraphs, merged_next_page = merge_paragraphs_vectors(
-            paragraphs, vectors, count, page, min_score_semantic, kbid
-        )
-        next_page = next_page or merged_next_page
+    api_results = KnowledgeboxFindResults(
+        resources={},
+        query=real_query,
+        total=total_paragraphs,
+        page_number=page,
+        page_size=count,
+        next_page=next_page,
+        min_score=MinScore(bm25=_round(min_score_bm25), semantic=_round(min_score_semantic)),
+        best_matches=[],
+    )
 
-        api_results = KnowledgeboxFindResults(
-            resources={},
-            query=real_query,
-            total=total_paragraphs,
-            page_number=page,
-            page_size=count,
-            next_page=next_page,
-            min_score=MinScore(bm25=_round(min_score_bm25), semantic=_round(min_score_semantic)),
-            best_matches=[],
-        )
+    await fetch_find_metadata(
+        api_results.resources,
+        api_results.best_matches,
+        result_paragraphs,
+        kbid,
+        show,
+        field_type_filter,
+        extracted,
+        highlight,
+        ematches,
+    )
+    api_results.relations = await merge_relations_results(relations, requested_relations)
 
-        await fetch_find_metadata(
-            api_results.resources,
-            api_results.best_matches,
-            result_paragraphs,
-            kbid,
-            show,
-            field_type_filter,
-            extracted,
-            highlight,
-            ematches,
-        )
-        api_results.relations = await merge_relations_results(relations, requested_relations)
-
-        return api_results
-    finally:
-        rcache.clear()
+    return api_results

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -69,9 +69,9 @@ from nucliadb_protos.nodereader_pb2 import (
     VectorSearchResponse,
 )
 
-from .cache import get_resource_cache, get_resource_from_cache
+from .cache import get_resource_from_cache
 from .metrics import merge_observer
-from .paragraphs import ExtractedTextCache, get_paragraph_text, get_text_sentence
+from .paragraphs import get_paragraph_text, get_text_sentence
 
 Bm25Score = tuple[float, float]
 TimestampScore = datetime.datetime
@@ -206,53 +206,46 @@ async def merge_suggest_paragraph_results(
     if len(suggest_responses) > 1:
         sort_results_by_score(raw_paragraph_list)
 
-    rcache = get_resource_cache(clear=True)
-    etcache = ExtractedTextCache()
-    try:
-        result_paragraph_list: list[Paragraph] = []
-        for result in raw_paragraph_list[:10]:
-            _, field_type, field = result.field.split("/")
-            text = await get_paragraph_text(
-                kbid=kbid,
-                rid=result.uuid,
-                field=result.field,
-                start=result.start,
-                end=result.end,
-                split=result.split,
-                highlight=highlight,
-                ematches=ematches,  # type: ignore
-                matches=result.matches,  # type: ignore
-                extracted_text_cache=etcache,
-            )
-            labels = await get_labels_paragraph(result, kbid)
-            new_paragraph = Paragraph(
-                score=result.score.bm25,
-                rid=result.uuid,
-                field_type=field_type,
-                field=field,
-                text=text,
-                labels=labels,
-                position=TextPosition(
-                    index=result.metadata.position.index,
-                    start=result.metadata.position.start,
-                    end=result.metadata.position.end,
-                    page_number=result.metadata.position.page_number,
-                ),
-            )
-            if len(result.metadata.position.start_seconds) or len(result.metadata.position.end_seconds):
-                new_paragraph.start_seconds = list(result.metadata.position.start_seconds)
-                new_paragraph.end_seconds = list(result.metadata.position.end_seconds)
-            else:
-                # TODO: Remove once we are sure all data has been migrated!
-                seconds_positions = await get_seconds_paragraph(result, kbid)
-                if seconds_positions is not None:
-                    new_paragraph.start_seconds = seconds_positions[0]
-                    new_paragraph.end_seconds = seconds_positions[1]
-            result_paragraph_list.append(new_paragraph)
-        return Paragraphs(results=result_paragraph_list, query=query, min_score=0)
-    finally:
-        etcache.clear()
-        rcache.clear()
+    result_paragraph_list: list[Paragraph] = []
+    for result in raw_paragraph_list[:10]:
+        _, field_type, field = result.field.split("/")
+        text = await get_paragraph_text(
+            kbid=kbid,
+            rid=result.uuid,
+            field=result.field,
+            start=result.start,
+            end=result.end,
+            split=result.split,
+            highlight=highlight,
+            ematches=ematches,  # type: ignore
+            matches=result.matches,  # type: ignore
+        )
+        labels = await get_labels_paragraph(result, kbid)
+        new_paragraph = Paragraph(
+            score=result.score.bm25,
+            rid=result.uuid,
+            field_type=field_type,
+            field=field,
+            text=text,
+            labels=labels,
+            position=TextPosition(
+                index=result.metadata.position.index,
+                start=result.metadata.position.start,
+                end=result.metadata.position.end,
+                page_number=result.metadata.position.page_number,
+            ),
+        )
+        if len(result.metadata.position.start_seconds) or len(result.metadata.position.end_seconds):
+            new_paragraph.start_seconds = list(result.metadata.position.start_seconds)
+            new_paragraph.end_seconds = list(result.metadata.position.end_seconds)
+        else:
+            # TODO: Remove once we are sure all data has been migrated!
+            seconds_positions = await get_seconds_paragraph(result, kbid)
+            if seconds_positions is not None:
+                new_paragraph.start_seconds = seconds_positions[0]
+                new_paragraph.end_seconds = seconds_positions[1]
+        result_paragraph_list.append(new_paragraph)
+    return Paragraphs(results=result_paragraph_list, query=query, min_score=0)
 
 
 async def merge_vectors_results(
@@ -383,64 +376,59 @@ async def merge_paragraph_results(
         next_page = True
 
     result_paragraph_list: list[Paragraph] = []
-    etcache = ExtractedTextCache()
-    try:
-        for result, _ in raw_paragraph_list[min(skip, length) : min(end, length)]:
-            _, field_type, field = result.field.split("/")
-            text = await get_paragraph_text(
-                kbid=kbid,
-                rid=result.uuid,
-                field=result.field,
-                start=result.start,
-                end=result.end,
-                split=result.split,
-                highlight=highlight,
-                ematches=ematches,
-                matches=result.matches,  # type: ignore
-                extracted_text_cache=etcache,
-            )
-            labels = await get_labels_paragraph(result, kbid)
-            fuzzy_result = len(result.matches) > 0
-            new_paragraph = Paragraph(
-                score=result.score.bm25,
-                rid=result.uuid,
-                field_type=field_type,
-                field=field,
-                text=text,
-                labels=labels,
-                position=TextPosition(
-                    index=result.metadata.position.index,
-                    start=result.metadata.position.start,
-                    end=result.metadata.position.end,
-                    page_number=result.metadata.position.page_number,
-                ),
-                fuzzy_result=fuzzy_result,
-            )
-            if len(result.metadata.position.start_seconds) or len(result.metadata.position.end_seconds):
-                new_paragraph.start_seconds = list(result.metadata.position.start_seconds)
-                new_paragraph.end_seconds = list(result.metadata.position.end_seconds)
-            else:
-                # TODO: Remove once we are sure all data has been migrated!
-                seconds_positions = await get_seconds_paragraph(result, kbid)
-                if seconds_positions is not None:
-                    new_paragraph.start_seconds = seconds_positions[0]
-                    new_paragraph.end_seconds = seconds_positions[1]
-
-            result_paragraph_list.append(new_paragraph)
-            if new_paragraph.rid not in resources:
-                resources.append(new_paragraph.rid)
-        return Paragraphs(
-            results=result_paragraph_list,
-            facets=facets,
-            query=query,
-            total=total,
-            page_number=page,
-            page_size=count,
-            next_page=next_page,
-            min_score=min_score,
+    for result, _ in raw_paragraph_list[min(skip, length) : min(end, length)]:
+        _, field_type, field = result.field.split("/")
+        text = await get_paragraph_text(
+            kbid=kbid,
+            rid=result.uuid,
+            field=result.field,
+            start=result.start,
+            end=result.end,
+            split=result.split,
+            highlight=highlight,
+            ematches=ematches,
+            matches=result.matches,  # type: ignore
         )
-    finally:
-        etcache.clear()
+        labels = await get_labels_paragraph(result, kbid)
+        fuzzy_result = len(result.matches) > 0
+        new_paragraph = Paragraph(
+            score=result.score.bm25,
+            rid=result.uuid,
+            field_type=field_type,
+            field=field,
+            text=text,
+            labels=labels,
+            position=TextPosition(
+                index=result.metadata.position.index,
+                start=result.metadata.position.start,
+                end=result.metadata.position.end,
+                page_number=result.metadata.position.page_number,
+            ),
+            fuzzy_result=fuzzy_result,
+        )
+        if len(result.metadata.position.start_seconds) or len(result.metadata.position.end_seconds):
+            new_paragraph.start_seconds = list(result.metadata.position.start_seconds)
+            new_paragraph.end_seconds = list(result.metadata.position.end_seconds)
+        else:
+            # TODO: Remove once we are sure all data has been migrated!
+            seconds_positions = await get_seconds_paragraph(result, kbid)
+            if seconds_positions is not None:
+                new_paragraph.start_seconds = seconds_positions[0]
+                new_paragraph.end_seconds = seconds_positions[1]
+
+        result_paragraph_list.append(new_paragraph)
+        if new_paragraph.rid not in resources:
+            resources.append(new_paragraph.rid)
+    return Paragraphs(
+        results=result_paragraph_list,
+        facets=facets,
+        query=query,
+        total=total,
+        page_number=page,
+        page_size=count,
+        next_page=next_page,
+        min_score=min_score,
+    )
 
 
 @merge_observer.wrap({"type": "merge_relations"})
@@ -519,36 +507,30 @@ async def merge_results(
 
     api_results = KnowledgeboxSearchResults()
 
-    rcache = get_resource_cache(clear=True)
-    try:
-        resources: list[str] = list()
-        api_results.fulltext = await merge_documents_results(
-            documents, resources, count, page, kbid, sort, min_score=min_score.bm25
-        )
+    resources: list[str] = list()
+    api_results.fulltext = await merge_documents_results(
+        documents, resources, count, page, kbid, sort, min_score=min_score.bm25
+    )
 
-        api_results.paragraphs = await merge_paragraph_results(
-            paragraphs,
-            resources,
-            kbid,
-            count,
-            page,
-            highlight,
-            sort,
-            min_score=min_score.bm25,
-        )
+    api_results.paragraphs = await merge_paragraph_results(
+        paragraphs,
+        resources,
+        kbid,
+        count,
+        page,
+        highlight,
+        sort,
+        min_score=min_score.bm25,
+    )
 
-        api_results.sentences = await merge_vectors_results(
-            vectors, resources, kbid, count, page, min_score=min_score.semantic
-        )
+    api_results.sentences = await merge_vectors_results(
+        vectors, resources, kbid, count, page, min_score=min_score.semantic
+    )
 
-        api_results.relations = await merge_relations_results(relations, requested_relations)
+    api_results.relations = await merge_relations_results(relations, requested_relations)
 
-        api_results.resources = await fetch_resources(
-            resources, kbid, show, field_type_filter, extracted
-        )
-        return api_results
-    finally:
-        rcache.clear()
+    api_results.resources = await fetch_resources(resources, kbid, show, field_type_filter, extracted)
+    return api_results
 
 
 async def merge_paragraphs_results(
@@ -568,26 +550,22 @@ async def merge_paragraphs_results(
 
     api_results = ResourceSearchResults()
 
-    rcache = get_resource_cache(clear=True)
-    try:
-        resources: list[str] = list()
-        api_results.paragraphs = await merge_paragraph_results(
-            paragraphs,
-            resources,
-            kbid,
-            count,
-            page,
-            highlight=highlight_split,
-            sort=SortOptions(
-                field=SortField.SCORE,
-                order=SortOrder.DESC,
-                limit=None,
-            ),
-            min_score=min_score,
-        )
-        return api_results
-    finally:
-        rcache.clear()
+    resources: list[str] = list()
+    api_results.paragraphs = await merge_paragraph_results(
+        paragraphs,
+        resources,
+        kbid,
+        count,
+        page,
+        highlight=highlight_split,
+        sort=SortOptions(
+            field=SortField.SCORE,
+            order=SortOrder.DESC,
+            limit=None,
+        ),
+        min_score=min_score,
+    )
+    return api_results
 
 
 async def merge_suggest_entities_results(

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -22,6 +22,7 @@ import datetime
 import math
 from typing import Any, Optional, Set, Union
 
+from nucliadb.search.search import cache
 from nucliadb.search.search.fetch import (
     fetch_resources,
     get_labels_paragraph,
@@ -69,7 +70,6 @@ from nucliadb_protos.nodereader_pb2 import (
     VectorSearchResponse,
 )
 
-from .cache import get_resource_from_cache
 from .metrics import merge_observer
 from .paragraphs import get_paragraph_text, get_text_sentence
 
@@ -96,7 +96,7 @@ async def get_sort_value(
         return (item.score.bm25, item.score.booster)
 
     score: Any = None
-    resource = await get_resource_from_cache(kbid, item.uuid)
+    resource = await cache.get_resource(kbid, item.uuid)
     if resource is None:
         return score
 

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -25,9 +25,8 @@ from typing import Optional
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
+from nucliadb.search.search import cache
 from nucliadb_telemetry import metrics
-
-from .cache import get_field_extracted_text, get_resource_from_cache
 
 logger = logging.getLogger(__name__)
 PRE_WORD = string.punctuation + " "
@@ -67,7 +66,7 @@ async def get_paragraph_from_full_text(
 
     This requires downloading the full text and then slicing it.
     """
-    extracted_text = await get_field_extracted_text(field)
+    extracted_text = await cache.get_field_extracted_text(field)
     if extracted_text is None:
         if log_on_missing_field:
             logger.warning(
@@ -103,7 +102,7 @@ async def get_paragraph_text(
     log_on_missing_field: bool = True,
 ) -> str:
     if orm_resource is None:
-        orm_resource = await get_resource_from_cache(kbid, rid)
+        orm_resource = await cache.get_resource(kbid, rid)
         if orm_resource is None:
             if log_on_missing_field:
                 logger.warning(
@@ -143,7 +142,7 @@ async def get_text_sentence(
     Leave separated from get paragraph for now until we understand the differences
     better.
     """
-    orm_resource = await get_resource_from_cache(kbid, rid)
+    orm_resource = await cache.get_resource(kbid, rid)
 
     if orm_resource is None:
         logger.warning(f"{rid} does not exist on DB")

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 import re
 import string
@@ -26,10 +25,9 @@ from typing import Optional
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
-from nucliadb_protos.utils_pb2 import ExtractedText
 from nucliadb_telemetry import metrics
 
-from .cache import get_resource_from_cache
+from .cache import get_field_extracted_text, get_resource_from_cache
 
 logger = logging.getLogger(__name__)
 PRE_WORD = string.punctuation + " "
@@ -55,60 +53,6 @@ GET_PARAGRAPH_LATENCY = metrics.Observer(
 )
 
 
-EXTRACTED_CACHE_OPS = metrics.Counter("nucliadb_extracted_text_cache_ops", labels={"type": ""})
-
-
-class ExtractedTextCache:
-    """
-    Used to cache extracted text from a resource in memory during
-    the process of search results serialization.
-    """
-
-    def __init__(self):
-        self.locks = {}
-        self.values = {}
-
-    def get_value(self, key: str) -> Optional[ExtractedText]:
-        return self.values.get(key)
-
-    def get_lock(self, key: str) -> asyncio.Lock:
-        return self.locks.setdefault(key, asyncio.Lock())
-
-    def set_value(self, key: str, value: ExtractedText) -> None:
-        self.values[key] = value
-
-    def clear(self):
-        self.values.clear()
-        self.locks.clear()
-
-
-async def get_field_extracted_text(
-    field: Field, cache: Optional[ExtractedTextCache] = None
-) -> Optional[ExtractedText]:
-    if cache is None:
-        return await field.get_extracted_text()
-
-    key = f"{field.kbid}/{field.uuid}/{field.id}"
-    extracted_text = cache.get_value(key)
-    if extracted_text is not None:
-        EXTRACTED_CACHE_OPS.inc({"type": "hit"})
-        return extracted_text
-
-    async with cache.get_lock(key):
-        # Check again in case another task already fetched it
-        extracted_text = cache.get_value(key)
-        if extracted_text is not None:
-            EXTRACTED_CACHE_OPS.inc({"type": "hit"})
-            return extracted_text
-
-        EXTRACTED_CACHE_OPS.inc({"type": "miss"})
-        extracted_text = await field.get_extracted_text()
-        if extracted_text is not None:
-            # Only cache if we actually have extracted text
-            cache.set_value(key, extracted_text)
-        return extracted_text
-
-
 @GET_PARAGRAPH_LATENCY.wrap({"type": "full"})
 async def get_paragraph_from_full_text(
     *,
@@ -116,7 +60,6 @@ async def get_paragraph_from_full_text(
     start: int,
     end: int,
     split: Optional[str] = None,
-    extracted_text_cache: Optional[ExtractedTextCache] = None,
     log_on_missing_field: bool = True,
 ) -> str:
     """
@@ -124,7 +67,7 @@ async def get_paragraph_from_full_text(
 
     This requires downloading the full text and then slicing it.
     """
-    extracted_text = await get_field_extracted_text(field, cache=extracted_text_cache)
+    extracted_text = await get_field_extracted_text(field)
     if extracted_text is None:
         if log_on_missing_field:
             logger.warning(
@@ -157,7 +100,6 @@ async def get_paragraph_text(
     orm_resource: Optional[
         ResourceORM
     ] = None,  # allow passing in orm_resource to avoid extra DB calls or txn issues
-    extracted_text_cache: Optional[ExtractedTextCache] = None,
     log_on_missing_field: bool = True,
 ) -> str:
     if orm_resource is None:
@@ -179,7 +121,6 @@ async def get_paragraph_text(
         start=start,
         end=end,
         split=split,
-        extracted_text_cache=extracted_text_cache,
         log_on_missing_field=log_on_missing_field,
     )
 

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -24,7 +24,7 @@ import string
 from typing import Optional
 
 from nucliadb.ingest.fields.base import Field
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb_protos.utils_pb2 import ExtractedText
 from nucliadb_telemetry import metrics
@@ -171,7 +171,7 @@ async def get_paragraph_text(
             return ""
 
     _, field_type, field = field.split("/")
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
 
     text = await get_paragraph_from_full_text(
@@ -208,7 +208,7 @@ async def get_text_sentence(
         logger.warning(f"{rid} does not exist on DB")
         return ""
 
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     extracted_text = await field_obj.get_extracted_text()
     if extracted_text is None:

--- a/nucliadb/src/nucliadb/search/search/results_hydrator/base.py
+++ b/nucliadb/src/nucliadb/search/search/results_hydrator/base.py
@@ -29,7 +29,6 @@ from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.serialize import managed_serialize
 from nucliadb.search.search import paragraphs
-from nucliadb.search.search.cache import get_resource_cache
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName
 from nucliadb_models.search import (
@@ -90,63 +89,56 @@ async def hydrate_external(
     """
     hydrate_ops = []
     semaphore = asyncio.Semaphore(max_parallel_operations)
-    extracted_text_cache = paragraphs.ExtractedTextCache()
-    rcache = get_resource_cache(clear=True)
-    try:
-        resource_ids = set()
-        for text_block in query_results.iter_matching_text_blocks():
-            if (
-                text_block_min_score is not None and text_block.score < text_block_min_score
-            ):  # pragma: no cover
-                # Ignore text blocks with a score lower than the minimum
-                continue
-            resource_id = text_block.resource_id
-            resource_ids.add(resource_id)
-            find_resource = retrieval_results.resources.setdefault(
-                resource_id, FindResource(id=resource_id, fields={})
-            )
-            find_field = find_resource.fields.setdefault(text_block.field_id, FindField(paragraphs={}))
+    resource_ids = set()
+    for text_block in query_results.iter_matching_text_blocks():
+        if (
+            text_block_min_score is not None and text_block.score < text_block_min_score
+        ):  # pragma: no cover
+            # Ignore text blocks with a score lower than the minimum
+            continue
+        resource_id = text_block.resource_id
+        resource_ids.add(resource_id)
+        find_resource = retrieval_results.resources.setdefault(
+            resource_id, FindResource(id=resource_id, fields={})
+        )
+        find_field = find_resource.fields.setdefault(text_block.field_id, FindField(paragraphs={}))
 
-            async def _hydrate_text_block(**kwargs):
-                async with semaphore:
-                    await hydrate_text_block(**kwargs)
+        async def _hydrate_text_block(**kwargs):
+            async with semaphore:
+                await hydrate_text_block(**kwargs)
 
-            hydrate_ops.append(
-                asyncio.create_task(
-                    _hydrate_text_block(
-                        kbid=kbid,
-                        text_block=text_block,
-                        options=text_block_options,
-                        extracted_text_cache=extracted_text_cache,
-                        field_paragraphs=find_field.paragraphs,
-                    )
+        hydrate_ops.append(
+            asyncio.create_task(
+                _hydrate_text_block(
+                    kbid=kbid,
+                    text_block=text_block,
+                    options=text_block_options,
+                    field_paragraphs=find_field.paragraphs,
                 )
             )
+        )
 
-        async def _hydrate_resource_metadata(**kwargs):
-            async with semaphore:
-                await hydrate_resource_metadata(**kwargs)
+    async def _hydrate_resource_metadata(**kwargs):
+        async with semaphore:
+            await hydrate_resource_metadata(**kwargs)
 
-        if len(resource_ids) > 0:
-            async with get_driver().transaction(read_only=True) as ro_txn:
-                for resource_id in resource_ids:
-                    hydrate_ops.append(
-                        asyncio.create_task(
-                            _hydrate_resource_metadata(
-                                txn=ro_txn,
-                                kbid=kbid,
-                                resource_id=resource_id,
-                                options=resource_options,
-                                find_resources=retrieval_results.resources,
-                            )
+    if len(resource_ids) > 0:
+        async with get_driver().transaction(read_only=True) as ro_txn:
+            for resource_id in resource_ids:
+                hydrate_ops.append(
+                    asyncio.create_task(
+                        _hydrate_resource_metadata(
+                            txn=ro_txn,
+                            kbid=kbid,
+                            resource_id=resource_id,
+                            options=resource_options,
+                            find_resources=retrieval_results.resources,
                         )
                     )
+                )
 
-        if len(hydrate_ops) > 0:
-            await asyncio.gather(*hydrate_ops)
-    finally:
-        extracted_text_cache.clear()
-        rcache.clear()
+    if len(hydrate_ops) > 0:
+        await asyncio.gather(*hydrate_ops)
 
 
 @hydrator_observer.wrap({"type": "text_block"})
@@ -154,7 +146,6 @@ async def hydrate_text_block(
     kbid: str,
     text_block: TextBlockMatch,
     options: TextBlockHydrationOptions,
-    extracted_text_cache: paragraphs.ExtractedTextCache,
     field_paragraphs: dict[str, FindParagraph],
 ) -> None:
     """
@@ -167,7 +158,6 @@ async def hydrate_text_block(
         start=text_block.position_start,
         end=text_block.position_end,
         split=text_block.subfield_id,
-        extracted_text_cache=extracted_text_cache,
     )
     field_paragraphs[text_block.id] = FindParagraph(
         score=text_block.score,

--- a/nucliadb/src/nucliadb/train/generators/field_classifier.py
+++ b/nucliadb/src/nucliadb/train/generators/field_classifier.py
@@ -23,7 +23,7 @@ from typing import AsyncGenerator
 from fastapi import HTTPException
 
 from nucliadb.common.cluster.base import AbstractIndexNode
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.train import logger
 from nucliadb.train.generators.utils import batchify, get_resource_from_cache_or_db
 from nucliadb_protos.dataset_pb2 import (
@@ -93,7 +93,7 @@ async def get_field_text(kbid: str, rid: str, field: str, field_type: str) -> st
         logger.error(f"{rid} does not exist on DB")
         return ""
 
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     extracted_text = await field_obj.get_extracted_text()
     if extracted_text is None:

--- a/nucliadb/src/nucliadb/train/generators/image_classifier.py
+++ b/nucliadb/src/nucliadb/train/generators/image_classifier.py
@@ -23,7 +23,7 @@ from typing import Any, AsyncGenerator
 
 from nucliadb.common.cluster.base import AbstractIndexNode
 from nucliadb.ingest.fields.base import Field
-from nucliadb.ingest.orm.resource import KB_REVERSE, Resource
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB, Resource
 from nucliadb.train import logger
 from nucliadb.train.generators.utils import batchify, get_resource_from_cache_or_db
 from nucliadb_protos.dataset_pb2 import (
@@ -68,7 +68,7 @@ async def generate_image_classification_payloads(
             return
 
         _, field_type_key, field_key = item.field.split("/")
-        field_type = KB_REVERSE[field_type_key]
+        field_type = FIELD_TYPE_STR_TO_PB[field_type_key]
 
         if field_type not in VISUALLY_ANNOTABLE_FIELDS:
             continue
@@ -139,7 +139,7 @@ async def get_page_selections(resource: Resource, field: Field) -> dict[int, lis
     for fieldmetadata in basic.fieldmetadata:
         if (
             fieldmetadata.field.field == field.id
-            and fieldmetadata.field.field_type == KB_REVERSE[field.type]
+            and fieldmetadata.field.field_type == FIELD_TYPE_STR_TO_PB[field.type]
         ):
             for selection in fieldmetadata.page_selections:
                 page_selections[selection.page] = selection.visual  # type: ignore
@@ -150,7 +150,7 @@ async def get_page_selections(resource: Resource, field: Field) -> dict[int, lis
 
 async def get_page_structure(field: Field) -> list[tuple[str, PageStructure]]:
     page_structures: list[tuple[str, PageStructure]] = []
-    field_type = KB_REVERSE[field.type]
+    field_type = FIELD_TYPE_STR_TO_PB[field.type]
     if field_type == FieldType.FILE:
         fed = await field.get_file_extracted_data()  # type: ignore
         if fed is None:

--- a/nucliadb/src/nucliadb/train/generators/paragraph_streaming.py
+++ b/nucliadb/src/nucliadb/train/generators/paragraph_streaming.py
@@ -21,7 +21,7 @@
 from typing import AsyncGenerator
 
 from nucliadb.common.cluster.base import AbstractIndexNode
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.train import logger
 from nucliadb.train.generators.utils import batchify, get_resource_from_cache_or_db
 from nucliadb_protos.dataset_pb2 import (
@@ -65,7 +65,7 @@ async def generate_paragraph_streaming_payloads(
             logger.error(f"{rid} does not exist on DB")
             continue
 
-        field_type_int = KB_REVERSE[field_type]
+        field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
         field_obj = await orm_resource.get_field(field, field_type_int, load=False)
 
         extracted_text = await field_obj.get_extracted_text()

--- a/nucliadb/src/nucliadb/train/generators/question_answer_streaming.py
+++ b/nucliadb/src/nucliadb/train/generators/question_answer_streaming.py
@@ -21,7 +21,7 @@
 from typing import AsyncGenerator
 
 from nucliadb.common.cluster.base import AbstractIndexNode
-from nucliadb.ingest.orm.resource import FIELD_TYPE_TO_ID, KB_REVERSE
+from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR, FIELD_TYPE_STR_TO_PB
 from nucliadb.train import logger
 from nucliadb.train.generators.utils import (
     batchify,
@@ -85,7 +85,7 @@ async def generate_question_answer_streaming_payloads(
                         item.cancelled_by_user = qa_annotation_pb.cancelled_by_user
                         yield item
 
-        field_type_int = KB_REVERSE[field_type]
+        field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
         field_obj = await orm_resource.get_field(field, field_type_int, load=False)
 
         question_answers_pb = await field_obj.get_question_answers()
@@ -136,4 +136,4 @@ async def iter_stream_items(
 
 
 def is_same_field(field: FieldID, field_id: str, field_type: str) -> bool:
-    return field.field == field_id and FIELD_TYPE_TO_ID[field.field_type] == field_type
+    return field.field == field_id and FIELD_TYPE_PB_TO_STR[field.field_type] == field_type

--- a/nucliadb/src/nucliadb/train/generators/sentence_classifier.py
+++ b/nucliadb/src/nucliadb/train/generators/sentence_classifier.py
@@ -23,7 +23,7 @@ from typing import AsyncGenerator
 from fastapi import HTTPException
 
 from nucliadb.common.cluster.base import AbstractIndexNode
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.train import logger
 from nucliadb.train.generators.utils import batchify, get_resource_from_cache_or_db
 from nucliadb_protos.dataset_pb2 import (
@@ -103,7 +103,7 @@ async def get_sentences(kbid: str, result: str) -> list[str]:
         logger.error(f"{rid} does not exist on DB")
         return []
 
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     extracted_text = await field_obj.get_extracted_text()
     field_metadata = await field_obj.get_field_metadata()

--- a/nucliadb/src/nucliadb/train/generators/token_classifier.py
+++ b/nucliadb/src/nucliadb/train/generators/token_classifier.py
@@ -22,7 +22,7 @@ from collections import OrderedDict
 from typing import AsyncGenerator, cast
 
 from nucliadb.common.cluster.base import AbstractIndexNode
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.train import logger
 from nucliadb.train.generators.utils import batchify, get_resource_from_cache_or_db
 from nucliadb_protos.dataset_pb2 import (
@@ -94,7 +94,7 @@ async def get_field_text(
         logger.error(f"{rid} does not exist on DB")
         return {}, {}, {}
 
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     extracted_text = await field_obj.get_extracted_text()
     if extracted_text is None:

--- a/nucliadb/src/nucliadb/train/generators/utils.py
+++ b/nucliadb/src/nucliadb/train/generators/utils.py
@@ -23,7 +23,7 @@ from typing import Any, AsyncIterator, Optional
 
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.train import SERVICE_NAME, logger
 from nucliadb.train.types import TrainBatchType
@@ -73,7 +73,7 @@ async def get_paragraph(kbid: str, paragraph_id: str) -> str:
         logger.error(f"{rid} does not exist on DB")
         return ""
 
-    field_type_int = KB_REVERSE[field_type]
+    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
     field_obj = await orm_resource.get_field(field, field_type_int, load=False)
     extracted_text = await field_obj.get_extracted_text()
     if extracted_text is None:

--- a/nucliadb/tests/ingest/fixtures.py
+++ b/nucliadb/tests/ingest/fixtures.py
@@ -36,7 +36,7 @@ from nucliadb.ingest.consumer import service as consumer_service
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.processor import Processor
-from nucliadb.ingest.orm.resource import KB_REVERSE, Resource
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB, Resource
 from nucliadb.ingest.service.writer import WriterServicer
 from nucliadb.ingest.settings import settings
 from nucliadb.tests.vectors import V1, V2, V3
@@ -672,7 +672,7 @@ async def create_resource(storage: Storage, driver: Driver, knowledgebox_ingest:
 
 
 async def add_field_id(resource: Resource, field: Field):
-    field_type = KB_REVERSE[field.type]
+    field_type = FIELD_TYPE_STR_TO_PB[field.type]
     field_id = rpb.FieldID(field_type=field_type, field=field.id)
     await resource.update_all_field_ids(updated=[field_id])
 

--- a/nucliadb/tests/ingest/unit/orm/test_brain_vectors.py
+++ b/nucliadb/tests/ingest/unit/orm/test_brain_vectors.py
@@ -30,7 +30,8 @@ def test_apply_field_vectors_for_matryoshka_embeddings():
     MATRYOSHKA_DIMENSION = 10
 
     rid = uuid.uuid4().hex
-    field_id = uuid.uuid4().hex
+    field_id = f"u/{uuid.uuid4().hex}"
+    fid = ids.FieldId.from_string(f"{rid}/{field_id}")
     vectors = utils_pb2.VectorObject(
         vectors=utils_pb2.Vectors(
             vectors=[
@@ -45,18 +46,12 @@ def test_apply_field_vectors_for_matryoshka_embeddings():
         )
     )
     paragraph_key = ids.ParagraphId(
-        field_id=ids.FieldId(
-            rid=rid,
-            field_id=field_id,
-        ),
+        field_id=fid,
         paragraph_start=0,
         paragraph_end=10,
     )
     vector_key = ids.VectorId(
-        field_id=ids.FieldId(
-            rid=rid,
-            field_id=field_id,
-        ),
+        field_id=fid,
         index=0,
         vector_start=0,
         vector_end=10,

--- a/nucliadb/tests/nucliadb/integration/test_ask.py
+++ b/nucliadb/tests/nucliadb/integration/test_ask.py
@@ -544,3 +544,22 @@ async def test_ask_assert_audit_retrieval_contexts(
     assert {(f"{rid}/a/title/0-11", f"The title {i}") for i, rid in enumerate(resources)} == {
         (a.text_block_id, a.text) for a in retrieved_context
     }
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("knowledgebox", ("EXPERIMENTAL", "STABLE"), indirect=True)
+async def test_ask_rag_strategy_neighbouring_paragraphs(
+    nucliadb_reader: AsyncClient, knowledgebox, resources
+):
+    resp = await nucliadb_reader.post(
+        f"/kb/{knowledgebox}/ask",
+        json={
+            "query": "title",
+            "rag_strategies": [{"name": "neighbouring_paragraphs", "before": 2, "after": 2}],
+            "debug": True,
+        },
+        headers={"X-Synchronous": "True"},
+    )
+    assert resp.status_code == 200
+    ask_response = SyncAskResponse.model_validate_json(resp.content)
+    assert ask_response.prompt_context is not None

--- a/nucliadb/tests/nucliadb/integration/test_ask.py
+++ b/nucliadb/tests/nucliadb/integration/test_ask.py
@@ -344,7 +344,7 @@ async def test_ask_capped_context(nucliadb_reader: AsyncClient, knowledgebox, re
         },
         headers={"X-Synchronous": "True"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
     resp_data = SyncAskResponse.model_validate_json(resp.content)
     assert resp_data.prompt_context is not None
     assert len(resp_data.prompt_context) == 6

--- a/nucliadb/tests/nucliadb/integration/test_ask.py
+++ b/nucliadb/tests/nucliadb/integration/test_ask.py
@@ -226,7 +226,7 @@ async def test_ask_rag_options_extend_with_fields(nucliadb_reader: AsyncClient, 
             "rag_strategies": [{"name": "field_extension", "fields": ["a/summary"]}],
         },
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.text
     _ = parse_ask_response(resp)
 
     # Make sure the prompt context is properly crafted

--- a/nucliadb/tests/nucliadb/unit/common/external_index_providers/test_pinecone.py
+++ b/nucliadb/tests/nucliadb/unit/common/external_index_providers/test_pinecone.py
@@ -207,7 +207,7 @@ def test_iter_matching_text_blocks(query_response):
     text_blocks = list(query_results.iter_matching_text_blocks())
     assert len(text_blocks) == 1
     text_block = text_blocks[0]
-    assert text_block.id == "rid/f/field/0/0-10"
+    assert text_block.id == "rid/f/field/0-10"
     assert text_block.score == 0.8
     assert text_block.order == 0
     assert text_block.text is None

--- a/nucliadb/tests/nucliadb/unit/common/test_ids.py
+++ b/nucliadb/tests/nucliadb/unit/common/test_ids.py
@@ -18,10 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from nucliadb_protos.resources_pb2 import FieldType
 import pytest
 
 from nucliadb.common.ids import FieldId, ParagraphId, VectorId
+from nucliadb_protos.resources_pb2 import FieldType
 
 
 def test_field_ids():

--- a/nucliadb/tests/nucliadb/unit/common/test_ids.py
+++ b/nucliadb/tests/nucliadb/unit/common/test_ids.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from nucliadb_protos.resources_pb2 import FieldType
 import pytest
 
 from nucliadb.common.ids import FieldId, ParagraphId, VectorId
@@ -44,7 +45,8 @@ def test_field_ids():
     assert field_id.key == "field_id"
     assert field_id.subfield_id == "subfield_id"
     assert field_id.full() == "rid/u/field_id/subfield_id"
-    assert field_id.field_type == "u"
+    assert field_id.type == "u"
+    assert field_id.pb_type == FieldType.LINK
 
 
 def test_paragraph_ids():
@@ -64,6 +66,13 @@ def test_paragraph_ids():
     assert paragraph_id.field_id.full() == "rid/u/field_id/subfield_id"
     assert paragraph_id.paragraph_start == 0
     assert paragraph_id.paragraph_end == 10
+
+    vid = VectorId.from_string("rid/u/field_id/0/0-10")
+    paragraph_id = ParagraphId.from_vector_id(vid)
+    assert paragraph_id.field_id.full() == "rid/u/field_id"
+    assert paragraph_id.paragraph_start == 0
+    assert paragraph_id.paragraph_end == 10
+    assert paragraph_id.full() == "rid/u/field_id/0-10"
 
 
 def test_vector_ids():

--- a/nucliadb/tests/nucliadb/unit/common/test_ids.py
+++ b/nucliadb/tests/nucliadb/unit/common/test_ids.py
@@ -33,13 +33,15 @@ def test_field_ids():
 
     field_id = FieldId.from_string("rid/u/field_id")
     assert field_id.rid == "rid"
-    assert field_id.field_id == "u/field_id"
+    assert field_id.type == "u"
+    assert field_id.key == "field_id"
     assert field_id.subfield_id is None
     assert field_id.full() == "rid/u/field_id"
 
     field_id = FieldId.from_string("rid/u/field_id/subfield_id")
     assert field_id.rid == "rid"
-    assert field_id.field_id == "u/field_id"
+    assert field_id.type == "u"
+    assert field_id.key == "field_id"
     assert field_id.subfield_id == "subfield_id"
     assert field_id.full() == "rid/u/field_id/subfield_id"
     assert field_id.field_type == "u"

--- a/nucliadb/tests/search/unit/search/results_hydrator/test_base.py
+++ b/nucliadb/tests/search/unit/search/results_hydrator/test_base.py
@@ -66,4 +66,4 @@ async def test_hydrate_external():
         assert len(fields) == 1
         paragraphs = fields["rid/f/field"].paragraphs
         assert len(paragraphs) == 1
-        assert paragraphs["rid/f/field/0/0-10"].text == "some text"
+        assert paragraphs["rid/f/field/0-10"].text == "some text"

--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -264,7 +264,7 @@ def test_capped_prompt_context():
 @pytest.mark.asyncio
 async def test_hierarchy_promp_context(kb):
     with mock.patch(
-        "nucliadb.search.search.chat.prompt.paragraphs.get_paragraph_text",
+        "nucliadb.search.search.chat.prompt.get_paragraph_text",
         side_effect=["Title text", "Summary text"],
     ):
         context = chat_prompt.CappedPromptContext(max_size=int(1e6))

--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -21,7 +21,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nucliadb.ingest.orm.resource import KB_REVERSE
+from nucliadb.common.ids import ParagraphId
+from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
 from nucliadb.search.search.chat import prompt as chat_prompt
 from nucliadb_models.search import (
     SCORE_TYPE,
@@ -127,7 +128,7 @@ async def test_get_expanded_conversation_messages_question(kb, messages):
     )
 
     kb.get.assert_called_with("rid")
-    kb.get.return_value.get_field.assert_called_with("field_id", KB_REVERSE["c"], load=True)
+    kb.get.return_value.get_field.assert_called_with("field_id", FIELD_TYPE_STR_TO_PB["c"], load=True)
 
 
 @pytest.mark.asyncio
@@ -308,3 +309,37 @@ async def test_hierarchy_promp_context(kb):
         # Chec that the original text of the paragraphs is preserved
         assert ordered_paragraphs[0].text == "First Paragraph text"
         assert ordered_paragraphs[1].text == "Second paragraph text"
+
+
+def test_get_neighbouring_paragraph_indexes():
+    field_paragraphs = [
+        ParagraphId.from_string("r1/f/f1/0-10"),
+        ParagraphId.from_string("r1/f/f1/10-20"),
+        ParagraphId.from_string("r1/f/f1/20-30"),
+        ParagraphId.from_string("r1/f/f1/30-40"),
+        ParagraphId.from_string("r1/f/f1/40-50"),
+        ParagraphId.from_string("r1/f/f1/50-60"),
+        ParagraphId.from_string("r1/f/f1/60-70"),
+        ParagraphId.from_string("r1/f/f1/70-80"),
+    ]
+    matching_paragraph = field_paragraphs[2]
+
+    assert chat_prompt.get_neighbouring_paragraph_indexes(
+        field_paragraphs, matching_paragraph, before=100, after=100
+    ) == [0, 1, 2, 3, 4, 5, 6, 7]
+
+    assert chat_prompt.get_neighbouring_paragraph_indexes(
+        field_paragraphs, matching_paragraph, before=2, after=2
+    ) == [0, 1, 2, 3, 4]
+
+    assert chat_prompt.get_neighbouring_paragraph_indexes(
+        field_paragraphs, matching_paragraph, before=1, after=0
+    ) == [1, 2]
+
+    assert chat_prompt.get_neighbouring_paragraph_indexes(
+        field_paragraphs, matching_paragraph, before=0, after=1
+    ) == [2, 3]
+
+    assert chat_prompt.get_neighbouring_paragraph_indexes(
+        field_paragraphs, matching_paragraph, before=0, after=0
+    ) == [2]

--- a/nucliadb/tests/search/unit/search/test_paragraphs.py
+++ b/nucliadb/tests/search/unit/search/test_paragraphs.py
@@ -101,7 +101,7 @@ async def test_get_field_extracted_text_is_cached(field):
 
     # Run 10 times in parallel to check that the cache is working
     set_extracted_text_cache()
-    futures = [paragraphs.get_field_extracted_text(field) for _ in range(10)]
+    futures = [paragraphs.cache.get_field_extracted_text(field) for _ in range(10)]
     await asyncio.gather(*futures)
 
     field.get_extracted_text.assert_awaited_once()
@@ -110,8 +110,8 @@ async def test_get_field_extracted_text_is_cached(field):
 async def test_get_field_extracted_text_is_not_cached_when_none(field):
     field.get_extracted_text = AsyncMock(return_value=None)
 
-    await paragraphs.get_field_extracted_text(field)
-    await paragraphs.get_field_extracted_text(field)
+    await paragraphs.cache.get_field_extracted_text(field)
+    await paragraphs.cache.get_field_extracted_text(field)
 
     assert field.get_extracted_text.await_count == 2
 

--- a/nucliadb/tests/search/unit/search/test_paragraphs.py
+++ b/nucliadb/tests/search/unit/search/test_paragraphs.py
@@ -23,7 +23,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from nucliadb.search.search import paragraphs
+from nucliadb.search.search import cache, paragraphs
+from nucliadb.search.search.cache import set_extracted_text_cache
 from nucliadb_protos.utils_pb2 import ExtractedText
 
 
@@ -99,8 +100,8 @@ async def test_get_field_extracted_text_is_cached(field):
     field.get_extracted_text = AsyncMock(side_effect=fake_get_extracted_text_from_gcloud)
 
     # Run 10 times in parallel to check that the cache is working
-    etcache = paragraphs.ExtractedTextCache()
-    futures = [paragraphs.get_field_extracted_text(field, cache=etcache) for _ in range(10)]
+    set_extracted_text_cache()
+    futures = [paragraphs.get_field_extracted_text(field) for _ in range(10)]
     await asyncio.gather(*futures)
 
     field.get_extracted_text.assert_awaited_once()
@@ -116,7 +117,7 @@ async def test_get_field_extracted_text_is_not_cached_when_none(field):
 
 
 def test_extracted_text_cache():
-    etcache = paragraphs.ExtractedTextCache()
+    etcache = cache.ExtractedTextCache()
     assert etcache.get_value("foo") is None
 
     assert isinstance(etcache.get_lock("foo"), asyncio.Lock)

--- a/nucliadb/tests/search/unit/search/test_paragraphs.py
+++ b/nucliadb/tests/search/unit/search/test_paragraphs.py
@@ -63,7 +63,7 @@ class TestGetParagraphText:
         mock = AsyncMock()
         mock.get_field.return_value = field
         with patch(
-            "nucliadb.search.search.paragraphs.get_resource_from_cache",
+            "nucliadb.search.search.paragraphs.cache.get_resource",
             return_value=mock,
         ):
             yield mock

--- a/nucliadb/tests/train/test_question_answer_streaming.py
+++ b/nucliadb/tests/train/test_question_answer_streaming.py
@@ -24,7 +24,7 @@ from typing import AsyncIterator
 import aiohttp
 import pytest
 
-from nucliadb.ingest.orm.resource import FIELD_TYPE_TO_ID
+from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
 from nucliadb_protos import resources_pb2 as rpb
@@ -126,11 +126,11 @@ def smb_wonder_bm(kbid: str) -> BrokerMessage:
 
     start = 0
     end = len(paragraphs[0])
-    paragraph_0_id = f"{rid}/{FIELD_TYPE_TO_ID[rpb.FieldType.FILE]}/smb-wonder/{start}-{end}"
+    paragraph_0_id = f"{rid}/{FIELD_TYPE_PB_TO_STR[rpb.FieldType.FILE]}/smb-wonder/{start}-{end}"
 
     start = len(paragraphs[0])
     end = len(paragraphs[0]) + len(paragraphs[1])
-    paragraph_1_id = f"{rid}/{FIELD_TYPE_TO_ID[rpb.FieldType.FILE]}/smb-wonder/{start}-{end}"
+    paragraph_1_id = f"{rid}/{FIELD_TYPE_PB_TO_STR[rpb.FieldType.FILE]}/smb-wonder/{start}-{end}"
 
     question = "What is SMB Wonder?"
     field_builder.add_question_answer(

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -1089,7 +1089,16 @@ class ChatRequest(BaseModel):
     rag_strategies: list[RagStrategies] = Field(
         default=[],
         title="RAG context building strategies",
-        description="Options for tweaking how the context for the LLM model is crafted. `full_resource` will add the full text of the matching resources to the context. `field_extension` will add the text of the matching resource's specified fields to the context. If empty, the default strategy is used.",  # noqa
+        description=(
+            """Options for tweaking how the context for the LLM model is crafted:
+- `full_resource` will add the full text of the matching resources to the context.
+- `field_extension` will add the text of the matching resource's specified fields to the context.
+- `hierarchy` will add the title and summary text of the parent resource to the context for each matching paragraph.
+- `neighbouring_paragraphs` will add the sorrounding paragraphs to the context for each matching paragraph.
+If empty, the default strategy is used.
+`full_resource`, `hierarchy` and `neighbouring_paragraphs` are exclusive strategies: if selected, they must be the only strategy.
+"""
+        ),
     )
     rag_images_strategies: list[RagImagesStrategies] = Field(
         default=[],

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -888,6 +888,7 @@ class RagStrategyName:
     FIELD_EXTENSION = "field_extension"
     FULL_RESOURCE = "full_resource"
     HIERARCHY = "hierarchy"
+    NEIGHBOURING_PARAGRAPHS = "neighbouring_paragraphs"
 
 
 class ImageRagStrategyName:
@@ -959,6 +960,22 @@ class HierarchyResourceStrategy(RagStrategy):
     )
 
 
+class NeighbouringParagraphsStrategy(RagStrategy):
+    name: Literal["neighbouring_paragraphs"]
+    before: int = Field(
+        default=2,
+        title="Before",
+        description="Number of previous neighbouring paragraphs to add to the context, for each matching paragraph in the retrieval step.",
+        ge=0,
+    )
+    after: int = Field(
+        default=2,
+        title="After",
+        description="Number of following neighbouring paragraphs to add to the context, for each matching paragraph in the retrieval step.",
+        ge=0,
+    )
+
+
 class TableImageStrategy(ImageRagStrategy):
     name: Literal["tables"]
 
@@ -977,7 +994,12 @@ class ParagraphImageStrategy(ImageRagStrategy):
 
 
 RagStrategies = Annotated[
-    Union[FieldExtensionStrategy, FullResourceStrategy, HierarchyResourceStrategy],
+    Union[
+        FieldExtensionStrategy,
+        FullResourceStrategy,
+        HierarchyResourceStrategy,
+        NeighbouringParagraphsStrategy,
+    ],
     Field(discriminator="name"),
 ]
 RagImagesStrategies = Annotated[
@@ -1114,10 +1136,11 @@ class ChatRequest(BaseModel):
         if len(unique_strategy_names) != len(rag_strategies):
             raise ValueError("There must be at most one strategy of each type")
 
-        # If full_resource or hierarchy strategies is chosen, they must be the only strategy
+        # If any of the unique strategies are chosen, they must be the only strategy
         for unique_strategy_name in (
             RagStrategyName.FULL_RESOURCE,
             RagStrategyName.HIERARCHY,
+            RagStrategyName.NEIGHBOURING_PARAGRAPHS,
         ):
             if unique_strategy_name in unique_strategy_names and len(rag_strategies) > 1:
                 raise ValueError(

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -20,6 +20,8 @@
 import unittest
 import unittest.mock
 
+import pytest
+
 import nucliadb_sdk
 from nucliadb_models.metadata import RelationType
 from nucliadb_models.search import (
@@ -167,3 +169,18 @@ def test_ask_stream(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
     )
     assert isinstance(resp, SyncAskResponse)
     sdk.session.headers.pop("X-Synchronous", None)
+
+
+@pytest.mark.parametrize(
+    "rag_strategies",
+    [
+        [{"name": "full_resource"}],
+        [{"name": "neighbouring_paragraphs", "before": 1, "after": 1}],
+        [{"name": "hierarchy", "count": 40}],
+        [{"name": "field_extension", "fields": ["a/title", "a/summary"]}],
+    ],
+)
+def test_ask_rag_strategies(docs_dataset, sdk: nucliadb_sdk.NucliaDB, rag_strategies):
+    sdk.ask(
+        kbid=docs_dataset, query="Does Nuclia offer RAG as a service?", rag_strategies=rag_strategies
+    )


### PR DESCRIPTION
### Description
Add a new rag strategy for the `/ask` endpoint:

```json
{
  "name": "neighbouring_paragraphs",
  "before": 3,
  "after": 0,
}
```
That allows to include sorrounding paragraphs to the ones matched on the retrieval step in the context sent to the LLM

Additionally, the PR:

- Refactors a bit the resource and extracted text cache implementation so that we only retrieve the resource and the texts once per request! (using context vars)
- Improves a bit the ids parsing logic


### How was this PR tested?
Unit and integration tests
