### PR TITLE
Add option for anonymous credentials in GcsStorage

### DIFF
--- a/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
+++ b/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
@@ -117,6 +117,7 @@ async def gcs_storage(gcs, gcs_storage_settings: dict[str, Any]):
         deadletter_bucket=extended_storage_settings.gcs_deadletter_bucket,
         indexing_bucket=extended_storage_settings.gcs_indexing_bucket,
         labels=storage_settings.gcs_bucket_labels,
+        anonymous=True,
     )
     await storage.initialize()
     yield storage


### PR DESCRIPTION
Tests using GCS storage were trying to use default credentials on each test setup. Locally, this was taking ~6s per test. With more than 300 tests using storage, this saves almost half of the time running nucliadb tests :)