### PR TITLE
Add some basic metrics

### DIFF
--- a/charts/nidx/templates/api-deploy.yaml
+++ b/charts/nidx/templates/api-deploy.yaml
@@ -31,6 +31,7 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        nidxMetrics: "enabled"
     spec:
       {{- with .Values.searcher.nodeSelector }}
       nodeSelector:
@@ -60,6 +61,8 @@ spec:
             value: "/run/nidx.sock"
         ports:
         {{- with .Values.searcher.resources }}
+        - name: metrics
+          containerPort: 10010
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/nidx/templates/indexer-deploy.yaml
+++ b/charts/nidx/templates/indexer-deploy.yaml
@@ -30,6 +30,7 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        nidxMetrics: "enabled"
     spec:
       {{- with .Values.indexer.nodeSelector }}
       nodeSelector:
@@ -63,6 +64,8 @@ spec:
           - name: CONTROL_SOCKET
             value: "/run/nidx.sock"
         ports:
+        - name: metrics
+          containerPort: 10010
         {{- with .Values.indexer.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/nidx/templates/worker-deploy.yaml
+++ b/charts/nidx/templates/worker-deploy.yaml
@@ -30,6 +30,7 @@ spec:
         chart: "{{ .Chart.Name }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        nidxMetrics: "enabled"
     spec:
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
@@ -64,6 +65,8 @@ spec:
           - name: CONTROL_SOCKET
             value: "/run/nidx.sock"
         ports:
+        - name: metrics
+          containerPort: 10010
         {{- with .Values.worker.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/nidx/src/searcher/index_cache.rs
+++ b/nidx/src/searcher/index_cache.rs
@@ -35,7 +35,8 @@ use tokio::sync::{Mutex, Semaphore};
 use uuid::Uuid;
 
 use crate::metadata::{IndexId, IndexKind, Segment, SegmentId};
-use crate::metrics::searcher::{IndexKindLabels, INDEX_LOAD_TIME};
+use crate::metrics::searcher::INDEX_LOAD_TIME;
+use crate::metrics::IndexKindLabels;
 use crate::NidxMetadata;
 
 use super::sync::{Operations, ShardIndexes, SyncMetadata};

--- a/nidx/src/telemetry/duration_layer.rs
+++ b/nidx/src/telemetry/duration_layer.rs
@@ -1,0 +1,74 @@
+// Copyright (C) 2021 Bosutech XXI S.L.
+//
+// nucliadb is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at info@nuclia.com.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::time::Instant;
+
+use tracing::{
+    field::Visit,
+    span::{Attributes, Id},
+    Subscriber,
+};
+use tracing_core::Field;
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+use crate::metrics;
+
+/// tracing_subscriber Layer that export span durations as prometheus metrics
+pub struct DurationLayer;
+
+struct Duration(Instant, String);
+
+struct ExtractNameVisitor(Option<String>);
+
+impl Visit for ExtractNameVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "otel.name" {
+            self.0 = Some(value.to_string())
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing_core::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+impl<S> Layer<S> for DurationLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).unwrap();
+
+        let mut extractor = ExtractNameVisitor(None);
+        attrs.record(&mut extractor);
+        let name = extractor.0.unwrap_or(span.name().to_string());
+
+        span.extensions_mut().insert(Duration(Instant::now(), name));
+    }
+
+    fn on_close(&self, id: tracing_core::span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).unwrap();
+        let extensions = span.extensions();
+
+        if let Some(Duration(t, name)) = extensions.get() {
+            metrics::common::SPAN_DURATION
+                .get_or_create(&vec![("span".to_string(), name.clone())])
+                .observe(t.elapsed().as_secs_f64());
+        }
+    }
+}

--- a/nidx/src/telemetry/middleware.rs
+++ b/nidx/src/telemetry/middleware.rs
@@ -81,7 +81,7 @@ where
 
         let span = info_span!(
             target: "nidx",
-            "nidx:grpc-call", // placeholder that will be substituted by otel.name
+            "nidx::grpc", // placeholder that will be substituted by otel.name
             otel.name = name,
             rpc.system = "grpc",
             rpc.service = service,


### PR DESCRIPTION
Added some metrics:
- Time for each instrumented span (this includes grpcs calls, index searches, etc.). This acts as a fallback to get basic timings on most stuff happening on nidx.
- Time per-index and total for indexing a message or merging job
- Success/failure rate for indexer/worker