### PR TITLE
Cleaner indexing

### DIFF
--- a/nucliadb/src/nucliadb/common/external_index_providers/base.py
+++ b/nucliadb/src/nucliadb/common/external_index_providers/base.py
@@ -168,7 +168,6 @@ class ExternalIndexManager(abc.ABC, metaclass=abc.ABCMeta):
         Indexes a resource to the external index provider.
         """
         if not self.supports_rollover and to_rollover_indexes:
-            self.clean_index_message(resource_data)
             logger.info(
                 "Indexing to rollover indexes not supported",
                 extra={
@@ -192,19 +191,8 @@ class ExternalIndexManager(abc.ABC, metaclass=abc.ABCMeta):
                 await self._index_resource(
                     resource_uuid, resource_data, to_rollover_indexes=to_rollover_indexes
                 )
-                self.clean_index_message(resource_data)
             except Exception as ex:
                 raise ExternalIndexingError() from ex
-
-    def clean_index_message(self, index_message: Resource) -> None:
-        """
-        Clear the fields that are already stored in the external index,
-        and we don't want to store them again in the IndexNode cluster.
-        """
-        index_message.ClearField("sentences_to_delete")
-        index_message.ClearField("paragraphs_to_delete")
-        index_message.ClearField("paragraphs")
-        index_message.ClearField("relations")
 
     async def get_index_counts(self) -> IndexCounts:
         """

--- a/nucliadb/src/nucliadb/ingest/orm/processor/__init__.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/__init__.py
@@ -28,6 +28,7 @@ import nats.js.errors
 from nucliadb.common import datamanagers, locking
 from nucliadb.common.cluster.settings import settings as cluster_settings
 from nucliadb.common.cluster.utils import get_shard_manager
+from nucliadb.common.external_index_providers.base import ExternalIndexManager
 from nucliadb.common.external_index_providers.manager import get_external_index_manager
 from nucliadb.common.maindb.driver import Driver, Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, MaindbServerError
@@ -188,11 +189,14 @@ class Processor:
                     shard = await kb.get_resource_shard(shard_id)
                     if shard is None:
                         raise AttributeError("Shard not available")
-                    await self._maybe_external_index_delete_resource(message.kbid, uuid)
                     await pgcatalog_delete(txn, message.kbid, uuid)
-                    await self.index_node_shard_manager.delete_resource(
-                        shard, message.uuid, seqid, partition, message.kbid
-                    )
+                    external_index_manager = await get_external_index_manager(kbid=message.kbid)
+                    if external_index_manager is not None:
+                        await self.external_index_delete_resource(external_index_manager, uuid)
+                    else:
+                        await self.index_node_shard_manager.delete_resource(
+                            shard, message.uuid, seqid, partition, message.kbid
+                        )
                     try:
                         await kb.delete_resource(message.uuid)
                     except Exception as exc:
@@ -281,6 +285,7 @@ class Processor:
                         resource.replace_indexer(await resource.generate_index_message(reindex=True))
 
                 if resource and resource.modified:
+                    await pgcatalog_update(txn, kbid, resource)
                     await self.index_resource(  # noqa
                         resource=resource,
                         txn=txn,
@@ -291,7 +296,6 @@ class Processor:
                         kb=kb,
                         source=messages_source(messages),
                     )
-
                     if transaction_check:
                         await sequence_manager.set_last_seqid(txn, partition, seqid)
                     await txn.commit()
@@ -373,6 +377,34 @@ class Processor:
 
         return None
 
+    async def get_or_assign_resource_shard(
+        self, txn: Transaction, kb: KnowledgeBox, uuid: str
+    ) -> writer_pb2.ShardObject:
+        kbid = kb.kbid
+        async with locking.distributed_lock(
+            locking.RESOURCE_INDEX_LOCK.format(kbid=kbid, resource_id=uuid)
+        ):
+            # we need to have a lock at indexing time because we don't know if
+            # a resource was move to another shard while it was being indexed
+            shard_id = await datamanagers.resources.get_resource_shard_id(txn, kbid=kbid, rid=uuid)
+
+        shard = None
+        if shard_id is not None:
+            # Resource already has a shard assigned
+            shard = await kb.get_resource_shard(shard_id)
+            if shard is None:
+                raise AttributeError("Shard not available")
+        else:
+            # It's a new resource, get KB's current active shard to place new resource on
+            shard = await self.index_node_shard_manager.get_current_active_shard(txn, kbid)
+            if shard is None:
+                # No current shard available, create a new one
+                shard = await self.index_node_shard_manager.create_shard_by_kbid(txn, kbid)
+            await datamanagers.resources.set_resource_shard_id(
+                txn, kbid=kbid, rid=uuid, shard=shard.shard
+            )
+        return shard
+
     @processor_observer.wrap({"type": "index_resource"})
     async def index_resource(
         self,
@@ -386,32 +418,12 @@ class Processor:
         source: nodewriter_pb2.IndexMessageSource.ValueType,
     ) -> None:
         validate_indexable_resource(resource.indexer.brain)
