### PR TITLE
Add noop reranker + fix double rerank on /ask

### DIFF
--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -55,7 +55,7 @@ from nucliadb.search.search.exceptions import (
 )
 from nucliadb.search.search.metrics import RAGMetrics
 from nucliadb.search.search.query import QueryParser
-from nucliadb.search.search.rerankers import RankedItem, apply_reranking, sort_reranked
+from nucliadb.search.search.rerankers import RankedItem, apply_reranking, sort_by_score
 from nucliadb.search.utilities import get_predict
 from nucliadb_models.search import (
     SCORE_TYPE,
@@ -221,7 +221,7 @@ class AskResult:
                 RankedItem(id=paragraph_id, score=score, score_type=SCORE_TYPE.RERANKER)
                 for paragraph_id, score in self._reranking.context_scores.items()
             ]
-            sort_reranked(reranked)
+            sort_by_score(reranked)
             apply_reranking(self.main_results, reranked)
 
         yield RetrievalAskResponseItem(

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -184,7 +184,9 @@ async def run_main_query(
     find_request.rephrase_prompt = parse_rephrase_prompt(item)
     # predict reranker will be done in their stream to avoid a round trip
     # between nucliadb and predict
-    if item.reranker != Reranker.PREDICT_RERANKER:
+    if item.reranker == Reranker.PREDICT_RERANKER:
+        find_request.reranker = Reranker.NOOP
+    else:
         find_request.reranker = item.reranker
     # We don't support pagination, we always get the top_k results.
     find_request.top_k = item.top_k

--- a/nucliadb/src/nucliadb/search/search/rerankers.py
+++ b/nucliadb/src/nucliadb/search/search/rerankers.py
@@ -86,6 +86,30 @@ class Reranker(ABC):
         ...
 
 
+class NoopReranker(Reranker):
+    """No-operation reranker. Given a list of items to rerank, it does nothing
+    with them and return the items in the same order. It can be use to not alter
+    the previous ordering.
+    """
+
+    @property
+    def needs_extra_results(self) -> bool:
+        return False
+
+    def items_needed(self, requested: int, shards: int = 1) -> int:
+        return requested
+
+    async def rerank(self, items: list[RerankableItem], options: RerankingOptions) -> list[RankedItem]:
+        return [
+            RankedItem(
+                id=item.id,
+                score=item.score,
+                score_type=item.score_type,
+            )
+            for item in items
+        ]
+
+
 class PredictReranker(Reranker):
     @property
     def needs_extra_results(self) -> bool:
@@ -171,6 +195,8 @@ def get_reranker(kind: search_models.Reranker) -> Reranker:
         reranker = PredictReranker()
     elif kind == search_models.Reranker.MULTI_MATCH_BOOSTER:
         reranker = MultiMatchBoosterReranker()
+    elif kind == search_models.Reranker.NOOP:
+        reranker = NoopReranker()
     else:
         logger.warning(f"Unknown reranker requested: {kind}. Using multi-match booster instead")
         reranker = MultiMatchBoosterReranker()

--- a/nucliadb/src/nucliadb/search/search/rerankers.py
+++ b/nucliadb/src/nucliadb/search/search/rerankers.py
@@ -121,7 +121,7 @@ class PredictReranker(Reranker):
             )
             for id, score in response.context_scores.items()
         ]
-        sort_reranked(reranked)
+        sort_by_score(reranked)
         best = reranked[: options.top_k]
         return best
 
@@ -161,7 +161,7 @@ class MultiMatchBoosterReranker(Reranker):
                 reranked_by_id[item.id].score_type = SCORE_TYPE.BOTH
 
         reranked = list(reranked_by_id.values())
-        sort_reranked(reranked)
+        sort_by_score(reranked)
         return reranked
 
 
@@ -177,7 +177,7 @@ def get_reranker(kind: search_models.Reranker) -> Reranker:
     return reranker
 
 
-def sort_reranked(items: list[RankedItem]):
+def sort_by_score(items: list[RankedItem]):
     """Sort `items` in place by decreasing score"""
     items.sort(key=lambda item: item.score, reverse=True)
 

