### PR TITLE
Rollback bucket only after bucket really created

### DIFF
--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -201,12 +201,12 @@ class KnowledgeBox:
                 storage = await get_storage(service_name=SERVICE_NAME)
 
                 created = await storage.create_kb(kbid)
-                rollback_ops.append(partial(storage.delete_kb, kbid))
                 if not created:
                     logger.error(f"KB {kbid} could not be created")
                     raise KnowledgeBoxCreationError(
                         f"KB blob storage could not be created (slug={slug})"
                     )
+                rollback_ops.append(partial(storage.delete_kb, kbid))
 
                 # Create shards in index nodes
 


### PR DESCRIPTION
### Description
Not sure about this... If bucket creation function works as expected, this change should be the way to go. Only when we have really created the bucket, we add it to `rollback_ops`. On the other side, if creation fails but the bucket was created, this won't remove it

### How was this PR tested?
Describe how you tested this PR.
