### PR TITLE
Add CI check for oldest supported python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,34 @@ jobs:
           done
           exit $ERROR
 
+  pre-checks-python-old:
+    name: "Pre-checks: Python lint 3.9"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Set up PDM
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: "3.9.20"
+          cache: true
+      - name: Install venv
+        run: pdm sync -d --clean --no-editable
+      - name: Upload virtualenv to cache
+        uses: actions/cache/save@v4
+        with:
+          path: .venv
+          key: venv-${{ github.sha }}
+
+      - name: Lint source code
+        run: |
+          source .venv/bin/activate
+          for package in nucliadb nucliadb_utils nucliadb_telemetry nucliadb_sdk nucliadb_dataset nucliadb_models nucliadb_sidecar nucliadb_node_binding nucliadb_performance
+          do
+              make -C $package lint || ERROR=1
+          done
+          exit $ERROR
+
   lint-helm:
     name: Lint all helm charts
     runs-on: ubuntu-24.04
@@ -460,6 +488,7 @@ jobs:
       - nucliadb-tests
       - nucliadb-components-tests
       - python-packages-tests
+      - pre-checks-python-old
     steps:
       - name: CI passed
         run: echo "CI passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,10 @@ jobs:
           cache: true
       - name: Install venv
         run: pdm sync -d --clean --no-editable
+      - name: Clean build
+        run: find . -name build | xargs rm -r || true
       - name: Lint source code
         run: |
-          rm -r build
           source .venv/bin/activate
           for package in nucliadb nucliadb_utils nucliadb_telemetry nucliadb_sdk nucliadb_dataset nucliadb_models nucliadb_sidecar nucliadb_node_binding nucliadb_performance
           do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,9 @@ jobs:
           cache: true
       - name: Install venv
         run: pdm sync -d --clean --no-editable
-      - name: Upload virtualenv to cache
-        uses: actions/cache/save@v4
-        with:
-          path: .venv
-          key: venv-${{ github.sha }}
-
       - name: Lint source code
         run: |
+          rm -r build
           source .venv/bin/activate
           for package in nucliadb nucliadb_utils nucliadb_telemetry nucliadb_sdk nucliadb_dataset nucliadb_models nucliadb_sidecar nucliadb_node_binding nucliadb_performance
           do


### PR DESCRIPTION
Lint Python with the oldest supported version (3.9) so we don't accidentally break backwards compatibility.