### PR TITLE
Cleanly handle shard deletion in replication

### DIFF
--- a/nucliadb_node/src/cache/reader_cache.rs
+++ b/nucliadb_node/src/cache/reader_cache.rs
@@ -74,7 +74,7 @@ impl ShardReaderCache {
         let shard_path = disk_structure::shard_path_by_id(&self.shards_path.clone(), id);
 
         if !ShardMetadata::exists(&shard_path) {
-            return Err(node_error!(ShardNotFoundError("Shard {shard_path:?} is not on disk")));
+            return Err(node_error!(ShardNotFoundError(id.clone())));
         }
         let shard = ShardReader::new(id.clone(), &shard_path)
             .map_err(|error| node_error!("Shard {shard_path:?} could not be loaded from disk: {error:?}"))?;

--- a/nucliadb_node/src/cache/writer_cache.rs
+++ b/nucliadb_node/src/cache/writer_cache.rs
@@ -65,7 +65,7 @@ impl InnerCache {
 
     pub fn get(&mut self, id: &ShardId) -> NodeResult<CacheResult<ShardId, ShardWriter>> {
         if self.blocked_shards.contains(id) {
-            return Err(node_error!(ShardNotFoundError("Shard {shard_path:?} is not on disk")));
+            return Err(node_error!(ShardNotFoundError(id.clone())));
         }
 
         Ok(self.active_shards.get(id))
@@ -77,7 +77,7 @@ impl InnerCache {
         shard: Arc<ShardWriter>,
     ) -> NodeResult<Arc<ShardWriter>> {
         if self.blocked_shards.contains(&shard.id) {
-            return Err(node_error!(ShardNotFoundError("Shard {shard_path:?} is not on disk")));
+            return Err(node_error!(ShardNotFoundError(shard.id.clone())));
         }
 
         self.active_shards.loaded(guard, &shard);
@@ -157,7 +157,7 @@ impl ShardWriterCache {
         let shard_path = disk_structure::shard_path_by_id(&self.shards_path.clone(), id);
 
         if !ShardMetadata::exists(&shard_path) {
-            return Err(node_error!(ShardNotFoundError("Shard {shard_path:?} is not on disk")));
+            return Err(node_error!(ShardNotFoundError(id.clone())));
         }
         let metadata = metadata_manager.get(id.clone()).expect("Shard metadata not found. This should not happen");
         let shard = ShardWriter::open(metadata)

--- a/nucliadb_node/src/errors.rs
+++ b/nucliadb_node/src/errors.rs
@@ -20,7 +20,7 @@
 use std::fmt::Display;
 
 #[derive(Debug)]
-pub struct ShardNotFoundError(pub &'static str);
+pub struct ShardNotFoundError(pub String);
 
 impl Display for ShardNotFoundError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
1. drops a known problem to a warn! to avoid killing sentry quota. In particular, a shard being deleted between getting the shard list and trying to download it.
2. Tries to handle more cleanly the case where a shard is half-downloaded to the replica and is incomplete enough that it does not open, basically by deleting and redownloading it (edited) 

also fixes some error reporting that was not using format! so the error contained `{}` instead of the actual values