### PR TITLE
Storage inserts instead of uploads

### DIFF
--- a/nucliadb_utils/src/nucliadb_utils/storages/azure.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/azure.py
@@ -215,6 +215,9 @@ class AzureStorage(Storage):
         async for obj in self.object_store.iterate(bucket, prefix):
             yield obj
 
+    async def insert_object(self, bucket_name: str, key: str, data: bytes) -> None:
+        await self.object_store.insert(bucket_name, key, data)
+
 
 class AzureObjectStore(ObjectStore):
     def __init__(self, account_url: str, connection_string: Optional[str] = None):
@@ -335,6 +338,10 @@ class AzureObjectStore(ObjectStore):
                 content_disposition=f"attachment; filename={metadata.filename}",
             ),
         )
+
+    async def insert(self, bucket: str, key: str, data: bytes) -> None:
+        container_client = self.service_client.get_container_client(bucket)
+        await container_client.upload_blob(name=key, data=data, length=len(data))
 
     async def download(self, bucket: str, key: str) -> bytes:
         container_client = self.service_client.get_container_client(bucket)

--- a/nucliadb_utils/src/nucliadb_utils/storages/local.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/local.py
@@ -278,8 +278,13 @@ class LocalStorage(Storage):
         return deleted
 
     async def iterate_objects(self, bucket: str, prefix: str) -> AsyncGenerator[ObjectInfo, None]:
-        for key in glob.glob(f"{bucket}/{prefix}*"):
-            yield ObjectInfo(name=key)
+        pathname = f"{self.get_file_path(bucket, prefix)}*"
+        for key in glob.glob(pathname):
+            if key.endswith(".metadata"):
+                # Skip metadata files -- they are internal to the local-storage implementation.
+                continue
+            name = key.split("/")[-1]
+            yield ObjectInfo(name=name)
 
     async def download(self, bucket_name: str, key: str, range: Optional[Range] = None):
         key_path = self.get_file_path(bucket_name, key)

--- a/nucliadb_utils/src/nucliadb_utils/storages/local.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/local.py
@@ -292,3 +292,9 @@ class LocalStorage(Storage):
             return
         async for chunk in super().download(bucket_name, key, range=range):
             yield chunk
+
+    async def insert_object(self, bucket: str, key: str, data: bytes) -> None:
+        path = self.get_file_path(bucket, key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as file:
+            file.write(data)

--- a/nucliadb_utils/src/nucliadb_utils/storages/object_store.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/object_store.py
@@ -98,6 +98,18 @@ class ObjectStore(abc.ABC, metaclass=abc.ABCMeta):
     ) -> None: ...
 
     @abc.abstractmethod
+    async def insert(
+        self,
+        bucket: str,
+        key: str,
+        data: bytes,
+    ) -> None:
+        """
+        Insert data to the object storage without any metadata
+        """
+        ...
+
+    @abc.abstractmethod
     async def download(self, bucket: str, key: str) -> bytes: ...
 
     @abc.abstractmethod

--- a/nucliadb_utils/src/nucliadb_utils/storages/storage.py
+++ b/nucliadb_utils/src/nucliadb_utils/storages/storage.py
@@ -208,9 +208,7 @@ class Storage(abc.ABC, metaclass=abc.ABCMeta):
             txid=reindex_id,
         )
         message_serialized = message.SerializeToString()
-        logger.debug("Starting to upload bytes")
         await self.uploadbytes(self.indexing_bucket, key, message_serialized)
-        logger.debug("Finished to upload bytes")
         return key
 
     async def get_indexing(self, payload: IndexMessage) -> BrainResource:
@@ -531,6 +529,13 @@ class Storage(abc.ABC, metaclass=abc.ABCMeta):
 
     async def del_stream_message(self, key: str) -> None:
         await self.delete_upload(key, cast(str, self.indexing_bucket))
+
+    @abc.abstractmethod
+    async def insert_object(self, bucket: str, key: str, data: bytes) -> None:
+        """
+        Put some binary data into the object storage without any object metadata.
+        """
+        ...
 
 
 async def iter_and_add_size(

--- a/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
+++ b/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
@@ -86,6 +86,7 @@ def gcs():
 
 def running_in_mac_os() -> bool:
     import os
+
     return os.uname().sysname == "Darwin"
 
 

--- a/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
+++ b/nucliadb_utils/src/nucliadb_utils/tests/gcs.py
@@ -75,10 +75,18 @@ class GCS(BaseImage):
 @pytest.fixture(scope="session")
 def gcs():
     container = GCS()
-    _, port = container.run()
-    public_api_url = f"http://172.17.0.1:{port}"
+    host, port = container.run()
+    if running_in_mac_os():
+        public_api_url = f"http://{host}:{port}"
+    else:
+        public_api_url = f"http://172.17.0.1:{port}"
     yield public_api_url
     container.stop()
+
+
+def running_in_mac_os() -> bool:
+    import os
+    return os.uname().sysname == "Darwin"
 
 
 @pytest.fixture(scope="function")

--- a/nucliadb_utils/tests/integration/storages/test_object_store.py
+++ b/nucliadb_utils/tests/integration/storages/test_object_store.py
@@ -116,6 +116,14 @@ async def objects_crud_test(object_store: ObjectStore):
     with pytest.raises(ObjectNotFoundError):
         await object_store.delete(bucket_name, object_key)
 
+    # Insert object
+    object_data = BytesIO(b"Hello, world!")
+    object_key = "folder/file.txt"
+    await object_store.insert(bucket_name, object_key, object_data.getvalue())
+
+    # Check object exists by downloading it
+    assert await object_store.download(bucket_name, object_key) == object_data.getvalue()
+
 
 async def objects_upload_download_test(object_store: ObjectStore):
     bucket_name = str(uuid.uuid4())

--- a/nucliadb_utils/tests/integration/storages/test_storage.py
+++ b/nucliadb_utils/tests/integration/storages/test_storage.py
@@ -93,6 +93,17 @@ async def storage_test(storage: Storage):
         assert object_info.name == key1
     assert found
 
+    # Check insert object
+    key = "barbafoo"
+    data = b"lorem ipsum"
+    await storage.insert_object(bucket, key, data)
+
+    # Check that the inserted object is there and has the right data
+    downloaded_data = b""
+    async for chunk in storage.download(bucket, key):
+        downloaded_data += chunk
+    assert downloaded_data == data
+
     deleted = await storage.schedule_delete_kb(kbid1)
     assert deleted
 


### PR DESCRIPTION
### Description
This PR aims to speed up the way we store extracted metadata (protobuff serialized as binaries) to the object store.
Right now we are doing so as regular uploads, which include 3 requests to the storage (start, append, finish). The PR replaces these with a simple insert/put request.

### How was this PR tested?
Improved existing integration tests, and local tests.