### PR TITLE
Nidx atomic indexing

### DIFF
--- a/nidx/nidx_paragraph/src/fuzzy_query.rs
+++ b/nidx/nidx_paragraph/src/fuzzy_query.rs
@@ -179,7 +179,6 @@ pub struct FuzzyTermQuery {
     distance: u8,
     /// Should a transposition cost 1 or 2?
     transposition_cost_one: bool,
-    ///
     prefix: bool,
 }
 

--- a/nidx/nidx_paragraph/src/resource_indexer.rs
+++ b/nidx/nidx_paragraph/src/resource_indexer.rs
@@ -113,9 +113,6 @@ pub fn index_paragraphs(
             let field_uuid = format!("{}/{}", resource.resource.as_ref().unwrap().uuid, field);
             doc.add_text(schema.field_uuid, field_uuid.clone());
 
-            // TODO: Deletion handling
-            // let paragraph_term = Term::from_field_text(schema.paragraph, paragraph_id);
-            // writer.delete_term(paragraph_term);
             writer.add_document(doc)?;
         }
     }

--- a/nidx/nidx_vector/src/data_point/disk_hnsw.rs
+++ b/nidx/nidx_vector/src/data_point/disk_hnsw.rs
@@ -321,15 +321,15 @@ mod tests {
     #[test]
     fn hnsw_deserialize_test() {
         let no_nodes = 3;
-        let cnx0 = vec![vec![(Address(1), 1.0)], vec![(Address(2), 2.0)], vec![(Address(3), 3.0)]];
+        let cnx0 = [vec![(Address(1), 1.0)], vec![(Address(2), 2.0)], vec![(Address(3), 3.0)]];
         let layer0 = RAMLayer {
             out: cnx0.iter().enumerate().map(|(i, c)| (Address(i), c.clone())).collect(),
         };
-        let cnx1 = vec![vec![(Address(1), 4.0)], vec![(Address(2), 5.0)]];
+        let cnx1 = [vec![(Address(1), 4.0)], vec![(Address(2), 5.0)]];
         let layer1 = RAMLayer {
             out: cnx1.iter().enumerate().map(|(i, c)| (Address(i), c.clone())).collect(),
         };
-        let cnx2 = vec![vec![(Address(1), 6.0)]];
+        let cnx2 = [vec![(Address(1), 6.0)]];
         let layer2 = RAMLayer {
             out: cnx2.iter().enumerate().map(|(i, c)| (Address(i), c.clone())).collect(),
         };

--- a/nidx/nidx_vector/src/lib.rs
+++ b/nidx/nidx_vector/src/lib.rs
@@ -78,8 +78,6 @@ impl VectorIndexer {
         config: VectorConfig,
         open_index: impl OpenIndexMetadata<VectorSegmentMeta>,
     ) -> anyhow::Result<VectorSegmentMetadata> {
-        // TODO: Maybe segments should not get a DTrie of deletions and just a hashset of them, and we can handle building that here?
-        // Wait and see how the Tantivy indexes turn out
         let mut delete_log = data_point_provider::DTrie::new();
         for (key, seq) in open_index.deletions() {
             delete_log.insert(key.as_bytes(), seq);

--- a/nidx/src/api/shards.rs
+++ b/nidx/src/api/shards.rs
@@ -39,7 +39,7 @@ pub async fn create_shard(
     let mut tx = meta.transaction().await?;
     let shard = Shard::create(&mut *tx, kbid).await?;
     // TODO: Rename to be closer to API naming? Includes changing DB type, Kind enums, etc.
-    Index::create(&mut *tx, shard.id, "text", IndexConfig::nex_text()).await?;
+    Index::create(&mut *tx, shard.id, "text", IndexConfig::new_text()).await?;
     Index::create(&mut *tx, shard.id, "paragraph", IndexConfig::new_paragraph()).await?;
     Index::create(&mut *tx, shard.id, "relation", IndexConfig::new_relation()).await?;
     for (vectorset_id, config) in vector_configs.into_iter() {
@@ -76,9 +76,7 @@ pub async fn delete_shard(meta: &NidxMetadata, shard_id: Uuid) -> NidxResult<()>
 pub async fn delete_vectorset(meta: &NidxMetadata, shard_id: Uuid, vectorset: &str) -> NidxResult<()> {
     let mut tx = meta.transaction().await?;
 
-    // TODO: query to check how many vector indexes we have left
-    let count =
-        Index::for_shard(&mut *tx, shard_id).await?.iter().filter(|index| index.kind == IndexKind::Vector).count();
+    let count = Index::for_shard(&mut *tx, shard_id).await?.iter().filter(|i| i.kind == IndexKind::Vector).count();
     if count <= 1 {
         return Err(NidxError::InvalidRequest("Can't delete the last vectorset".to_string()));
     }

--- a/nidx/src/indexer.rs
+++ b/nidx/src/indexer.rs
@@ -166,6 +166,8 @@ pub async fn download_message(storage: Arc<DynObjectStore>, storage_key: &str) -
     Ok(resource)
 }
 
+type IndexingResult = (Segment, usize, Vec<String>);
+
 #[instrument(skip_all)]
 pub async fn index_resource(
     meta: &NidxMetadata,
@@ -184,7 +186,7 @@ pub async fn index_resource(
     let num_vector_indexes = indexes.iter().filter(|i| matches!(i.kind, IndexKind::Vector)).count();
     let single_vector_index = num_vector_indexes == 1;
 
-    let mut tasks: JoinSet<anyhow::Result<Option<(Segment, usize, Vec<String>)>>> = JoinSet::new();
+    let mut tasks: JoinSet<anyhow::Result<Option<IndexingResult>>> = JoinSet::new();
     for index in indexes {
         let resource = Arc::clone(&resource);
         let meta = meta.clone();

--- a/nidx/src/indexer.rs
+++ b/nidx/src/indexer.rs
@@ -119,8 +119,6 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
             warn!(?e, "Error acking index message");
             continue;
         }
-
-        // TODO: Delete indexer message on success
     }
 
     Ok(())

--- a/nidx/src/indexer.rs
+++ b/nidx/src/indexer.rs
@@ -112,7 +112,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
         .instrument(span)
         .await
         {
-            warn!(?e, "Error processing index message");
+            error!(?seq, ?e, "Error processing index message");
             continue;
         }
 

--- a/nidx/src/metadata/index.rs
+++ b/nidx/src/metadata/index.rs
@@ -55,6 +55,7 @@ impl IndexId {
     }
 }
 
+#[derive(Clone)]
 pub struct Index {
     pub id: IndexId,
     pub shard_id: Uuid,
@@ -158,8 +159,8 @@ impl Index {
         .await
     }
 
-    pub async fn updated(&self, meta: impl Executor<'_, Database = Postgres>) -> sqlx::Result<()> {
-        sqlx::query!("UPDATE indexes SET updated_at = NOW() WHERE id = $1", self.id as IndexId).execute(meta).await?;
+    pub async fn updated(meta: impl Executor<'_, Database = Postgres>, index_id: &IndexId) -> sqlx::Result<()> {
+        sqlx::query!("UPDATE indexes SET updated_at = NOW() WHERE id = $1", index_id as &IndexId).execute(meta).await?;
         Ok(())
     }
 

--- a/nidx/src/metadata/index.rs
+++ b/nidx/src/metadata/index.rs
@@ -263,7 +263,7 @@ impl TryInto<VectorConfig> for IndexConfig {
 }
 
 impl IndexConfig {
-    pub fn nex_text() -> Self {
+    pub fn new_text() -> Self {
         Self::Text(())
     }
 

--- a/nidx/src/scheduler.rs
+++ b/nidx/src/scheduler.rs
@@ -565,7 +565,7 @@ mod tests {
             let indexes = vec![
                 Index::create(&meta.pool, shard.id, "multilingual", VectorConfig::default().into()).await?,
                 Index::create(&meta.pool, shard.id, "english", VectorConfig::default().into()).await?,
-                Index::create(&meta.pool, shard.id, "fulltext", IndexConfig::nex_text()).await?,
+                Index::create(&meta.pool, shard.id, "fulltext", IndexConfig::new_text()).await?,
                 Index::create(&meta.pool, shard.id, "keyword", IndexConfig::new_paragraph()).await?,
                 Index::create(&meta.pool, shard.id, "relation", IndexConfig::new_relation()).await?,
             ];

--- a/nidx/src/worker.rs
+++ b/nidx/src/worker.rs
@@ -69,7 +69,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
 
             match run_job(&meta, &job, storage.clone(), &work_path).instrument(span).await {
                 Ok(_) => info!(job.id, "Job completed"),
-                Err(e) => warn!(job.id, ?e, "Job failed"),
+                Err(e) => error!(job.id, ?e, "Merge job failed"),
             }
 
             // Stop keep alives
@@ -114,7 +114,6 @@ pub async fn run_job(
     storage: Arc<DynObjectStore>,
     work_path: &Path,
 ) -> anyhow::Result<()> {
-    // TODO: Should jobs be generic or keep the merge_job idea?
     let segments = job.segments(&meta.pool).await?;
     let index = Index::get(&meta.pool, job.index_id).await?;
     for s in &segments {
@@ -173,7 +172,8 @@ pub async fn run_job(
     segment.mark_ready(&mut *tx, size as i64).await?;
     Segment::mark_many_for_deletion(&mut *tx, &segment_ids).await?;
     Index::updated(&mut *tx, &index.id).await?;
-    // Delete task if successful. TODO: Mark as failed otherwise?
+
+    // Delete task if successful.
     job.finish(&mut *tx).await?;
     tx.commit().await?;
 

--- a/nidx/src/worker.rs
+++ b/nidx/src/worker.rs
@@ -172,7 +172,7 @@ pub async fn run_job(
     let mut tx = meta.transaction().await?;
     segment.mark_ready(&mut *tx, size as i64).await?;
     Segment::mark_many_for_deletion(&mut *tx, &segment_ids).await?;
-    index.updated(&mut *tx).await?;
+    Index::updated(&mut *tx, &index.id).await?;
     // Delete task if successful. TODO: Mark as failed otherwise?
     job.finish(&mut *tx).await?;
     tx.commit().await?;

--- a/nucliadb/src/nucliadb/common/cluster/manager.py
+++ b/nucliadb/src/nucliadb/common/cluster/manager.py
@@ -581,7 +581,8 @@ class StandaloneKBShardManager(KBShardManager):
 
             # Delete indexing message (no longer needed)
             try:
-                await storage.delete_upload(storage_key, storage.indexing_bucket)
+                if storage.indexing_bucket:
+                    await storage.delete_upload(storage_key, storage.indexing_bucket)
             except Exception:
                 pass
 

--- a/nucliadb/src/nucliadb/common/cluster/manager.py
+++ b/nucliadb/src/nucliadb/common/cluster/manager.py
@@ -579,6 +579,12 @@ class StandaloneKBShardManager(KBShardManager):
 
             await nidx.index(indexpb)
 
+            # Delete indexing message (no longer needed)
+            try:
+                await storage.delete_upload(storage_key, storage.indexing_bucket)
+            except Exception:
+                pass
+
 
 def get_all_shard_nodes(
     shard: writer_pb2.ShardObject,

--- a/nucliadb_utils/src/nucliadb_utils/storages/local.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/local.py
@@ -263,6 +263,9 @@ class LocalStorage(Storage):
         file_path = self.get_file_path(bucket_name, uri)
         if os.path.exists(file_path):
             os.remove(file_path)
+        metadata_path = f"{file_path}.metadata"
+        if os.path.exists(metadata_path):
+            os.remove(metadata_path)
 
     async def schedule_delete_kb(self, kbid: str):
         bucket = self.get_bucket_name(kbid)


### PR DESCRIPTION
When receiving an index message, commit all newly created segments (for each index) at once. This means that if some of them fail, nothing will be indexed, and we can try reprocessing safely.