### PR TITLE
Metadata extension RAG strategy

### DIFF
--- a/nucliadb/requirements.txt
+++ b/nucliadb/requirements.txt
@@ -36,6 +36,7 @@ google-cloud-storage
 gcloud
 oauth2client
 jwcrypto>=1.5.6
+pyyaml>=5.1
 
 fastapi-versioning>=0.10.0
 # At some point FastAPI will drop support for pydantic v1

--- a/nucliadb/src/nucliadb/common/ids.py
+++ b/nucliadb/src/nucliadb/common/ids.py
@@ -134,6 +134,10 @@ class ParagraphId:
     def __hash__(self) -> int:
         return hash(self.full())
 
+    @property
+    def rid(self) -> str:
+        return self.field_id.rid
+
     @classmethod
     def from_string(cls, value: str) -> "ParagraphId":
         parts = value.split("/")
@@ -189,6 +193,10 @@ class VectorId:
 
     def __hash__(self) -> int:
         return hash(self.full())
+
+    @property
+    def rid(self) -> str:
+        return self.field_id.rid
 
     @classmethod
     def from_string(cls, value: str) -> "VectorId":

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -20,7 +20,10 @@
 import asyncio
 import copy
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple, cast
+from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
+
+import yaml
+from pydantic import BaseModel
 
 from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.common.maindb.utils import get_driver
@@ -28,10 +31,11 @@ from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
 from nucliadb.ingest.orm.resource import FIELD_TYPE_STR_TO_PB
-from nucliadb.search import logger
 from nucliadb.search.search import cache
 from nucliadb.search.search.chat.images import get_page_image, get_paragraph_image
 from nucliadb.search.search.paragraphs import get_paragraph_text
