### PR TITLE
Faster merging

### DIFF
--- a/nidx/Cargo.lock
+++ b/nidx/Cargo.lock
@@ -976,6 +976,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1905,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bit-set",
+ "fxhash",
  "lazy_static",
  "libc",
  "memmap2 0.5.10",

--- a/nidx/Cargo.toml
+++ b/nidx/Cargo.toml
@@ -72,3 +72,7 @@ telemetry = [
 itertools = "0.13.0"
 nidx_tests = { path = "nidx_tests" }
 rand = "0.8.5"
+
+[profile.samply]
+inherits = "release"
+debug = true

--- a/nidx/nidx_vector/Cargo.toml
+++ b/nidx/nidx_vector/Cargo.toml
@@ -17,6 +17,7 @@ nidx_protos = { version = "0.1.0", path = "../nidx_protos" }
 tracing = "0.1.40"
 serde = { version = "1.0.210", features = ["derive"] }
 anyhow = "1.0.89"
+fxhash = "0.2.1"
 
 [target.'cfg(not(all(target_os="linux",target_arch="aarch64")))'.dependencies]
 simsimd = "4.3.1"

--- a/nidx/nidx_vector/src/data_point/mod.rs
+++ b/nidx/nidx_vector/src/data_point/mod.rs
@@ -41,6 +41,7 @@ use ops_hnsw::HnswOps;
 use ram_hnsw::RAMHnsw;
 use std::collections::HashSet;
 use std::path::Path;
+use std::time::Instant;
 use std::{fs, io};
 
 pub use ops_hnsw::DataRetriever;
@@ -126,9 +127,10 @@ where
 
     // Creating the hnsw for the new node store.
     let tracker = Retriever::new(&[], &nodes, &NoDLog, config, -1.0);
-    let mut ops = HnswOps::new(&tracker);
+    let mut ops = HnswOps::new(&tracker, false);
+    let t = Instant::now();
     for id in start_node_index..no_nodes {
-        ops.insert(Address(id), &mut index)
+        ops.insert(Address(id), &mut index);
     }
 
     {
@@ -193,7 +195,7 @@ pub fn create(path: &Path, elems: Vec<Elem>, config: &VectorConfig, tags: HashSe
     // Creating the HNSW using the mmaped nodes
     let mut index = RAMHnsw::new();
     let tracker = Retriever::new(&[], &nodes, &NoDLog, config, -1.0);
-    let mut ops = HnswOps::new(&tracker);
+    let mut ops = HnswOps::new(&tracker, false);
     for id in 0..no_nodes {
         ops.insert(Address(id), &mut index)
     }
@@ -498,7 +500,7 @@ impl OpenDataPoint {
         let encoded_query = config.vector_type.encode(query);
         let tracker = Retriever::new(&encoded_query, &self.nodes, delete_log, config, min_score);
         let filter = FormulaFilter::new(filter);
-        let ops = HnswOps::new(&tracker);
+        let ops = HnswOps::new(&tracker, true);
         let neighbours =
             ops.search(Address(self.metadata.records), self.index.as_ref(), results, filter, with_duplicates);
 

--- a/nidx/nidx_vector/src/data_point/ram_hnsw.rs
+++ b/nidx/nidx_vector/src/data_point/ram_hnsw.rs
@@ -18,8 +18,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
-use std::collections::HashMap;
-
+use fxhash::FxHashMap;
 use ops_hnsw::{Hnsw, Layer};
 
 use super::*;
@@ -36,7 +35,7 @@ pub type Edge = f32;
 
 #[derive(Default, Clone)]
 pub struct RAMLayer {
-    pub out: HashMap<Address, Vec<(Address, Edge)>>,
+    pub out: FxHashMap<Address, Vec<(Address, Edge)>>,
 }
 
 impl RAMLayer {

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -174,7 +174,7 @@ pub struct MergeSettings {
 impl Default for MergeSettings {
     fn default() -> Self {
         Self {
-            max_deletions: 100,
+            max_deletions: 500,
             log_merge: Default::default(),
             vector_merge: Default::default(),
         }


### PR DESCRIPTION
### Description
* `madvise` calls were taking too long and offer very little value when merging/indexing a segment, since it will already be loaded into memory from all the copying of nodes. So we disable it in that case, while keeping it enabled when searching.
* After this, I noticed we were taking a significant chunk of time accessing the HashSet of visited nodes, so I switched over to a faster implementation.

Together, this means ~2x speedup of merges.