### PR TITLE
Don't serialize unset values on SDK requests

### DIFF
--- a/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
@@ -182,7 +182,7 @@ def _parse_list_of_pydantic(
     output = []
     for item in data:
         if isinstance(item, BaseModel):
-            output.append(item.model_dump())
+            output.append(item.model_dump(by_alias=True, exclude_defaults=True))
         else:
             output.append(item)
     return orjson.dumps(output).decode("utf-8")
@@ -244,7 +244,7 @@ def _request_builder(
                     if not isinstance(content, request_type):  # type: ignore
                         raise TypeError(f"Expected {request_type}, got {type(content)}")
                     else:
-                        data = content.model_dump_json(by_alias=True)
+                        data = content.model_dump_json(by_alias=True, exclude_defaults=True)
                 except TypeError:
                     if not isinstance(content, list):
                         raise
@@ -255,7 +255,9 @@ def _request_builder(
                 for key in list(kwargs.keys()):
                     if key in request_type.model_fields:  # type: ignore
                         content_data[key] = kwargs.pop(key)
-                data = request_type.model_validate(content_data).model_dump_json(by_alias=True)  # type: ignore
+                data = request_type.model_validate(content_data).model_dump_json(  # type: ignore
+                    by_alias=True, exclude_defaults=True
+                )
         elif is_raw_request_content(content):
             raw_content = content
 

--- a/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
@@ -182,7 +182,7 @@ def _parse_list_of_pydantic(
     output = []
     for item in data:
         if isinstance(item, BaseModel):
-            output.append(item.model_dump(by_alias=True, exclude_defaults=True))
+            output.append(item.model_dump(by_alias=True, exclude_unset=True))
         else:
             output.append(item)
     return orjson.dumps(output).decode("utf-8")
@@ -244,7 +244,7 @@ def _request_builder(
                     if not isinstance(content, request_type):  # type: ignore
                         raise TypeError(f"Expected {request_type}, got {type(content)}")
                     else:
-                        data = content.model_dump_json(by_alias=True, exclude_defaults=True)
+                        data = content.model_dump_json(by_alias=True, exclude_unset=True)
                 except TypeError:
                     if not isinstance(content, list):
                         raise
@@ -256,7 +256,7 @@ def _request_builder(
                     if key in request_type.model_fields:  # type: ignore
                         content_data[key] = kwargs.pop(key)
                 data = request_type.model_validate(content_data).model_dump_json(  # type: ignore
-                    by_alias=True, exclude_defaults=True
+                    by_alias=True, exclude_unset=True
                 )
         elif is_raw_request_content(content):
             raw_content = content

--- a/nucliadb_sdk/tests/test_request_serialization.py
+++ b/nucliadb_sdk/tests/test_request_serialization.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import json
+from unittest.mock import Mock, patch
+
+import nucliadb_sdk
+from nucliadb_models.search import FindRequest, KnowledgeboxFindResults, SearchOptions
+from nucliadb_sdk import Region
+
+
+def test_find_request_serialization() -> None:
+    sdk = nucliadb_sdk.NucliaDB(region=Region.ON_PREM, url="http://fake:8080")
+
+    with patch.object(
+        sdk,
+        "_request",
+        return_value=Mock(content=KnowledgeboxFindResults(resources={}).model_dump_json()),
+    ) as spy:
+        req = FindRequest(query="love", features=[SearchOptions.RELATIONS])
+
+        sdk.find(kbid="kbid", content=req)
+
+        sent = json.loads(spy.call_args.kwargs["data"])
+
+        assert sent == {"query": "love", "features": [SearchOptions.RELATIONS.value]}
+        assert sent == req.model_dump(exclude_unset=True)


### PR DESCRIPTION
### Description
To minimize friction between API changes and SDK versions, this PR removes unset parameters from API calls. This way, only explicitly set values are sent to the server. That way, the server can evolve more flexibly without breaking the SDK.

This could lead to a weird situation where the user can see a default in a model, the server has a differnet one and leaving it unset will use the server one instead of the one in the user's local model. However, as the service is a live API without strong versioning, live documentation should always be the reference.