### PR TITLE
Fix Pinecone /find response field ids

### DIFF
--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -21,6 +21,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Optional, cast
 
+from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.serialize import managed_serialize
@@ -79,13 +80,19 @@ async def set_text_value(
     async with max_operations:
         assert result_paragraph.paragraph
         assert result_paragraph.paragraph.position
+        _, field_type, field_key = result_paragraph.field.split("/")
         result_paragraph.paragraph.text = await paragraphs.get_paragraph_text(
             kbid=kbid,
-            rid=result_paragraph.rid,
-            field=result_paragraph.field,
-            start=result_paragraph.paragraph.position.start,
-            end=result_paragraph.paragraph.position.end,
-            split=result_paragraph.split,
+            paragraph_id=ParagraphId(
+                field_id=FieldId(
+                    rid=result_paragraph.rid,
+                    type=field_type,
+                    key=field_key,
+                    subfield_id=result_paragraph.split,
+                ),
+                paragraph_start=result_paragraph.paragraph.position.start,
+                paragraph_end=result_paragraph.paragraph.position.end,
+            ),
             highlight=highlight,
             ematches=ematches,
             matches=[],  # TODO

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -22,6 +22,7 @@ import datetime
 import math
 from typing import Any, Optional, Set, Union
 
+from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.search.search import cache
 from nucliadb.search.search.fetch import (
     fetch_resources,
@@ -211,11 +212,16 @@ async def merge_suggest_paragraph_results(
         _, field_type, field = result.field.split("/")
         text = await get_paragraph_text(
             kbid=kbid,
-            rid=result.uuid,
-            field=result.field,
-            start=result.start,
-            end=result.end,
-            split=result.split,
+            paragraph_id=ParagraphId(
+                field_id=FieldId(
+                    rid=result.uuid,
+                    type=field_type,
+                    key=field,
+                    subfield_id=result.split,
+                ),
+                paragraph_start=result.start,
+                paragraph_end=result.end,
+            ),
             highlight=highlight,
             ematches=ematches,  # type: ignore
             matches=result.matches,  # type: ignore
@@ -380,11 +386,16 @@ async def merge_paragraph_results(
         _, field_type, field = result.field.split("/")
         text = await get_paragraph_text(
             kbid=kbid,
-            rid=result.uuid,
-            field=result.field,
-            start=result.start,
-            end=result.end,
-            split=result.split,
+            paragraph_id=ParagraphId(
+                field_id=FieldId(
+                    rid=result.uuid,
+                    type=field_type,
+                    key=field,
+                    subfield_id=result.split,
+                ),
+                paragraph_start=result.start,
+                paragraph_end=result.end,
+            ),
             highlight=highlight,
             ematches=ematches,
             matches=result.matches,  # type: ignore

--- a/nucliadb/src/nucliadb/search/search/results_hydrator/base.py
+++ b/nucliadb/src/nucliadb/search/search/results_hydrator/base.py
@@ -152,16 +152,11 @@ async def hydrate_text_block(
     """
     Fetch the text for a text block and update the FindParagraph object.
     """
-    _, field_type, field_key = text_block.field_id.split("/")
+    field_id = FieldId.from_string(text_block.field_id)
     text = await paragraphs.get_paragraph_text(
         kbid=kbid,
         paragraph_id=ParagraphId(
-            field_id=FieldId(
-                rid=text_block.resource_id,
-                type=field_type,
-                key=field_key,
-                subfield_id=text_block.subfield_id,
-            ),
+            field_id=field_id,
             paragraph_start=text_block.position_start,
             paragraph_end=text_block.position_end,
         ),

--- a/nucliadb/src/nucliadb/search/search/results_hydrator/base.py
+++ b/nucliadb/src/nucliadb/search/search/results_hydrator/base.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 
 from nucliadb.common.external_index_providers.base import QueryResults as ExternalIndexQueryResults
 from nucliadb.common.external_index_providers.base import TextBlockMatch
+from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.serialize import managed_serialize
@@ -151,13 +152,19 @@ async def hydrate_text_block(
     """
     Fetch the text for a text block and update the FindParagraph object.
     """
+    _, field_type, field_key = text_block.field_id.split("/")
     text = await paragraphs.get_paragraph_text(
         kbid=kbid,
-        rid=text_block.resource_id,
-        field=text_block.field_id,
-        start=text_block.position_start,
-        end=text_block.position_end,
-        split=text_block.subfield_id,
+        paragraph_id=ParagraphId(
+            field_id=FieldId(
+                rid=text_block.resource_id,
+                type=field_type,
+                key=field_key,
+                subfield_id=text_block.subfield_id,
+            ),
+            paragraph_start=text_block.position_start,
+            paragraph_end=text_block.position_end,
+        ),
     )
     field_paragraphs[text_block.id] = FindParagraph(
         score=text_block.score,

--- a/nucliadb/tests/search/unit/search/test_paragraphs.py
+++ b/nucliadb/tests/search/unit/search/test_paragraphs.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from nucliadb.common.ids import ParagraphId
 from nucliadb.search.search import cache, paragraphs
 from nucliadb.search.search.cache import set_extracted_text_cache
 from nucliadb_protos.utils_pb2 import ExtractedText
@@ -72,11 +73,7 @@ class TestGetParagraphText:
         assert (
             await paragraphs.get_paragraph_text(
                 kbid="kbid",
-                rid="rid",
-                field="/t/text",
-                start=0,
-                end=12,
-                split=None,
+                paragraph_id=ParagraphId.from_string("rid/t/text/0-12"),
                 highlight=True,
                 ematches=None,
                 matches=None,


### PR DESCRIPTION
### Description
Pinecone /find response was returning field ids as `{rid}/{type}/{key}` while index node results return without the resource id

### How was this PR tested?
Describe how you tested this PR.
