### PR TITLE
Use new entities field in FieldMetadata

### DIFF
--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -500,9 +500,9 @@ class ResourceBrain:
                 )
         # Data Augmentation + Processor entities
         for data_augmentation_task_id, entities in metadata.entities.items():
-            for entity in entities.entities:
-                entity_text = entity.text
-                entity_label = entity.label
+            for ent in entities.entities:
+                entity_text = ent.text
+                entity_label = ent.label
                 # Seems like we don't care about where the entity is in the text
                 # entity_positions = entity.positions
                 labels["e"].add(

--- a/nucliadb/src/nucliadb/ingest/orm/brain.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain.py
@@ -498,7 +498,30 @@ class ResourceBrain:
                         to=relation_node_label,
                     )
                 )
+        # Data Augmentation + Processor entities
+        for data_augmentation_task_id, entities in metadata.entities.items():
+            for entity in entities.entities:
+                entity_text = entity.text
+                entity_label = entity.label
+                # Seems like we don't care about where the entity is in the text
+                # entity_positions = entity.positions
+                labels["e"].add(
+                    f"{entity_label}/{entity_text}"
+                )  # Add data_augmentation_task_id as a prefix?
+                relation_node_entity = RelationNode(
+                    value=entity_text,
+                    ntype=RelationNode.NodeType.ENTITY,
+                    subtype=entity_label,
+                )
+                rel = Relation(
+                    relation=Relation.ENTITY,
+                    source=relation_node_document,
+                    to=relation_node_entity,
+                )
+                self.brain.relations.append(rel)
 
+        # Legacy processor entities
+        # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
         for klass_entity, _ in metadata.positions.items():
             labels["e"].add(klass_entity)
             entity_array = klass_entity.split("/")

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -690,9 +690,6 @@ class Resource:
                 break
 
     async def _apply_field_computed_metadata(self, field_metadata: FieldComputedMetadataWrapper):
-        import pdb
-
-        pdb.set_trace()
         assert self.basic is not None
         maybe_update_basic_summary(self.basic, field_metadata.metadata.metadata.summary)
 

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -24,7 +24,9 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Type, Union
+
 from google.protobuf.internal.containers import ScalarMap
+
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -690,6 +690,9 @@ class Resource:
                 break
 
     async def _apply_field_computed_metadata(self, field_metadata: FieldComputedMetadataWrapper):
