### PR TITLE
Fix vectorsets dimensions

### DIFF
--- a/nucliadb/src/migrations/0027_rollover_texts3.py
+++ b/nucliadb/src/migrations/0027_rollover_texts3.py
@@ -59,8 +59,15 @@ async def maybe_fix_vector_dimensions(context: ExecutionContext, kbid: str) -> N
         if vectorset.vectorset_index_config.vector_dimension != 0:
             return
 
-        logger.info(f"Fixing KB vectorset dimension", extra={"kbid": kbid})
         learning_model_metadata = learning_config.into_semantic_model_metadata()
+        logger.info(
+            f"Fixing KB vectorset dimension",
+            extra={
+                "kbid": kbid,
+                "from": vectorset.vectorset_index_config.vector_dimension,
+                "to": learning_model_metadata.vector_dimension,
+            },
+        )
         vectorset.vectorset_index_config.vector_dimension = learning_model_metadata.vector_dimension
 
         await datamanagers.vectorsets.set(txn, kbid=kbid, config=vectorset)

--- a/nucliadb/src/migrations/0027_rollover_texts3.py
+++ b/nucliadb/src/migrations/0027_rollover_texts3.py
@@ -23,12 +23,44 @@
 Rollover for nucliadb_texts3
 """
 
+import logging
+
+from nucliadb import learning_proxy
+from nucliadb.common import datamanagers
 from nucliadb.common.cluster.rollover import rollover_kb_index
 from nucliadb.migrator.context import ExecutionContext
+
+logger = logging.getLogger(__name__)
 
 
 async def migrate(context: ExecutionContext) -> None: ...
 
 
 async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
+    await maybe_fix_vector_dimensions(context, kbid)
     await rollover_kb_index(context, kbid)
+
+
+async def maybe_fix_vector_dimensions(context: ExecutionContext, kbid: str) -> None:
+    learning_config = await learning_proxy.get_configuration(kbid)
+    if learning_config is None:
+        logger.warning(f"KB has no learning config", extra={"kbid": kbid})
+        return
+
+    async with context.kv_driver.transaction() as txn:
+        vectorsets = [vs async for vs in datamanagers.vectorsets.iter(txn, kbid=kbid)]
+        if len(vectorsets) != 1:
+            # If multiple vectorsets, they are new shards created correctly, we can safely skip it
+            logger.warning(f"KB has {len(vectorsets)} vectorsets, skipping...", extra={"kbid": kbid})
+            return
+        vectorset = vectorsets[0][1]
+
+        # Correct value, skip
+        if vectorset.vectorset_index_config.vector_dimension != 0:
+            return
+
+        logger.info(f"Fixing KB vectorset dimension", extra={"kbid": kbid})
+        learning_model_metadata = learning_config.into_semantic_model_metadata()
+        vectorset.vectorset_index_config.vector_dimension = learning_model_metadata.vector_dimension
+
+        await datamanagers.vectorsets.set(txn, kbid=kbid, config=vectorset)


### PR DESCRIPTION
Fixes some vectorsets that were created with incorrect dimensions. This must be done before the rollover, or the resulting shards will fail due to "inconsistent dimensions".