### PR TITLE
Update GHA to Ubuntu 24

### DIFF
--- a/.github/workflows/_build-img-nucliadb.yml
+++ b/.github/workflows/_build-img-nucliadb.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   build-img:
     name: Build image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       imageid: ${{ steps.build-image.outputs.imageid }}
       digest: ${{ steps.build-image.outputs.digest }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository
@@ -33,8 +33,8 @@ jobs:
 
     - uses: actions/checkout@master
       with:
-        persist-credentials: false 
-        fetch-depth: 0 
+        persist-credentials: false
+        fetch-depth: 0
 
     - run: python bump.py --sem=${{ inputs.semType }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   # Pre-checks
   format-rust:
     name: "Pre-checks: Rust code Format"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: rustfmt
@@ -26,7 +26,7 @@ jobs:
 
   clippy-rust:
     name: "Pre-checks: Clippy lint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add clippy
@@ -36,7 +36,7 @@ jobs:
 
   nidx-format-rust:
     name: "nidx: Rust code Format"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: rustfmt
@@ -44,7 +44,7 @@ jobs:
 
   nidx-clippy-rust:
     name: "nidx: Clippy lint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add clippy
@@ -58,7 +58,7 @@ jobs:
 
   updated-protos:
     name: "Pre-checks: Protos up-to-date"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: write-all
     needs:
       - build-virtual-env
@@ -82,7 +82,7 @@ jobs:
 
   pre-checks-python:
     name: "Pre-checks: Python lint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-virtual-env
     steps:
@@ -108,7 +108,7 @@ jobs:
 
   lint-helm:
     name: Lint all helm charts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -126,7 +126,7 @@ jobs:
 
   check-licenses:
     name: Check Licenses
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Check License Header
@@ -140,7 +140,7 @@ jobs:
           command: check licenses
 
   check-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-virtual-env
     steps:
@@ -161,7 +161,7 @@ jobs:
   # Builds
   build-node-binaries:
     name: Build node binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -175,7 +175,7 @@ jobs:
 
   build-virtual-env:
     name: Build virtual environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -195,7 +195,7 @@ jobs:
   # Tests
   sidecar-tests:
     name: Sidecar tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-node-binaries
       - build-virtual-env
@@ -234,7 +234,7 @@ jobs:
 
   nucliadb-search-tests:
     name: NucliaDB search tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-node-binaries
       - build-virtual-env
@@ -276,7 +276,7 @@ jobs:
 
   node-rust-tests:
     name: Node Rust tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -285,7 +285,7 @@ jobs:
 
   nidx-tests:
     name: nidx tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:15
@@ -313,7 +313,7 @@ jobs:
 
   nucliadb-tests:
     name: NucliaDB tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-virtual-env
     strategy:
@@ -359,7 +359,7 @@ jobs:
 
   nucliadb-components-tests:
     name: NucliaDB components tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-virtual-env
     strategy:
@@ -401,7 +401,7 @@ jobs:
 
   python-packages-tests:
     name: Python packages tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-virtual-env
     strategy:
@@ -445,7 +445,7 @@ jobs:
   # Depends on all tests to pass
   ci-passed:
     name: CI passed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - format-rust
       - clippy-rust

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build-node-image:
     name: Build node image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
 
   upload-chart-nucliadb-shared:
     name: Deploy nucliadb shared
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Generate a token
       id: app-token
@@ -137,7 +137,7 @@ jobs:
 
   upload-chart-nucliadb-node:
     name: Upload Node chart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-python-images
       - build-node-image
@@ -206,7 +206,7 @@ jobs:
 
   upload-charts-nucliadb-component:
     name: Upload NucliaDB component charts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version_number: ${{ steps.version_step.outputs.version_number }}
     needs:
@@ -283,7 +283,7 @@ jobs:
 
   upload-chart-nidx:
     name: Upload nidx chart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: inputs.environment == 'dev'
     needs:
       - build-nidx-image
@@ -351,7 +351,7 @@ jobs:
 
   deploy-nucliadb-components:
     name: Deploy NucliaDB components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !failure() && !cancelled() }}
     needs:
       - upload-chart-nucliadb-shared

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
     # Chart configuration: e2e/conf/chart.values.yaml
     #
     name: E2E Kubernetes Cluster Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nucliadb_node_release.yml
+++ b/.github/workflows/nucliadb_node_release.yml
@@ -119,7 +119,7 @@ jobs:
   list-pypi-files:
     needs: [build]
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
 
   release:
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push'
 
     steps:

--- a/.github/workflows/public_release.yml
+++ b/.github/workflows/public_release.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   release:
     name: Tag and release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -94,7 +94,7 @@ jobs:
 
   tag-stable:
     name: Tag current latest as stable
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push'
 
     steps:
@@ -123,7 +123,7 @@ jobs:
 
   docs:
     name: 'Upload API specs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push'
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build_wheels:
     name: Build wheels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Generate a token
@@ -80,7 +80,7 @@ jobs:
 
   push-docker:
     name: Build and push nucliadb docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -123,7 +123,7 @@ jobs:
 
   deploy:
     name: Deploy Helm chart and trigger internal CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: push-docker
 
     steps:

--- a/Dockerfile.node_prebuilt
+++ b/Dockerfile.node_prebuilt
@@ -4,7 +4,7 @@
 # For a version that compiles the binaries inside docker, see `Dockerfile.node`
 #
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 ENV DATA_PATH=data
 ENV RUST_LOG=nucliadb_node=DEBUG


### PR DESCRIPTION
This is happening: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

Better to update before we are forced to :)

This is specially relevant since we do the hack of compiling rust binaries in the GHA runner and the moving them inside the docker container, which requires that runner and dockerfile base image are somewhat synchronized (they need to have a compatible glibc version).