### PR TITLE
Reindex all questions when adding a new one

### DIFF
--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -305,9 +305,7 @@ class Field:
                 self.extracted_text = payload
         return self.extracted_text
 
-    async def set_vectors(
-        self, payload: ExtractedVectorsWrapper
-    ) -> tuple[Optional[VectorObject], bool, list[str]]:
+    async def set_vectors(self, payload: ExtractedVectorsWrapper) -> Optional[VectorObject]:
         vectorset = payload.vectorset_id
         if self.type in SUBFIELDFIELDS:
             try:
@@ -361,9 +359,7 @@ class Field:
                 self.extracted_vectors = payload
         return self.extracted_vectors
 
-    async def set_field_metadata(
-        self, payload: FieldComputedMetadataWrapper
-    ) -> tuple[FieldComputedMetadata, list[str], dict[str, list[str]]]:
+    async def set_field_metadata(self, payload: FieldComputedMetadataWrapper) -> FieldComputedMetadata:
         if self.type in SUBFIELDFIELDS:
             try:
                 actual_payload: Optional[FieldComputedMetadata] = await self.get_field_metadata(

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -394,7 +394,6 @@ class Field:
             metadata.last_index.FromDatetime(datetime.now())
 
         paragraphs_to_replace = []
-        replace_splits = {}
         if actual_payload is None:
             # Its first metadata
             await self.storage.upload_pb(sf, payload.metadata)
@@ -405,9 +404,6 @@ class Field:
                 actual_payload.split_metadata[key].CopyFrom(value)
             for key in payload.metadata.deleted_splits:
                 if key in actual_payload.split_metadata:
-                    replace_splits[key] = [
-                        f"{x.start}-{x.end}" for x in actual_payload.split_metadata[key].paragraphs
-                    ]
                     del actual_payload.split_metadata[key]
             if payload.metadata.metadata:
                 actual_payload.metadata.CopyFrom(payload.metadata.metadata)
@@ -415,7 +411,7 @@ class Field:
             await self.storage.upload_pb(sf, actual_payload)
             self.computed_metadata = actual_payload
 
-        return self.computed_metadata, paragraphs_to_replace, replace_splits
+        return self.computed_metadata, paragraphs_to_replace
 
     async def get_field_metadata(self, force: bool = False) -> Optional[FieldComputedMetadata]:
         if self.computed_metadata is None or force:

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -393,7 +393,6 @@ class Field:
                 metadata.thumbnail.CopyFrom(cf_split)
             metadata.last_index.FromDatetime(datetime.now())
 
-        paragraphs_to_replace = []
         if actual_payload is None:
             # Its first metadata
             await self.storage.upload_pb(sf, payload.metadata)
@@ -407,11 +406,10 @@ class Field:
                     del actual_payload.split_metadata[key]
             if payload.metadata.metadata:
                 actual_payload.metadata.CopyFrom(payload.metadata.metadata)
-                paragraphs_to_replace = [f"{x.start}-{x.end}" for x in metadata.paragraphs]
             await self.storage.upload_pb(sf, actual_payload)
             self.computed_metadata = actual_payload
 
-        return self.computed_metadata, paragraphs_to_replace
+        return self.computed_metadata
 
     async def get_field_metadata(self, force: bool = False) -> Optional[FieldComputedMetadata]:
         if self.computed_metadata is None or force:

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -340,7 +340,7 @@ class Field:
                 pb.ParseFromString(raw_payload.read())
                 raw_payload.flush()
                 payload.vectors.CopyFrom(pb)
-            vo = payload.vectors
+            vo = actual_payload
             # We know its payload.body
             for key, value in payload.vectors.split_vectors.items():
                 actual_payload.split_vectors[key].CopyFrom(value)

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -322,8 +322,6 @@ class Field:
 
         sf = self._get_extracted_vectors_storage_field(vectorset)
         vo: Optional[VectorObject] = None
-        replace_field: bool = True
-        replace_splits = []
         if actual_payload is None:
             # Its first extracted text
             if payload.HasField("file"):
@@ -346,14 +344,12 @@ class Field:
                 actual_payload.split_vectors[key].CopyFrom(value)
             for key in payload.vectors.deleted_splits:
                 if key in actual_payload.split_vectors:
-                    replace_splits.append(key)
                     del actual_payload.split_vectors[key]
             if len(payload.vectors.vectors.vectors) > 0:
-                replace_field = True
                 actual_payload.vectors.CopyFrom(payload.vectors.vectors)
             await self.storage.upload_pb(sf, actual_payload)
             self.extracted_vectors = actual_payload
-        return vo, replace_field, replace_splits
+        return vo
 
     async def get_vectors(
         self, vectorset: Optional[str] = None, force: bool = False

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -259,10 +259,8 @@ class ResourceBrain:
         *,
         vectorset: Optional[str] = None,
         replace_field: bool = False,
-        replace_splits: Optional[list[str]] = None,
         matryoshka_vector_dimension: Optional[int] = None,
     ):
-        replace_splits = replace_splits or []
         fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():
             _field_id = ids.FieldId(
@@ -317,14 +315,6 @@ class ResourceBrain:
                 vector,
                 vectorset=vectorset,
                 matryoshka_vector_dimension=matryoshka_vector_dimension,
-            )
-
-        for split in replace_splits:
-            self.brain.sentences_to_delete.append(
-                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key, subfield_id=split).full()
-            )
-            self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key, subfield_id=split).full()
             )
 
         if replace_field:

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -43,7 +43,7 @@ from nucliadb_protos.resources_pb2 import (
     UserFieldMetadata,
     UserMetadata,
 )
