### PR TITLE
Add an index on KBID for counting results

### DIFF
--- a/nucliadb/src/migrations/pg/0003_catalog_kbid_index.py
+++ b/nucliadb/src/migrations/pg/0003_catalog_kbid_index.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from nucliadb.common.maindb.pg import PGTransaction
+
+
+async def migrate(txn: PGTransaction) -> None:
+    async with txn.connection.cursor() as cur:
+        await cur.execute("CREATE INDEX ON catalog(kbid);")


### PR DESCRIPTION
Create an explicit index on KBID for faster filtering. This is a common operation when counting results, which are used in any request on the catalog. Before it was using the (kbid, created_at) index which is larger and thus the queries are slower (about 2x).