+from nucliadb_models.labels import translate_system_to_alias_label
+from nucliadb_models.metadata import Extra, Origin
 from nucliadb_models.search import (
     SCORE_TYPE,
     FieldExtensionStrategy,
@@ -41,6 +45,8 @@ from nucliadb_models.search import (
     ImageRagStrategy,
     ImageRagStrategyName,
     KnowledgeboxFindResults,
+    MetadataExtensionStrategy,
+    MetadataExtensionType,
     NeighbouringParagraphsStrategy,
     PageImageStrategy,
     PromptContext,
@@ -61,6 +67,8 @@ MAX_RESOURCE_FIELD_TASKS = 4
 # Number of messages to pull after a match in a message
 # The hope here is it will be enough to get the answer to the question.
 CONVERSATION_MESSAGE_CONTEXT_EXPANSION = 15
+
+TextBlockId = Union[ParagraphId, FieldId]
 
 
 class CappedPromptContext:
@@ -89,6 +97,9 @@ class CappedPromptContext:
             if size_available > 0:
                 self.output[key] = value[:size_available]
                 self._size += len(self.output[key])
+
+    def __getitem__(self, key: str) -> str:
+        return self.output.__getitem__(key)
 
     @property
     def size(self) -> int:
@@ -244,7 +255,7 @@ async def full_resource_prompt_context(
     kbid: str,
     ordered_paragraphs: list[FindParagraph],
     resource: Optional[str],
-    number_of_full_resources: Optional[int] = None,
+    strategy: FullResourceStrategy,
 ) -> None:
     """
     Algorithm steps:
@@ -273,7 +284,7 @@ async def full_resource_prompt_context(
     resource_extracted_texts = await run_concurrently(
         [
             get_resource_extracted_texts(kbid, resource_uuid)
-            for resource_uuid in ordered_resources[:number_of_full_resources]
+            for resource_uuid in ordered_resources[: strategy.count]
         ],
         max_concurrent=MAX_RESOURCE_TASKS,
     )
@@ -286,11 +297,157 @@ async def full_resource_prompt_context(
             context[field.resource_unique_id] = extracted_text
 
 
+async def extend_prompt_context_with_metadata(
+    context: CappedPromptContext,
+    kbid: str,
+    metadata_extension: MetadataExtensionStrategy,
+) -> None:
+    parsed_text_block_ids = _parse_text_block_ids(context)
+    if len(parsed_text_block_ids) == 0:
+        return
+
+    if MetadataExtensionType.ORIGIN in metadata_extension.types:
+        await extend_prompt_context_with_origin_metadata(context, kbid, parsed_text_block_ids)
+
+    if MetadataExtensionType.CLASSIFICATION_LABELS in metadata_extension.types:
+        await extend_prompt_context_with_classification_labels(context, kbid, parsed_text_block_ids)
+
+    if MetadataExtensionType.NER in metadata_extension.types:
+        await extend_prompt_context_with_ner(context, kbid, parsed_text_block_ids)
+
+    if MetadataExtensionType.EXTRA_METADATA in metadata_extension.types:
+        await extend_prompt_context_with_extra_metadata(context, kbid, parsed_text_block_ids)
+
+
+def _parse_text_block_ids(context: CappedPromptContext) -> list[TextBlockId]:
+    tb_ids: list[TextBlockId] = []
+    for text_block_id in context.output.keys():
+        try:
+            tb_ids.append(ParagraphId.from_string(text_block_id))
+        except ValueError:
+            try:
+                tb_ids.append(FieldId.from_string(text_block_id))
+            except ValueError:
+                # Some text block ids are not paragraphs nor fields, so they are skipped
+                continue
+    return tb_ids
+
+
+async def extend_prompt_context_with_origin_metadata(context, kbid, text_block_ids: list[TextBlockId]):
+    async def _get_origin(kbid: str, rid: str) -> tuple[str, Optional[Origin]]:
+        origin = None
+        resource = await cache.get_resource(kbid, rid)
+        if resource is not None:
+            pb_origin = await resource.get_origin()
+            if pb_origin is not None:
+                origin = Origin.from_message(pb_origin)
+        return rid, origin
+
+    # Fetch the origin metadata for the resource of the matching paragraphs
+    rids = {tb_id.rid for tb_id in text_block_ids}
+    origins = await run_concurrently([_get_origin(kbid, rid) for rid in rids])
+    rid_to_origin = {rid: origin for rid, origin in origins if origin is not None}
+    for tb_id in text_block_ids:
+        origin = rid_to_origin.get(tb_id.rid)
+        if origin is not None and tb_id.full() in context.output:
+            context[tb_id.full()] += f"\n\\DOCUMENT METADATA AT ORIGIN:\n{to_yaml(origin)}"
+
+
+async def extend_prompt_context_with_classification_labels(
+    context, kbid, text_block_ids: list[TextBlockId]
+):
+    async def _get_labels(kbid: str, _id: TextBlockId) -> tuple[TextBlockId, list[str]]:
+        fid = _id if isinstance(_id, FieldId) else _id.field_id
+        labels = set()
+        resource = await cache.get_resource(kbid, fid.rid)
+        if resource is not None:
+            pb_basic = await resource.get_basic()
+            if pb_basic is not None:
+                # Add the classification labels of the resource
+                for classif in pb_basic.usermetadata.classifications:
+                    labels.add(f"/l/{classif.labelset}/{classif.label}")
+                # ADd the classifications labels of the field
+                for fc in pb_basic.computedmetadata.field_classifications:
+                    if fc.field.field == fid.key and fc.field.field_type == fid.pb_type:
+                        for classif in fc.classifications:
+                            if classif.cancelled_by_user:
+                                continue
+                            labels.add(f"/l/{classif.labelset}/{classif.label}")
+        return _id, list(labels)
+
+    # Fetch the resource labels of each matching paragraph
+    classif_labels = await run_concurrently([_get_labels(kbid, tb_id) for tb_id in text_block_ids])
+    tb_id_to_labels = {tb_id: labels for tb_id, labels in classif_labels if len(labels) > 0}
+    for tb_id in text_block_ids:
+        labels = tb_id_to_labels.get(tb_id)
+        if labels is not None and tb_id.full() in context.output:
+            translated_labels = [translate_system_to_alias_label(label) for label in labels]
+            labels_text = "DOCUMENT CLASSIFICATION LABELS:"
+            for label in translated_labels:
+                labels_text += f"\n- {label}"
+            context[tb_id.full()] += "\n\n" + labels_text
+
+
+async def extend_prompt_context_with_ner(context, kbid, text_block_ids: list[TextBlockId]):
+    async def _get_ners(kbid: str, _id: TextBlockId) -> tuple[TextBlockId, list[str]]:
+        fid = _id if isinstance(_id, FieldId) else _id.field_id
+        ners = set()
+        resource = await cache.get_resource(kbid, fid.rid)
+        if resource is not None:
+            field = await resource.get_field(fid.key, fid.pb_type, load=False)
+            fcm = await field.get_field_metadata()
+            if fcm is not None:
+                for token, family in fcm.metadata.ner.values():
+                    ners.add(f"{family}/{token}")
+        return _id, list(ners)
+
+    # Fetch the resource labels of each matching paragraph
+    nerss = await run_concurrently([_get_ners(kbid, tb_id) for tb_id in text_block_ids])
+    tb_id_to_ners = {tb_id: ners for tb_id, ners in nerss if len(ners) > 0}
+    for tb_id in text_block_ids:
+        ners = tb_id_to_ners.get(tb_id)
+        if ners is not None and tb_id.full() in context.output:
+            ners_text = "DOCUMENT NERS:"
+            for ner_label in ners:
+                token, family = ner_label.split("/")
+                ners_text += f"\n- {token} ({family})"
+            context[tb_id.full()] += "\n\n" + ners_text
+
+
+async def extend_prompt_context_with_extra_metadata(context, kbid, text_block_ids: list[TextBlockId]):
+    async def _get_extra(kbid: str, rid: str) -> tuple[str, Optional[Extra]]:
+        extra = None
+        resource = await cache.get_resource(kbid, rid)
+        if resource is not None:
+            pb_extra = await resource.get_extra()
+            if pb_extra is not None:
+                extra = Extra.from_message(pb_extra)
+        return rid, extra
+
+    # Fetch the extra metadata for the resource of the matching paragraphs
+    rids = {tb_id.rid for tb_id in text_block_ids}
+    extras = await run_concurrently([_get_extra(kbid, rid) for rid in rids])
+    rid_to_extra = {rid: extra for rid, extra in extras if extra is not None}
+    for tb_id in text_block_ids:
+        extra = rid_to_extra.get(tb_id.rid)
+        if extra is not None and tb_id.full() in context.output:
+            context[tb_id.full()] += f"\n\\DOCUMENT EXTRA METADATA:\n{to_yaml(extra)}"
+
+
+def to_yaml(obj: BaseModel) -> str:
+    return yaml.dump(
+        obj.model_dump(exclude_none=True, exclude_defaults=True, exclude_unset=True),
+        default_flow_style=False,
+        indent=2,
+        sort_keys=True,
+    )
+
+
 async def composed_prompt_context(
     context: CappedPromptContext,
     kbid: str,
     ordered_paragraphs: list[FindParagraph],
-    extend_with_fields: list[str],
+    field_extension: Optional[FieldExtensionStrategy] = None,
 ) -> None:
     """
     Algorithm steps:
@@ -306,14 +463,15 @@ async def composed_prompt_context(
             ordered_resources.append(resource_uuid)
 
     # Fetch the extracted texts of the specified fields for each resource
+    extend_fields = field_extension.fields if field_extension else []
     extend_field_ids = []
     for resource_uuid in ordered_resources:
-        for field_id in extend_with_fields:
+        for field_id in extend_fields:
             try:
-                fid = FieldId.from_string(f"{resource_uuid}/{field_id}")
+                fid = FieldId.from_string(f"{resource_uuid}/{field_id.strip('/')}")
                 extend_field_ids.append(fid)
             except ValueError:
-                logger.info("Invalid field id to extend", extra={"field_id": field_id, "kbid": kbid})
+                # Invalid field id, skiping
                 continue
 
     tasks = [get_resource_field_extracted_text(kbid, fid) for fid in extend_field_ids]
@@ -422,8 +580,7 @@ async def neighbouring_paragraphs_prompt_context(
     context: CappedPromptContext,
     kbid: str,
     ordered_text_blocks: list[FindParagraph],
-    before: int = 0,
-    after: int = 0,
+    strategy: NeighbouringParagraphsStrategy,
 ) -> None:
     """
     This function will get the paragraph texts and then craft a context with the neighbouring paragraphs of the
@@ -453,8 +610,8 @@ async def neighbouring_paragraphs_prompt_context(
                 get_paragraph_text_with_neighbours(
                     kbid=kbid,
                     pid=pid,
-                    before=before,
-                    after=after,
+                    before=strategy.before,
+                    after=strategy.after,
                     field_paragraphs=paragraphs_by_field.get(pid.field_id, []),
                 )
             )
@@ -473,14 +630,14 @@ async def hierarchy_prompt_context(
     context: CappedPromptContext,
     kbid: str,
     ordered_paragraphs: list[FindParagraph],
-    paragraphs_extra_characters: int = 0,
+    strategy: HierarchyResourceStrategy,
 ) -> None:
     """
     This function will get the paragraph texts (possibly with extra characters, if extra_characters > 0) and then
     craft a context with all paragraphs of the same resource grouped together. Moreover, on each group of paragraphs,
     it includes the resource title and summary so that the LLM can have a better understanding of the context.
     """
-    paragraphs_extra_characters = max(paragraphs_extra_characters, 0)
+    paragraphs_extra_characters = max(strategy.count, 0)
     # Make a copy of the ordered paragraphs to avoid modifying the original list, which is returned
     # in the response to the user
     ordered_paragraphs_copy = copy.deepcopy(ordered_paragraphs)
@@ -637,64 +794,55 @@ class PromptContextBuilder:
             await default_prompt_context(context, self.kbid, self.ordered_paragraphs)
             return
 
-        full_resource_strategy = False
-        number_of_full_resources = len(self.ordered_paragraphs)
-        hierarchy_strategy = False
-        hierarchy_paragraphs_extended_characters = 0
-        neighbouring_paragraphs_strategy = False
-        neighbouring_paragraphs_range = (0, 0)
-        extend_with_fields: list[str] = []
+        full_resource_strategy: Optional[FullResourceStrategy] = None
+        hierarchy_strategy: Optional[HierarchyResourceStrategy] = None
+        neighbouring_paragraphs_strategy: Optional[NeighbouringParagraphsStrategy] = None
+        extend_with_fields_strategy: Optional[FieldExtensionStrategy] = None
+        metadata_extension: Optional[MetadataExtensionStrategy] = None
         for strategy in self.strategies:
             if strategy.name == RagStrategyName.FIELD_EXTENSION:
-                strategy = cast(FieldExtensionStrategy, strategy)
-                extend_with_fields.extend(strategy.fields)
+                extend_with_fields_strategy = cast(FieldExtensionStrategy, strategy)
             elif strategy.name == RagStrategyName.FULL_RESOURCE:
-                strategy = cast(FullResourceStrategy, strategy)
-                full_resource_strategy = True
+                full_resource_strategy = cast(FullResourceStrategy, strategy)
                 if self.resource:
-                    number_of_full_resources = 1
-                elif strategy.count is not None and strategy.count > 0:
-                    number_of_full_resources = strategy.count
+                    # When the retrieval is scoped to a specific resource
+                    # the full resource strategy only includes that resource
+                    full_resource_strategy.count = 1
             elif strategy.name == RagStrategyName.HIERARCHY:
-                strategy = cast(HierarchyResourceStrategy, strategy)
-                hierarchy_strategy = True
-                if strategy.count is not None and strategy.count > 0:
-                    hierarchy_paragraphs_extended_characters = strategy.count
+                hierarchy_strategy = cast(HierarchyResourceStrategy, strategy)
             elif strategy.name == RagStrategyName.NEIGHBOURING_PARAGRAPHS:
-                strategy = cast(NeighbouringParagraphsStrategy, strategy)
-                neighbouring_paragraphs_strategy = True
-                neighbouring_paragraphs_range = (strategy.before, strategy.after)
+                neighbouring_paragraphs_strategy = cast(NeighbouringParagraphsStrategy, strategy)
+            elif strategy.name == RagStrategyName.METADATA_EXTENSION:
+                metadata_extension = cast(MetadataExtensionStrategy, strategy)
 
         if full_resource_strategy:
             await full_resource_prompt_context(
-                context,
-                self.kbid,
-                self.ordered_paragraphs,
-                self.resource,
-                number_of_full_resources,
+                context, self.kbid, self.ordered_paragraphs, self.resource, full_resource_strategy
             )
         elif hierarchy_strategy:
             await hierarchy_prompt_context(
                 context,
                 self.kbid,
                 self.ordered_paragraphs,
-                hierarchy_paragraphs_extended_characters,
+                hierarchy_strategy,
             )
         elif neighbouring_paragraphs_strategy:
             await neighbouring_paragraphs_prompt_context(
                 context,
                 self.kbid,
                 self.ordered_paragraphs,
-                before=neighbouring_paragraphs_range[0],
-                after=neighbouring_paragraphs_range[1],
+                neighbouring_paragraphs_strategy,
             )
         else:
             await composed_prompt_context(
                 context,
                 self.kbid,
                 self.ordered_paragraphs,
-                extend_with_fields=extend_with_fields,
+                extend_with_fields_strategy,
             )
+
+        if metadata_extension:
+            await extend_prompt_context_with_metadata(context, self.kbid, metadata_extension)
 
 
 @dataclass

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -349,7 +349,7 @@ async def extend_prompt_context_with_origin_metadata(context, kbid, text_block_i
     for tb_id in text_block_ids:
         origin = rid_to_origin.get(tb_id.rid)
         if origin is not None and tb_id.full() in context.output:
-            context[tb_id.full()] += f"\n\n\\DOCUMENT METADATA AT ORIGIN:\n{to_yaml(origin)}"
+            context[tb_id.full()] += f"\n\nDOCUMENT METADATA AT ORIGIN:\n{to_yaml(origin)}"
 
 
 async def extend_prompt_context_with_classification_labels(
@@ -429,7 +429,7 @@ async def extend_prompt_context_with_extra_metadata(context, kbid, text_block_id
     for tb_id in text_block_ids:
         extra = rid_to_extra.get(tb_id.rid)
         if extra is not None and tb_id.full() in context.output:
-            context[tb_id.full()] += f"\n\n\\DOCUMENT EXTRA METADATA:\n{to_yaml(extra)}"
+            context[tb_id.full()] += f"\n\nDOCUMENT EXTRA METADATA:\n{to_yaml(extra)}"
 
 
 def to_yaml(obj: BaseModel) -> str:

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -312,7 +312,7 @@ async def extend_prompt_context_with_metadata(
     if MetadataExtensionType.CLASSIFICATION_LABELS in metadata_extension.types:
         await extend_prompt_context_with_classification_labels(context, kbid, parsed_text_block_ids)
 
-    if MetadataExtensionType.NER in metadata_extension.types:
+    if MetadataExtensionType.NERS in metadata_extension.types:
         await extend_prompt_context_with_ner(context, kbid, parsed_text_block_ids)
 
     if MetadataExtensionType.EXTRA_METADATA in metadata_extension.types:

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -350,7 +350,7 @@ async def extend_prompt_context_with_origin_metadata(context, kbid, text_block_i
     for tb_id in text_block_ids:
         origin = rid_to_origin.get(tb_id.rid)
         if origin is not None and tb_id.full() in context.output:
-            context[tb_id.full()] += f"\n\\DOCUMENT METADATA AT ORIGIN:\n{to_yaml(origin)}"
+            context[tb_id.full()] += f"\n\n\\DOCUMENT METADATA AT ORIGIN:\n{to_yaml(origin)}"
 
 
 async def extend_prompt_context_with_classification_labels(
@@ -431,7 +431,7 @@ async def extend_prompt_context_with_extra_metadata(context, kbid, text_block_id
     for tb_id in text_block_ids:
         extra = rid_to_extra.get(tb_id.rid)
         if extra is not None and tb_id.full() in context.output:
-            context[tb_id.full()] += f"\n\\DOCUMENT EXTRA METADATA:\n{to_yaml(extra)}"
+            context[tb_id.full()] += f"\n\n\\DOCUMENT EXTRA METADATA:\n{to_yaml(extra)}"
 
 
 def to_yaml(obj: BaseModel) -> str:

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -299,22 +299,22 @@ async def full_resource_prompt_context(
 async def extend_prompt_context_with_metadata(
     context: CappedPromptContext,
     kbid: str,
-    metadata_extension: MetadataExtensionStrategy,
+    strategy: MetadataExtensionStrategy,
 ) -> None:
     parsed_text_block_ids = _parse_text_block_ids(context)
     if len(parsed_text_block_ids) == 0:
         return
 
-    if MetadataExtensionType.ORIGIN in metadata_extension.types:
+    if MetadataExtensionType.ORIGIN in strategy.types:
         await extend_prompt_context_with_origin_metadata(context, kbid, parsed_text_block_ids)
 
-    if MetadataExtensionType.CLASSIFICATION_LABELS in metadata_extension.types:
+    if MetadataExtensionType.CLASSIFICATION_LABELS in strategy.types:
         await extend_prompt_context_with_classification_labels(context, kbid, parsed_text_block_ids)
 
-    if MetadataExtensionType.NERS in metadata_extension.types:
+    if MetadataExtensionType.NERS in strategy.types:
         await extend_prompt_context_with_ner(context, kbid, parsed_text_block_ids)
 
-    if MetadataExtensionType.EXTRA_METADATA in metadata_extension.types:
+    if MetadataExtensionType.EXTRA_METADATA in strategy.types:
         await extend_prompt_context_with_extra_metadata(context, kbid, parsed_text_block_ids)
 
 

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -397,7 +397,7 @@ async def extend_prompt_context_with_ner(context, kbid, text_block_ids: list[Tex
             field = await resource.get_field(fid.key, fid.pb_type, load=False)
             fcm = await field.get_field_metadata()
             if fcm is not None:
-                for token, family in fcm.metadata.ner.values():
+                for token, family in fcm.metadata.ner.items():
                     ners.add(f"{family}/{token}")
         return _id, list(ners)
 

--- a/nucliadb/tests/fixtures.py
+++ b/nucliadb/tests/fixtures.py
@@ -631,6 +631,7 @@ async def pg_maindb_driver(pg_maindb_settings: DriverSettings):
 # Coma separated list of drivers
 DEFAULT_MAINDB_DRIVER = "pg"
 
+
 def maindb_settings_lazy_fixtures(default_drivers: str = DEFAULT_MAINDB_DRIVER):
     driver_types = os.environ.get("TESTING_MAINDB_DRIVERS", default_drivers)
     return [lazy_fixture.lf(f"{driver_type}_maindb_settings") for driver_type in driver_types.split(",")]

--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -29,6 +29,7 @@ from nucliadb_models.search import (
     FindField,
     FindParagraph,
     FindResource,
+    HierarchyResourceStrategy,
     KnowledgeboxFindResults,
     MinScore,
 )
@@ -297,10 +298,7 @@ async def test_hierarchy_promp_context(kb):
         )
         ordered_paragraphs = chat_prompt.get_ordered_paragraphs(find_results)
         await chat_prompt.hierarchy_prompt_context(
-            context,
-            "kbid",
-            ordered_paragraphs,
-            paragraphs_extra_characters=0,
+            context, "kbid", ordered_paragraphs, HierarchyResourceStrategy()
         )
         assert (
             context.output["r1/f/f1/0-10"]

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -982,7 +982,7 @@ class NeighbouringParagraphsStrategy(RagStrategy):
 class MetadataExtensionType(str, Enum):
     ORIGIN = "origin"
     CLASSIFICATION_LABELS = "classification_labels"
-    NER = "ner"
+    NERS = "ners"
     EXTRA_METADATA = "extra_metadata"
 
 
@@ -1005,6 +1005,10 @@ List of resource metadata types to add to the context.
 
 Types for which the metadata is not found at the resource are ignored and not added to the context.
 """,
+        examples=[
+            ["origin", "classification_labels"],
+            ["ners"],
+        ],
     )
 
 
@@ -1140,7 +1144,7 @@ If empty, the default strategy is used. `full_resource`, `hierarchy` and `neighb
             ],
             [{"name": "hierarchy", "count": 2}],
             [{"name": "neighbouring_paragraphs", "before": 2, "after": 2}],
-            [{"name": "metadata_extension", "origin": ["tags", "metadata.author", "created", "url"]}],
+            [{"name": "metadata_extension", "types": ["origin", "classification_labels"]}],
         ],
     )
     rag_images_strategies: list[RagImagesStrategies] = Field(

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -850,7 +850,7 @@ ALLOWED_FIELD_TYPES: dict[str, str] = {
 
 
 class FieldExtensionStrategy(RagStrategy):
-    name: Literal["field_extension"]
+    name: Literal["field_extension"] = "field_extension"
     fields: Set[str] = Field(
         title="Fields",
         description="List of field ids to extend the context with. It will try to extend the retrieval context with the specified fields in the matching resources. The field ids have to be in the format `{field_type}/{field_name}`, like 'a/title', 'a/summary' for title and summary fields or 't/amend' for a text field named 'amend'.",  # noqa
@@ -879,7 +879,7 @@ class FieldExtensionStrategy(RagStrategy):
 
 
 class FullResourceStrategy(RagStrategy):
-    name: Literal["full_resource"]
+    name: Literal["full_resource"] = "full_resource"
     count: Optional[int] = Field(
         default=None,
         title="Count",
@@ -889,7 +889,7 @@ class FullResourceStrategy(RagStrategy):
 
 
 class HierarchyResourceStrategy(RagStrategy):
-    name: Literal["hierarchy"]
+    name: Literal["hierarchy"] = "hierarchy"
     count: int = Field(
         default=0,
         title="Count",
@@ -899,7 +899,7 @@ class HierarchyResourceStrategy(RagStrategy):
 
 
 class NeighbouringParagraphsStrategy(RagStrategy):
-    name: Literal["neighbouring_paragraphs"]
+    name: Literal["neighbouring_paragraphs"] = "neighbouring_paragraphs"
     before: int = Field(
         default=2,
         title="Before",
@@ -927,7 +927,7 @@ class MetadataExtensionStrategy(RagStrategy):
     This strategy can be combined with any of the other strategies.
     """
 
-    name: Literal["metadata_extension"]
+    name: Literal["metadata_extension"] = "metadata_extension"
     types: set[MetadataExtensionType] = Field(
         min_length=1,
         title="Types",

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -178,6 +178,7 @@ def test_ask_stream(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
         [{"name": "neighbouring_paragraphs", "before": 1, "after": 1}],
         [{"name": "hierarchy", "count": 40}],
         [{"name": "field_extension", "fields": ["a/title", "a/summary"]}],
+        [{"name": "metadata_extension", "origin": ["url", "collaborators"]}],
     ],
 )
 def test_ask_rag_strategies(docs_dataset, sdk: nucliadb_sdk.NucliaDB, rag_strategies):

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -178,7 +178,12 @@ def test_ask_stream(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
         [{"name": "neighbouring_paragraphs", "before": 1, "after": 1}],
         [{"name": "hierarchy", "count": 40}],
         [{"name": "field_extension", "fields": ["a/title", "a/summary"]}],
-        [{"name": "metadata_extension", "origin": ["url", "collaborators"]}],
+        [
+            {
+                "name": "metadata_extension",
+                "types": ["origin", "classification_labels", "ner", "extra_metadata"],
+            }
+        ],
     ],
 )
 def test_ask_rag_strategies(docs_dataset, sdk: nucliadb_sdk.NucliaDB, rag_strategies):

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -181,7 +181,7 @@ def test_ask_stream(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
         [
             {
                 "name": "metadata_extension",
-                "types": ["origin", "classification_labels", "ner", "extra_metadata"],
+                "types": ["origin", "classification_labels", "ners", "extra_metadata"],
             }
         ],
     ],

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "sdk", "sidecar"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:f0357caf0e4cc3f84eff51945696b3bedb44e66a6ab9aaf9e8af1996c8610aff"
+content_hash = "sha256:58191ec87d413066b2e4293ab9d07a56e0b9b08d2015a841f7eb0e216f95fd71"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -2035,6 +2035,7 @@ dependencies = [
     "pydantic-settings>=2.2",
     "pydantic>=2.6",
     "pyjwt>=2.4.0",
+    "pyyaml>=5.1",
     "sentry-sdk>=2.8.0",
     "sniffio>=1.2.0",
     "types-aiofiles>=0.8.3",
@@ -3857,6 +3858,17 @@ dependencies = [
 files = [
     {file = "types-pyOpenSSL-24.1.0.20240722.tar.gz", hash = "sha256:47913b4678a01d879f503a12044468221ed8576263c1540dcb0484ca21b08c39"},
     {file = "types_pyOpenSSL-24.1.0.20240722-py3-none-any.whl", hash = "sha256:6a7a5d2ec042537934cfb4c9d4deb0e16c4c6250b09358df1f083682fe6fda54"},
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20240808"
+requires_python = ">=3.8"
+summary = "Typing stubs for PyYAML"
+groups = ["dev"]
+files = [
+    {file = "types-PyYAML-6.0.12.20240808.tar.gz", hash = "sha256:b8f76ddbd7f65440a8bda5526a9607e4c7a322dc2f8e1a8c405644f9a6f4b9af"},
+    {file = "types_PyYAML-6.0.12.20240808-py3-none-any.whl", hash = "sha256:deda34c5c655265fc517b546c902aa6eed2ef8d3e921e4765fe606fe2afe8d35"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,11 @@ dev = [
     "-e file:///${PROJECT_ROOT}/nucliadb_protos/python",
     "-e file:///${PROJECT_ROOT}/nucliadb_telemetry[all]",
     "-e file:///${PROJECT_ROOT}/nucliadb_utils[cache,fastapi,storages]",
-
     # Linting
     "mypy-protobuf>=3.6.0",
     "mypy==1.10",
     "ruff==0.4.8",
     "pre-commit==2.20.0",
-
     # Testing
     "pytest==8.2.2",
     "pytest-asyncio~=0.23.0",
@@ -56,6 +54,7 @@ dev = [
     "jsonschema",
     "pytest-xdist>=3.6.1",
     "pdbpp>=0.10.3",
+    "types-PyYAML>=6.0.12.20240808",
 ]
 sdk = [
     "-e file:///${PROJECT_ROOT}/nucliadb_sdk#egg=nucliadb-sdk",


### PR DESCRIPTION
### Description
New RAG strategy that appends resource/field metadata to the text blocks of the context sent to the LLM.
This RAG strategy can be combined with any other strategies.

Example payload
```json
{
    "query": "who is Riho Iida?",
    "context": [],
    "show": [
        "basic",
        "origin"
    ],
    "features": [
        "semantic"
    ],
    "debug": true,
    "rag_strategies": [
        {
            "name": "metadata_extension",
            "types": ["origin", "classification_labels"]
        }
    ]
}
```

### How was this PR tested?
Unit, integration and local tests