-
-        async with locking.distributed_lock(
-            locking.RESOURCE_INDEX_LOCK.format(kbid=kbid, resource_id=uuid)
-        ):
-            # we need to have a lock at indexing time because we don't know if
-            # a resource was move to another shard while it was being indexed
-            shard_id = await datamanagers.resources.get_resource_shard_id(txn, kbid=kbid, rid=uuid)
-
-        shard = None
-        if shard_id is not None:
-            shard = await kb.get_resource_shard(shard_id)
-
-        if shard is None:
-            # It's a new resource, get current active shard to place
-            # new resource on
-            shard = await self.index_node_shard_manager.get_current_active_shard(txn, kbid)
-            if shard is None:
-                # no shard available, create a new one
-                shard = await self.index_node_shard_manager.create_shard_by_kbid(txn, kbid)
-            await datamanagers.resources.set_resource_shard_id(
-                txn, kbid=kbid, rid=uuid, shard=shard.shard
-            )
-
-        if shard is not None:
-            index_message = resource.indexer.brain
-            await self._maybe_external_index_add_resource(kbid, uuid, index_message)
+        shard = await self.get_or_assign_resource_shard(txn, kb, uuid)
+        index_message = resource.indexer.brain
+        external_index_manager = await get_external_index_manager(kbid=kbid)
+        if external_index_manager is not None:
+            await self.external_index_add_resource(external_index_manager, uuid, index_message)
+        else:
             await self.index_node_shard_manager.add_resource(
                 shard,
                 index_message,
@@ -421,51 +433,56 @@ class Processor:
                 source=source,
             )
 
-            await pgcatalog_update(txn, kbid, resource)
-        else:
-            raise AttributeError("Shard is not available")
-
-    async def _maybe_external_index_delete_resource(self, kbid: str, resource_uuid: str):
-        external_index_manager = await get_external_index_manager(kbid=kbid)
-        if external_index_manager is None:
+    async def external_index_delete_resource(
+        self, external_index_manager: ExternalIndexManager, resource_uuid: str
+    ):
+        if self.should_skip_external_index(external_index_manager):
+            logger.warning(
+                "Skipping external index delete resource",
+                extra={
+                    "kbid": external_index_manager.kbid,
+                    "rid": resource_uuid,
+                    "provider": external_index_manager.type.value,
+                },
+            )
             return
         await external_index_manager.delete_resource(resource_uuid=resource_uuid)
 
