### PR TITLE
Safer vectorset creation

### DIFF
--- a/nucliadb/src/nucliadb/writer/vectorsets.py
+++ b/nucliadb/src/nucliadb/writer/vectorsets.py
@@ -47,10 +47,6 @@ from nucliadb_telemetry import errors
 from nucliadb_utils.utilities import get_storage
 
 
-class EmbeddingNotFound(Exception):
-    pass
-
-
 async def add(kbid: str, vectorset_id: str) -> None:
     # First off, add the vectorset to the learning configuration if it's not already there
     lconfig = await learning_proxy.get_configuration(kbid)


### PR DESCRIPTION
### Description
When creating a vectorset, make sure any previous async deletion keys are removed.

This is a corner case but it is to make that if the user does:
1- create vectorset A
2- delete vectorset A
3- create vectorset A

the purge doesn't end up deleting all vectors after step 3.

### How was this PR tested?
Describe how you tested this PR.
