### PR TITLE
Remove deprecated labelset logic

### DIFF
--- a/nucliadb/src/migrations/0011_materialize_labelset_ids.py
+++ b/nucliadb/src/migrations/0011_materialize_labelset_ids.py
@@ -26,7 +26,6 @@ Tikv doesn't really like scanning a lot of keys, so we need to materialize the l
 
 import logging
 
-from nucliadb.common import datamanagers
 from nucliadb.migrator.context import ExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -35,14 +34,4 @@ logger = logging.getLogger(__name__)
 async def migrate(context: ExecutionContext) -> None: ...
 
 
-async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
-    async with context.kv_driver.transaction() as txn:
-        labelset_list = await datamanagers.labels._get_labelset_ids(txn, kbid=kbid)
-        if labelset_list is not None:
-            logger.info("No need for labelset list migration", extra={"kbid": kbid})
-            return
-
-        labelset_list = await datamanagers.labels._deprecated_scan_labelset_ids(txn, kbid=kbid)
-        await datamanagers.labels._set_labelset_ids(txn, kbid=kbid, labelsets=labelset_list)
-        logger.info("Labelset list migrated", extra={"kbid": kbid})
-        await txn.commit()
+async def migrate_kb(context: ExecutionContext, kbid: str) -> None: ...

--- a/nucliadb/src/nucliadb/common/datamanagers/labels.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/labels.py
@@ -37,7 +37,9 @@ async def get_labels(txn: Transaction, *, kbid: str) -> kb_pb2.Labels:
     Get all labels for a knowledge box (from multiple labelsets)
     """
     labels = kb_pb2.Labels()
-    labelset_ids = await _get_labelset_ids_bw_compat(txn, kbid=kbid)
+    labelset_ids = await _get_labelset_ids(txn, kbid=kbid)
+    if labelset_ids is None:
+        return labels
     for labelset_id in labelset_ids:
         labelset = await txn.get(KB_LABELSET.format(kbid=kbid, id=labelset_id))
         if not labelset:
@@ -46,26 +48,6 @@ async def get_labels(txn: Transaction, *, kbid: str) -> kb_pb2.Labels:
         ls.ParseFromString(labelset)
         labels.labelset[labelset_id].CopyFrom(ls)
     return labels
-
-
-async def _get_labelset_ids_bw_compat(txn: Transaction, *, kbid: str) -> list[str]:
-    labelsets = await _get_labelset_ids(txn, kbid=kbid)
-    if labelsets is not None:
-        return labelsets
-    # TODO: Remove this after migration #11
-    return await _deprecated_scan_labelset_ids(txn, kbid=kbid)
-
-
-async def _deprecated_scan_labelset_ids(txn: Transaction, *, kbid: str) -> list[str]:
-    logger.warning(
-        "Scanning labelset ids. This is not optimal and should have been migrated.", extra={"kbid": kbid}
-    )
-    labelsets = []
-    labels_key = KB_LABELS.format(kbid=kbid)
-    async for key in txn.keys(labels_key, count=-1, include_start=False):
-        lsid = key.split("/")[-1]
-        labelsets.append(lsid)
-    return labelsets
 
 
 async def _get_labelset_ids(txn: Transaction, *, kbid: str) -> Optional[list[str]]:
@@ -80,9 +62,7 @@ async def _add_to_labelset_ids(txn: Transaction, *, kbid: str, labelsets: list[s
     previous = await _get_labelset_ids(txn, kbid=kbid)
     needs_set = False
     if previous is None:
-        # TODO: Remove this after migration #11
         needs_set = True
-        previous = await _deprecated_scan_labelset_ids(txn, kbid=kbid)
     for labelset in labelsets:
         if labelset not in previous:
             needs_set = True
@@ -92,12 +72,11 @@ async def _add_to_labelset_ids(txn: Transaction, *, kbid: str, labelsets: list[s
 
 
 async def _delete_from_labelset_ids(txn: Transaction, *, kbid: str, labelsets: list[str]) -> None:
-    needs_set = False
     previous = await _get_labelset_ids(txn, kbid=kbid)
     if previous is None:
-        # TODO: Remove this after migration #11
-        needs_set = True
-        previous = await _deprecated_scan_labelset_ids(txn, kbid=kbid)
+        # Nothing to delete
+        return
+    needs_set = False
     for labelset in labelsets:
         if labelset in previous:
             needs_set = True

--- a/nucliadb/src/nucliadb/common/datamanagers/labels.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/labels.py
@@ -63,7 +63,7 @@ async def _add_to_labelset_ids(txn: Transaction, *, kbid: str, labelsets: list[s
     previous = await _get_labelset_ids(txn, kbid=kbid)
     if previous is not None:
         updated.update(previous)
-    if set(previous or {}) != updated:
+    if previous is None or previous != updated:
         await _set_labelset_ids(txn, kbid=kbid, labelsets=list(updated))
 
 


### PR DESCRIPTION
### Description
We don't need to scan anymore as we've been materializing the list of labelset ids for a long time now

### How was this PR tested?
existing tests and local tests
