### PR TITLE
Index only upon processing message received

### DIFF
--- a/nucliadb/src/nucliadb/common/external_index_providers/base.py
+++ b/nucliadb/src/nucliadb/common/external_index_providers/base.py
@@ -168,7 +168,6 @@ class ExternalIndexManager(abc.ABC, metaclass=abc.ABCMeta):
         Indexes a resource to the external index provider.
         """
         if not self.supports_rollover and to_rollover_indexes:
-            self.clean_index_message(resource_data)
             logger.info(
                 "Indexing to rollover indexes not supported",
                 extra={
@@ -192,19 +191,8 @@ class ExternalIndexManager(abc.ABC, metaclass=abc.ABCMeta):
                 await self._index_resource(
                     resource_uuid, resource_data, to_rollover_indexes=to_rollover_indexes
                 )
-                self.clean_index_message(resource_data)
             except Exception as ex:
                 raise ExternalIndexingError() from ex
-
-    def clean_index_message(self, index_message: Resource) -> None:
-        """
-        Clear the fields that are already stored in the external index,
-        and we don't want to store them again in the IndexNode cluster.
-        """
-        index_message.ClearField("sentences_to_delete")
-        index_message.ClearField("paragraphs_to_delete")
-        index_message.ClearField("paragraphs")
-        index_message.ClearField("relations")
 
     async def get_index_counts(self) -> IndexCounts:
         """

--- a/nucliadb/src/nucliadb/ingest/orm/processor/__init__.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/__init__.py
@@ -386,12 +386,14 @@ class Processor:
         Typically, we only index a resource when we receive the broker message coming from its processing.
         However, there are some exceptions to this rule:
         - If the message is coming from the writer and has some entity annotations
+        - If the message is coming from the writer and has security information
         """
         message_from_processing = message.source == writer_pb2.BrokerMessage.MessageSource.PROCESSOR
         has_entity_annotations = any(
             len(field_metadata.token) > 0 for field_metadata in message.basic.fieldmetadata
         )
-        return message_from_processing or has_entity_annotations
+        has_security = message.HasField("security")
+        return message_from_processing or has_entity_annotations or has_security
 
     @processor_observer.wrap({"type": "index_resource"})
     async def index_resource(

--- a/nucliadb/tests/nucliadb/integration/test_entities.py
+++ b/nucliadb/tests/nucliadb/integration/test_entities.py
@@ -175,7 +175,7 @@ async def annotated_entities(
         assert retries < 10, "Broker message indexing took too much, might be a test error"
 
         # small sleep to give time for indexing
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.2)
         retries += 1
 
 
@@ -205,9 +205,9 @@ async def entities(
 ):
     """Single fixture to get entities injected in different ways."""
     # Ensure entities are properly stored/indexed
-    await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "cat")
-    await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "dolphin")
-    await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "bird")
+    await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "cat", timeout=2)
+    await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "dolphin", timeout=2)
+    await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "bird", timeout=2)
 
 
 @pytest.mark.asyncio

--- a/nucliadb/tests/nucliadb/integration/test_find.py
+++ b/nucliadb/tests/nucliadb/integration/test_find.py
@@ -48,8 +48,6 @@ async def test_find_with_label_changes(
     assert resp.status_code == 201
     rid = resp.json()["uuid"]
 
-    await asyncio.sleep(1)
-
     # should get 1 result
     resp = await nucliadb_reader.post(
         f"/kb/{knowledgebox}/find",

--- a/nucliadb/tests/utils/entities.py
+++ b/nucliadb/tests/utils/entities.py
@@ -68,7 +68,7 @@ async def wait_until_entity(
             GetEntitiesGroupRequest(kb=KnowledgeBoxID(uuid=kbid), group=group)
         )
         found = entity in response.group.entities
-        assert time.time() - start < timeout, "Timeout while waiting for entity {group}/{entity}"
+        assert time.time() - start < timeout, f"Timeout while waiting for entity {group}/{entity}"
 
         if not found:
             await asyncio.sleep(0.1)


### PR DESCRIPTION
### Description
We no longer need to index anything when ingesting writer messages, as the catalog is responsible for showing the title and the labels to the user after an upload/resource creation request is finished.

Also, when a kb is configured with an external index provider, we no longer need to index on our index either.

### How was this PR tested?
Describe how you tested this PR.
