### PR TITLE
Always replicate vectors metadata

### DIFF
--- a/nucliadb_vectors/src/service/writer.rs
+++ b/nucliadb_vectors/src/service/writer.rs
@@ -32,7 +32,7 @@ use nucliadb_core::protos::ResourceId;
 use nucliadb_core::tracing::{self, *};
 use nucliadb_core::vectors::MergeMetrics;
 use nucliadb_core::vectors::*;
-use nucliadb_core::{IndexFiles, RawReplicaState};
+use nucliadb_core::IndexFiles;
 use nucliadb_procs::measure;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -192,11 +192,6 @@ impl VectorWriter for VectorWriterService {
     fn get_index_files(&self, prefix: &str, ignored_segment_ids: &[String]) -> NodeResult<IndexFiles> {
         // Should be called along with a lock at a higher level to be safe
         let replica_state = replication::get_index_files(&self.path, prefix, ignored_segment_ids)?;
-
-        if replica_state.files.is_empty() {
-            // exit with no changes
-            return Ok(IndexFiles::Other(RawReplicaState::default()));
-        }
 
         Ok(IndexFiles::Other(replica_state))
     }


### PR DESCRIPTION
Vectors metadata was not being replicated when no segments changed. This is wrong because of two things:
- Deletions are only kept in metadata, so deleting a resource wouldn't be replicated.
- Empty indexes / empty KBs won't replicate anything and fail to open

The second case used to work before https://github.com/nuclia/nucliadb/pull/2492 because we created a dummy shard which included some empty metadata files for the vectors index.