### PR TITLE
Charts: Use `serviceAccountName` in pod spec instead of deprecated `serviceAccount`

### DIFF
--- a/charts/nidx/templates/indexer-deploy.yaml
+++ b/charts/nidx/templates/indexer-deploy.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirst
-      serviceAccount: {{ .Values.indexer.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.indexer.serviceAccount | default "default" }}
       containers:
       - name: nidx-indexer
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nidx/templates/scheduler-deploy.yaml
+++ b/charts/nidx/templates/scheduler-deploy.yaml
@@ -55,7 +55,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirst
-      serviceAccount: {{ .Values.scheduler.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.scheduler.serviceAccount | default "default" }}
       containers:
       - name: nidx-scheduler
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nidx/templates/searcher-deploy.yaml
+++ b/charts/nidx/templates/searcher-deploy.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirst
-      serviceAccount: {{ .Values.searcher.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.searcher.serviceAccount | default "default" }}
       containers:
       - name: nidx-searcher
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nidx/templates/worker-deploy.yaml
+++ b/charts/nidx/templates/worker-deploy.yaml
@@ -49,7 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirst
-      serviceAccount: {{ .Values.worker.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.worker.serviceAccount | default "default" }}
       containers:
       - name: nidx-worker
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb/templates/sts.yaml
+++ b/charts/nucliadb/templates/sts.yaml
@@ -46,7 +46,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount:  {{ .Values.serviceAccount | default "default" }}
+      serviceAccountName:  {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: app
         image: "{{ .Values.image }}:{{ .Values.imageVersion | default .Chart.AppVersion }}"

--- a/charts/nucliadb_ingest/templates/_cronjob_purge.tpl
+++ b/charts/nucliadb_ingest/templates/_cronjob_purge.tpl
@@ -38,7 +38,7 @@ spec:
 {{ toYaml .Values.extra_pod_annotations | indent 12 }}
             {{- end }}
         spec:
-          serviceAccount: {{ ((.Values.purgeCron).serviceAccount) | default "default" }}
+          serviceAccountName: {{ ((.Values.purgeCron).serviceAccount) | default "default" }}
           nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 12 }}
           topologySpreadConstraints:

--- a/charts/nucliadb_ingest/templates/exporter.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/exporter.deploy.yaml
@@ -49,7 +49,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ ((.Values.exporter).serviceAccount) | default "default" }}
+      serviceAccountName: {{ ((.Values.exporter).serviceAccount) | default "default" }}
       containers:
       - name: metrics-exporter
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-orm-grpc.deploy.yaml
@@ -46,7 +46,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ ((.Values.ingest_orm_grpc).serviceAccount) | default "default" }}
+      serviceAccountName: {{ ((.Values.ingest_orm_grpc).serviceAccount) | default "default" }}
       containers:
       - name: ingest-orm-grpc
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-processed-consumer.deploy.yaml
@@ -43,7 +43,7 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
-      serviceAccount: {{ ((.Values.ingest_processed_consumer).serviceAccount) | default "default" }}
+      serviceAccountName: {{ ((.Values.ingest_processed_consumer).serviceAccount) | default "default" }}
       dnsPolicy: ClusterFirst
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}

--- a/charts/nucliadb_ingest/templates/ingest-subscriber-workers.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/ingest-subscriber-workers.deploy.yaml
@@ -47,7 +47,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ ((.Values.ingest_subscriber_workers).serviceAccount) | default "default" }}
+      serviceAccountName: {{ ((.Values.ingest_subscriber_workers).serviceAccount) | default "default" }}
       containers:
       - name: ingest-subscriber-workers
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -58,7 +58,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ ((.Values.ingest).serviceAccount) | default "default" }}
+      serviceAccountName: {{ ((.Values.ingest).serviceAccount) | default "default" }}
       containers:
       - name: ingest
         securityContext:

--- a/charts/nucliadb_ingest/templates/migrator.deploy.yaml
+++ b/charts/nucliadb_ingest/templates/migrator.deploy.yaml
@@ -49,7 +49,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount:  {{ ((.Values.migrator).serviceAccount) | default "default" }}
+      serviceAccountName:  {{ ((.Values.migrator).serviceAccount) | default "default" }}
       containers:
       - name: migrator
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_ingest/templates/rebalance.cronjob.yaml
+++ b/charts/nucliadb_ingest/templates/rebalance.cronjob.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml .Values.extra_pod_annotations | indent 12 }}
             {{- end }}
         spec:
-          serviceAccount: {{ ((.Values.purgeCron).serviceAccount) | default "default" }}
+          serviceAccountName: {{ ((.Values.purgeCron).serviceAccount) | default "default" }}
           nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 12 }}
           topologySpreadConstraints:

--- a/charts/nucliadb_node/templates/node.replicas.deploy.yaml
+++ b/charts/nucliadb_node/templates/node.replicas.deploy.yaml
@@ -91,7 +91,7 @@ spec:
 {{ toYaml $values.readReplicas.tolerations | indent 8 }}
 {{- end }}
       dnsPolicy: ClusterFirst
-      serviceAccount:  {{ (($values.readReplicas).serviceAccount) | default "default" }}
+      serviceAccountName:  {{ (($values.readReplicas).serviceAccount) | default "default" }}
       volumes:
       - name: data-dir
         emptyDir:

--- a/charts/nucliadb_node/templates/node.sts.yaml
+++ b/charts/nucliadb_node/templates/node.sts.yaml
@@ -56,7 +56,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ .Values.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.serviceAccount | default "default" }}
 {{- if .Values.nats.secretName }}
       volumes:
       - name: nats-creds

--- a/charts/nucliadb_reader/templates/reader.deploy.yaml
+++ b/charts/nucliadb_reader/templates/reader.deploy.yaml
@@ -45,7 +45,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ .Values.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: reader
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_search/templates/search.deploy.yaml
+++ b/charts/nucliadb_search/templates/search.deploy.yaml
@@ -45,7 +45,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ .Values.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: search
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_train/templates/train.deploy.yaml
+++ b/charts/nucliadb_train/templates/train.deploy.yaml
@@ -45,7 +45,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ .Values.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: train
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"

--- a/charts/nucliadb_writer/templates/writer.deploy.yaml
+++ b/charts/nucliadb_writer/templates/writer.deploy.yaml
@@ -45,7 +45,7 @@ spec:
 {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
 {{- end }}
-      serviceAccount: {{ .Values.serviceAccount | default "default" }}
+      serviceAccountName: {{ .Values.serviceAccount | default "default" }}
       containers:
       - name: writer
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"


### PR DESCRIPTION
### Description
Replaces `serviceAccount` with `serviceAccountName` in all helm templates. The original `serviceAccount`field in pod spec is now deprecated: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podspec-v1-core


### How was this PR tested?
Describe how you tested this PR.
