### PR TITLE
Graceful shutdown

### DIFF
--- a/nidx/Cargo.lock
+++ b/nidx/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "pyo3",
  "tempfile",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/nidx/nidx_binding/Cargo.toml
+++ b/nidx/nidx_binding/Cargo.toml
@@ -14,3 +14,4 @@ nidx_protos = { version = "0.1.0", path = "../nidx_protos" }
 pyo3 = "0.22.0"
 tempfile = "3.14.0"
 tokio = "1.41.1"
+tokio-util = { version = "0.7.12", features = ["io", "io-util", "compat"] }

--- a/nidx/src/api.rs
+++ b/nidx/src/api.rs
@@ -21,17 +21,18 @@
 pub mod grpc;
 pub mod shards;
 
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use crate::{grpc_server::GrpcServer, Settings};
 
-pub async fn run(settings: Settings) -> anyhow::Result<()> {
+pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Result<()> {
     let meta = settings.metadata.clone();
 
     let service = grpc::ApiServer::new(meta).into_service();
     let server = GrpcServer::new("0.0.0.0:10000").await?;
     debug!("Running API at port {}", server.port()?);
-    server.serve(service).await?;
+    server.serve(service, shutdown).await?;
 
     Ok(())
 }

--- a/nidx/src/searcher.rs
+++ b/nidx/src/searcher.rs
@@ -32,6 +32,9 @@ use object_store::DynObjectStore;
 use sync::run_sync;
 use sync::SyncMetadata;
 use tokio::sync::watch;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::*;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -62,25 +65,58 @@ impl SyncedSearcher {
         }
     }
 
-    pub async fn run(&self, storage: Arc<DynObjectStore>, watcher: Option<watch::Sender<SyncStatus>>) {
+    pub async fn run(
+        &self,
+        storage: Arc<DynObjectStore>,
+        shutdown: CancellationToken,
+        watcher: Option<watch::Sender<SyncStatus>>,
+    ) -> anyhow::Result<()> {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1000);
         let index_cache_copy = self.index_cache.clone();
-        let refresher_task = tokio::task::spawn(async move {
-            while let Some(index_id) = rx.recv().await {
-                // TODO: Do something smarter
-                index_cache_copy.remove(&index_id).await;
-            }
-        });
-        let sync_task =
-            tokio::task::spawn(run_sync(self.meta.clone(), storage.clone(), self.sync_metadata.clone(), tx, watcher));
-        tokio::select! {
-            r = sync_task => {
-                println!("sync_task() completed first {:?}", r)
-            }
-            r = refresher_task => {
-                println!("refresher_task() completed first {:?}", r)
+
+        let mut tasks = JoinSet::new();
+        let refresher_task = tasks
+            .spawn(async move {
+                while let Some(index_id) = rx.recv().await {
+                    // TODO: Do something smarter
+                    index_cache_copy.remove(&index_id).await;
+                }
+
+                Ok(())
+            })
+            .id();
+
+        let sync_task = tasks.spawn(run_sync(
+            self.meta.clone(),
+            storage.clone(),
+            self.sync_metadata.clone(),
+            shutdown.clone(),
+            tx,
+            watcher,
+        ));
+        let sync_task_id = sync_task.id();
+
+        while let Some(join_result) = tasks.join_next_with_id().await {
+            let (id, result) = join_result.unwrap();
+            let task_name = if id == refresher_task {
+                "refresher"
+            } else if id == sync_task_id {
+                "sync"
+            } else {
+                unreachable!()
+            };
+            if let Err(e) = result {
+                error!("Task {task_name} exited with error {e:?}");
+                return Err(e);
+            } else {
+                info!("Task {task_name} exited without error");
+                if !shutdown.is_cancelled() {
+                    panic!("Unexpected task termination without graceful shutdown");
+                }
             }
         }
+
+        Ok(())
     }
 
     pub fn index_cache(&self) -> Arc<IndexCache> {
@@ -88,7 +124,7 @@ impl SyncedSearcher {
     }
 }
 
-pub async fn run(settings: Settings) -> anyhow::Result<()> {
+pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Result<()> {
     let work_dir = tempdir()?;
     let meta = settings.metadata.clone();
     let storage = settings.storage.as_ref().expect("Storage settings needed").object_store.clone();
@@ -97,15 +133,29 @@ pub async fn run(settings: Settings) -> anyhow::Result<()> {
 
     let api = grpc::SearchServer::new(meta.clone(), searcher.index_cache());
     let server = GrpcServer::new("0.0.0.0:10001").await?;
-    let api_task = tokio::task::spawn(server.serve(api.into_service()));
-    let search_task = tokio::task::spawn(async move { searcher.run(storage, None).await });
 
-    tokio::select! {
-        r = search_task => {
-            println!("sync_task() completed first {:?}", r)
-        }
-        r = api_task => {
-            println!("api_task() completed first {:?}", r)
+    let mut tasks = JoinSet::new();
+    let api_task = tasks.spawn(server.serve(api.into_service(), shutdown.clone())).id();
+    let shutdown2 = shutdown.clone();
+    let search_task = tasks.spawn(async move { searcher.run(storage, shutdown2, None).await }).id();
+
+    while let Some(join_result) = tasks.join_next_with_id().await {
+        let (id, result) = join_result.unwrap();
+        let task_name = if id == api_task {
+            "searcher_api"
+        } else if id == search_task {
+            "synced_searcher"
+        } else {
+            unreachable!()
+        };
+        if let Err(e) = result {
+            error!("Task {task_name} exited with error {e:?}");
+            return Err(e);
+        } else {
+            info!("Task {task_name} exited without error");
+            if !shutdown.is_cancelled() {
+                panic!("Unexpected task termination without graceful shutdown");
+            }
         }
     }
 

--- a/nidx/tests/synced_searcher.rs
+++ b/nidx/tests/synced_searcher.rs
@@ -32,6 +32,7 @@ use nidx_tests::*;
 use nidx_vector::config::VectorConfig;
 use nidx_vector::VectorSearcher;
 use tempfile::tempdir;
+use tokio_util::sync::CancellationToken;
 
 #[sqlx::test]
 async fn test_synchronization(pool: sqlx::PgPool) -> anyhow::Result<()> {
@@ -42,7 +43,8 @@ async fn test_synchronization(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let synced_searcher = SyncedSearcher::new(meta.clone(), work_dir.path());
     let index_cache = synced_searcher.index_cache();
     let storage_copy = storage.clone();
-    let search_task = tokio::spawn(async move { synced_searcher.run(storage_copy, None).await });
+    let search_task =
+        tokio::spawn(async move { synced_searcher.run(storage_copy, CancellationToken::new(), None).await });
 
     let index = Index::create(
         &meta.pool,


### PR DESCRIPTION
### Description

Graceful shutdown for nidx, per component:

* scheduler: Just quit
* indexer & worker: finish current job and quit
* api: cleanly shutdown http server (finish serving current request, don't accept more)
* searcher: cleanly shutdown http server (same as api). For sync task, finish syncing current index and then quit. Technically we could immediately exit, but the code is much simpler this way, and I don't mind waiting a couple of seconds extra.