-    async def _maybe_external_index_add_resource(
+    def should_skip_external_index(self, external_index_manager: ExternalIndexManager) -> bool:
+        """
+        This is a safety measure to skip external indexing in case that the external index provider is not working.
+        As we don't want to block the ingestion pipeline, this is a temporary measure until we implement async consumers
+        to index to external indexes.
+        """
+        kbid = external_index_manager.kbid
+        provider_type = external_index_manager.type.value
+        return has_feature(
+            const.Features.SKIP_EXTERNAL_INDEX,
+            context={"kbid": kbid, "provider": provider_type},
+            default=False,
+        )
+
+    async def external_index_add_resource(
         self,
-        kbid: str,
+        external_index_manager: ExternalIndexManager,
         resource_uuid: str,
         index_message: PBBrainResource,
     ):
         if not has_vectors_operation(index_message):
             return
-
-        external_index_manager = await get_external_index_manager(kbid=kbid)
-        if external_index_manager is None:
-            # No external index manager, nothing to do
-            return
-
-        provider_type = external_index_manager.type.value
-        if has_feature(
-            const.Features.SKIP_EXTERNAL_INDEX,
-            context={"kbid": kbid, "provider": provider_type},
-            default=False,
-        ):
-            # This is a safety measure to skip external indexing in case that the external index provider is not working.
-            # As we don't want to block the ingestion pipeline, this is a temporary measure until we implement async consumers
-            # to index to external indexes.
+        if self.should_skip_external_index(external_index_manager):
             logger.warning(
                 "Skipping external index for resource",
                 extra={
-                    "kbid": kbid,
+                    "kbid": external_index_manager.kbid,
                     "rid": resource_uuid,
-                    "provider": provider_type,
+                    "provider": external_index_manager.type.value,
                 },
             )
-        else:
-            await external_index_manager.index_resource(
-                resource_uuid=resource_uuid, resource_data=index_message
-            )
+            return
+        await external_index_manager.index_resource(
+            resource_uuid=resource_uuid, resource_data=index_message
+        )
 
     async def multi(self, message: writer_pb2.BrokerMessage, seqid: int) -> None:
         self.messages.setdefault(message.multiid, []).append(message)

--- a/nucliadb/src/nucliadb/ingest/service/writer.py
+++ b/nucliadb/src/nucliadb/ingest/service/writer.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import uuid
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator
 
 from nucliadb.common import datamanagers
 from nucliadb.common.cluster.exceptions import AlreadyExists, EntitiesGroupNotFound
@@ -26,6 +26,7 @@ from nucliadb.common.cluster.manager import get_index_nodes
 from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
 from nucliadb.common.external_index_providers.exceptions import ExternalIndexCreationError
+from nucliadb.common.external_index_providers.manager import get_external_index_manager
 from nucliadb.common.maindb.utils import setup_driver
 from nucliadb.ingest import SERVICE_NAME, logger
 from nucliadb.ingest.orm.broker_message import generate_broker_message
@@ -446,32 +447,17 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
                 kbobj = KnowledgeBoxORM(txn, self.storage, request.kbid)
                 resobj = ResourceORM(txn, self.storage, kbobj, request.rid)
                 resobj.disable_vectors = not request.reindex_vectors
-
                 brain = await resobj.generate_index_message(reindex=True)
-                shard_id = await datamanagers.resources.get_resource_shard_id(
-                    txn, kbid=request.kbid, rid=request.rid
-                )
-                shard: Optional[writer_pb2.ShardObject] = None
-                if shard_id is not None:
-                    shard = await kbobj.get_resource_shard(shard_id)
-
-                if shard is None:
-                    shard = await self.shards_manager.get_current_active_shard(txn, request.kbid)
-                    if shard is None:
-                        # no shard currently exists, create one
-                        shard = await self.shards_manager.create_shard_by_kbid(txn, request.kbid)
-
-                    await datamanagers.resources.set_resource_shard_id(
-                        txn, kbid=request.kbid, rid=request.rid, shard=shard.shard
-                    )
-
-                if shard is not None:
-                    index_message = brain.brain
-                    await self.proc._maybe_external_index_add_resource(
+                shard = await self.proc.get_or_assign_resource_shard(txn, kbobj, request.rid)
+                index_message = brain.brain
+                external_index_manager = await get_external_index_manager(kbid=request.kbid)
+                if external_index_manager is not None:
+                    await self.proc.external_index_add_resource(
                         request.kbid,
                         request.rid,
                         index_message,
                     )
+                else:
                     await self.shards_manager.add_resource(
                         shard,
                         index_message,
@@ -480,7 +466,6 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
                         kb=request.kbid,
                         reindex_id=uuid.uuid4().hex,
                     )
-
                 response = IndexStatus()
                 return response
         except Exception as e:

--- a/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
@@ -131,6 +131,7 @@ async def _kb_counters(
         counters.sentences = node_index_counts.sentences
         is_small_kb = node_index_counts.paragraphs < MAX_PARAGRAPHS_FOR_SMALL_KB
         resource_count = await get_resources_count(kbid, force_calculate=is_small_kb)
+        counters.resources = resource_count
     counters.index_size = counters.paragraphs * AVG_PARAGRAPH_SIZE_BYTES
     if debug and queried_shards is not None:
         counters.shards = queried_shards


### PR DESCRIPTION
### Description
- When KB has an external index configured, we no longer need to index also in the node index. The reason for this was to have a catalog implementation, but now have the pg one always ready!
- Isolate shard to resource assignation logic

### How was this PR tested?
Existing tests
