### PR TITLE
Remove legacy rank fusion algorithm from the API

### DIFF
--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -34,9 +34,6 @@ class RankFusion(BaseModel):
     window: int = Field(le=500)
 
 
-class LegacyRankFusion(RankFusion): ...
-
-
 class ReciprocalRankFusion(RankFusion):
     k: float = Field(default=60.0)
     boosting: search_models.ReciprocalRankFusionWeights = Field(

--- a/nucliadb/src/nucliadb/search/search/query_parser/parser.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parser.py
@@ -23,7 +23,6 @@ from pydantic import ValidationError
 
 from nucliadb.search.search.query_parser.exceptions import ParserError
 from nucliadb.search.search.query_parser.models import (
-    LegacyRankFusion,
     MultiMatchBoosterReranker,
     NoopReranker,
     PredictReranker,
@@ -83,15 +82,10 @@ class _FindParser:
         window = min(top_k, 500)
 
         if isinstance(self.item.rank_fusion, search_models.RankFusionName):
-            if self.item.rank_fusion == search_models.RankFusionName.LEGACY:
-                rank_fusion = LegacyRankFusion(window=window)
-            elif self.item.rank_fusion == search_models.RankFusionName.RECIPROCAL_RANK_FUSION:
+            if self.item.rank_fusion == search_models.RankFusionName.RECIPROCAL_RANK_FUSION:
                 rank_fusion = ReciprocalRankFusion(window=window)
             else:
                 raise ParserError(f"Unknown rank fusion algorithm: {self.item.rank_fusion}")
-
-        elif isinstance(self.item.rank_fusion, search_models.LegacyRankFusion):
-            rank_fusion = LegacyRankFusion(window=window)
 
         elif isinstance(self.item.rank_fusion, search_models.ReciprocalRankFusion):
             user_window = self.item.rank_fusion.window

--- a/nucliadb/src/nucliadb/search/search/rank_fusion.py
+++ b/nucliadb/src/nucliadb/search/search/rank_fusion.py
@@ -107,6 +107,16 @@ class LegacyRankFusion(RankFusionAlgorithm):
         return merged
 
 
+class CombSimple(RankFusionAlgorithm):
+    @rank_fusion_observer.wrap({"type": "legacy"})
+    def _fuse(
+        self, keyword: Iterable[TextBlockMatch], semantic: Iterable[TextBlockMatch]
+    ) -> list[TextBlockMatch]:
+        merged = [*keyword, *semantic]
+        merged.sort(key=lambda r: r.score, reverse=True)
+        return merged
+
+
 class ReciprocalRankFusion(RankFusionAlgorithm):
     """Rank-based rank fusion algorithm. Discounts the weight of documents
     occurring deep in retrieved lists using a reciprocal distribution. It can be

--- a/nucliadb/src/nucliadb/search/search/rank_fusion.py
+++ b/nucliadb/src/nucliadb/search/search/rank_fusion.py
@@ -107,16 +107,6 @@ class LegacyRankFusion(RankFusionAlgorithm):
         return merged
 
 
-class CombSimple(RankFusionAlgorithm):
-    @rank_fusion_observer.wrap({"type": "legacy"})
-    def _fuse(
-        self, keyword: Iterable[TextBlockMatch], semantic: Iterable[TextBlockMatch]
-    ) -> list[TextBlockMatch]:
-        merged = [*keyword, *semantic]
-        merged.sort(key=lambda r: r.score, reverse=True)
-        return merged
-
-
 class ReciprocalRankFusion(RankFusionAlgorithm):
     """Rank-based rank fusion algorithm. Discounts the weight of documents
     occurring deep in retrieved lists using a reciprocal distribution. It can be

--- a/nucliadb/src/nucliadb/search/search/rank_fusion.py
+++ b/nucliadb/src/nucliadb/search/search/rank_fusion.py
@@ -186,10 +186,7 @@ def get_rank_fusion(rank_fusion: parser_models.RankFusion) -> RankFusionAlgorith
     algorithm: RankFusionAlgorithm
     window = rank_fusion.window
 
-    if isinstance(rank_fusion, parser_models.LegacyRankFusion):
-        algorithm = LegacyRankFusion(window=window)
-
-    elif isinstance(rank_fusion, parser_models.ReciprocalRankFusion):
+    if isinstance(rank_fusion, parser_models.ReciprocalRankFusion):
         algorithm = ReciprocalRankFusion(
             k=rank_fusion.k,
             window=window,
@@ -199,6 +196,6 @@ def get_rank_fusion(rank_fusion: parser_models.RankFusion) -> RankFusionAlgorith
 
     else:
         logger.error(f"Unknown rank fusion algorithm {type(rank_fusion)}: {rank_fusion}. Using default")
-        algorithm = LegacyRankFusion(window=window)
+        algorithm = ReciprocalRankFusion(window=window)
 
     return algorithm

--- a/nucliadb/tests/nucliadb/integration/search/post_retrieval/test_rank_fusion.py
+++ b/nucliadb/tests/nucliadb/integration/search/post_retrieval/test_rank_fusion.py
@@ -27,7 +27,6 @@ from nucliadb.search.search import find, find_merge
 from nucliadb_models.search import (
     SCORE_TYPE,
     KnowledgeboxFindResults,
-    LegacyRankFusion,
     ReciprocalRankFusion,
     RerankerName,
 )
@@ -36,7 +35,6 @@ from nucliadb_models.search import (
 @pytest.mark.parametrize(
     "rank_fusion,expected_score_types",
     [
-        (LegacyRankFusion().model_dump(), {SCORE_TYPE.BM25}),
         (ReciprocalRankFusion().model_dump(), {SCORE_TYPE.RANK_FUSION}),
     ],
 )

--- a/nucliadb/tests/nucliadb/integration/test_find.py
+++ b/nucliadb/tests/nucliadb/integration/test_find.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 
+from nucliadb.search.search.rank_fusion import LegacyRankFusion
 from nucliadb_models.search import SearchOptions
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from nucliadb_utils.exceptions import LimitsExceededError
@@ -472,15 +473,16 @@ async def test_find_highlight(
 ):
     kbid = philosophy_books_kb
 
-    resp = await nucliadb_reader.post(
-        f"/kb/{kbid}/find",
-        json={
-            "query": "Who was Marcus Aurelius?",
-            "features": ["keyword", "semantic", "relations"],
-            "highlight": True,
-        },
-    )
-    assert resp.status_code == 200
+    with patch("nucliadb.search.search.find.get_rank_fusion", return_value=LegacyRankFusion(window=20)):
+        resp = await nucliadb_reader.post(
+            f"/kb/{kbid}/find",
+            json={
+                "query": "Who was Marcus Aurelius?",
+                "features": ["keyword", "semantic", "relations"],
+                "highlight": True,
+            },
+        )
+        assert resp.status_code == 200
 
     body = resp.json()
     assert len(body["resources"]) == 1

--- a/nucliadb/tests/search/unit/search/test_query_parsing.py
+++ b/nucliadb/tests/search/unit/search/test_query_parsing.py
@@ -40,7 +40,6 @@ def test_find_query_parsing__top_k():
 @pytest.mark.parametrize(
     "rank_fusion,expected",
     [
-        (search_models.RankFusionName.LEGACY, parser_models.LegacyRankFusion(window=20)),
         (
             search_models.RankFusionName.RECIPROCAL_RANK_FUSION,
             parser_models.ReciprocalRankFusion(window=20),

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -45,9 +45,7 @@ from nucliadb_protos.nodereader_pb2 import DocumentScored, ParagraphResult
 @pytest.mark.parametrize(
     "rank_fusion,expected_type",
     [
-        (search_models.RankFusionName.LEGACY, LegacyRankFusion),
         (search_models.RankFusionName.RECIPROCAL_RANK_FUSION, ReciprocalRankFusion),
-        (search_models.LegacyRankFusion(), LegacyRankFusion),
         (search_models.ReciprocalRankFusion(), ReciprocalRankFusion),
     ],
 )

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -365,16 +365,11 @@ class SortOptions(BaseModel):
 
 
 class RankFusionName(str, Enum):
-    LEGACY = "legacy"
     RECIPROCAL_RANK_FUSION = "rrf"
 
 
 class _BaseRankFusion(BaseModel):
     name: str
-
-
-class LegacyRankFusion(_BaseRankFusion):
-    name: Literal[RankFusionName.LEGACY] = RankFusionName.LEGACY
 
 
 class ReciprocalRankFusionWeights(BaseModel):
@@ -409,7 +404,7 @@ This kind of boosting can be useful in multilingual search, for example, where k
 
 
 RankFusion = Annotated[
-    Union[LegacyRankFusion, ReciprocalRankFusion],
+    Union[ReciprocalRankFusion],
     Field(discriminator="name"),
 ]
 
@@ -587,7 +582,7 @@ class SearchParamDefaults:
         description="List of search features to use. Each value corresponds to a lookup into on of the different indexes",
     )
     rank_fusion = ParamDefault(
-        default=RankFusionName.LEGACY,
+        default=RankFusionName.RECIPROCAL_RANK_FUSION,
         title="Rank fusion",
         description="Rank fusion algorithm to use to merge results from multiple retrievers (keyword, semantic)",
     )

--- a/nucliadb_models/tests/test_search.py
+++ b/nucliadb_models/tests/test_search.py
@@ -95,11 +95,8 @@ def test_find_request_fulltext_feature_not_allowed():
 @pytest.mark.parametrize(
     "rank_fusion,expected",
     [
-        ("legacy", search.RankFusionName.LEGACY),
         ("rrf", search.RankFusionName.RECIPROCAL_RANK_FUSION),
-        (search.RankFusionName.LEGACY, search.RankFusionName.LEGACY),
         (search.RankFusionName.RECIPROCAL_RANK_FUSION, search.RankFusionName.RECIPROCAL_RANK_FUSION),
-        (search.LegacyRankFusion(), search.LegacyRankFusion()),
         (search.ReciprocalRankFusion(), search.ReciprocalRankFusion()),
     ],
 )


### PR DESCRIPTION
### Description
Legacy rank fusion was an heuristic built long time ago. We consider RRF better, so this PR changes the default and removes the legacy algorithm from the public API. The algorithm implementation hasn't been removed yet.

### How was this PR tested?
Existing tests