+        import pdb
+
+        pdb.set_trace()
         assert self.basic is not None
         maybe_update_basic_summary(self.basic, field_metadata.metadata.metadata.summary)
 

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -23,9 +23,7 @@ import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from typing import TYPE_CHECKING, Any, AsyncIterator, Optional, Type, Union
-
-from google.protobuf.internal.containers import ScalarMap
+from typing import TYPE_CHECKING, Any, AsyncIterator, MutableMapping, Optional, Type
 
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG
@@ -1258,9 +1256,7 @@ def extract_field_metadata_languages(
     return list(languages)
 
 
-def _update_entities_dict(
-    target_entites_dict: Union[dict[str, str], ScalarMap[str, str]], field_metadata: FieldMetadata
-):
+def _update_entities_dict(target_entites_dict: MutableMapping[str, str], field_metadata: FieldMetadata):
     """
     Update the entities dict with the entities from the field metadata.
     Method created to ease the transition from legacy ner field to new entities field.
@@ -1268,12 +1264,12 @@ def _update_entities_dict(
     # Data Augmentation + Processor entities
     # This will overwrite entities detected from more than one data augmentation task
     # TODO: Change TrainMetadata proto to accept multiple entities with the same text
-    ents = {
+    entity_map = {
         entity.text: entity.label
         for data_augmentation_task_id, entities_wrapper in field_metadata.entities.items()
         for entity in entities_wrapper.entities
     }
-    target_entites_dict.update(ents)
+    target_entites_dict.update(entity_map)
 
     # Legacy processor entities
     # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -70,6 +70,7 @@ async def set_resource_field_extracted_data(
     shortened_metadata_wanted = ExtractedDataTypeName.SHORTENED_METADATA in wanted_extracted_data
     if metadata_wanted or shortened_metadata_wanted:
         data_fcm = await field.get_field_metadata()
+
         if data_fcm is not None:
             field_data.metadata = models.FieldComputedMetadata.from_message(
                 data_fcm, shortened=shortened_metadata_wanted and not metadata_wanted

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -70,7 +70,6 @@ async def set_resource_field_extracted_data(
     shortened_metadata_wanted = ExtractedDataTypeName.SHORTENED_METADATA in wanted_extracted_data
     if metadata_wanted or shortened_metadata_wanted:
         data_fcm = await field.get_field_metadata()
-
         if data_fcm is not None:
             field_data.metadata = models.FieldComputedMetadata.from_message(
                 data_fcm, shortened=shortened_metadata_wanted and not metadata_wanted

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -413,6 +413,12 @@ async def extend_prompt_context_with_ner(context, kbid, text_block_ids: list[Tex
             field = await resource.get_field(fid.key, fid.pb_type, load=False)
             fcm = await field.get_field_metadata()
             if fcm is not None:
+                # Data Augmentation + Processor entities
+                for data_aumgentation_task_id, entities_wrapper in fcm.metadata.entities.items():
+                    for entity in entities_wrapper.entities:
+                        ners.setdefault(entity.label, set()).add(entity.text)
+                # Legacy processor entities
+                # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
                 for token, family in fcm.metadata.ner.items():
                     ners.setdefault(family, set()).add(token)
         return _id, ners

--- a/nucliadb/src/nucliadb/train/generators/token_classifier.py
+++ b/nucliadb/src/nucliadb/train/generators/token_classifier.py
@@ -139,6 +139,36 @@ async def get_field_text(
     field_metadata = await field_obj.get_field_metadata()
     # Check computed definition of entities
     if field_metadata is not None:
+        # Data Augmentation + Processor entities
+        for data_augmentation_task_id, entities in field_metadata.metadata.entities.items():
+            for entity in entities.entities:
+                entity_text = entity.text
+                entity_label = entity.label
+                entity_positions = entity.positions
+                if entity_label in valid_entity_groups:
+                    split_ners[MAIN].setdefault(entity_label, {}).setdefault(entity_text, [])
+                    for position in entity_positions:
+                        split_ners[MAIN][entity_label][entity_text].append(
+                            (position.start, position.end)
+                        )
+
+        for split, split_metadata in field_metadata.split_metadata.items():
+            for data_augmentation_task_id, entities in split_metadata.entities.items():
+                for entity in entities.entities:
+                    entity_text = entity.text
+                    entity_label = entity.label
+                    entity_positions = entity.positions
+                    if entity_label in valid_entity_groups:
+                        split_ners.setdefault(split, {}).setdefault(entity_label, {}).setdefault(
+                            entity_text, []
+                        )
+                        for position in entity_positions:
+                            split_ners[split][entity_label][entity_text].append(
+                                (position.start, position.end)
+                            )
+
+        # Legacy processor entities
+        # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
         for entity_key, positions in field_metadata.metadata.positions.items():
             entities = entity_key.split("/")
             entity_group = entities[0]

--- a/nucliadb/tests/ingest/fixtures.py
+++ b/nucliadb/tests/ingest/fixtures.py
@@ -388,7 +388,7 @@ def make_field_metadata(field_id):
     ex1.metadata.metadata.last_summary.FromDatetime(datetime.now())
     ex1.metadata.metadata.thumbnail.CopyFrom(THUMBNAIL)
     # Data Augmentation + Processor entities
-    ex1.metadata.metadata.entities["my-task-id"].entities.extend(
+    ex1.metadata.metadata.entities["processor"].entities.extend(
         [
             rpb.FieldEntity(
                 text="document",
@@ -397,11 +397,14 @@ def make_field_metadata(field_id):
             ),
         ]
     )
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    ex1.metadata.metadata.positions["ENTITY/document"].entity = "document"
-    ex1.metadata.metadata.positions["ENTITY/document"].position.extend(
-        [rpb.Position(start=0, end=5), rpb.Position(start=13, end=18)]
+    ex1.metadata.metadata.entities["my-task-id"].entities.extend(
+        [
+            rpb.FieldEntity(
+                text="document",
+                label="NOUN",
+                positions=[rpb.Position(start=0, end=5), rpb.Position(start=13, end=18)],
+            ),
+        ]
     )
     return ex1
 
@@ -523,14 +526,12 @@ def broker_resource(
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
-    # Data Augmentation + Processor entities
     fcm.metadata.metadata.entities["processor"].entities.extend(
         [rpb.FieldEntity(text="Ramon", label="PERSON")]
     )
-
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    fcm.metadata.metadata.ner["Ramon"] = "PERSON"
+    fcm.metadata.metadata.entities["my-data-augmentation"].entities.extend(
+        [rpb.FieldEntity(text="Ramon", label="CTO")]
+    )
 
     c1 = rpb.Classification()
     c1.label = "label1"

--- a/nucliadb/tests/ingest/fixtures.py
+++ b/nucliadb/tests/ingest/fixtures.py
@@ -387,6 +387,18 @@ def make_field_metadata(field_id):
     ex1.metadata.metadata.last_extract.FromDatetime(datetime.now())
     ex1.metadata.metadata.last_summary.FromDatetime(datetime.now())
     ex1.metadata.metadata.thumbnail.CopyFrom(THUMBNAIL)
+    # Data Augmentation + Processor entities
+    ex1.metadata.metadata.entities["my-task-id"].entities.extend(
+        [
+            rpb.FieldEntity(
+                text="document",
+                label="ENTITY",
+                positions=[rpb.Position(start=0, end=5), rpb.Position(start=13, end=18)],
+            ),
+        ]
+    )
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     ex1.metadata.metadata.positions["ENTITY/document"].entity = "document"
     ex1.metadata.metadata.positions["ENTITY/document"].position.extend(
         [rpb.Position(start=0, end=5), rpb.Position(start=13, end=18)]
@@ -511,6 +523,13 @@ def broker_resource(
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
+    # Data Augmentation + Processor entities
+    fcm.metadata.metadata.entities["processor"].entities.extend(
+        [rpb.FieldEntity(text="Ramon", label="PERSON")]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     fcm.metadata.metadata.ner["Ramon"] = "PERSON"
 
     c1 = rpb.Classification()

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -50,6 +50,7 @@ from nucliadb_protos.resources_pb2 import (
     ExtractedVectorsWrapper,
     FieldComputedMetadata,
     FieldComputedMetadataWrapper,
+    FieldEntity,
     FieldID,
     FieldMetadata,
     FieldQuestionAnswerWrapper,
@@ -59,7 +60,6 @@ from nucliadb_protos.resources_pb2 import (
     Origin,
     Paragraph,
     QuestionAnswer,
-    FieldEntity,
 )
 from nucliadb_protos.resources_pb2 import Metadata as PBMetadata
 from nucliadb_protos.utils_pb2 import Vector, VectorObject, Vectors

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -59,6 +59,7 @@ from nucliadb_protos.resources_pb2 import (
     Origin,
     Paragraph,
     QuestionAnswer,
+    FieldEntity,
 )
 from nucliadb_protos.resources_pb2 import Metadata as PBMetadata
 from nucliadb_protos.utils_pb2 import Vector, VectorObject, Vectors
@@ -166,6 +167,13 @@ async def test_ingest_messages_autocommit(kbid: str, processor):
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
+    # Data Augmentation + Processor entities
+    fcm.metadata.metadata.entities["processor"].entities.extend(
+        [FieldEntity(text="Ramon", label="PERSON")]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     fcm.metadata.metadata.ner["Ramon"] = "PERSON"
 
     c1 = Classification()

--- a/nucliadb/tests/ingest/integration/ingest/test_relations.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_relations.py
@@ -25,10 +25,10 @@ from nucliadb.ingest import SERVICE_NAME
 from nucliadb_protos.resources_pb2 import (
     Classification,
     FieldComputedMetadataWrapper,
+    FieldEntity,
     FieldID,
     FieldText,
     FieldType,
-    FieldEntity,
 )
 from nucliadb_protos.utils_pb2 import Relation, RelationNode
 from nucliadb_protos.writer_pb2 import BrokerMessage

--- a/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
@@ -29,12 +29,12 @@ from nucliadb_protos.resources_pb2 import (
     Classification,
     FieldComputedMetadata,
     FieldComputedMetadataWrapper,
+    FieldEntity,
     FieldID,
     FieldType,
     Paragraph,
     Position,
     Sentence,
-    FieldEntity,
 )
 from nucliadb_utils.storages.storage import Storage
 

--- a/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
@@ -34,6 +34,7 @@ from nucliadb_protos.resources_pb2 import (
     Paragraph,
     Position,
     Sentence,
+    FieldEntity,
 )
 from nucliadb_utils.storages.storage import Storage
 
@@ -58,10 +59,22 @@ async def test_create_resource_orm_metadata(
     p1.classifications.append(cl1)
     ex1.metadata.metadata.paragraphs.append(p1)
     ex1.metadata.metadata.classifications.append(cl1)
-    ex1.metadata.metadata.ner["Ramon"] = "PEOPLE"
     ex1.metadata.metadata.last_index.FromDatetime(datetime.now())
     ex1.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     ex1.metadata.metadata.last_extract.FromDatetime(datetime.now())
+    # Data Augmentation + Processor entities
+    ex1.metadata.metadata.entities["my-task-id"].entities.extend(
+        [
+            FieldEntity(
+                text="Ramon",
+                label="PEOPLE",
+                positions=[Position(start=0, end=5), Position(start=23, end=28)],
+            )
+        ]
+    )
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
+    ex1.metadata.metadata.ner["Ramon"] = "PEOPLE"
     ex1.metadata.metadata.positions["document"].entity = "Ramon"
     ex1.metadata.metadata.positions["document"].position.extend(
         [Position(start=0, end=5), Position(start=23, end=28)]
@@ -97,7 +110,15 @@ async def test_create_resource_orm_metadata_split(
     p1.classifications.append(cl1)
     ex1.metadata.split_metadata["ff1"].paragraphs.append(p1)
     ex1.metadata.split_metadata["ff1"].classifications.append(cl1)
+    # Data Augmentation + Processor entities
+    ex1.metadata.split_metadata["ff1"].entities["processor"].entities.extend(
+        [FieldEntity(text="Ramon", label="PERSON")]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     ex1.metadata.split_metadata["ff1"].ner["Ramon"] = "PEOPLE"
+
     ex1.metadata.split_metadata["ff1"].last_index.FromDatetime(datetime.now())
     ex1.metadata.split_metadata["ff1"].last_understanding.FromDatetime(datetime.now())
     ex1.metadata.split_metadata["ff1"].last_extract.FromDatetime(datetime.now())

--- a/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
@@ -72,13 +72,6 @@ async def test_create_resource_orm_metadata(
             )
         ]
     )
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    ex1.metadata.metadata.ner["Ramon"] = "PEOPLE"
-    ex1.metadata.metadata.positions["document"].entity = "Ramon"
-    ex1.metadata.metadata.positions["document"].position.extend(
-        [Position(start=0, end=5), Position(start=23, end=28)]
-    )
 
     field_obj: Text = await r.get_field(ex1.field.field, ex1.field.field_type, load=False)
     await field_obj.set_field_metadata(ex1)
@@ -110,14 +103,9 @@ async def test_create_resource_orm_metadata_split(
     p1.classifications.append(cl1)
     ex1.metadata.split_metadata["ff1"].paragraphs.append(p1)
     ex1.metadata.split_metadata["ff1"].classifications.append(cl1)
-    # Data Augmentation + Processor entities
     ex1.metadata.split_metadata["ff1"].entities["processor"].entities.extend(
         [FieldEntity(text="Ramon", label="PERSON")]
     )
-
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    ex1.metadata.split_metadata["ff1"].ner["Ramon"] = "PEOPLE"
 
     ex1.metadata.split_metadata["ff1"].last_index.FromDatetime(datetime.now())
     ex1.metadata.split_metadata["ff1"].last_understanding.FromDatetime(datetime.now())
@@ -138,7 +126,9 @@ async def test_create_resource_orm_metadata_split(
     p1.classifications.append(cl1)
     ex2.metadata.split_metadata["ff2"].paragraphs.append(p1)
     ex2.metadata.split_metadata["ff2"].classifications.append(cl1)
-    ex2.metadata.split_metadata["ff2"].ner["Ramon"] = "PEOPLE"
+    ex1.metadata.split_metadata["ff1"].entities["processor"].entities.extend(
+        [FieldEntity(text="Ramon", label="PEOPLE")]
+    )
     ex2.metadata.split_metadata["ff2"].last_index.FromDatetime(datetime.now())
     ex2.metadata.split_metadata["ff2"].last_understanding.FromDatetime(datetime.now())
     ex2.metadata.split_metadata["ff2"].last_extract.FromDatetime(datetime.now())

--- a/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
@@ -447,7 +447,7 @@ async def test_generate_index_message_contains_all_metadata(
         assert field in fields_to_be_found
         fields_to_be_found.remove(field)
         assert text.text == "MyText"
-        assert {"/l/labelset1/label1", "/e/ENTITY/document", "e/NOUN/document"}.issubset(
+        assert {"/l/labelset1/label1", "/e/ENTITY/document", "/e/NOUN/document"}.issubset(
             set(text.labels)
         )
         if field in ("u/link", "t/text1"):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
@@ -369,7 +369,11 @@ async def test_generate_broker_message(
     lfcm = [fcm for fcm in bm.field_metadata if fcm.field.field == "link1"][0]
     assert lfcm.metadata.metadata.links[0] == "https://nuclia.com"
     assert len(lfcm.metadata.metadata.paragraphs) == 1
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     assert len(lfcm.metadata.metadata.positions) == 1
+    # Add this check when processor sends the entities in the new format
+    # assert len(lfcm.metadata.metadata.entities) == 1
     assert lfcm.metadata.metadata.HasField("last_index")
     assert lfcm.metadata.metadata.HasField("last_understanding")
     assert lfcm.metadata.metadata.HasField("last_extract")

--- a/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
@@ -369,11 +369,9 @@ async def test_generate_broker_message(
     lfcm = [fcm for fcm in bm.field_metadata if fcm.field.field == "link1"][0]
     assert lfcm.metadata.metadata.links[0] == "https://nuclia.com"
     assert len(lfcm.metadata.metadata.paragraphs) == 1
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    assert len(lfcm.metadata.metadata.positions) == 1
-    # Add this check when processor sends the entities in the new format
-    # assert len(lfcm.metadata.metadata.entities) == 1
+    assert len(lfcm.metadata.metadata.entities["processor"].entities) == 1
+    assert len(lfcm.metadata.metadata.entities["my-task-id"].entities) == 1
+
     assert lfcm.metadata.metadata.HasField("last_index")
     assert lfcm.metadata.metadata.HasField("last_understanding")
     assert lfcm.metadata.metadata.HasField("last_extract")
@@ -449,7 +447,9 @@ async def test_generate_index_message_contains_all_metadata(
         assert field in fields_to_be_found
         fields_to_be_found.remove(field)
         assert text.text == "MyText"
-        assert {"/l/labelset1/label1", "/e/ENTITY/document"}.issubset(set(text.labels))
+        assert {"/l/labelset1/label1", "/e/ENTITY/document", "e/NOUN/document"}.issubset(
+            set(text.labels)
+        )
         if field in ("u/link", "t/text1"):
             assert "/e/Location/My home" in text.labels
 

--- a/nucliadb/tests/nucliadb/integration/search/test_filters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters.py
@@ -37,6 +37,7 @@ from nucliadb_protos.resources_pb2 import (
     Position,
     TokenSplit,
     UserFieldMetadata,
+    FieldEntity,
 )
 from nucliadb_protos.utils_pb2 import Vector
 from nucliadb_protos.writer_pb2_grpc import WriterStub
@@ -115,9 +116,17 @@ def broker_message_with_entities(kbid):
     fmw = FieldComputedMetadataWrapper()
     fmw.field.CopyFrom(field)
     family, entity = EntityLabels.DETECTED.split("/")
-    fmw.metadata.metadata.ner[entity] = family
     pos = Position(start=60, end=64)
+    # Data Augmentation + Processor entities
+    fmw.metadata.metadata.entities["my-task-id"].entities.extend(
+        [
+            FieldEntity(text=entity, label=family, positions=[pos]),
+        ]
+    )
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     fmw.metadata.metadata.positions[EntityLabels.DETECTED].position.append(pos)
+    fmw.metadata.metadata.ner[entity] = family
 
     par1 = Paragraph()
     par1.start = 0

--- a/nucliadb/tests/nucliadb/integration/search/test_filters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters.py
@@ -123,10 +123,6 @@ def broker_message_with_entities(kbid):
             FieldEntity(text=entity, label=family, positions=[pos]),
         ]
     )
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    fmw.metadata.metadata.positions[EntityLabels.DETECTED].position.append(pos)
-    fmw.metadata.metadata.ner[entity] = family
 
     par1 = Paragraph()
     par1.start = 0

--- a/nucliadb/tests/nucliadb/integration/search/test_filters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters.py
@@ -30,6 +30,7 @@ from nucliadb_protos.resources_pb2 import (
     ExtractedTextWrapper,
     ExtractedVectorsWrapper,
     FieldComputedMetadataWrapper,
+    FieldEntity,
     FieldID,
     FieldType,
     Paragraph,
@@ -37,7 +38,6 @@ from nucliadb_protos.resources_pb2 import (
     Position,
     TokenSplit,
     UserFieldMetadata,
-    FieldEntity,
 )
 from nucliadb_protos.utils_pb2 import Vector
 from nucliadb_protos.writer_pb2_grpc import WriterStub

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -343,7 +343,7 @@ async def test_extracted_shortened_metadata(
     fcmw.metadata.metadata.relations.append(relations)
     fcmw.metadata.split_metadata["split"].relations.append(relations)
 
-    # Data Augmentation + Processor entities
+    # Add some ners with position
     fcmw.metadata.metadata.entities["my-task-id"].entities.extend(
         [
             rpb.FieldEntity(text="Barcelona", label="CITY", positions=[rpb.Position(start=1, end=2)]),
@@ -354,17 +354,6 @@ async def test_extracted_shortened_metadata(
             rpb.FieldEntity(text="Barcelona", label="CITY", positions=[rpb.Position(start=1, end=2)]),
         ]
     )
-
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    # Add some ners
-    ner = {"Barcelona": "CITY/Barcelona"}
-    fcmw.metadata.metadata.ner.update(ner)
-    fcmw.metadata.split_metadata["split"].ner.update(ner)
-    # Add some positions
-    position = rpb.Position(start=1, end=2)
-    fcmw.metadata.metadata.positions["foo"].position.append(position)
-    fcmw.metadata.split_metadata["split"].positions["foo"].position.append(position)
 
     # Add some classification
     classification = rpb.Classification(label="foo", labelset="bar")

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -343,11 +343,24 @@ async def test_extracted_shortened_metadata(
     fcmw.metadata.metadata.relations.append(relations)
     fcmw.metadata.split_metadata["split"].relations.append(relations)
 
+    # Data Augmentation + Processor entities
+    fcmw.metadata.metadata.entities["my-task-id"].entities.extend(
+        [
+            rpb.FieldEntity(text="Barcelona", label="CITY", positions=[rpb.Position(start=1, end=2)]),
+        ]
+    )
+    fcmw.metadata.split_metadata["split"].entities["my-task-id"].entities.extend(
+        [
+            rpb.FieldEntity(text="Barcelona", label="CITY", positions=[rpb.Position(start=1, end=2)]),
+        ]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     # Add some ners
     ner = {"Barcelona": "CITY/Barcelona"}
     fcmw.metadata.metadata.ner.update(ner)
     fcmw.metadata.split_metadata["split"].ner.update(ner)
-
     # Add some positions
     position = rpb.Position(start=1, end=2)
     fcmw.metadata.metadata.positions["foo"].position.append(position)

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -344,12 +344,12 @@ async def test_extracted_shortened_metadata(
     fcmw.metadata.split_metadata["split"].relations.append(relations)
 
     # Add some ners with position
-    fcmw.metadata.metadata.entities["my-task-id"].entities.extend(
+    fcmw.metadata.metadata.entities["processor"].entities.extend(
         [
             rpb.FieldEntity(text="Barcelona", label="CITY", positions=[rpb.Position(start=1, end=2)]),
         ]
     )
-    fcmw.metadata.split_metadata["split"].entities["my-task-id"].entities.extend(
+    fcmw.metadata.split_metadata["split"].entities["processor"].entities.extend(
         [
             rpb.FieldEntity(text="Barcelona", label="CITY", positions=[rpb.Position(start=1, end=2)]),
         ]
@@ -364,6 +364,7 @@ async def test_extracted_shortened_metadata(
 
     await inject_message(nucliadb_grpc, br)
 
+    # TODO: Remove ner and positions once fields are removed
     cropped_fields = ["ner", "positions", "relations", "classifications"]
 
     # Check that when 'shortened_metadata' in extracted param fields are cropped

--- a/nucliadb/tests/nucliadb/integration/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/test_labels.py
@@ -117,14 +117,9 @@ def broker_resource(knowledgebox: str) -> BrokerMessage:
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
-    # Data Augmentation + Processor entities
     fcm.metadata.metadata.entities["processor"].entities.extend(
         [rpb.FieldEntity(text="Ramon", label="PERSON")]
     )
-
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    fcm.metadata.metadata.ner["Ramon"] = "PERSON"
 
     fcm.metadata.metadata.classifications.append(c1)
 

--- a/nucliadb/tests/nucliadb/integration/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/test_labels.py
@@ -117,7 +117,15 @@ def broker_resource(knowledgebox: str) -> BrokerMessage:
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
+    # Data Augmentation + Processor entities
+    fcm.metadata.metadata.entities["processor"].entities.extend(
+        [rpb.FieldEntity(text="Ramon", label="PERSON")]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     fcm.metadata.metadata.ner["Ramon"] = "PERSON"
+
     fcm.metadata.metadata.classifications.append(c1)
 
     bm.field_metadata.append(fcm)

--- a/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
+++ b/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
@@ -318,6 +318,13 @@ async def _inject_broker_message(nucliadb_grpc: WriterStub, kbid: str, rid: str,
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
+    # Data Augmentation + Processor entities
+    fcm.metadata.metadata.entities["processor"].entities.extend(
+        [rpb.FieldEntity(text="Ramon", label="PERSON")]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     fcm.metadata.metadata.ner["Ramon"] = "PERSON"
 
     c1 = rpb.Classification()

--- a/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
+++ b/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
@@ -318,14 +318,9 @@ async def _inject_broker_message(nucliadb_grpc: WriterStub, kbid: str, rid: str,
     fcm.metadata.metadata.last_index.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_understanding.FromDatetime(datetime.now())
     fcm.metadata.metadata.last_extract.FromDatetime(datetime.now())
-    # Data Augmentation + Processor entities
     fcm.metadata.metadata.entities["processor"].entities.extend(
         [rpb.FieldEntity(text="Ramon", label="PERSON")]
     )
-
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    fcm.metadata.metadata.ner["Ramon"] = "PERSON"
 
     c1 = rpb.Classification()
     c1.label = "label1"

--- a/nucliadb/tests/reader/integration/api/v1/test_reader_resource.py
+++ b/nucliadb/tests/reader/integration/api/v1/test_reader_resource.py
@@ -314,4 +314,15 @@ async def test_get_resource_extracted_metadata(nucliadb_reader: AsyncClient, tes
 
     resource = resp.json()
     metadata = resource["data"]["texts"]["text1"]["extracted"]["metadata"]["metadata"]
+
+    # Check that the processor entity is in the legacy metadata
+    # TODO: Remove once deprecated fields are removed
     assert metadata["positions"]["ENTITY/document"]["entity"] == "document"
+    # Check that we recieved entities in the new fields
+    assert metadata["entities"]["processor"]["entities"][0]["text"] == "document"
+    assert metadata["entities"]["processor"]["entities"][0]["label"] == "ENTITY"
+    assert len(metadata["entities"]["processor"]["entities"][0]["positions"]) == 2
+
+    assert metadata["entities"]["my-task-id"]["entities"][0]["text"] == "document"
+    assert metadata["entities"]["my-task-id"]["entities"][0]["label"] == "NOUN"
+    assert len(metadata["entities"]["my-task-id"]["entities"][0]["positions"]) == 2

--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -419,14 +419,9 @@ async def test_extend_prompt_context_with_metadata():
     resource.get_basic = AsyncMock(return_value=basic)
     field = mock.Mock()
     fcm = rpb2.FieldComputedMetadata()
-    # Data Augmentation + Processor entities
     fcm.metadata.entities["processor"].entities.extend(
         [rpb2.FieldEntity(text="Barcelona", label="LOCATION")]
     )
-
-    # Legacy processor entities
-    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-    fcm.metadata.ner.update({"Barcelona": "LOCATION"})
 
     field.get_field_metadata = AsyncMock(return_value=fcm)
     resource.get_field = AsyncMock(return_value=field)

--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -419,7 +419,15 @@ async def test_extend_prompt_context_with_metadata():
     resource.get_basic = AsyncMock(return_value=basic)
     field = mock.Mock()
     fcm = rpb2.FieldComputedMetadata()
+    # Data Augmentation + Processor entities
+    fcm.metadata.entities["processor"].entities.extend(
+        [rpb2.FieldEntity(text="Barcelona", label="LOCATION")]
+    )
+
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     fcm.metadata.ner.update({"Barcelona": "LOCATION"})
+
     field.get_field_metadata = AsyncMock(return_value=fcm)
     resource.get_field = AsyncMock(return_value=field)
     resource.get_extra = AsyncMock(return_value=extra)

--- a/nucliadb/tests/train/fixtures.py
+++ b/nucliadb/tests/train/fixtures.py
@@ -37,12 +37,12 @@ from nucliadb_protos.knowledgebox_pb2 import EntitiesGroup, Label, LabelSet
 from nucliadb_protos.resources_pb2 import (
     ExtractedTextWrapper,
     FieldComputedMetadataWrapper,
+    FieldEntity,
     FieldID,
     FieldType,
     Paragraph,
     Position,
     Sentence,
-    FieldEntity,
 )
 from nucliadb_protos.writer_pb2 import BrokerMessage, SetEntitiesRequest
 from nucliadb_protos.writer_pb2_grpc import WriterStub

--- a/nucliadb/tests/train/fixtures.py
+++ b/nucliadb/tests/train/fixtures.py
@@ -42,6 +42,7 @@ from nucliadb_protos.resources_pb2 import (
     Paragraph,
     Position,
     Sentence,
+    FieldEntity,
 )
 from nucliadb_protos.writer_pb2 import BrokerMessage, SetEntitiesRequest
 from nucliadb_protos.writer_pb2_grpc import WriterStub
@@ -189,6 +190,15 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
     fcmw.metadata.metadata.paragraphs.append(p1)
     fcmw.metadata.metadata.paragraphs.append(p2)
 
+    # Data Augmentation + Processor entities
+    fcmw.metadata.metadata.entities["my-task-id"].entities.extend(
+        [
+            FieldEntity(text="Barcelona", label="CITY", positions=[Position(start=43, end=52)]),
+            FieldEntity(text="Manresa", label="CITY"),
+        ]
+    )
+    # Legacy processor entities
+    # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
     # Add a ner with positions
     fcmw.metadata.metadata.ner.update(
         {
@@ -198,6 +208,7 @@ def broker_processed_resource(knowledgebox, number, rid) -> BrokerMessage:
     )
     fcmw.metadata.metadata.positions["CITY/Barcelona"].entity = "Barcelona"
     fcmw.metadata.metadata.positions["CITY/Barcelona"].position.append(Position(start=43, end=52))
+
     message2.field_metadata.append(fcmw)
 
     etw = ExtractedTextWrapper()

--- a/nucliadb/tests/utils/broker_messages/fields.py
+++ b/nucliadb/tests/utils/broker_messages/fields.py
@@ -146,7 +146,20 @@ class FieldBuilder:
         )
         self._user_metadata.token.append(entity)
 
-    def with_extracted_entity(self, klass: str, name: str, *, positions: list[rpb.Position]):
+    def with_extracted_entity(
+        self,
+        klass: str,
+        name: str,
+        *,
+        positions: list[rpb.Position],
+        data_augmentation_task_id: str = "processor",
+    ):
+        # Data Augmentation + Processor entities
+        self._extracted_metadata.metadata.metadata.entities[data_augmentation_task_id].entities.append(
+            rpb.FieldEntity(text=name, label=klass)
+        )
+        # Legacy processor entities
+        # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
         entity = self._extracted_metadata.metadata.metadata.positions[f"{klass}/{name}"]
         entity.entity = name
         entity.position.extend(positions)

--- a/nucliadb/tests/utils/broker_messages/fields.py
+++ b/nucliadb/tests/utils/broker_messages/fields.py
@@ -154,15 +154,9 @@ class FieldBuilder:
         positions: list[rpb.Position],
         data_augmentation_task_id: str = "processor",
     ):
-        # Data Augmentation + Processor entities
         self._extracted_metadata.metadata.metadata.entities[data_augmentation_task_id].entities.append(
-            rpb.FieldEntity(text=name, label=klass)
+            rpb.FieldEntity(text=name, label=klass, positions=positions)
         )
-        # Legacy processor entities
-        # TODO: Remove once processor doesn't use this anymore and remove the positions and ner fields from the message
-        entity = self._extracted_metadata.metadata.metadata.positions[f"{klass}/{name}"]
-        entity.entity = name
-        entity.position.extend(positions)
 
     def with_user_paragraph_labels(self, key: str, labelset: str, labels: list[str]):
         classifications = labels_to_classifications(labelset, labels)

--- a/nucliadb_models/src/nucliadb_models/extracted.py
+++ b/nucliadb_models/src/nucliadb_models/extracted.py
@@ -167,7 +167,7 @@ class FieldComputedMetadata(BaseModel):
         cls,
         message: resources_pb2.FieldComputedMetadata,
     ) -> None:
-        large_fields = ["ner", "relations", "positions", "classifications"]
+        large_fields = ["ner", "relations", "positions", "classifications", "entities"]
         for field in large_fields:
             message.metadata.ClearField(field)  # type: ignore
         for metadata in message.split_metadata.values():


### PR DESCRIPTION
### Description
* Adds ingestion of entities in FieldMetadata through the new field with fallback to the legacy field
* Sets the stage to deprecate the use of the fields `ner` and `positions`
* Keeps resource API backwards compatibility

The changes are compatible with
- current state (processor entities in legacy field + data augmentation entities in new)
- processor entities in both new and legacy fields 
- using only the new fields

### How was this PR tested?
Modified existing tests and fixtures to use the new field. Extended ingestion tests to test that data augmentation entities were being ingested
