### PR TITLE
Cleaner ner metadata extension

### DIFF
--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -382,5 +382,5 @@ async def test_extend_prompt_context_with_metadata():
         text_block = context.output[paragraph_id.full()]
         assert "DOCUMENT METADATA AT ORIGIN" in text_block
         assert "DOCUMENT CLASSIFICATION LABELS" in text_block
-        assert "DOCUMENT NERS" in text_block
+        assert "DOCUMENT NAMED ENTITIES (NERs)" in text_block
         assert "DOCUMENT EXTRA METADATA" in text_block


### PR DESCRIPTION
### Description
Does not repeat the family name for every ner token (so it uses less LLM tokens)

Before:
```
DOCUMENT NERS:
- PERSON (Suzuko Mimori)
- ORG (NHK Educational TV)
- DATE (2018)
- PERSON (Nozomi Toujou)
- WORK_OF_ART (天才てれびくんMAX)
- WORK_OF_ART (Shougaiken gibu no okurimono)
- WORK_OF_ART (Boarding School Juliet)
- EVENT (the Japan Educational Film Festival)
- WORK_OF_ART (Tensai Terebi Kun MAX)
- DATE (11 years old)
- WORK_OF_ART (School Idol Project)
- DATE (2003)
- DATE (2002)
- DATE (August 2014)
- GPE (Japan)
- WORK_OF_ART (障害犬ギブのおくりもの)
- WORK_OF_ART (Pool (プール)
- PERSON (Aina Kusuda)
- PERSON (Riho Iida)
- DATE (2017)
- WORK_OF_ART (Love Live!)
- PERSON (Pile)
- DATE (2014)
- PERSON (Lily White)
- ORG (Pure 2)
- PERSON (Maki Nishikino)
- PERSON (Rin Hoshizora)
- PERSON (Umi Sonoda)
- ORG (4to6)
- DATE (January 1, 2022)
- PERSON (Iida)
```

After:
```
DOCUMENT NAMED ENTITIES:
 - PERSON:
   - Aina Kusuda
   - Iida
   - Lily White
   - Maki Nishikino
   - Nozomi Toujou
   - Pile
   - Riho Iida
   - Rin Hoshizora
   - Suzuko Mimori
   - Umi Sonoda
 - WORK_OF_ART:
   - Boarding School Juliet
   - Love Live!
   - Pool (プール
   - School Idol Project
   - Shougaiken gibu no okurimono
   - Tensai Terebi Kun MAX
   - 天才てれびくんMAX
   - 障害犬ギブのおくりもの
 - DATE:
   - 11 years old
   - 2002
   - 2003
   - 2014
   - 2017
   - 2018
   - August 2014
   - January 1, 2022
 - EVENT:
   - the Japan Educational Film Festival
 - GPE:
   - Japan
 - ORG:
   - 4to6
   - NHK Educational TV
   - Pure 2
```

### How was this PR tested?
local tests
