### PR TITLE
Nidx parallel downloads

### DIFF
--- a/nidx/nidx_binding/src/lib.rs
+++ b/nidx/nidx_binding/src/lib.rs
@@ -114,7 +114,12 @@ impl NidxBinding {
         let shutdown2 = shutdown.clone();
         tokio::task::spawn(async move {
             searcher
-                .run(settings_copy.storage.as_ref().unwrap().object_store.clone(), shutdown2, Some(sync_reporter))
+                .run(
+                    settings_copy.storage.as_ref().unwrap().object_store.clone(),
+                    settings_copy.searcher.clone().unwrap_or_default(),
+                    shutdown2,
+                    Some(sync_reporter),
+                )
                 .await
         });
 

--- a/nidx/src/metadata/merge_job.rs
+++ b/nidx/src/metadata/merge_job.rs
@@ -20,6 +20,7 @@
 use super::{IndexId, NidxMetadata, Segment, SegmentId};
 use nidx_types::Seq;
 use sqlx::{types::time::PrimitiveDateTime, Executor, Postgres};
+use tracing::*;
 
 #[derive(Clone)]
 pub struct MergeJob {
@@ -57,7 +58,7 @@ impl MergeJob {
         .await?
         .rows_affected();
         if affected != segment_ids.len() as u64 {
-            println!("Not all segments updated");
+            warn!("Not all segments added to the merge job");
             tx.rollback().await?;
             Err(sqlx::Error::RowNotFound)
         } else {

--- a/nidx/src/searcher/sync.rs
+++ b/nidx/src/searcher/sync.rs
@@ -20,7 +20,9 @@
 
 use crate::metadata::{Index, IndexId, IndexKind, SegmentId};
 use crate::metrics;
+use crate::settings::SearcherSettings;
 use crate::{segment_store::download_segment, NidxMetadata};
+use anyhow::anyhow;
 use nidx_types::Seq;
 use object_store::DynObjectStore;
 use sqlx::postgres::types::PgInterval;
@@ -31,8 +33,9 @@ use std::{
     path::PathBuf,
 };
 use std::{sync::Arc, time::Duration};
-use tokio::sync::watch;
 use tokio::sync::{mpsc::Sender, OwnedRwLockReadGuard, RwLock, RwLockReadGuard};
+use tokio::sync::{watch, Semaphore};
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::*;
 use uuid::Uuid;
@@ -51,6 +54,7 @@ pub async fn run_sync(
     meta: NidxMetadata,
     storage: Arc<DynObjectStore>,
     index_metadata: Arc<SyncMetadata>,
+    settings: SearcherSettings,
     shutdown: CancellationToken,
     notifier: Sender<IndexId>,
     sync_status: Option<watch::Sender<SyncStatus>>,
@@ -111,18 +115,41 @@ pub async fn run_sync(
                 vec![]
             };
 
+            let sync_semaphore = Arc::new(Semaphore::new(settings.parallel_index_syncs));
+            let mut tasks = JoinSet::new();
             for index in indexes.into_iter().chain(retry_indexes.into_iter()) {
                 let index_id = index.id;
                 let meta2 = meta.clone();
                 let index_metadata2 = Arc::clone(&index_metadata);
                 let notifier2 = notifier.clone();
                 let storage2 = Arc::clone(&storage);
-                if let Err(e) = sync_index(&meta2, storage2, index_metadata2, index, &notifier2).await {
+                let sync_semaphore = Arc::clone(&sync_semaphore);
+
+                tasks.spawn(async move {
+                    let Ok(_permit) = sync_semaphore.acquire().await else {
+                        // Semaphore was closed, just exit
+                        return (index_id, Err(anyhow!("Cancelled")));
+                    };
+                    info!(?index_id, "Syncing index");
+                    (index_id, sync_index(&meta2, storage2, index_metadata2, index, &notifier2).await)
+                });
+            }
+
+            while let Some(result) = tasks.join_next().await {
+                if shutdown.is_cancelled() {
+                    sync_semaphore.close();
+                }
+                let (index_id, result) = result.expect("Join error");
+                if let Err(e) = result {
+                    // If shutted down, we are just joining the tasks before exiting
+                    if shutdown.is_cancelled() {
+                        continue;
+                    }
                     let retries = failed_indexes.entry(index_id).or_default();
                     if *retries > 2 {
                         error!(?index_id, ?e, "Index failed to update multiple times, will keep retrying forever")
                     } else {
-                        warn!(?index_id, "Index failed to update, will retry")
+                        warn!(?index_id, ?e, "Index failed to update, will retry")
                     }
                     *retries += 1;
                 } else {
@@ -176,24 +203,33 @@ async fn sync_index(
     let diff = sync_metadata.diff(&index.id, &operations).await;
 
     // Download new segments
+    let mut tasks = JoinSet::new();
     for segment_id in diff.added_segments {
         let storage2 = Arc::clone(&storage);
         let location = sync_metadata.segment_location(&index.id, &segment_id);
 
-        // Download segment has some built-in retries (in object_store crate)
-        // but failing here is expensive, so we do some extra retries
-        let mut retries = 0;
-        loop {
-            let result = download_segment(storage2.clone(), segment_id, location.clone()).await;
-            if let Err(e) = result {
-                if retries > 3 {
-                    return Err(e);
+        tasks.spawn(async move {
+            // Download segment has some built-in retries (in object_store crate)
+            // but failing here is expensive, so we do some extra retries
+            let mut retries = 0;
+            loop {
+                let result = download_segment(storage2.clone(), segment_id, location.clone()).await;
+                if let Err(e) = result {
+                    if retries > 3 {
+                        return Err(e);
+                    }
+                    retries += 1;
+                } else {
+                    break;
                 }
-                retries += 1;
-            } else {
-                break;
             }
-        }
+            Ok(())
+        });
+    }
+
+    let results = tasks.join_all().await;
+    if let Some(failure) = results.into_iter().find_map(Result::err) {
+        return Err(failure);
     }
 
     // Switch meta

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -22,13 +22,16 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as base64;
 use base64::Engine;
 use config::{Config, Environment};
 use object_store::aws::AmazonS3Builder;
+use object_store::limit::LimitStore;
 use object_store::local::LocalFileSystem;
 use object_store::memory::InMemory;
+use object_store::ClientOptions;
 use object_store::{gcp::GoogleCloudStorageBuilder, DynObjectStore};
 use serde::{Deserialize, Deserializer};
 
@@ -36,7 +39,7 @@ use crate::NidxMetadata;
 
 #[derive(Clone, Deserialize, Debug)]
 #[serde(tag = "object_store", rename_all = "lowercase")]
-pub enum ObjectStoreConfig {
+pub enum ObjectStoreKind {
     Memory,
     File {
         file_path: String,
@@ -55,10 +58,26 @@ pub enum ObjectStoreConfig {
     },
 }
 
+fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<u64>, D::Error> {
+    Ok(Some(String::deserialize(deserializer)?.parse().expect("Expected a number")))
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct ObjectStoreConfig {
+    #[serde(flatten)]
+    kind: ObjectStoreKind,
+
+    #[serde(default, deserialize_with = "deserialize_u64")]
+    max_requests: Option<u64>,
+
+    #[serde(default, deserialize_with = "deserialize_u64")]
+    timeout: Option<u64>,
+}
+
 impl ObjectStoreConfig {
     pub fn client(&self) -> Arc<DynObjectStore> {
-        match self {
-            Self::Gcs {
+        let store: Box<DynObjectStore> = match &self.kind {
+            ObjectStoreKind::Gcs {
                 bucket,
                 base64_creds,
                 endpoint,
@@ -77,9 +96,12 @@ impl ObjectStoreConfig {
                     }
                     _ => {}
                 };
-                Arc::new(builder.build().unwrap())
+                if let Some(t) = self.timeout {
+                    builder = builder.with_client_options(ClientOptions::new().with_timeout(Duration::from_secs(t)));
+                }
+                Box::new(builder.build().unwrap())
             }
-            Self::S3 {
+            ObjectStoreKind::S3 {
                 bucket,
                 client_id,
                 client_secret,
@@ -98,12 +120,21 @@ impl ObjectStoreConfig {
                     // This is needed for minio compatibility
                     builder = builder.with_endpoint(endpoint.clone().unwrap()).with_allow_http(true);
                 }
-                Arc::new(builder.build().unwrap())
+                if let Some(t) = self.timeout {
+                    builder = builder.with_client_options(ClientOptions::new().with_timeout(Duration::from_secs(t)));
+                }
+                Box::new(builder.build().unwrap())
             }
-            Self::File {
+            ObjectStoreKind::File {
                 file_path,
-            } => Arc::new(LocalFileSystem::new_with_prefix(file_path).unwrap()),
-            Self::Memory => Arc::new(InMemory::new()),
+            } => Box::new(LocalFileSystem::new_with_prefix(file_path).unwrap()),
+            ObjectStoreKind::Memory => Box::new(InMemory::new()),
+        };
+
+        if let Some(max_requests) = self.max_requests {
+            Arc::new(LimitStore::new(store, max_requests as usize))
+        } else {
+            Arc::new(store)
         }
     }
 }
@@ -169,6 +200,19 @@ pub struct TelemetrySettings {
     pub sentry: Option<SentryConfig>,
 }
 
+#[derive(Clone, Deserialize, Debug)]
+pub struct SearcherSettings {
+    pub parallel_index_syncs: usize,
+}
+
+impl Default for SearcherSettings {
+    fn default() -> Self {
+        Self {
+            parallel_index_syncs: 2,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct EnvSettings {
     /// Connection to the metadata database
@@ -182,6 +226,9 @@ pub struct EnvSettings {
     /// Storage configuration for our segments
     /// Required by indexer, worker, searcher
     pub storage: Option<StorageSettings>,
+
+    /// Searcher-specific configuration
+    pub searcher: Option<SearcherSettings>,
 
     /// Merge scheduling algorithm configuration
     /// Required by scheduler

--- a/nidx/tests/synced_searcher.rs
+++ b/nidx/tests/synced_searcher.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 
 use nidx::indexer::{index_resource, process_index_message};
 use nidx::searcher::SyncedSearcher;
+use nidx::settings::SearcherSettings;
 use nidx::{
     metadata::{Index, Shard},
     NidxMetadata,
@@ -43,8 +44,9 @@ async fn test_synchronization(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let synced_searcher = SyncedSearcher::new(meta.clone(), work_dir.path());
     let index_cache = synced_searcher.index_cache();
     let storage_copy = storage.clone();
-    let search_task =
-        tokio::spawn(async move { synced_searcher.run(storage_copy, CancellationToken::new(), None).await });
+    let search_task = tokio::spawn(async move {
+        synced_searcher.run(storage_copy, SearcherSettings::default(), CancellationToken::new(), None).await
+    });
 
     let index = Index::create(
         &meta.pool,


### PR DESCRIPTION
### Description
Brings back parallel downloads to nidx with proper limits this time:
- Limit of parallel synced index. This limits number of tokio tasks and also helps individual index to finish faster (rather than getting stuck getting one segment per each index).
- Limit of parallel requests and adjustable timeouts. This is done at the storage layer, so we have a global limit.
- Better error handling: Use a tmp directory to avoid leaving trash around, and avoid redownloading data that we already have (also useful in the future if we keep the disk from run to run).