### PR TITLE
Restore credentials type check

### DIFF
--- a/nucliadb/src/nucliadb/writer/tus/gcs.py
+++ b/nucliadb/src/nucliadb/writer/tus/gcs.py
@@ -33,6 +33,7 @@ from urllib.parse import quote_plus
 
 import aiohttp
 import backoff
+import google.auth.compute_engine.credentials  # type: ignore
 import google.auth.transport.requests  # type: ignore
 import google.oauth2.credentials  # type: ignore
 from google.auth.exceptions import DefaultCredentialsError  # type: ignore
@@ -90,7 +91,9 @@ class GCloudBlobStore(BlobStore):
         return {"AUTHORIZATION": f"Bearer {token}"}
 
     def _get_access_token(self):
-        if isinstance(self._credentials, google.oauth2.credentials.Credentials):
+        if isinstance(
+            self._credentials, google.auth.compute_engine.credentials.Credentials
+        ) or isinstance(self._credentials, google.oauth2.credentials.Credentials):
             # google default auth object
             if self._credentials.expired or self._credentials.valid is False:
                 request = google.auth.transport.requests.Request()


### PR DESCRIPTION
I changed the instance check because it was needed for tests and I could not find a reason for this in stage. See https://github.com/nuclia/nucliadb/pull/2629/files#diff-de63ba458edfc7511c8b3b3b820b6606c2aa951ba40487d2b1f2dbadde3b69c0R93

It turns out is needed, so leaving both cases for now. There is probably a better way to do this, but could not find it.