--- a/nucliadb/tests/nucliadb/integration/search/test_reranker.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_reranker.py
@@ -24,7 +24,9 @@ from httpx import AsyncClient
 from nucliadb_models.search import Reranker
 
 
-@pytest.mark.parametrize("reranker", [Reranker.MULTI_MATCH_BOOSTER, Reranker.PREDICT_RERANKER])
+@pytest.mark.parametrize(
+    "reranker", [Reranker.MULTI_MATCH_BOOSTER, Reranker.PREDICT_RERANKER, Reranker.NOOP]
+)
 async def test_reranker(
     nucliadb_reader: AsyncClient,
     philosophy_books_kb: str,

--- a/nucliadb/tests/nucliadb/integration/test_ask.py
+++ b/nucliadb/tests/nucliadb/integration/test_ask.py
@@ -947,7 +947,6 @@ async def test_rag_image_rag_strategies(
 @pytest.mark.parametrize(
     "reranker,expected_reranker",
     [
-        ("", Reranker.MULTI_MATCH_BOOSTER),
         (Reranker.MULTI_MATCH_BOOSTER, Reranker.MULTI_MATCH_BOOSTER),
         (Reranker.PREDICT_RERANKER, Reranker.NOOP),
         (Reranker.NOOP, Reranker.NOOP),

--- a/nucliadb/tests/nucliadb/integration/test_ask.py
+++ b/nucliadb/tests/nucliadb/integration/test_ask.py
@@ -947,8 +947,10 @@ async def test_rag_image_rag_strategies(
 @pytest.mark.parametrize(
     "reranker,expected_reranker",
     [
-        (Reranker.PREDICT_RERANKER, Reranker.MULTI_MATCH_BOOSTER),
+        ("", Reranker.MULTI_MATCH_BOOSTER),
         (Reranker.MULTI_MATCH_BOOSTER, Reranker.MULTI_MATCH_BOOSTER),
+        (Reranker.PREDICT_RERANKER, Reranker.NOOP),
+        (Reranker.NOOP, Reranker.NOOP),
     ],
 )
 async def test_ask_forwarding_rerank_options_to_find(

--- a/nucliadb/tests/search/unit/test_reranker.py
+++ b/nucliadb/tests/search/unit/test_reranker.py
@@ -27,7 +27,7 @@ from nucliadb.search.search.rerankers import (
     Reranker,
     RerankingOptions,
     apply_reranking,
-    sort_reranked,
+    sort_by_score,
 )
 from nucliadb_models.internal.predict import RerankResponse
 from nucliadb_models.search import (
@@ -56,7 +56,7 @@ class DummyReranker(Reranker):
             )
             for item in items
         ]
-        sort_reranked(reranked)
+        sort_by_score(reranked)
         return reranked
 
 

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -392,17 +392,22 @@ class SortOptions(BaseModel):
 class Reranker(str, Enum):
     """Rerankers
 
-    - Multi-match booster: given a set of results from different sources, e.g.,
-      keyword and semantic search boost results appearing in both sets
+    - Multi-match booster (default): given a set of results from different
+      sources, e.g., keyword and semantic search boost results appearing in both
+      sets
 
     - Predict reranker: after retrieval, send the results to Predict API to
       rerank it. This method uses a reranker model, so one can expect better
       results at expenses of more latency
 
+    - No-operation (noop) reranker: maintain order and do not rerank the results
+      after retrieval
+
     """
 
     MULTI_MATCH_BOOSTER = "multi_match_booster"
     PREDICT_RERANKER = "predict"
+    NOOP = "noop"
 
 
 class KnowledgeBoxCount(BaseModel):


### PR DESCRIPTION
### Description
An /ask using predict reranker was reranked twice. Adding a new noop reranker allows us to not rerank it in nucliadb and predict API.

A noop reranker can also help with pagination, as a reranker breaks the assumption that `page(10) + page(10) == page(20)` (a reranker may promote results and alter the order depending on the number of items requested)

### How was this PR tested?
Manual testing and unit test. An integration test with proper mocks is too complex
