### PR TITLE
Change event name for promotions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -367,7 +367,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: nuclia/core-apps
-          event-type: test-new-promotions
+          event-type: promotions
           client-payload: |-
             {
               "commit-sha": "${{ github.sha }}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: nuclia/core-apps
-          event-type: test-new-promotions
+          event-type: promotions
           client-payload: |-
             {
               "commit-sha": "${{ github.sha }}",


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows for deployment and release processes. The primary change is the modification of the `event-type` parameter to use a more general event type.

Changes to GitHub workflows:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L370-R370): Updated the `event-type` parameter from `test-new-promotions` to `promotions` in the `jobs:` section.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L201-R201): Updated the `event-type` parameter from `test-new-promotions` to `promotions` in the `jobs:` section.### Description
Describe the proposed changes made in this PR.

