### PR TITLE
Don't push to chart museum

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,6 @@ jobs:
       run: |-
         helm lint charts/nucliadb_shared
         helm package charts/nucliadb_shared
-        curl --data-binary "@nucliadb_shared-${{ steps.version_step.outputs.version_number }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
         helm push nucliadb_shared-${{ steps.version_step.outputs.version_number }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
   upload-chart-nucliadb-node:
@@ -201,7 +200,6 @@ jobs:
         run: |-
           helm lint charts/nucliadb_node
           helm package charts/nucliadb_node
-          curl --data-binary "@nucliadb_node-${{ steps.version_step.outputs.version_number }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
           helm push nucliadb_node-${{ steps.version_step.outputs.version_number }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
   upload-charts-nucliadb-component:
@@ -278,7 +276,6 @@ jobs:
         run: |-
           helm lint charts/nucliadb_${{ matrix.component }}
           helm package charts/nucliadb_${{ matrix.component }}
-          curl --data-binary "@nucliadb_${{ matrix.component }}-${{ steps.version_step.outputs.version_number }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
           helm push nucliadb_${{ matrix.component }}-${{ steps.version_step.outputs.version_number }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
   upload-chart-nidx:
@@ -346,7 +343,6 @@ jobs:
         run: |-
           helm lint charts/nidx
           helm package charts/nidx
-          curl --data-binary "@nidx-${{ steps.version_step.outputs.version_number }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
           helm push nidx-${{ steps.version_step.outputs.version_number }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
   deploy-nucliadb-components:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,6 @@ jobs:
         run: |-
           helm lint charts/nucliadb
           helm package charts/nucliadb
-          curl --data-binary "@nucliadb-${{ steps.version_step.outputs.helm_version }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
           helm push nucliadb-${{ steps.version_step.outputs.helm_version }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
       - name: Send to promotion queue


### PR DESCRIPTION
This pull request involves updates to the deployment and release workflows, specifically changing the method of uploading Helm charts to an artifact registry. The changes remove the `curl` commands used to upload the charts and replace them with `helm push` commands.

### Updates to deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L135): Removed `curl` commands and replaced them with `helm push` for uploading `nucliadb_shared` Helm charts.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L204): Removed `curl` commands and replaced them with `helm push` for uploading `nucliadb_node` Helm charts.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L281): Removed `curl` commands and replaced them with `helm push` for uploading Helm charts for components specified by a matrix.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L349): Removed `curl` commands and replaced them with `helm push` for uploading `nidx` Helm charts.

### Updates to release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L193): Removed `curl` commands and replaced them with `helm push` for uploading `nucliadb` Helm charts.### Description
Describe the proposed changes made in this PR.