-from nucliadb_protos.utils_pb2 import Relation, RelationNode, VectorObject
+from nucliadb_protos.utils_pb2 import Relation, RelationNode
 
 FilePagePositions = dict[int, tuple[int, int]]
 
@@ -336,9 +336,6 @@ class ResourceBrain:
         sentence_pb.metadata.representation.is_a_table = paragraph_pb.metadata.representation.is_a_table
 
         sentence_pb.metadata.position.index = paragraph_pb.metadata.position.index
-
-    def delete_vectors(self, field_key: str, vo: VectorObject):
-        self.brain.sentences_to_delete.append(f"{self.rid}/{field_key}")
 
     def set_processing_status(self, basic: Basic, previous_status: Optional[Metadata.Status.ValueType]):
         """

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -367,9 +367,6 @@ class ResourceBrain:
         sentence_pb.metadata.position.index = paragraph_pb.metadata.position.index
 
     def delete_vectors(self, field_key: str, vo: VectorObject):
-        for subfield, _ in vo.split_vectors.items():
-            self.brain.sentences_to_delete.append(f"{self.rid}/{field_key}/{subfield}")
-
         self.brain.sentences_to_delete.append(f"{self.rid}/{field_key}")
 
     def set_processing_status(self, basic: Basic, previous_status: Optional[Metadata.Status.ValueType]):

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -220,7 +220,7 @@ class ResourceBrain:
             for relation in relations.relations:
                 self.brain.relations.append(relation)
 
-    def delete_metadata(self, field_key: str):
+    def delete_field(self, field_key: str):
         ftype, fkey = field_key.split("/")
         full_field_id = ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
         self.brain.paragraphs_to_delete.append(full_field_id)

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -93,7 +93,6 @@ class ResourceBrain:
         field_key: str,
         metadata: FieldComputedMetadata,
         paragraphs_to_replace: list[str],
-        replace_splits: dict[str, list[str]],
         page_positions: Optional[FilePagePositions],
         extracted_text: Optional[ExtractedText],
         basic_user_field_metadata: Optional[UserFieldMetadata] = None,
@@ -222,34 +221,14 @@ class ResourceBrain:
             for relation in relations.relations:
                 self.brain.relations.append(relation)
 
-        for split, sentences in replace_splits.items():
-            for sentence in sentences:
-                self.brain.paragraphs_to_delete.append(f"{self.rid}/{field_key}/{split}/{sentence}")
-
         for paragraph_to_delete in paragraphs_to_replace:
             self.brain.paragraphs_to_delete.append(f"{self.rid}/{field_key}/{paragraph_to_delete}")
 
     def delete_metadata(self, field_key: str, metadata: FieldComputedMetadata):
         ftype, fkey = field_key.split("/")
-        for subfield, metadata_split in metadata.split_metadata.items():
-            self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, type=ftype, key=fkey, subfield_id=subfield).full()
-            )
-            # TODO: Bw/c, remove this when paragraph deletion by field_id gets
-            # promoted
-            for paragraph in metadata_split.paragraphs:
-                self.brain.paragraphs_to_delete.append(
-                    f"{self.rid}/{field_key}/{subfield}/{paragraph.start}-{paragraph.end}"
-                )
-
         for paragraph in metadata.metadata.paragraphs:
             self.brain.paragraphs_to_delete.append(
                 ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
-            )
-            # TODO: Bw/c, remove this when paragraph deletion by field_id gets
-            # promoted
-            self.brain.paragraphs_to_delete.append(
-                f"{self.rid}/{field_key}/{paragraph.start}-{paragraph.end}"
             )
 
     def apply_field_vectors(

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -92,7 +92,6 @@ class ResourceBrain:
         self,
         field_key: str,
         metadata: FieldComputedMetadata,
-        paragraphs_to_replace: list[str],
         page_positions: Optional[FilePagePositions],
         extracted_text: Optional[ExtractedText],
         basic_user_field_metadata: Optional[UserFieldMetadata] = None,
@@ -221,15 +220,11 @@ class ResourceBrain:
             for relation in relations.relations:
                 self.brain.relations.append(relation)
 
-        for paragraph_to_delete in paragraphs_to_replace:
-            self.brain.paragraphs_to_delete.append(f"{self.rid}/{field_key}/{paragraph_to_delete}")
-
-    def delete_metadata(self, field_key: str, metadata: FieldComputedMetadata):
+    def delete_metadata(self, field_key: str):
         ftype, fkey = field_key.split("/")
-        for paragraph in metadata.metadata.paragraphs:
-            self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
-            )
+        full_field_id = ids.FieldId(rid=self.rid, type=ftype, key=fkey).full()
+        self.brain.paragraphs_to_delete.append(full_field_id)
+        self.brain.sentences_to_delete.append(full_field_id)
 
     def apply_field_vectors(
         self,
@@ -297,12 +292,9 @@ class ResourceBrain:
             )
 
         if replace_field:
-            self.brain.sentences_to_delete.append(
-                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key).full()
-            )
-            self.brain.paragraphs_to_delete.append(
-                ids.FieldId(rid=self.rid, type=fid.type, key=fid.key).full()
-            )
+            full_field_id = ids.FieldId(rid=self.rid, type=fid.type, key=fid.key).full()
+            self.brain.sentences_to_delete.append(full_field_id)
+            self.brain.paragraphs_to_delete.append(full_field_id)
 
     def _apply_field_vector(
         self,

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -222,7 +222,6 @@ class Resource:
                             field_id,
                             field_metadata,
                             paragraphs_to_replace=[],
-                            replace_splits={},
                             page_positions=page_positions,
                             extracted_text=await field_obj.get_extracted_text(),
                             basic_user_field_metadata=user_field_metadata,
@@ -340,7 +339,6 @@ class Resource:
                     field_key,
                     field_metadata,
                     paragraphs_to_replace=paragraphs_to_replace,
-                    replace_splits={},
                     page_positions=page_positions,
                     extracted_text=await field.get_extracted_text(),
                     basic_user_field_metadata=user_field_metadata,
@@ -715,7 +713,6 @@ class Resource:
         (
             metadata,
             paragraphs_to_replace,
-            replace_splits,
         ) = await field_obj.set_field_metadata(field_metadata)
         field_key = self.generate_field_id(field_metadata.field)
 
@@ -739,7 +736,6 @@ class Resource:
             field_key,
             metadata,
             paragraphs_to_replace=paragraphs_to_replace,
-            replace_splits=replace_splits,
             page_positions=page_positions,
             extracted_text=extracted_text,
             basic_user_field_metadata=user_field_metadata,

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -221,7 +221,6 @@ class Resource:
                         self.indexer.apply_field_metadata(
                             field_id,
                             field_metadata,
-                            paragraphs_to_replace=[],
                             page_positions=page_positions,
                             extracted_text=await field_obj.get_extracted_text(),
                             basic_user_field_metadata=user_field_metadata,
@@ -329,16 +328,9 @@ class Resource:
                         ),
                         None,
                     )
-                if reindex:
-                    paragraphs_to_replace = [
-                        f"{p.start}-{p.end}" for p in field_metadata.metadata.paragraphs
-                    ]
-                else:
-                    paragraphs_to_replace = []
                 brain.apply_field_metadata(
                     field_key,
                     field_metadata,
-                    paragraphs_to_replace=paragraphs_to_replace,
                     page_positions=page_positions,
                     extracted_text=await field.get_extracted_text(),
                     basic_user_field_metadata=user_field_metadata,
@@ -480,7 +472,7 @@ class Resource:
 
         metadata = await field_obj.get_field_metadata()
         if metadata is not None:
-            self.indexer.delete_metadata(field_key=field_key, metadata=metadata)
+            self.indexer.delete_metadata(field_key=field_key)
 
         await field_obj.delete()
 
@@ -710,10 +702,7 @@ class Resource:
             field_metadata.field.field_type,
             load=False,
         )
-        (
-            metadata,
-            paragraphs_to_replace,
-        ) = await field_obj.set_field_metadata(field_metadata)
+        metadata = await field_obj.set_field_metadata(field_metadata)
         field_key = self.generate_field_id(field_metadata.field)
 
         page_positions: Optional[FilePagePositions] = None
@@ -735,7 +724,6 @@ class Resource:
             self.indexer.apply_field_metadata,
             field_key,
             metadata,
-            paragraphs_to_replace=paragraphs_to_replace,
             page_positions=page_positions,
             extracted_text=extracted_text,
             basic_user_field_metadata=user_field_metadata,

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -466,9 +466,6 @@ class Resource:
                 self.all_fields_keys.remove(field)
 
         field_key = self.generate_field_id(FieldID(field_type=type, field=key))
-        vo = await field_obj.get_vectors()
-        if vo is not None:
-            self.indexer.delete_vectors(field_key=field_key, vo=vo)
 
         metadata = await field_obj.get_field_metadata()
         if metadata is not None:

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -472,7 +472,7 @@ class Resource:
 
         metadata = await field_obj.get_field_metadata()
         if metadata is not None:
-            self.indexer.delete_metadata(field_key=field_key)
+            self.indexer.delete_field(field_key=field_key)
 
         await field_obj.delete()
 

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -764,11 +764,7 @@ class Resource:
             field_vectors.field.field_type,
             load=False,
         )
-        (
-            vo,
-            replace_field_sentences,
-            replace_splits_sentences,
-        ) = await field_obj.set_vectors(field_vectors)
+        vo = await field_obj.set_vectors(field_vectors)
 
         # Prepare vectors to be indexed
 
@@ -797,8 +793,7 @@ class Resource:
                 field_key,
                 vo,
                 vectorset=vectorset_id,
-                replace_field=replace_field_sentences,
-                replace_splits=replace_splits_sentences,
+                replace_field=True,
                 matryoshka_vector_dimension=dimension,
             )
             loop = asyncio.get_running_loop()

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -749,10 +749,7 @@ async def test_ingest_delete_field(
         # Field is deleted
         brain_mock.assert_called_once()
         brain = brain_mock.call_args[0][0]
-        assert set(brain.paragraphs_to_delete) == {
-            f"{rid}/f/some_text",
-            f"{rid}/f/some_text/0-5",
-        }
+        assert brain.paragraphs_to_delete == [f"{rid}/f/some_text"]
         assert brain.sentences_to_delete == [f"{rid}/f/some_text"]
 
 
@@ -803,9 +800,6 @@ async def test_ingest_update_labels(
         # Field is reindexed
         brain_mock.assert_called_once()
         brain = brain_mock.call_args[0][0]
-        assert set(brain.paragraphs_to_delete) == {
-            f"{rid}/f/some_text",
-            f"{rid}/f/some_text/0-5",
-        }
+        assert f"{rid}/f/some_text" in brain.paragraphs_to_delete
         assert f"{rid}/f/some_text" in brain.sentences_to_delete
         assert "/l/names/john" in brain.labels

--- a/nucliadb/tests/ingest/unit/orm/test_brain.py
+++ b/nucliadb/tests/ingest/unit/orm/test_brain.py
@@ -58,7 +58,6 @@ def test_apply_field_metadata_marks_duplicated_paragraphs():
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,
-        paragraphs_to_replace=[],
         replace_splits={},
         page_positions={},
         extracted_text=et,
@@ -97,7 +96,6 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,
-        paragraphs_to_replace=[],
         replace_splits={},
         page_positions={},
         extracted_text=et,
@@ -196,7 +194,6 @@ def test_apply_field_metadata_populates_page_number():
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,
-        paragraphs_to_replace=[],
         replace_splits={},
         page_positions=page_positions,
         extracted_text=None,

--- a/nucliadb/tests/ingest/unit/orm/test_brain.py
+++ b/nucliadb/tests/ingest/unit/orm/test_brain.py
@@ -58,7 +58,6 @@ def test_apply_field_metadata_marks_duplicated_paragraphs():
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,
-        replace_splits={},
         page_positions={},
         extracted_text=et,
     )
@@ -96,7 +95,6 @@ def test_apply_field_metadata_marks_duplicated_paragraphs_on_split_metadata():
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,
-        replace_splits={},
         page_positions={},
         extracted_text=et,
     )
@@ -194,7 +192,6 @@ def test_apply_field_metadata_populates_page_number():
     br.apply_field_metadata(
         field_key,
         fcmw.metadata,
-        replace_splits={},
         page_positions=page_positions,
         extracted_text=None,
     )

--- a/nucliadb_paragraphs3/src/writer.rs
+++ b/nucliadb_paragraphs3/src/writer.rs
@@ -87,15 +87,9 @@ impl ParagraphWriter for ParagraphWriterService {
         debug!("{id:?} - Processing paragraphs to delete: starts at {v} ms");
 
         // Delete all paragraphs matching the field_uuid
-        //
-        // Bw/c delete by paragraph_id
         for field_or_paragraph_id in &resource.paragraphs_to_delete {
             let field_uuid_term = Term::from_field_text(self.schema.field_uuid, field_or_paragraph_id);
             self.writer.delete_term(field_uuid_term);
-            // TODO: remove deletion by paragraph_id when deletion by field gets
-            // promoted
-            let paragraph_uuid_term = Term::from_field_text(self.schema.paragraph, field_or_paragraph_id);
-            self.writer.delete_term(paragraph_uuid_term);
         }
 
         self.writer.commit()?;


### PR DESCRIPTION
# Changes

## Always send all splits to the index each time
This makes it so we send the entire conversation field to the index when adding a new question. This way the granularity of the index is the field and it doesn't have to know about splits and could make our code simpler.

## Remove splits from `paragraphs_to_delete` and `sentences_to_delete`
We are always sending all splits, so we can reindex the entire field

## Remove per-paragraph deletion from `paragraphs_to_delete`
This was started a few months ago and the changes are already propagated everywhere

## Remove vectors on field deletion
When deleting a field, `delete_metadata()` was called which deleted only from paragraph index, not vectors index.