### PR TITLE
Remove redundant asyncio marks in tests and fixtures

### DIFF
--- a/nucliadb/tests/ingest/integration/consumer/test_materializer.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_materializer.py
@@ -32,8 +32,6 @@ from nucliadb_utils.audit.stream import StreamAuditStorage
 from nucliadb_utils.utilities import Utility, clean_utility, set_utility
 from tests.ingest.fixtures import create_resource
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 def nats():

--- a/nucliadb/tests/ingest/integration/consumer/test_pull.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_pull.py
@@ -36,8 +36,6 @@ from nucliadb_utils.fastapi.run import start_server
 from nucliadb_utils.nats import NatsConnectionManager
 from nucliadb_utils.tests import free_port
 
-pytestmark = pytest.mark.asyncio
-
 
 def create_broker_message(kbid: str) -> BrokerMessage:
     bm = BrokerMessage()

--- a/nucliadb/tests/ingest/integration/consumer/test_service.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_service.py
@@ -19,14 +19,10 @@
 #
 import uuid
 
-import pytest
-
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_utils import const
 from nucliadb_utils.nats import NatsConnectionManager
 from nucliadb_utils.transaction import TransactionUtility
-
-pytestmark = pytest.mark.asyncio
 
 
 def create_broker_message(kbid: str) -> BrokerMessage:

--- a/nucliadb/tests/ingest/integration/consumer/test_shard_creator.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_shard_creator.py
@@ -20,13 +20,9 @@
 
 import asyncio
 
-import pytest
-
 from nucliadb.ingest.consumer import shard_creator
 from nucliadb_protos import writer_pb2
 from nucliadb_utils import const
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_shard_auto_create(

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -112,7 +112,6 @@ def kbid(
     yield knowledgebox_ingest
 
 
-@pytest.mark.asyncio
 async def test_ingest_messages_autocommit(kbid: str, processor):
     rid = str(uuid.uuid4())
     message1: BrokerMessage = BrokerMessage(
@@ -215,7 +214,6 @@ async def test_ingest_messages_autocommit(kbid: str, processor):
     assert pb.texts["a/summary"].text == "My summary"
 
 
-@pytest.mark.asyncio
 async def test_ingest_error_message(kbid: str, storage: Storage, processor, maindb_driver: Driver):
     filename = f"{dirname(__file__)}/assets/resource.pb"
     with open(filename, "r") as f:
@@ -258,7 +256,6 @@ async def test_ingest_error_message(kbid: str, storage: Storage, processor, main
         assert field_obj.value.body == message0.texts["wikipedia_ml"].body
 
 
-@pytest.mark.asyncio
 async def test_ingest_messages_origin(
     local_files,
     storage: Storage,
@@ -353,7 +350,6 @@ async def get_audit_messages(sub):
     return auditreq
 
 
-@pytest.mark.asyncio
 async def test_ingest_audit_stream_files_only(
     local_files,
     storage: Storage,
@@ -485,7 +481,6 @@ async def test_ingest_audit_stream_files_only(
     await client.close()
 
 
-@pytest.mark.asyncio
 async def test_qa(
     local_files,
     storage: Storage,
@@ -543,7 +538,6 @@ async def test_qa(
     await stream_processor.process(message=message, seqid=2)
 
 
-@pytest.mark.asyncio
 async def test_ingest_audit_stream_mixed(
     local_files,
     storage: Storage,
@@ -611,7 +605,6 @@ async def test_ingest_audit_stream_mixed(
     await client.close()
 
 
-@pytest.mark.asyncio
 async def test_ingest_account_seq_stored(
     local_files,
     storage: Storage,
@@ -639,7 +632,6 @@ async def test_ingest_account_seq_stored(
     assert basic.queue == 0
 
 
-@pytest.mark.asyncio
 async def test_ingest_processor_handles_missing_kb(
     local_files,
     storage: Storage,
@@ -654,7 +646,6 @@ async def test_ingest_processor_handles_missing_kb(
     await stream_processor.process(message=message, seqid=1)
 
 
-@pytest.mark.asyncio
 async def test_ingest_autocommit_deadletter_marks_resource(
     kbid: str, processor: Processor, storage, maindb_driver: Driver
 ):
@@ -717,7 +708,6 @@ def message_resource_with_vectors(knowledgebox_ingest, rid):
     return message
 
 
-@pytest.mark.asyncio
 async def test_ingest_delete_field(
     local_files,
     storage: Storage,
@@ -767,7 +757,6 @@ async def test_ingest_delete_field(
         assert brain.sentences_to_delete == [f"{rid}/f/some_text"]
 
 
-@pytest.mark.asyncio
 async def test_ingest_update_labels(
     local_files,
     storage: Storage,

--- a/nucliadb/tests/ingest/integration/ingest/test_processing_engine.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_processing_engine.py
@@ -37,7 +37,6 @@ from tests.utils.aiohttp_session import get_mocked_session
         {"seqid": 1, "queue": "shared"},
     ],
 )
-@pytest.mark.asyncio
 async def test_send_to_process(onprem, mock_payload):
     """
     Test that send_to_process does not fail
@@ -62,7 +61,6 @@ async def test_send_to_process(onprem, mock_payload):
 
 
 @pytest.mark.parametrize("onprem", [True, False])
-@pytest.mark.asyncio
 async def test_delete_from_processing(onprem):
     """
     Test that send_to_process does not fail

--- a/nucliadb/tests/ingest/integration/ingest/test_relations.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_relations.py
@@ -19,8 +19,6 @@
 #
 import uuid
 
-import pytest
-
 from nucliadb.ingest import SERVICE_NAME
 from nucliadb_protos.resources_pb2 import (
     Classification,
@@ -35,7 +33,6 @@ from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_utils.utilities import get_indexing, get_storage
 
 
-@pytest.mark.asyncio
 async def test_ingest_relations_indexing(
     fake_node, local_files, storage, knowledgebox_ingest, processor
 ):
@@ -64,7 +61,6 @@ async def test_ingest_relations_indexing(
     assert pb.relations[2] == r2
 
 
-@pytest.mark.asyncio
 async def test_ingest_label_relation_extraction(
     fake_node, local_files, storage, knowledgebox_ingest, processor
 ):
@@ -94,7 +90,6 @@ async def test_ingest_label_relation_extraction(
         assert pb.relations[i].to.value == f"{labelset}/{label}"
 
 
-@pytest.mark.asyncio
 async def test_ingest_colab_relation_extraction(
     fake_node, local_files, storage, knowledgebox_ingest, processor
 ):
@@ -117,7 +112,6 @@ async def test_ingest_colab_relation_extraction(
         assert pb.relations[i].to.value == collaborator
 
 
-@pytest.mark.asyncio
 async def test_ingest_field_metadata_relation_extraction(
     fake_node, local_files, storage, knowledgebox_ingest, processor
 ):
@@ -205,7 +199,6 @@ async def test_ingest_field_metadata_relation_extraction(
         assert generated_relation in pb.relations
 
 
-@pytest.mark.asyncio
 async def test_ingest_field_relations_relation_extraction(
     fake_node, local_files, storage, knowledgebox_ingest, processor
 ):

--- a/nucliadb/tests/ingest/integration/ingest/test_vectorsets.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_vectorsets.py
@@ -21,8 +21,6 @@ import random
 import uuid
 from typing import Optional
 
-import pytest
-
 from nucliadb.common import datamanagers
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest import SERVICE_NAME
@@ -39,7 +37,6 @@ from nucliadb_utils.utilities import get_indexing, get_storage
 from tests.ingest.fixtures import make_extracted_text
 
 
-@pytest.mark.asyncio
 async def test_ingest_broker_message_with_vectorsets(
     fake_node,
     storage,

--- a/nucliadb/tests/ingest/integration/orm/test_orm_extracted.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_extracted.py
@@ -21,8 +21,6 @@ from os.path import dirname, getsize
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -35,7 +33,6 @@ from nucliadb_protos.resources_pb2 import (
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_extracted(storage: Storage, txn, fake_node, knowledgebox_ingest: str):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox_ingest)
@@ -55,7 +52,6 @@ async def test_create_resource_orm_extracted(storage: Storage, txn, fake_node, k
     assert ex2.text == ex1.body.text
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_extracted_file(
     local_files,
     storage: Storage,
@@ -95,7 +91,6 @@ async def test_create_resource_orm_extracted_file(
     assert ex3.text == ex2.text
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_extracted_delta(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_conversation.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_conversation.py
@@ -21,8 +21,6 @@ from datetime import datetime
 from os.path import dirname, getsize
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.conversation import PAGE_SIZE, Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import CloudFile, FieldType, Message, MessageContent
@@ -30,7 +28,6 @@ from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_field_conversation(
     storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):
@@ -71,7 +68,6 @@ async def test_create_resource_orm_field_conversation(
     assert convfield.value[2].messages[-1].content.text == "299 hello"
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_field_conversation_file(
     local_files, storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_file.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_file.py
@@ -21,8 +21,6 @@ from datetime import datetime
 from os.path import dirname, getsize
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import CloudFile, FieldType
@@ -30,7 +28,6 @@ from nucliadb_protos.resources_pb2 import FieldFile as PBFieldFile
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_field_file(
     local_files, storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_link.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_link.py
@@ -20,8 +20,6 @@
 from datetime import datetime
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.link import Link
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import FieldLink as PBFieldLink
@@ -29,7 +27,6 @@ from nucliadb_protos.resources_pb2 import FieldType
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_field_link(
     storage: Storage, cache, fake_node, knowledgebox_ingest: str, maindb_driver
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_text.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_text.py
@@ -19,8 +19,6 @@
 #
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import FieldText as PBFieldText
@@ -28,7 +26,6 @@ from nucliadb_protos.resources_pb2 import FieldType
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_field_text(storage, txn, cache, fake_node, knowledgebox_ingest: str):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox_ingest)
@@ -42,7 +39,6 @@ async def test_create_resource_orm_field_text(storage, txn, cache, fake_node, kn
     assert textfield.value.body == t2.body
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_field_text_file(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_file_extracted.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_file_extracted.py
@@ -21,8 +21,6 @@ from os.path import dirname, getsize
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -34,7 +32,6 @@ from nucliadb_protos.resources_pb2 import (
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_file_extracted(
     local_files, storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_knowledgebox.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_knowledgebox.py
@@ -51,7 +51,6 @@ async def shard_manager(
         set_utility(Utility.SHARD_MANAGER, original)
 
 
-@pytest.mark.asyncio
 async def test_create_knowledgebox(
     storage: Storage,
     maindb_driver: Driver,
@@ -83,7 +82,6 @@ async def test_create_knowledgebox(
         assert config.description == description
 
 
-@pytest.mark.asyncio
 async def test_create_knowledgebox_with_multiple_vectorsets(
     storage: Storage,
     maindb_driver: Driver,
@@ -133,7 +131,6 @@ async def test_create_knowledgebox_with_multiple_vectorsets(
         assert set(vs2.matryoshka_dimensions) == {256, 512, 2048}
 
 
-@pytest.mark.asyncio
 async def test_create_knowledgebox_without_vectorsets_is_not_allowed(
     storage: Storage,
     maindb_driver: Driver,
@@ -143,7 +140,6 @@ async def test_create_knowledgebox_without_vectorsets_is_not_allowed(
         await KnowledgeBox.create(maindb_driver, kbid="kbid", slug="slug", semantic_models={})
 
 
-@pytest.mark.asyncio
 async def test_create_knowledgebox_with_same_kbid(
     storage: Storage,
     maindb_driver: Driver,
@@ -168,7 +164,6 @@ async def test_create_knowledgebox_with_same_kbid(
         )
 
 
-@pytest.mark.asyncio
 async def test_create_knowledgebox_with_same_slug(
     storage: Storage,
     maindb_driver: Driver,
@@ -193,7 +188,6 @@ async def test_create_knowledgebox_with_same_slug(
         )
 
 
-@pytest.mark.asyncio
 async def test_delete_knowledgebox(
     storage: Storage,
     maindb_driver: Driver,
@@ -215,14 +209,12 @@ async def test_delete_knowledgebox(
     assert exists is False
 
 
-@pytest.mark.asyncio
 async def test_delete_knowledgebox_handles_unexisting_kb(storage: Storage, maindb_driver: Driver):
     idonotexist = uuid.uuid4().hex
     kbid = await KnowledgeBox.delete(maindb_driver, kbid=idonotexist)
     assert kbid is None
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_purge_handles_unexisting_shard_payload(
     storage: Storage, maindb_driver: Driver
 ):
@@ -230,7 +222,6 @@ async def test_knowledgebox_purge_handles_unexisting_shard_payload(
     await KnowledgeBox.purge(maindb_driver, kbid=idonotexist)
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_delete_all_kb_keys(
     storage,
     cache,

--- a/nucliadb/tests/ingest/integration/orm/test_orm_large_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_large_metadata.py
@@ -21,8 +21,6 @@ from os.path import dirname, getsize
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -36,7 +34,6 @@ from nucliadb_protos.resources_pb2 import (
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_large_metadata(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):
@@ -61,7 +58,6 @@ async def test_create_resource_orm_large_metadata(
     assert ex2.metadata.tokens["tok"] == ex1.real.metadata.tokens["tok"]
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_large_metadata_file(
     local_files, storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_link_extracted.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_link_extracted.py
@@ -22,15 +22,12 @@ from os.path import dirname, getsize
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.link import Link
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import CloudFile, FieldType, LinkExtractedData
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_link_extracted(
     local_files, storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
@@ -21,8 +21,6 @@ from datetime import datetime
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -39,7 +37,6 @@ from nucliadb_protos.resources_pb2 import (
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_metadata(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):
@@ -83,7 +80,6 @@ async def test_create_resource_orm_metadata(
     assert ex2.metadata.mime_type == ex1.metadata.metadata.mime_type
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_metadata_split(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
@@ -21,8 +21,6 @@ from datetime import datetime
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.common import datamanagers
 from nucliadb.ingest.orm.broker_message import generate_broker_message
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
@@ -51,7 +49,6 @@ from nucliadb_protos.writer_pb2 import (
 from tests.ingest.fixtures import create_resource
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_with_basic(storage, txn, cache, fake_node, knowledgebox_ingest: str):
     basic = PBBasic(
         icon="text/plain",
@@ -105,7 +102,6 @@ async def test_create_resource_orm_with_basic(storage, txn, cache, fake_node, kn
     assert o2.source_id == "My Source"
 
 
-@pytest.mark.asyncio
 async def test_iterate_paragraphs(storage, txn, cache, fake_node, knowledgebox_ingest: str):
     # Create a resource
     basic = PBBasic(
@@ -150,7 +146,6 @@ async def test_iterate_paragraphs(storage, txn, cache, fake_node, knowledgebox_i
         assert paragraph.metadata.labels.paragraph[0].label in ("label1", "label2")
 
 
-@pytest.mark.asyncio
 async def test_paragraphs_with_page(storage, txn, cache, fake_node, knowledgebox_ingest: str):
     # Create a resource
     basic = PBBasic(
@@ -209,7 +204,6 @@ async def test_paragraphs_with_page(storage, txn, cache, fake_node, knowledgebox
             assert metadata.metadata.representation.file == "myfile"
 
 
-@pytest.mark.asyncio
 async def test_vector_duplicate_fields(storage, txn, cache, fake_node, knowledgebox_ingest: str):
     basic = PBBasic(title="My title", summary="My summary")
     basic.metadata.status = PBMetadata.Status.PROCESSED

--- a/nucliadb/tests/ingest/integration/orm/test_orm_vectors.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_vectors.py
@@ -21,8 +21,6 @@ from os.path import dirname, getsize
 from typing import Optional
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -35,7 +33,6 @@ from nucliadb_protos.utils_pb2 import Vector, VectorObject, Vectors
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_vector(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):
@@ -57,7 +54,6 @@ async def test_create_resource_orm_vector(
     assert ex2.vectors.vectors[0].vector == ex1.vectors.vectors.vectors[0].vector
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_vector_file(
     local_files, storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):
@@ -93,7 +89,6 @@ async def test_create_resource_orm_vector_file(
     assert ex3.vectors.vectors[0].vector == ex2.vectors.vectors[0].vector
 
 
-@pytest.mark.asyncio
 async def test_create_resource_orm_vector_split(
     storage: Storage, txn, cache, fake_node, knowledgebox_ingest: str
 ):

--- a/nucliadb/tests/ingest/integration/orm/test_send_to_process_generated_fields.py
+++ b/nucliadb/tests/ingest/integration/orm/test_send_to_process_generated_fields.py
@@ -54,7 +54,6 @@ def processing_utility(dummy_processing: ProcessingEngine) -> Iterable[Processin
     yield dummy_processing
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def dummy_processing() -> AsyncIterator[ProcessingEngine]:
     with patch.object(nuclia_settings, "dummy_processing", True):

--- a/nucliadb/tests/ingest/integration/servicer/test_entities_servicer.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_entities_servicer.py
@@ -20,13 +20,10 @@
 
 from uuid import uuid4
 
-import pytest
-
 from nucliadb_protos import knowledgebox_pb2, writer_pb2, writer_pb2_grpc
 from tests.ingest.fixtures import IngestFixture
 
 
-@pytest.mark.asyncio
 async def test_create_entities_group(
     grpc_servicer: IngestFixture, entities_manager_mock, hosted_nucliadb
 ):

--- a/nucliadb/tests/ingest/integration/servicer/test_list_members.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_list_members.py
@@ -19,14 +19,11 @@
 #
 
 
-import pytest
-
 from nucliadb_protos import writer_pb2_grpc
 from nucliadb_protos.writer_pb2 import ListMembersRequest, Member
 from tests.ingest.fixtures import IngestFixture
 
 
-@pytest.mark.asyncio
 async def test_list_members(grpc_servicer: IngestFixture):
     stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
 

--- a/nucliadb/tests/ingest/integration/servicer/test_reindex.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_reindex.py
@@ -19,15 +19,12 @@
 #
 from uuid import uuid4
 
-import pytest
-
 from nucliadb_protos import knowledgebox_pb2, writer_pb2, writer_pb2_grpc
 from nucliadb_protos.resources_pb2 import ExtractedVectorsWrapper, FieldType
 from nucliadb_protos.utils_pb2 import Vector
 from nucliadb_protos.writer_pb2 import BrokerMessage, IndexResource
 
 
-@pytest.mark.asyncio
 async def test_reindex_resource(grpc_servicer, fake_node, hosted_nucliadb):
     stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
 

--- a/nucliadb/tests/ingest/integration/servicer/test_shards_management.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_shards_management.py
@@ -19,13 +19,10 @@
 #
 from uuid import uuid4
 
-import pytest
-
 from nucliadb.common import datamanagers
 from nucliadb_protos import knowledgebox_pb2, writer_pb2, writer_pb2_grpc
 
 
-@pytest.mark.asyncio
 async def test_create_cleansup_on_error(grpc_servicer, fake_node, hosted_nucliadb):
     stub = writer_pb2_grpc.WriterStub(grpc_servicer.channel)
     # Create a KB

--- a/nucliadb/tests/ingest/unit/consumer/test_auditing.py
+++ b/nucliadb/tests/ingest/unit/consumer/test_auditing.py
@@ -27,8 +27,6 @@ from nucliadb.ingest.consumer import auditing
 from nucliadb_protos import nodereader_pb2
 from nucliadb_protos.writer_pb2 import Audit, BrokerMessage, Notification, ShardObject
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 def pubsub():

--- a/nucliadb/tests/ingest/unit/consumer/test_consumer.py
+++ b/nucliadb/tests/ingest/unit/consumer/test_consumer.py
@@ -38,7 +38,6 @@ def consumer(storage):
     yield IngestConsumer(None, "partition", storage, None)
 
 
-@pytest.mark.asyncio
 async def test_get_broker_message(consumer: IngestConsumer, storage):
     bm = BrokerMessage(kbid="kbid")
     msg = Mock(data=bm.SerializeToString(), headers={})
@@ -46,7 +45,6 @@ async def test_get_broker_message(consumer: IngestConsumer, storage):
     storage.get_stream_message.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_get_broker_message_proxied(consumer: IngestConsumer, storage):
     bm = BrokerMessage(kbid="kbid")
     bmr = BrokerMessageBlobReference(kbid="kbid", storage_key="storage_key")
@@ -59,7 +57,6 @@ async def test_get_broker_message_proxied(consumer: IngestConsumer, storage):
     storage.get_stream_message.assert_awaited_once_with("storage_key")
 
 
-@pytest.mark.asyncio
 async def test_clean_broker_message_proxied(consumer: IngestConsumer, storage):
     bmr = BrokerMessageBlobReference(kbid="kbid", storage_key="storage_key")
     msg = Mock(data=bmr.SerializeToString(), headers={"X-MESSAGE-TYPE": "PROXY"})

--- a/nucliadb/tests/ingest/unit/consumer/test_shard_creator.py
+++ b/nucliadb/tests/ingest/unit/consumer/test_shard_creator.py
@@ -28,8 +28,6 @@ from nucliadb.ingest.consumer import shard_creator
 from nucliadb_protos import nodereader_pb2
 from nucliadb_protos.writer_pb2 import Notification, ShardObject, Shards
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 def pubsub():

--- a/nucliadb/tests/ingest/unit/consumer/test_utils.py
+++ b/nucliadb/tests/ingest/unit/consumer/test_utils.py
@@ -20,11 +20,7 @@
 
 import asyncio
 
-import pytest
-
 from nucliadb.ingest.consumer import utils
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_delay_task_handler():

--- a/nucliadb/tests/ingest/unit/fields/test_conversation.py
+++ b/nucliadb/tests/ingest/unit/fields/test_conversation.py
@@ -61,7 +61,6 @@ def resource(txn, storage):
     yield resource
 
 
-@pytest.mark.asyncio
 async def test_get_metadata(resource):
     conv = Conversation("faq", resource)
     assert conv.value == {}
@@ -116,7 +115,6 @@ def get_message(id, who, to, text, attachments=None):
     return msg
 
 
-@pytest.mark.asyncio
 async def test_get_value(resource):
     conv = Conversation("faq", resource)
 

--- a/nucliadb/tests/ingest/unit/orm/test_resource.py
+++ b/nucliadb/tests/ingest/unit/orm/test_resource.py
@@ -44,7 +44,6 @@ from nucliadb_protos.resources_pb2 import (
 from nucliadb_protos.writer_pb2 import BrokerMessage
 
 
-@pytest.mark.asyncio
 async def test_get_file_page_positions():
     extracted_data = FileExtractedData()
     extracted_data.file_pages_previews.positions.extend(

--- a/nucliadb/tests/ingest/unit/test_partitions.py
+++ b/nucliadb/tests/ingest/unit/test_partitions.py
@@ -20,12 +20,9 @@
 import json
 import os
 
-import pytest
-
 from nucliadb.ingest.partitions import assign_partitions
 
 
-@pytest.mark.asyncio
 async def test_assign_partitions(partition_settings):
     expected_partition_list = []
     part = partition_settings.replica_number

--- a/nucliadb/tests/ingest/unit/test_processing.py
+++ b/nucliadb/tests/ingest/unit/test_processing.py
@@ -45,7 +45,6 @@ TEST_CLOUD_FILE = CloudFile(
 TEST_ITEM = PushPayload(uuid="foo", kbid="bar", userid="baz", partition=1)
 
 
-@pytest.mark.asyncio
 async def test_dummy_processing_engine():
     engine = DummyProcessingEngine()
     await engine.initialize()

--- a/nucliadb/tests/nucliadb/benchmarks/test_search.py
+++ b/nucliadb/tests/nucliadb/benchmarks/test_search.py
@@ -41,7 +41,6 @@ from tests.utils import inject_message
     disable_gc=True,
     warmup=False,
 )
-@pytest.mark.asyncio
 async def test_search_returns_labels(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -68,7 +67,6 @@ async def test_search_returns_labels(
     disable_gc=True,
     warmup=False,
 )
-@pytest.mark.asyncio
 async def test_search_relations(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/common/cluster/test_manager.py
+++ b/nucliadb/tests/nucliadb/integration/common/cluster/test_manager.py
@@ -138,7 +138,6 @@ async def shards(fake_nodes, fake_kbid: str, maindb_driver: Driver):
         (1, {"node-1", "node-2"}),
     ],
 )
-@pytest.mark.asyncio
 async def test_choose_node_always_prefer_the_same_node(shards, shard_index: int, nodes: set):
     shard = shards.shards[shard_index]
     node_ids = set()
@@ -177,7 +176,6 @@ async def test_choose_node_raises_if_no_nodes(shards):
         manager.choose_node(shard, use_nidx=False)
 
 
-@pytest.mark.asyncio
 async def test_apply_for_all_shards(fake_kbid: str, shards, maindb_driver: Driver):
     kbid = fake_kbid
 

--- a/nucliadb/tests/nucliadb/integration/common/cluster/test_rebalance.py
+++ b/nucliadb/tests/nucliadb/integration/common/cluster/test_rebalance.py
@@ -26,8 +26,6 @@ from nucliadb.common.cluster import rebalance
 from nucliadb.common.cluster.settings import settings
 from nucliadb.common.context import ApplicationContext
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 async def app_context(natsd, storage, nucliadb):

--- a/nucliadb/tests/nucliadb/integration/common/cluster/test_rollover.py
+++ b/nucliadb/tests/nucliadb/integration/common/cluster/test_rollover.py
@@ -28,8 +28,6 @@ from nucliadb.common import datamanagers
 from nucliadb.common.cluster import rollover
 from nucliadb.common.context import ApplicationContext
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 async def app_context(natsd, storage, nucliadb):

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_entities.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_entities.py
@@ -17,11 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb.common import datamanagers
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_set_duplicate_entities_index(maindb_driver):

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_labels.py
@@ -17,12 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb.common import datamanagers
 from nucliadb_protos.knowledgebox_pb2 import Labels
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_labelset_ids(maindb_driver):

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
@@ -25,8 +25,6 @@ from nucliadb.ingest.orm.resource import KB_RESOURCE_SLUG
 from nucliadb_protos import resources_pb2
 from nucliadb_protos.resources_pb2 import Basic
 
-pytestmark = pytest.mark.asyncio
-
 
 async def check_slug(driver: Driver, kbid, rid, slug):
     async with driver.transaction() as txn:

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_synonyms.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_synonyms.py
@@ -18,14 +18,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb.common import datamanagers
 from nucliadb.common.maindb.driver import Driver
 from nucliadb_protos import knowledgebox_pb2
 
 
-@pytest.mark.asyncio
 async def test_kb_synonyms(maindb_driver: Driver):
     kbid = "kbid"
 

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_vectorsets.py
@@ -18,14 +18,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb.common.datamanagers import vectorsets
 from nucliadb.common.maindb.driver import Driver
 from nucliadb_protos import knowledgebox_pb2
 
 
-@pytest.mark.asyncio
 async def test_kb_vectorsets(maindb_driver: Driver):
     kbid = "kbid"
     vectorset_id_1 = "gecko"

--- a/nucliadb/tests/nucliadb/integration/common/test_locking.py
+++ b/nucliadb/tests/nucliadb/integration/common/test_locking.py
@@ -26,7 +26,6 @@ import pytest
 from nucliadb.common import locking
 
 
-@pytest.mark.asyncio
 async def test_distributed_lock(maindb_driver):
     test_lock_key = uuid.uuid4().hex
 
@@ -52,7 +51,6 @@ async def test_distributed_lock(maindb_driver):
     await test_lock(0.0)
 
 
-@pytest.mark.asyncio
 async def test_distributed_lock_in_parallel(maindb_driver):
     """
     This tests that if multiple requests/tasks attempt to get the same lock,

--- a/nucliadb/tests/nucliadb/integration/migrator/test_migrator.py
+++ b/nucliadb/tests/nucliadb/integration/migrator/test_migrator.py
@@ -25,8 +25,6 @@ from nucliadb.migrator import migrator
 from nucliadb.migrator.context import ExecutionContext
 from nucliadb.migrator.settings import Settings
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 async def execution_context(natsd, storage, nucliadb):

--- a/nucliadb/tests/nucliadb/integration/search/test_autofilters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_autofilters.py
@@ -29,7 +29,6 @@ from nucliadb_models.internal.predict import (
 from tests.utils.predict import predict_query_hook
 
 
-@pytest.mark.asyncio
 async def test_autofilters_are_returned(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/search/test_filters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters.py
@@ -286,7 +286,6 @@ async def kbid(
     return knowledgebox
 
 
-@pytest.mark.asyncio
 async def test_filtering_before_and_after_reindexing(
     app_context, nucliadb_reader: AsyncClient, kbid: str
 ):

--- a/nucliadb/tests/nucliadb/integration/search/test_filters_expression.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters_expression.py
@@ -17,10 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 
-@pytest.mark.asyncio
 async def test_filtering_expression(nucliadb_reader, nucliadb_writer, knowledgebox):
     kbid = knowledgebox
 
@@ -93,7 +91,6 @@ async def test_filtering_expression(nucliadb_reader, nucliadb_writer, knowledgeb
         assert found_uuids == expected_uuids
 
 
-@pytest.mark.asyncio
 async def test_filtering_expression_validation(nucliadb_reader, nucliadb_writer):
     # Make sure we only allow one operator per filter
     resp = await nucliadb_reader.post(

--- a/nucliadb/tests/nucliadb/integration/search/test_hidden.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_hidden.py
@@ -33,7 +33,6 @@ async def create_resource(kbid, nucliadb_grpc):
     return message.uuid
 
 
-@pytest.mark.asyncio
 async def test_hidden_search(
     app_context,
     nucliadb_reader: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/search/test_search_sorting.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search_sorting.py
@@ -25,7 +25,6 @@ from httpx import AsyncClient
 from nucliadb_models.search import SearchOptions
 
 
-@pytest.mark.asyncio
 async def test_search_sort_by_score(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -60,7 +59,6 @@ async def test_search_sort_by_score(
         ("modified", "desc", lambda x: list(reversed(sorted(x)))),
     ],
 )
-@pytest.mark.asyncio
 async def test_search_sorted_by_creation_and_modification_dates(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -102,7 +100,6 @@ async def test_search_sorted_by_creation_and_modification_dates(
         ("title", "desc", lambda x: list(reversed(sorted(x)))),
     ],
 )
-@pytest.mark.asyncio
 async def test_limited_sorted_search_of_most_relevant_results(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -146,7 +143,6 @@ async def test_limited_sorted_search_of_most_relevant_results(
         assert sort_fields == sort_function(sort_fields)
 
 
-@pytest.mark.asyncio
 async def test_empty_query_search_for_ordered_resources_by_creation_date_desc(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -171,7 +167,6 @@ async def test_empty_query_search_for_ordered_resources_by_creation_date_desc(
         assert creation_dates == sorted(creation_dates, reverse=True)
 
 
-@pytest.mark.asyncio
 async def test_list_all_resources_by_creation_and_modification_dates_with_empty_queries(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -231,7 +226,6 @@ async def test_list_all_resources_by_creation_and_modification_dates_with_empty_
             assert sort_fields == sort_function(sort_fields)  # type: ignore
 
 
-@pytest.mark.asyncio
 async def test_search_sorting_most_relevant_results_with_pagination(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/tasks/test_tasks.py
+++ b/nucliadb/tests/nucliadb/integration/tasks/test_tasks.py
@@ -29,8 +29,6 @@ from nucliadb.common.cluster.settings import settings as cluster_settings
 from nucliadb.common.context import ApplicationContext
 from nucliadb_utils import const
 
-pytestmark = pytest.mark.asyncio
-
 
 @contextmanager
 def set_standalone_mode(value: bool):

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -55,7 +55,6 @@ from tests.utils import broker_resource, inject_message
 from tests.utils.dirty_index import wait_for_sync
 
 
-@pytest.mark.asyncio
 async def test_kb_creation_allows_setting_learning_configuration(
     nucliadb_manager,
     nucliadb_reader,
@@ -95,7 +94,6 @@ async def test_kb_creation_allows_setting_learning_configuration(
         )
 
 
-@pytest.mark.asyncio
 async def test_creation(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -221,7 +219,6 @@ async def test_creation(
     assert len(resp.content) > 0
 
 
-@pytest.mark.asyncio
 async def test_can_create_knowledgebox_with_colon_in_slug(nucliadb_manager: AsyncClient):
     resp = await nucliadb_manager.post("/kbs", json={"slug": "something:else"})
     assert resp.status_code == 201
@@ -231,7 +228,6 @@ async def test_can_create_knowledgebox_with_colon_in_slug(nucliadb_manager: Asyn
     assert resp.json()["kbs"][0]["slug"] == "something:else"
 
 
-@pytest.mark.asyncio
 async def test_serialize_errors(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,
@@ -281,7 +277,6 @@ async def test_serialize_errors(
         assert resp_json["data"][ftypestring][fid]["error"]["code"] == 1
 
 
-@pytest.mark.asyncio
 async def test_entitygroups(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,
@@ -320,7 +315,6 @@ async def test_entitygroups(
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_extracted_shortened_metadata(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,
@@ -399,7 +393,6 @@ async def test_extracted_shortened_metadata(
                 assert len(meta[cropped_field]) > 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "field_id,error",
     [
@@ -433,7 +426,6 @@ async def test_field_ids_are_validated(
         assert resp.status_code == 201
 
 
-@pytest.mark.asyncio
 async def test_extra(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,
@@ -510,7 +502,6 @@ async def test_extra(
     assert resp.json()["extra"] == extra
 
 
-@pytest.mark.asyncio
 async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -538,7 +529,6 @@ async def test_icon_doesnt_change_after_labeling_resource_sc_5625(
     assert resp.json()["icon"] == "application/pdf"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "slug,valid",
     [
@@ -564,7 +554,6 @@ async def test_resource_slug_validation(nucliadb_writer, nucliadb_reader, knowle
         assert f"Invalid slug: '{slug}'" in detail["msg"]
 
 
-@pytest.mark.asyncio
 async def test_icon_doesnt_change_after_adding_file_field_sc_2388(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -596,7 +585,6 @@ async def test_icon_doesnt_change_after_adding_file_field_sc_2388(
     assert resp.json()["icon"] == "text/plain"
 
 
-@pytest.mark.asyncio
 async def test_language_metadata(
     nucliadb_writer,
     nucliadb_reader,
@@ -668,7 +656,6 @@ async def test_language_metadata(
     assert res["metadata"]["languages"] == []
 
 
-@pytest.mark.asyncio
 async def test_story_7081(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -700,7 +687,6 @@ async def test_story_7081(
     assert data["origin"]["metadata"]["some"] == "data"
 
 
-@pytest.mark.asyncio
 async def test_question_answer(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -780,7 +766,6 @@ async def test_question_answer(
     }
 
 
-@pytest.mark.asyncio
 async def test_question_answer_annotations(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -835,7 +820,6 @@ async def test_question_answer_annotations(
     assert resource.fieldmetadata[0].question_answers[0] == qa_annotation  # type: ignore
 
 
-@pytest.mark.asyncio
 async def test_link_fields_store_css_selector(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -875,7 +859,6 @@ async def test_link_fields_store_css_selector(
     assert css_selector == "main"
 
 
-@pytest.mark.asyncio
 async def test_link_fields_store_xpath(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -915,7 +898,6 @@ async def test_link_fields_store_xpath(
     assert xpath == "my_xpath"
 
 
-@pytest.mark.asyncio
 async def test_pagination_limits(
     nucliadb_reader: AsyncClient,
 ):
@@ -996,7 +978,6 @@ async def test_dates_are_properly_validated(
     assert resp.json()["origin"]["created"] == "0001-01-01T00:00:00Z"
 
 
-@pytest.mark.asyncio
 async def test_file_computed_titles_are_set_on_resource_title(
     nucliadb_writer,
     nucliadb_grpc,

--- a/nucliadb/tests/nucliadb/integration/test_ask.py
+++ b/nucliadb/tests/nucliadb/integration/test_ask.py
@@ -56,7 +56,6 @@ def audit():
         yield audit_mock
 
 
-@pytest.mark.asyncio()
 async def test_ask(
     nucliadb_reader: AsyncClient,
     knowledgebox,
@@ -84,7 +83,6 @@ def find_incomplete_results():
         yield
 
 
-@pytest.mark.asyncio()
 async def test_ask_handles_incomplete_find_results(
     nucliadb_reader: AsyncClient,
     knowledgebox,
@@ -112,7 +110,6 @@ async def resource(nucliadb_writer, knowledgebox):
     yield rid
 
 
-@pytest.mark.asyncio()
 async def test_ask_synchronous(nucliadb_reader: AsyncClient, knowledgebox, resource):
     resp = await nucliadb_reader.post(
         f"/kb/{knowledgebox}/ask",
@@ -126,7 +123,6 @@ async def test_ask_synchronous(nucliadb_reader: AsyncClient, knowledgebox, resou
     assert resp_data.status == AnswerStatusCode.SUCCESS.prettify()
 
 
-@pytest.mark.asyncio()
 async def test_ask_with_citations(nucliadb_reader: AsyncClient, knowledgebox, resource):
     citations = {"foo": [], "bar": []}  # type: ignore
     citations_gen = CitationsGenerativeResponse(citations=citations)
@@ -147,7 +143,6 @@ async def test_ask_with_citations(nucliadb_reader: AsyncClient, knowledgebox, re
     assert resp_citations == citations
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize("debug", (True, False))
 async def test_sync_ask_returns_debug_mode(nucliadb_reader: AsyncClient, knowledgebox, resource, debug):
     # Make sure prompt context is returned if debug is True
@@ -201,7 +196,6 @@ def parse_ask_response(resp):
     return results
 
 
-@pytest.mark.asyncio()
 async def test_ask_rag_options_full_resource(nucliadb_reader: AsyncClient, knowledgebox, resources):
     resource1, resource2 = resources
 
@@ -233,7 +227,6 @@ async def test_ask_rag_options_full_resource(nucliadb_reader: AsyncClient, knowl
     assert prompt_context[f"{resource2}/t/text_field"] == "The body of the text field"
 
 
-@pytest.mark.asyncio()
 async def test_ask_full_resource_rag_strategy_with_exclude(
     nucliadb_reader: AsyncClient, knowledgebox, resources
 ):
@@ -288,7 +281,6 @@ async def test_ask_full_resource_rag_strategy_with_exclude(
     assert prompt_context[f"{resource2}/t/text_field"] == "The body of the text field"
 
 
-@pytest.mark.asyncio()
 async def test_ask_rag_options_extend_with_fields(nucliadb_reader: AsyncClient, knowledgebox, resources):
     resource1, resource2 = resources
 
@@ -321,7 +313,6 @@ async def test_ask_rag_options_extend_with_fields(nucliadb_reader: AsyncClient, 
     assert prompt_context[f"{resource2}/a/summary"] == "The summary 1"
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "invalid_payload,expected_error_msg",
     [
@@ -408,7 +399,6 @@ async def test_ask_rag_strategies_validation(nucliadb_reader, invalid_payload, e
         assert expected_error_msg in error_msg
 
 
-@pytest.mark.asyncio()
 async def test_ask_capped_context(nucliadb_reader: AsyncClient, knowledgebox, resources):
     # By default, max size is big enough to fit all the prompt context
     resp = await nucliadb_reader.post(
@@ -446,13 +436,11 @@ async def test_ask_capped_context(nucliadb_reader: AsyncClient, knowledgebox, re
     assert total_size <= max_size * 3
 
 
-@pytest.mark.asyncio()
 async def test_ask_on_a_kb_not_found(nucliadb_reader):
     resp = await nucliadb_reader.post("/kb/unknown_kb_id/ask", json={"query": "title"})
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio()
 async def test_ask_max_tokens(nucliadb_reader, knowledgebox, resources):
     # As an integer
     resp = await nucliadb_reader.post(
@@ -486,7 +474,6 @@ async def test_ask_max_tokens(nucliadb_reader, knowledgebox, resources):
     assert resp.status_code == 412
 
 
-@pytest.mark.asyncio()
 async def test_ask_on_resource(nucliadb_reader: AsyncClient, knowledgebox, resource):
     resp = await nucliadb_reader.post(
         f"/kb/{knowledgebox}/resource/{resource}/ask",
@@ -497,7 +484,6 @@ async def test_ask_on_resource(nucliadb_reader: AsyncClient, knowledgebox, resou
     SyncAskResponse.model_validate_json(resp.content)
 
 
-@pytest.mark.asyncio()
 async def test_ask_handles_stream_errors_on_predict(nucliadb_reader, knowledgebox, resource):
     predict = get_predict()
     prev = predict.ndjson_answer.copy()
@@ -533,7 +519,6 @@ async def test_ask_handles_stream_errors_on_predict(nucliadb_reader, knowledgebo
     predict.ndjson_answer = prev
 
 
-@pytest.mark.asyncio()
 async def test_ask_handles_stream_unexpected_errors_sync(nucliadb_reader, knowledgebox, resource):
     with mock.patch(
         "nucliadb.search.search.chat.ask.AskResult._stream",
@@ -548,7 +533,6 @@ async def test_ask_handles_stream_unexpected_errors_sync(nucliadb_reader, knowle
         assert resp.status_code == 500
 
 
-@pytest.mark.asyncio()
 async def test_ask_handles_stream_unexpected_errors_stream(nucliadb_reader, knowledgebox, resource):
     with mock.patch(
         "nucliadb.search.search.chat.ask.AskResult._stream",
@@ -568,7 +552,6 @@ async def test_ask_handles_stream_unexpected_errors_stream(nucliadb_reader, know
         )
 
 
-@pytest.mark.asyncio()
 async def test_ask_with_json_schema_output(
     nucliadb_reader: AsyncClient,
     knowledgebox,
@@ -602,7 +585,6 @@ async def test_ask_with_json_schema_output(
     assert answer_json["confidence"] == 0.5
 
 
-@pytest.mark.asyncio()
 async def test_ask_assert_audit_retrieval_contexts(
     nucliadb_reader: AsyncClient, knowledgebox, resources, audit
 ):
@@ -615,7 +597,6 @@ async def test_ask_assert_audit_retrieval_contexts(
     }
 
 
-@pytest.mark.asyncio()
 async def test_ask_rag_strategy_neighbouring_paragraphs(
     nucliadb_reader: AsyncClient, knowledgebox, resources
 ):
@@ -631,9 +612,6 @@ async def test_ask_rag_strategy_neighbouring_paragraphs(
     assert resp.status_code == 200
     ask_response = SyncAskResponse.model_validate_json(resp.content)
     assert ask_response.prompt_context is not None
-
-
-pytest.mark.asyncio()
 
 
 async def test_ask_rag_strategy_metadata_extension(

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -113,7 +113,6 @@ async def resource_with_conversation(nucliadb_grpc, nucliadb_writer, knowledgebo
     yield rid
 
 
-@pytest.mark.asyncio
 async def test_conversations(
     nucliadb_reader: AsyncClient,
     knowledgebox,
@@ -152,7 +151,6 @@ async def test_conversations(
     assert msgs[-1]["type"] == MessageType.ANSWER.value
 
 
-@pytest.mark.asyncio
 async def test_extracted_text_is_serialized_properly(
     nucliadb_reader: AsyncClient,
     knowledgebox,
@@ -171,7 +169,6 @@ async def test_extracted_text_is_serialized_properly(
     assert extracted.text.split_text["2"] == "Split text 2"  # type: ignore
 
 
-@pytest.mark.asyncio
 async def test_find_conversations(
     nucliadb_reader: AsyncClient,
     knowledgebox,

--- a/nucliadb/tests/nucliadb/integration/test_counters.py
+++ b/nucliadb/tests/nucliadb/integration/test_counters.py
@@ -17,11 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 from httpx import AsyncClient
 
 
-@pytest.mark.asyncio
 async def test_counters(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_deletion.py
+++ b/nucliadb/tests/nucliadb/integration/test_deletion.py
@@ -21,7 +21,6 @@
 import asyncio
 import dataclasses
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb_models.search import SearchOptions
@@ -39,7 +38,6 @@ from nucliadb_protos.writer_pb2_grpc import WriterStub
 from tests.utils import inject_message
 
 
-@pytest.mark.asyncio
 async def test_paragraph_index_deletions(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_entities.py
+++ b/nucliadb/tests/nucliadb/integration/test_entities.py
@@ -61,8 +61,6 @@ from tests.utils.entities import (
     wait_until_entity,
 )
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture
 async def text_field(
@@ -213,7 +211,6 @@ async def entities(
     await wait_until_entity(nucliadb_grpc, knowledgebox, "ANIMALS", "bird")
 
 
-@pytest.mark.asyncio
 async def test_get_entities_groups(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,
@@ -243,7 +240,6 @@ async def test_get_entities_groups(
     assert body["detail"] == "Entities group 'I-DO-NOT-EXIST' does not exist"
 
 
-@pytest.mark.asyncio
 async def test_list_entities_groups(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,
@@ -260,7 +256,6 @@ async def test_list_entities_groups(
     assert len(body["groups"]["ANIMALS"]["entities"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_create_entities_group_twice(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -279,7 +274,6 @@ async def test_create_entities_group_twice(
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
 async def test_update_entities_group(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -309,7 +303,6 @@ async def test_update_entities_group(
     assert body["entities"]["dog"]["value"] == "updated-dog"
 
 
-@pytest.mark.asyncio
 async def test_update_indexed_entities_group(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -337,7 +330,6 @@ async def test_update_indexed_entities_group(
     assert body["entities"]["dolphin"]["value"] == "updated-dolphin"
 
 
-@pytest.mark.asyncio
 async def test_update_entities_group_metadata(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -361,7 +353,6 @@ async def test_update_entities_group_metadata(
     assert body["color"] == "red"
 
 
-@pytest.mark.asyncio
 async def test_delete_entities_group(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -377,7 +368,6 @@ async def test_delete_entities_group(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_delete_and_recreate_entities_group(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -405,7 +395,6 @@ async def test_delete_and_recreate_entities_group(
     assert body["color"] == "white"
 
 
-@pytest.mark.asyncio
 async def test_entities_indexing(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,

--- a/nucliadb/tests/nucliadb/integration/test_field_external_file.py
+++ b/nucliadb/tests/nucliadb/integration/test_field_external_file.py
@@ -40,7 +40,6 @@ def nuclia_jwt_key():
     yield
 
 
-@pytest.mark.asyncio
 async def test_external_file_field(
     nuclia_jwt_key,
     nucliadb_reader,

--- a/nucliadb/tests/nucliadb/integration/test_find.py
+++ b/nucliadb/tests/nucliadb/integration/test_find.py
@@ -30,7 +30,6 @@ from nucliadb_protos.writer_pb2_grpc import WriterStub
 from nucliadb_utils.exceptions import LimitsExceededError
 
 
-@pytest.mark.asyncio
 async def test_find_with_label_changes(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -101,7 +100,6 @@ async def test_find_with_label_changes(
     assert len(body["resources"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_find_does_not_support_fulltext_search(
     nucliadb_reader: AsyncClient,
     knowledgebox,
@@ -120,7 +118,6 @@ async def test_find_does_not_support_fulltext_search(
     assert "fulltext search not supported" in resp.json()["detail"][0]["msg"]
 
 
-@pytest.mark.asyncio
 async def test_find_resource_filters(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -201,7 +198,6 @@ async def test_find_min_score(
     assert resp.json()["min_score"] == {"bm25": 0, "semantic": 0.5}
 
 
-@pytest.mark.asyncio
 async def test_story_7286(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -260,7 +256,6 @@ async def test_story_7286(
     assert len(body["resources"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_find_marks_fuzzy_results(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -319,7 +314,6 @@ def check_fuzzy_paragraphs(find_response, *, fuzzy_result: bool, n_expected: int
     assert found == n_expected
 
 
-@pytest.mark.asyncio
 async def test_find_returns_best_matches(
     nucliadb_reader: AsyncClient,
     philosophy_books_kb,
@@ -357,7 +351,6 @@ def find_with_limits_exceeded_error():
         yield
 
 
-@pytest.mark.asyncio()
 async def test_find_handles_limits_exceeded_error(
     nucliadb_reader, knowledgebox, find_with_limits_exceeded_error
 ):

--- a/nucliadb/tests/nucliadb/integration/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/test_labels.py
@@ -20,7 +20,6 @@
 import uuid
 from datetime import datetime
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb.ingest.orm.resource import (
@@ -164,7 +163,6 @@ async def inject_resource_with_paragraph_labels(knowledgebox, writer):
     return bm.uuid
 
 
-@pytest.mark.asyncio
 async def test_labels_global(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -196,7 +194,6 @@ async def test_labels_global(
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
 async def test_classification_labels_cancelled_by_the_user(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -241,7 +238,6 @@ async def test_classification_labels_cancelled_by_the_user(
     assert content["resources"][rid]["usermetadata"]["classifications"][0] == expected_label
 
 
-@pytest.mark.asyncio
 async def test_classification_labels_are_shown_in_resource_basic(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -313,7 +309,6 @@ def test_add_field_classifications():
     )
 
 
-@pytest.mark.asyncio
 async def test_fieldmetadata_classification_labels(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_labelsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_labelsets.py
@@ -18,11 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 from httpx import AsyncClient
 
 
-@pytest.mark.asyncio
 async def test_selection_labelsets(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
+++ b/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
@@ -100,7 +100,6 @@ def hosted_nucliadb():
         yield
 
 
-@pytest.mark.asyncio
 async def test_kb_creation(
     nucliadb_grpc: WriterStub,
     nucliadb_reader: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
+++ b/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
@@ -22,7 +22,6 @@
 import pytest
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "method,endpoint,params,payload",
     [
@@ -59,7 +58,6 @@ async def test_predict_proxy(nucliadb_reader, knowledgebox, method, endpoint, pa
     assert resp.status_code == 200, resp.text
 
 
-@pytest.mark.asyncio()
 async def test_predict_proxy_not_proxied_returns_422(
     nucliadb_reader,
     knowledgebox,
@@ -72,7 +70,6 @@ async def test_predict_proxy_not_proxied_returns_422(
     assert resp.status_code == 422
 
 
-@pytest.mark.asyncio()
 async def test_predict_proxy_returns_404_on_non_existing_kb(
     nucliadb_reader,
 ):

--- a/nucliadb/tests/nucliadb/integration/test_processing_status.py
+++ b/nucliadb/tests/nucliadb/integration/test_processing_status.py
@@ -37,7 +37,6 @@ from tests.utils import broker_resource, inject_message
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_endpoint_set_resource_status_to_pending(
     endpoint,
     expected_status,

--- a/nucliadb/tests/nucliadb/integration/test_purge.py
+++ b/nucliadb/tests/nucliadb/integration/test_purge.py
@@ -39,7 +39,6 @@ from nucliadb_protos import nodewriter_pb2, utils_pb2, writer_pb2
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_purge_deletes_everything_from_maindb(
     maindb_driver: Driver,
     storage: Storage,
@@ -103,7 +102,6 @@ async def test_purge_deletes_everything_from_maindb(
     assert len(keys_after_purge_storage) == 0
 
 
-@pytest.mark.asyncio
 async def test_purge_orphan_shards(
     maindb_driver: Driver,
     storage: Storage,
@@ -163,7 +161,6 @@ async def test_purge_orphan_shards(
     assert len(shards) == 0
 
 
-@pytest.mark.asyncio
 async def test_purge_orphan_shard_detection(
     maindb_driver: Driver,
     storage: Storage,

--- a/nucliadb/tests/nucliadb/integration/test_purge_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_purge_vectorsets.py
@@ -20,8 +20,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.orm.knowledgebox import KB_VECTORSET_TO_DELETE
 from nucliadb.purge import purge_kb_vectorsets
@@ -31,7 +29,6 @@ from nucliadb_utils.storages.storage import Storage
 from tests.nucliadb.knowledgeboxes.vectorsets import KbSpecs
 
 
-@pytest.mark.asyncio
 async def test_purge_vectorsets(
     maindb_driver: Driver,
     storage: Storage,

--- a/nucliadb/tests/nucliadb/integration/test_relations.py
+++ b/nucliadb/tests/nucliadb/integration/test_relations.py
@@ -32,7 +32,6 @@ from tests.utils import inject_message
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def resource_with_bm_relations(
     nucliadb_grpc: WriterStub,
     nucliadb_writer: AsyncClient,
@@ -57,7 +56,6 @@ async def resource_with_bm_relations(
     yield rid, "text1"
 
 
-@pytest.mark.asyncio
 async def test_api_aliases(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,
@@ -93,7 +91,6 @@ async def test_api_aliases(
     assert "from_" not in body["extracted"]["metadata"]["metadata"]["relations"][0]
 
 
-@pytest.mark.asyncio
 async def test_broker_message_relations(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,
@@ -141,7 +138,6 @@ async def test_broker_message_relations(
     assert len(body["extracted"]["metadata"]["metadata"]["relations"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_extracted_relations(
     nucliadb_grpc: WriterStub,
     nucliadb_reader: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/test_resources.py
@@ -29,7 +29,6 @@ from nucliadb.common.maindb.utils import get_driver
 from nucliadb.writer.api.v1.router import KB_PREFIX, RESOURCES_PREFIX
 
 
-@pytest.mark.asyncio
 async def test_resource_crud(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -70,7 +69,6 @@ async def test_resource_crud(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_list_resources(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -106,7 +104,6 @@ async def test_list_resources(
     assert got_rids == rids
 
 
-@pytest.mark.asyncio
 async def test_get_resource_field(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -137,7 +134,6 @@ async def test_get_resource_field(
     assert body_by_slug == body_by_rid
 
 
-@pytest.mark.asyncio
 async def test_resource_creation_slug_conflicts(
     nucliadb_writer: AsyncClient,
     knowledgebox,
@@ -174,7 +170,6 @@ async def test_resource_creation_slug_conflicts(
     assert resp.status_code == 201
 
 
-@pytest.mark.asyncio
 async def test_title_is_set_automatically_if_not_provided(
     nucliadb_reader,
     nucliadb_writer,
@@ -195,7 +190,6 @@ async def test_title_is_set_automatically_if_not_provided(
     assert body["title"] == rid
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("update_by", ["slug", "uuid"])
 async def test_resource_slug_modification(
     nucliadb_reader,
@@ -247,7 +241,6 @@ async def check_resource(nucliadb_reader, kbid, rid, slug, **body_checks):
         assert body[key] == value
 
 
-@pytest.mark.asyncio
 async def test_resource_slug_modification_rollbacks(
     nucliadb_reader,
     nucliadb_writer,
@@ -284,7 +277,6 @@ async def test_resource_slug_modification_rollbacks(
     await check_resource(nucliadb_reader, knowledgebox, rid, old_slug, title="New title")
 
 
-@pytest.mark.asyncio
 async def test_resource_slug_modification_handles_conflicts(
     nucliadb_writer,
     knowledgebox,
@@ -316,7 +308,6 @@ async def test_resource_slug_modification_handles_conflicts(
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
 async def test_resource_slug_modification_handles_unknown_resources(
     nucliadb_writer,
     knowledgebox,
@@ -330,7 +321,6 @@ async def test_resource_slug_modification_handles_unknown_resources(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_parallel_dup_resource_creation_raises_conflicts(
     nucliadb_writer,
     knowledgebox,

--- a/nucliadb/tests/nucliadb/integration/test_suggest.py
+++ b/nucliadb/tests/nucliadb/integration/test_suggest.py
@@ -26,7 +26,6 @@ from nucliadb_protos.writer_pb2 import BrokerMessage, OpStatusWriter
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 
 
-@pytest.mark.asyncio
 async def test_suggest_paragraphs(
     nucliadb_grpc: WriterStub,
     nucliadb_reader: AsyncClient,
@@ -149,7 +148,6 @@ async def test_suggest_paragraphs(
     assert len(body["paragraphs"]["results"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_suggest_related_entities(
     nucliadb_reader: AsyncClient, nucliadb_writer: AsyncClient, knowledgebox, request
 ):
@@ -257,7 +255,6 @@ async def test_suggest_related_entities(
     assert_expected_entities(body, {"Solomon Islands", "Israel"})
 
 
-@pytest.mark.asyncio
 async def test_suggestion_on_link_computed_titles_sc6088(
     nucliadb_writer,
     nucliadb_grpc,
@@ -314,7 +311,6 @@ async def test_suggestion_on_link_computed_titles_sc6088(
     assert suggested["text"] == extracted_title
 
 
-@pytest.mark.asyncio
 async def test_suggest_features(
     nucliadb_grpc: WriterStub,
     nucliadb_reader: AsyncClient,
@@ -371,7 +367,6 @@ async def test_suggest_features(
     assert len(body["paragraphs"]["results"]) == 0
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def texts(
     nucliadb_writer: AsyncClient,
@@ -426,7 +421,6 @@ async def texts(
     }
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def entities(nucliadb_writer: AsyncClient, knowledgebox: str):
     collaborators = ["Irene", "Anastasia"]
@@ -475,7 +469,6 @@ async def entities(nucliadb_writer: AsyncClient, knowledgebox: str):
     assert resp.status_code == 201
 
 
-@pytest.mark.asyncio
 async def test_search_kb_not_found(nucliadb_reader) -> None:
     resp = await nucliadb_reader.get(
         f"/kb/00000000000000/suggest?query=own+text",

--- a/nucliadb/tests/nucliadb/integration/test_summarize.py
+++ b/nucliadb/tests/nucliadb/integration/test_summarize.py
@@ -17,13 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 from httpx import AsyncClient
 
 from nucliadb_models.search import SummarizedResponse
 
 
-@pytest.mark.asyncio()
 async def test_summarize(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -63,7 +61,6 @@ async def test_summarize(
     assert set(response.resources.keys()) == set(resources)
 
 
-@pytest.mark.asyncio()
 async def test_summarize_unexisting_kb(
     nucliadb_reader: AsyncClient,
 ):

--- a/nucliadb/tests/nucliadb/integration/test_synonyms.py
+++ b/nucliadb/tests/nucliadb/integration/test_synonyms.py
@@ -22,7 +22,6 @@ import pytest
 from nucliadb_models.search import SearchOptions
 
 
-@pytest.mark.asyncio
 async def test_custom_synonyms_api(
     nucliadb_reader,
     nucliadb_writer,
@@ -88,7 +87,6 @@ async def knowledgebox_with_synonyms(nucliadb_writer, knowledgebox):
     yield kbid
 
 
-@pytest.mark.asyncio
 async def test_search_with_synonyms(
     nucliadb_reader,
     nucliadb_writer,
@@ -190,7 +188,6 @@ def get_pararagraphs(body):
     return paragraphs
 
 
-@pytest.mark.asyncio
 async def test_search_errors_if_vectors_or_relations_requested(
     nucliadb_reader,
     knowledgebox,

--- a/nucliadb/tests/nucliadb/integration/test_text_field_json.py
+++ b/nucliadb/tests/nucliadb/integration/test_text_field_json.py
@@ -19,13 +19,11 @@
 #
 import json
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb_models.text import TextFormat
 
 
-@pytest.mark.asyncio
 async def test_text_field_in_json_format(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -57,7 +55,6 @@ async def test_text_field_in_json_format(
     assert json.loads(body["data"]["texts"][field_id]["value"]["body"]) == payload
 
 
-@pytest.mark.asyncio
 async def test_text_field_with_invalid_json(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_tokens.py
+++ b/nucliadb/tests/nucliadb/integration/test_tokens.py
@@ -18,11 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 from httpx import AsyncClient
 
 
-@pytest.mark.asyncio
 async def test_metadata_tokens_cancelled_by_the_user_sc_3775(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_upload.py
+++ b/nucliadb/tests/nucliadb/integration/test_upload.py
@@ -19,13 +19,11 @@
 #
 import base64
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb.writer.tus import UPLOAD
 
 
-@pytest.mark.asyncio
 async def test_upload(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -64,7 +62,6 @@ async def test_upload(
     assert resp.content == content
 
 
-@pytest.mark.asyncio
 async def test_upload_guesses_content_type(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_usermetadata.py
+++ b/nucliadb/tests/nucliadb/integration/test_usermetadata.py
@@ -17,11 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 from httpx import AsyncClient
 
 
-@pytest.mark.asyncio
 async def test_labels_sc_2053(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_vectorsets.py
@@ -63,7 +63,6 @@ DEFAULT_VECTOR_DIMENSION = 512
 VECTORSET_DIMENSION = 12
 
 
-@pytest.mark.asyncio
 async def test_vectorsets_work_on_a_kb_with_a_single_vectorset(
     nucliadb_reader: AsyncClient,
     nucliadb_writer: AsyncClient,
@@ -122,7 +121,6 @@ async def test_vectorsets_work_on_a_kb_with_a_single_vectorset(
     "vectorset,expected",
     [(None, "multilingual"), ("", "multilingual"), ("myvectorset", "myvectorset")],
 )
-@pytest.mark.asyncio
 async def test_vectorset_parameter_without_default_vectorset(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,
@@ -182,7 +180,6 @@ async def test_vectorset_parameter_without_default_vectorset(
     "vectorset,expected",
     [(None, "multilingual"), ("", "multilingual"), ("myvectorset", "myvectorset")],
 )
-@pytest.mark.asyncio
 async def test_vectorset_parameter_with_default_vectorset(
     nucliadb_reader: AsyncClient,
     knowledgebox: str,

--- a/nucliadb/tests/nucliadb/integration/test_vectorsets_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_vectorsets_api.py
@@ -19,7 +19,6 @@
 #
 from unittest.mock import patch
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb.common import datamanagers
@@ -35,7 +34,6 @@ from nucliadb_protos.nodewriter_pb2 import VectorType
 MODULE = "nucliadb.writer.vectorsets"
 
 
-@pytest.mark.asyncio
 async def test_add_delete_vectorsets(
     nucliadb_manager: AsyncClient,
     knowledgebox,
@@ -111,7 +109,6 @@ async def test_add_delete_vectorsets(
                 assert vs is None
 
 
-@pytest.mark.asyncio
 async def test_learning_config_errors_are_proxied_correctly(
     nucliadb_manager: AsyncClient,
     knowledgebox,

--- a/nucliadb/tests/nucliadb/integration/test_visual_selections.py
+++ b/nucliadb/tests/nucliadb/integration/test_visual_selections.py
@@ -34,7 +34,6 @@ PAGE_0_SELECTION_COUNT = 18
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.asyncio
 async def annotated_file_field(
     nucliadb_writer: AsyncClient,
     knowledgebox: str,
@@ -96,7 +95,6 @@ async def annotated_file_field(
     yield (rid, field_id)
 
 
-@pytest.mark.asyncio
 async def test_visual_selection(nucliadb_reader: AsyncClient, knowledgebox: str, annotated_file_field):
     kbid = knowledgebox
     rid, field_id = annotated_file_field

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0017.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0017.py
@@ -19,8 +19,6 @@
 #
 from unittest.mock import Mock
 
-import pytest
-
 from nucliadb.common import datamanagers
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.migrator.models import Migration
@@ -30,7 +28,6 @@ from tests.nucliadb.migrations import get_migration
 migration: Migration = get_migration(17)
 
 
-@pytest.mark.asyncio
 async def test_migration_0017_kb(maindb_driver: Driver):
     execution_context = Mock()
     execution_context.kv_driver = maindb_driver

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0018.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0018.py
@@ -19,8 +19,6 @@
 #
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
-
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.kb import KB_SLUGS
 from nucliadb.common.maindb.driver import Driver
@@ -32,7 +30,6 @@ from tests.nucliadb.migrations import get_migration
 migration: Migration = get_migration(18)
 
 
-@pytest.mark.asyncio
 async def test_migration_0018_global(maindb_driver: Driver):
     execution_context = Mock()
     execution_context.kv_driver = maindb_driver

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0021.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0021.py
@@ -20,8 +20,6 @@
 import uuid
 from unittest.mock import Mock
 
-import pytest
-
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.migrator.models import Migration
 from nucliadb_protos import knowledgebox_pb2
@@ -30,7 +28,6 @@ from tests.nucliadb.migrations import get_migration
 migration: Migration = get_migration(21)
 
 
-@pytest.mark.asyncio
 async def test_migration_0021(maindb_driver: Driver):
     execution_context = Mock()
     execution_context.kv_driver = maindb_driver
@@ -59,7 +56,6 @@ async def test_migration_0021(maindb_driver: Driver):
         assert (await txn.get(f"/kbs/{kbid}/other")) == b"other data"
 
 
-@pytest.mark.asyncio
 async def test_migration_0021_kb_without_vectorset_key(maindb_driver: Driver):
     execution_context = Mock()
     execution_context.kv_driver = maindb_driver

--- a/nucliadb/tests/nucliadb/unit/common/cluster/discovery/test_k8s.py
+++ b/nucliadb/tests/nucliadb/unit/common/cluster/discovery/test_k8s.py
@@ -33,8 +33,6 @@ from nucliadb.common.cluster.discovery.types import IndexNodeMetadata
 from nucliadb.common.cluster.settings import Settings
 from nucliadb_protos import nodewriter_pb2
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 def writer_stub():

--- a/nucliadb/tests/nucliadb/unit/common/cluster/standalone/test_service.py
+++ b/nucliadb/tests/nucliadb/unit/common/cluster/standalone/test_service.py
@@ -29,8 +29,6 @@ from nucliadb_protos import nodereader_pb2, standalone_pb2
 from nucliadb_protos.noderesources_pb2 import ShardId
 from nucliadb_protos.utils_pb2 import RelationNode
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture
 def cluster_settings():

--- a/nucliadb/tests/nucliadb/unit/common/cluster/test_rollover.py
+++ b/nucliadb/tests/nucliadb/unit/common/cluster/test_rollover.py
@@ -27,8 +27,6 @@ from nucliadb.common.cluster.index_node import IndexNode
 from nucliadb.common.datamanagers.rollover import RolloverState
 from nucliadb_protos import writer_pb2
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture()
 def available_nodes():

--- a/nucliadb/tests/nucliadb/unit/common/maindb/test_utils.py
+++ b/nucliadb/tests/nucliadb/unit/common/maindb/test_utils.py
@@ -34,7 +34,6 @@ def reset_driver_utils():
     clean_utility(Utility.MAINDB_DRIVER)
 
 
-@pytest.mark.asyncio
 async def test_setup_driver_pg():
     mock = AsyncMock(initialized=False)
     with (
@@ -46,7 +45,6 @@ async def test_setup_driver_pg():
         mock.initialize.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_setup_driver_error():
     with (
         patch.object(settings, "driver", DriverConfig("pg")),

--- a/nucliadb/tests/nucliadb/unit/http_clients/test_processing.py
+++ b/nucliadb/tests/nucliadb/unit/http_clients/test_processing.py
@@ -79,7 +79,6 @@ class TestProcessingHTTPClient:
         cl.session.get.return_value = resp_handler
         yield cl
 
-    @pytest.mark.asyncio
     async def test_requests(self, client: processing.ProcessingHTTPClient, response):
         response_data = processing.RequestsResults(results=[], cursor=None)
         response.status = 200
@@ -87,7 +86,6 @@ class TestProcessingHTTPClient:
 
         assert await client.requests() == response_data
 
-    @pytest.mark.asyncio
     async def test_pull(self, client: processing.ProcessingHTTPClient, response):
         response_data = processing.PullResponse(status="ok", payload="foobar", msgid="1")
         response.status = 200
@@ -95,7 +93,6 @@ class TestProcessingHTTPClient:
 
         assert await client.pull(partition="1") == response_data
 
-    @pytest.mark.asyncio
     async def test_stats(self, client: processing.ProcessingHTTPClient, response):
         response_data = processing.StatsResponse(incomplete=1, scheduled=1)
         response.status = 200

--- a/nucliadb/tests/nucliadb/unit/http_clients/test_pypi.py
+++ b/nucliadb/tests/nucliadb/unit/http_clients/test_pypi.py
@@ -41,11 +41,9 @@ class TestPyPi:
         cl.session.get.return_value = response
         yield cl
 
-    @pytest.mark.asyncio
     async def test_get_latest_version(self, client):
         assert await client.get_latest_version("foo") == "1.0.0"
 
-    @pytest.mark.asyncio
     async def test_context_manager(self, client):
         async with client:
             pass

--- a/nucliadb/tests/nucliadb/unit/test_health.py
+++ b/nucliadb/tests/nucliadb/unit/test_health.py
@@ -27,8 +27,6 @@ from nucliadb import health
 from nucliadb.common.cluster import manager
 from nucliadb.ingest.settings import DriverConfig, settings
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture(autouse=True)
 def register_checks():

--- a/nucliadb/tests/nucliadb/unit/test_purge.py
+++ b/nucliadb/tests/nucliadb/unit/test_purge.py
@@ -24,8 +24,6 @@ import pytest
 from nucliadb import purge
 from nucliadb.common.cluster.exceptions import NodeError, ShardNotFound
 
-pytestmark = pytest.mark.asyncio
-
 
 class DataIterator:
     def __init__(self, data):

--- a/nucliadb/tests/search/fixtures.py
+++ b/nucliadb/tests/search/fixtures.py
@@ -72,7 +72,6 @@ def test_settings_search(storage, natsd, node, maindb_driver):  # type: ignore
     nucliadb_settings.nucliadb_ingest = f"localhost:{ingest_settings.grpc_port}"
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def dummy_predict() -> AsyncIterable[DummyPredictEngine]:
     original_setting = nuclia_settings.dummy_predict
@@ -93,7 +92,6 @@ async def dummy_predict() -> AsyncIterable[DummyPredictEngine]:
         set_utility(Utility.PREDICT, original_predict)
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def search_api(test_settings_search, transaction_utility, redis):  # type: ignore
     from nucliadb.common.cluster import manager

--- a/nucliadb/tests/search/integration/api/v1/test_ask_audit.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_audit.py
@@ -20,7 +20,6 @@
 from typing import Callable
 
 import nats
-import pytest
 from httpx import AsyncClient
 from nats.aio.client import Client
 from nats.js import JetStreamContext
@@ -37,7 +36,6 @@ async def get_audit_messages(sub):
     return auditreq
 
 
-@pytest.mark.asyncio
 async def test_ask_sends_only_one_audit(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str, stream_audit
 ) -> None:

--- a/nucliadb/tests/search/integration/api/v1/test_find.py
+++ b/nucliadb/tests/search/integration/api/v1/test_find.py
@@ -19,14 +19,12 @@
 #
 from typing import Callable
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb.search.api.v1.router import KB_PREFIX
 from nucliadb_models.resource import NucliaDBRoles
 
 
-@pytest.mark.asyncio
 async def test_find(search_api: Callable[..., AsyncClient], multiple_search_resource: str) -> None:
     kbid = multiple_search_resource
 

--- a/nucliadb/tests/search/integration/api/v1/test_search.py
+++ b/nucliadb/tests/search/integration/api/v1/test_search.py
@@ -39,7 +39,6 @@ RUNNING_IN_GH_ACTIONS = os.environ.get("CI", "").lower() == "true"
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.asyncio
 async def test_multiple_fuzzy_search_resource_all(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str
 ) -> None:
@@ -64,7 +63,6 @@ async def test_multiple_fuzzy_search_resource_all(
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.asyncio
 async def test_multiple_search_resource_all(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str
 ) -> None:
@@ -118,7 +116,6 @@ async def test_multiple_search_resource_all(
         assert resp.json()["fulltext"]["next_page"] is False
 
 
-@pytest.mark.asyncio
 @pytest.mark.flaky(reruns=3)
 async def test_search_resource_all(
     search_api: Callable[..., AsyncClient],
@@ -191,7 +188,6 @@ async def test_search_resource_all(
                     assert results[2][0].endswith("20-45")
 
 
-@pytest.mark.asyncio
 async def test_search_with_facets(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str
 ) -> None:

--- a/nucliadb/tests/search/integration/api/v1/test_suggest.py
+++ b/nucliadb/tests/search/integration/api/v1/test_suggest.py
@@ -32,7 +32,6 @@ from nucliadb_protos.writer_pb2 import Shards as PBShards
 
 
 @pytest.mark.flaky(reruns=5)
-@pytest.mark.asyncio
 async def test_suggest_resource_all(
     search_api: Callable[..., AsyncClient], test_search_resource: str
 ) -> None:

--- a/nucliadb/tests/search/integration/requesters/test_utils.py
+++ b/nucliadb/tests/search/integration/requesters/test_utils.py
@@ -33,7 +33,6 @@ from nucliadb_models.search import (
 )
 
 
-@pytest.mark.asyncio
 @pytest.mark.xfail  # pulling start/end position for vectors results needs to be fixed
 async def test_vector_result_metadata(
     search_api: Callable[..., AsyncClient], multiple_search_resource: str

--- a/nucliadb/tests/search/unit/api/v1/test_ask.py
+++ b/nucliadb/tests/search/unit/api/v1/test_ask.py
@@ -33,8 +33,6 @@ from nucliadb.search.search.exceptions import (
 )
 from nucliadb_utils.exceptions import LimitsExceededError
 
-pytestmark = pytest.mark.asyncio
-
 
 class DummyTestRequest(Request):
     @property

--- a/nucliadb/tests/search/unit/api/v1/test_predict_proxy.py
+++ b/nucliadb/tests/search/unit/api/v1/test_predict_proxy.py
@@ -30,8 +30,6 @@ from nucliadb.search.api.v1.predict_proxy import predict_proxy_endpoint
 from nucliadb.search.search.predict_proxy import PredictProxiedEndpoints
 from nucliadb_utils.exceptions import LimitsExceededError
 
-pytestmark = pytest.mark.asyncio
-
 MODULE = "nucliadb.search.api.v1.predict_proxy"
 
 

--- a/nucliadb/tests/search/unit/api/v1/test_summarize.py
+++ b/nucliadb/tests/search/unit/api/v1/test_summarize.py
@@ -29,8 +29,6 @@ from nucliadb.search.api.v1.summarize import summarize_endpoint
 from nucliadb.search.search.summarize import NoResourcesToSummarize
 from nucliadb_utils.exceptions import LimitsExceededError
 
-pytestmark = pytest.mark.asyncio
-
 
 class DummyTestRequest(Request):
     @property

--- a/nucliadb/tests/search/unit/search/requesters/test_utils.py
+++ b/nucliadb/tests/search/unit/search/requesters/test_utils.py
@@ -96,7 +96,6 @@ def faulty_search_methods():
         yield faulty_methods
 
 
-@pytest.mark.asyncio
 async def test_node_query_retries_primary_if_secondary_fails(
     fake_nodes,
     shard_manager,
@@ -127,7 +126,6 @@ def mocked_search_methods():
         yield methods
 
 
-@pytest.mark.asyncio
 async def test_node_dont_retry_if_secondary_succeeds(
     fake_nodes,
     shard_manager,

--- a/nucliadb/tests/search/unit/search/test_chat_prompt.py
+++ b/nucliadb/tests/search/unit/search/test_chat_prompt.py
@@ -79,7 +79,6 @@ def kb(field_obj):
     yield mock
 
 
-@pytest.mark.asyncio
 async def test_get_next_conversation_messages(field_obj, messages):
     assert (
         len(
@@ -108,7 +107,6 @@ async def test_get_next_conversation_messages(field_obj, messages):
     ) == [messages[3]]
 
 
-@pytest.mark.asyncio
 async def test_find_conversation_message(field_obj, messages):
     assert await chat_prompt.find_conversation_message(field_obj=field_obj, mident="3") == (
         messages[2],
@@ -117,14 +115,12 @@ async def test_find_conversation_message(field_obj, messages):
     )
 
 
-@pytest.mark.asyncio
 async def test_get_expanded_conversation_messages(kb, messages):
     assert await chat_prompt.get_expanded_conversation_messages(
         kb=kb, rid="rid", field_id="field_id", mident="3"
     ) == [messages[3]]
 
 
-@pytest.mark.asyncio
 async def test_get_expanded_conversation_messages_question(kb, messages):
     assert (
         await chat_prompt.get_expanded_conversation_messages(
@@ -137,7 +133,6 @@ async def test_get_expanded_conversation_messages_question(kb, messages):
     kb.get.return_value.get_field.assert_called_with("field_id", FIELD_TYPE_STR_TO_PB["c"], load=True)
 
 
-@pytest.mark.asyncio
 async def test_get_expanded_conversation_messages_missing(kb, messages):
     assert (
         await chat_prompt.get_expanded_conversation_messages(
@@ -174,7 +169,6 @@ def _create_find_result(
     )
 
 
-@pytest.mark.asyncio
 async def test_default_prompt_context(kb):
     result_text = " ".join(["text"] * 10)
     with (
@@ -259,7 +253,6 @@ def find_results():
     )
 
 
-@pytest.mark.asyncio
 async def test_prompt_context_builder_prepends_user_context(
     find_results: KnowledgeboxFindResults,
 ):
@@ -319,7 +312,6 @@ def test_capped_prompt_context():
     assert context.size == 0
 
 
-@pytest.mark.asyncio
 async def test_hierarchy_promp_context(kb):
     with mock.patch(
         "nucliadb.search.search.chat.prompt.get_paragraph_text",
@@ -444,7 +436,6 @@ async def test_extend_prompt_context_with_metadata():
         assert "DOCUMENT EXTRA METADATA" in text_block
 
 
-@pytest.mark.asyncio
 async def test_prompt_context_image_context_builder():
     result_text = " ".join(["text"] * 10)
     find_results = KnowledgeboxFindResults(

--- a/nucliadb/tests/search/unit/search/test_query.py
+++ b/nucliadb/tests/search/unit/search/test_query.py
@@ -95,7 +95,6 @@ class TestApplySynonymsToRequest:
         with patch("nucliadb.search.search.query.get_kb_synonyms", get_synonyms):
             yield qp
 
-    @pytest.mark.asyncio
     async def test_not_applies_if_empty_body(self, query_parser: QueryParser, get_synonyms):
         query_parser.query = ""
         search_request = Mock()
@@ -104,7 +103,6 @@ class TestApplySynonymsToRequest:
         get_synonyms.assert_not_awaited()
         search_request.ClearField.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_not_applies_if_synonyms_object_not_found(
         self, query_parser: QueryParser, get_synonyms
     ):
@@ -117,7 +115,6 @@ class TestApplySynonymsToRequest:
         request.ClearField.assert_not_called()
         get_synonyms.assert_awaited_once_with("kbid")
 
-    @pytest.mark.asyncio
     async def test_not_applies_if_synonyms_not_found_for_query(
         self, query_parser: QueryParser, get_synonyms
     ):
@@ -158,7 +155,6 @@ class TestVectorSetAndMatryoshkaParsing:
             ("vectorset_id", len(Q) - 20, "vectorset_id", len(Q) - 20),
         ],
     )
-    @pytest.mark.asyncio
     async def test_query_without_vectorset_nor_matryoshka(
         self,
         dummy_predict: PredictEngine,

--- a/nucliadb/tests/search/unit/test_app.py
+++ b/nucliadb/tests/search/unit/test_app.py
@@ -20,12 +20,8 @@
 import json
 from unittest.mock import patch
 
-import pytest
-
 from nucliadb.common.cluster.index_node import IndexNode
 from nucliadb.search import app
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_alive():

--- a/nucliadb/tests/search/unit/test_predict.py
+++ b/nucliadb/tests/search/unit/test_predict.py
@@ -53,7 +53,6 @@ from nucliadb_utils.exceptions import LimitsExceededError
 from tests.utils.aiohttp_session import get_mocked_session
 
 
-@pytest.mark.asyncio
 async def test_dummy_predict_engine():
     pe = DummyPredictEngine()
     await pe.initialize()
@@ -64,7 +63,6 @@ async def test_dummy_predict_engine():
     assert await pe.summarize("kbid", Mock(resources={}))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "onprem,expected_url,expected_header,expected_header_value",
     [
@@ -111,7 +109,6 @@ async def test_detect_entities_ok(onprem, expected_url, expected_header, expecte
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("onprem", [True, False])
 async def test_detect_entities_error(onprem):
     pe = PredictEngine(
@@ -136,7 +133,6 @@ def session_limits_exceeded():
     return session
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "method,args",
     [

--- a/nucliadb/tests/standalone/integration/test_basic.py
+++ b/nucliadb/tests/standalone/integration/test_basic.py
@@ -18,12 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb.search.api.v1.router import KB_PREFIX
 
 
-@pytest.mark.asyncio
 async def test_basic_patch_thumbnail_sc_2390(knowledgebox_one, nucliadb_reader, nucliadb_writer) -> None:
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{knowledgebox_one}/resources",

--- a/nucliadb/tests/standalone/integration/test_delete_field.py
+++ b/nucliadb/tests/standalone/integration/test_delete_field.py
@@ -18,13 +18,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb.search.api.v1.router import KB_PREFIX
 from tests.writer.test_fields import TEST_TEXT_PAYLOAD
 
 
-@pytest.mark.asyncio
 async def test_delete_field(
     knowledgebox_one,
     nucliadb_reader,

--- a/nucliadb/tests/standalone/integration/test_fieldmetadata.py
+++ b/nucliadb/tests/standalone/integration/test_fieldmetadata.py
@@ -18,12 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb.search.api.v1.router import KB_PREFIX
 
 
-@pytest.mark.asyncio
 async def test_fieldmetadata_crud(
     knowledgebox_one,
     nucliadb_reader,

--- a/nucliadb/tests/standalone/integration/test_introspect.py
+++ b/nucliadb/tests/standalone/integration/test_introspect.py
@@ -22,13 +22,10 @@ import os
 import tarfile
 import tempfile
 
-import pytest
-
 from nucliadb.standalone.introspect import ClusterInfo
 from nucliadb.standalone.settings import Settings
 
 
-@pytest.mark.asyncio
 async def test_introspect_endpoint(nucliadb_manager) -> None:
     # Generate some traffic to have some logs
     await nucliadb_manager.post("/not/found")

--- a/nucliadb/tests/standalone/integration/test_services.py
+++ b/nucliadb/tests/standalone/integration/test_services.py
@@ -18,12 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb.search.api.v1.router import KB_PREFIX
 
 
-@pytest.mark.asyncio
 async def test_entities_service(
     nucliadb_reader,
     nucliadb_writer,
@@ -66,7 +64,6 @@ async def test_entities_service(
     assert len(resp.json()["groups"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_labelsets_service(nucliadb_reader, nucliadb_writer, knowledgebox_one) -> None:
     payload = {
         "title": "labelset1",

--- a/nucliadb/tests/standalone/integration/test_upload_download.py
+++ b/nucliadb/tests/standalone/integration/test_upload_download.py
@@ -54,7 +54,6 @@ if not NIDX_ENABLED:
     storages.append(lazy_fixture.lf("azure_storage"))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "storage",
     storages,
@@ -212,7 +211,6 @@ async def test_file_tus_upload_and_download(
     assert resp.status_code == 416
 
 
-@pytest.mark.asyncio
 async def test_tus_upload_handles_unknown_upload_ids(
     configure_redis_dm, nucliadb_writer, nucliadb_reader, knowledgebox_one
 ):
@@ -227,7 +225,6 @@ async def test_tus_upload_handles_unknown_upload_ids(
     assert error_detail == "Resumable URI not found for upload_id: foobarid"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "storage",
     [

--- a/nucliadb/tests/standalone/unit/test_api_router.py
+++ b/nucliadb/tests/standalone/unit/test_api_router.py
@@ -26,8 +26,6 @@ from fastapi import Request
 from nucliadb.standalone import api_router
 from nucliadb.standalone.settings import Settings
 
-pytestmark = pytest.mark.asyncio
-
 
 class DummyTestRequest(Request):
     @property

--- a/nucliadb/tests/standalone/unit/test_auth.py
+++ b/nucliadb/tests/standalone/unit/test_auth.py
@@ -53,7 +53,6 @@ def test_get_mapped_roles():
     assert auth.get_mapped_roles(settings=Settings(auth_policy_user_default_roles=[]), data={}) == []
 
 
-@pytest.mark.asyncio
 async def test_auth_header_backend(http_request):
     backend = auth.get_auth_backend(
         Settings(
@@ -74,7 +73,6 @@ async def test_auth_header_backend(http_request):
     assert await backend.authenticate(http_request) is None
 
 
-@pytest.mark.asyncio
 async def test_oauth2_backend(http_request):
     backend = auth.get_auth_backend(
         settings=Settings(
@@ -107,7 +105,6 @@ async def test_oauth2_backend(http_request):
     assert await backend.authenticate(http_request) is None
 
 
-@pytest.mark.asyncio
 async def test_basic_backend(http_request):
     backend = auth.get_auth_backend(
         settings=Settings(
@@ -131,7 +128,6 @@ async def test_basic_backend(http_request):
     assert await backend.authenticate(http_request) is None
 
 
-@pytest.mark.asyncio
 async def test_auth_token_backend(http_request):
     jwk_key = orjson.dumps(jwk.JWK.generate(kty="oct", size=256, kid="dyn")).decode("utf-8")
     backend = auth.get_auth_backend(

--- a/nucliadb/tests/train/test_field_classification.py
+++ b/nucliadb/tests/train/test_field_classification.py
@@ -34,7 +34,6 @@ from tests.utils.broker_messages import BrokerMessageBuilder
 from tests.utils.dirty_index import wait_for_sync
 
 
-@pytest.mark.asyncio
 async def test_generator_field_classification(
     train_rest_api: aiohttp.ClientSession,
     knowledgebox_with_labels: str,
@@ -82,7 +81,6 @@ async def test_generator_field_classification(
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.asyncio
 async def knowledgebox_with_labels(
     nucliadb_grpc: WriterStub, nucliadb_writer: AsyncClient, knowledgebox: str
 ):

--- a/nucliadb/tests/train/test_field_streaming.py
+++ b/nucliadb/tests/train/test_field_streaming.py
@@ -20,7 +20,6 @@
 import asyncio
 
 import aiohttp
-import pytest
 
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
@@ -38,7 +37,6 @@ from tests.utils.broker_messages import BrokerMessageBuilder, FieldBuilder
 from tests.utils.dirty_index import wait_for_sync
 
 
-@pytest.mark.asyncio
 async def test_generator_field_streaming(
     train_rest_api: aiohttp.ClientSession,
     nucliadb_grpc: WriterStub,

--- a/nucliadb/tests/train/test_get_entities.py
+++ b/nucliadb/tests/train/test_get_entities.py
@@ -41,7 +41,6 @@ async def entities_manager_mock():
     nodes.EntitiesManager = original
 
 
-@pytest.mark.asyncio
 async def test_get_entities(
     train_client: TrainStub,
     knowledgebox_ingest: str,
@@ -59,7 +58,6 @@ async def test_get_entities(
     assert entities.groups["group1"].entities["entity1"].value == "PERSON"
 
 
-@pytest.mark.asyncio
 async def test_get_entities_kb_not_found(train_client: TrainStub) -> None:
     req = GetEntitiesRequest()
     req.kb.uuid = str(uuid.uuid4())
@@ -67,7 +65,6 @@ async def test_get_entities_kb_not_found(train_client: TrainStub) -> None:
     assert entities.status == GetEntitiesResponse.Status.NOTFOUND
 
 
-@pytest.mark.asyncio
 async def test_get_entities_error(
     train_client: TrainStub, knowledgebox_ingest: str, entities_manager_mock
 ) -> None:

--- a/nucliadb/tests/train/test_get_info.py
+++ b/nucliadb/tests/train/test_get_info.py
@@ -17,14 +17,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 from aioresponses import aioresponses
 
 from nucliadb_protos.train_pb2 import GetInfoRequest, TrainInfo
 from nucliadb_protos.train_pb2_grpc import TrainStub
 
 
-@pytest.mark.asyncio
 async def test_get_info(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_get_ontology.py
+++ b/nucliadb/tests/train/test_get_ontology.py
@@ -17,14 +17,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb_protos.train_pb2 import GetLabelsRequest
 from nucliadb_protos.train_pb2_grpc import TrainStub
 from nucliadb_protos.writer_pb2 import GetLabelsResponse
 
 
-@pytest.mark.asyncio
 async def test_get_ontology(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_get_ontology_count.py
+++ b/nucliadb/tests/train/test_get_ontology_count.py
@@ -17,14 +17,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 from aioresponses import aioresponses
 
 from nucliadb_protos.train_pb2 import GetLabelsetsCountRequest, LabelsetsCount
 from nucliadb_protos.train_pb2_grpc import TrainStub
 
 
-@pytest.mark.asyncio
 async def test_get_ontology_count(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_image_classification.py
+++ b/nucliadb/tests/train/test_image_classification.py
@@ -50,7 +50,6 @@ INVOICE_FILENAME = os.path.join(_testdata_dir, "invoice.pdf")
 INVOICE_SELECTIONS_FILENAME = os.path.join(_testdata_dir, "invoice_selections.json")
 
 
-@pytest.mark.asyncio
 async def test_generation_image_classification(
     train_rest_api: aiohttp.ClientSession,
     knowledgebox: str,
@@ -86,7 +85,6 @@ async def test_generation_image_classification(
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def image_classification_resource(
     writer_rest_api: aiohttp.ClientSession, nucliadb_grpc: WriterStub, knowledgebox: str
 ):

--- a/nucliadb/tests/train/test_list_fields.py
+++ b/nucliadb/tests/train/test_list_fields.py
@@ -17,13 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb_protos.train_pb2 import GetFieldsRequest
 from nucliadb_protos.train_pb2_grpc import TrainStub
 
 
-@pytest.mark.asyncio
 async def test_list_fields(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_list_paragraphs.py
+++ b/nucliadb/tests/train/test_list_paragraphs.py
@@ -17,13 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb_protos.train_pb2 import GetParagraphsRequest
 from nucliadb_protos.train_pb2_grpc import TrainStub
 
 
-@pytest.mark.asyncio
 async def test_list_paragraphs(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:
@@ -40,7 +38,6 @@ async def test_list_paragraphs(
     assert count == 30
 
 
-@pytest.mark.asyncio
 async def test_list_paragraphs_shows_ners_with_positions(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_list_resources.py
+++ b/nucliadb/tests/train/test_list_resources.py
@@ -17,13 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb_protos.train_pb2 import GetResourcesRequest
 from nucliadb_protos.train_pb2_grpc import TrainStub
 
 
-@pytest.mark.asyncio
 async def test_list_resource(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_list_sentences.py
+++ b/nucliadb/tests/train/test_list_sentences.py
@@ -17,13 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb_protos.train_pb2 import GetSentencesRequest
 from nucliadb_protos.train_pb2_grpc import TrainStub
 
 
-@pytest.mark.asyncio
 async def test_list_sentences(
     train_client: TrainStub, knowledgebox_ingest: str, test_pagination_resources
 ) -> None:
@@ -41,7 +39,6 @@ async def test_list_sentences(
     assert count == 40
 
 
-@pytest.mark.asyncio
 async def test_list_sentences_shows_ners_with_positions(
     train_client: TrainStub, knowledgebox: str, test_pagination_resources
 ) -> None:

--- a/nucliadb/tests/train/test_paragraph_classification.py
+++ b/nucliadb/tests/train/test_paragraph_classification.py
@@ -21,7 +21,6 @@ import asyncio
 import uuid
 
 import aiohttp
-import pytest
 
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
@@ -35,7 +34,6 @@ from tests.utils.broker_messages import BrokerMessageBuilder, FieldBuilder
 from tests.utils.dirty_index import wait_for_sync
 
 
-@pytest.mark.asyncio
 async def test_generator_paragraph_classification(
     train_rest_api: aiohttp.ClientSession,
     nucliadb_grpc: WriterStub,

--- a/nucliadb/tests/train/test_paragraph_streaming.py
+++ b/nucliadb/tests/train/test_paragraph_streaming.py
@@ -21,7 +21,6 @@ import asyncio
 from typing import AsyncIterator
 
 import aiohttp
-import pytest
 
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
@@ -50,7 +49,6 @@ async def get_paragraph_streaming_batch_from_response(
         yield pcb
 
 
-@pytest.mark.asyncio
 async def test_generator_paragraph_streaming(
     train_rest_api: aiohttp.ClientSession,
     nucliadb_grpc: WriterStub,

--- a/nucliadb/tests/train/test_question_answer_streaming.py
+++ b/nucliadb/tests/train/test_question_answer_streaming.py
@@ -22,7 +22,6 @@ import uuid
 from typing import AsyncIterator
 
 import aiohttp
-import pytest
 
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.train import API_PREFIX
@@ -52,7 +51,6 @@ async def get_question_answer_streaming_batch_from_response(
         yield pcb
 
 
-@pytest.mark.asyncio
 async def test_generator_question_answer_streaming(
     train_rest_api: aiohttp.ClientSession,
     nucliadb_grpc: WriterStub,
@@ -161,7 +159,6 @@ def smb_wonder_bm(kbid: str) -> BrokerMessage:
     return bm
 
 
-@pytest.mark.asyncio
 async def test_generator_question_answer_streaming_streams_qa_annotations(
     train_rest_api: aiohttp.ClientSession,
     writer_rest_api: aiohttp.ClientSession,

--- a/nucliadb/tests/train/test_sentence_classification.py
+++ b/nucliadb/tests/train/test_sentence_classification.py
@@ -21,7 +21,6 @@ import asyncio
 import uuid
 
 import aiohttp
-import pytest
 
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
@@ -35,7 +34,6 @@ from tests.utils.broker_messages import BrokerMessageBuilder, FieldBuilder
 from tests.utils.dirty_index import wait_for_sync
 
 
-@pytest.mark.asyncio
 async def test_generator_sentence_classification(
     train_rest_api: aiohttp.ClientSession,
     nucliadb_grpc: WriterStub,

--- a/nucliadb/tests/train/test_token_classification.py
+++ b/nucliadb/tests/train/test_token_classification.py
@@ -20,7 +20,6 @@
 import asyncio
 
 import aiohttp
-import pytest
 
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
@@ -35,7 +34,6 @@ from tests.utils.broker_messages import BrokerMessageBuilder, FieldBuilder
 from tests.utils.dirty_index import wait_for_sync
 
 
-@pytest.mark.asyncio
 async def test_generator_token_classification(
     train_rest_api: aiohttp.ClientSession,
     knowledgebox_with_entities: str,

--- a/nucliadb/tests/writer/test_fields.py
+++ b/nucliadb/tests/writer/test_fields.py
@@ -90,7 +90,6 @@ TEST_CONVERSATION_APPEND_MESSAGES_PAYLOAD = [
 ]
 
 
-@pytest.mark.asyncio
 async def test_resource_field_add(writer_api, knowledgebox_writer):
     knowledgebox_id = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
@@ -161,7 +160,6 @@ async def test_resource_field_add(writer_api, knowledgebox_writer):
         assert "seqid" in data
 
 
-@pytest.mark.asyncio
 async def test_resource_field_append_extra(writer_api, knowledgebox_writer):
     knowledgebox_id = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
@@ -189,7 +187,6 @@ async def test_resource_field_append_extra(writer_api, knowledgebox_writer):
         assert "seqid" in data
 
 
-@pytest.mark.asyncio
 async def test_resource_field_delete(writer_api, knowledgebox_writer):
     knowledgebox_id = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
@@ -227,7 +224,6 @@ async def test_resource_field_delete(writer_api, knowledgebox_writer):
         assert resp.status_code == 204
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "endpoint,payload",
     [
@@ -262,7 +258,6 @@ async def test_sync_ops(writer_api, knowledgebox_writer, endpoint, payload):
         assert resp.status_code in (201, 200)
 
 
-@pytest.mark.asyncio
 async def test_external_file_field(writer_api, knowledgebox_writer):
     knowledgebox_id = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
@@ -281,7 +276,6 @@ async def test_external_file_field(writer_api, knowledgebox_writer):
         assert resp.status_code == 201
 
 
-@pytest.mark.asyncio
 async def test_file_field_validation(writer_api, knowledgebox_writer):
     knowledgebox_id = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
@@ -313,7 +307,6 @@ async def test_file_field_validation(writer_api, knowledgebox_writer):
         ["delete", "", None],
     ],
 )
-@pytest.mark.asyncio()
 async def test_field_endpoints_by_slug(
     writer_api,
     knowledgebox_ingest,

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -23,7 +23,6 @@ import io
 import os
 from typing import Callable
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb.common import datamanagers
@@ -39,7 +38,6 @@ from nucliadb_utils.utilities import get_storage, get_transaction_utility
 ASSETS_PATH = os.path.dirname(__file__) + "/assets"
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_tus_options(
     writer_api: Callable[[list[NucliaDBRoles]], AsyncClient], knowledgebox_writer: str
 ):
@@ -74,7 +72,6 @@ async def test_knowledgebox_file_tus_options(
         assert resp.headers["tus-extension"] == "creation-defer-length"
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_tus_upload_root(writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         language = base64.b64encode(b"ca").decode()
@@ -163,7 +160,6 @@ async def test_knowledgebox_file_tus_upload_root(writer_api, knowledgebox_writer
         assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_upload_root(
     writer_api: Callable[[list[NucliaDBRoles]], AsyncClient],
     knowledgebox_writer: str,
@@ -217,7 +213,6 @@ async def test_knowledgebox_file_upload_root(
             assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_upload_root_headers(
     writer_api: Callable[[list[NucliaDBRoles]], AsyncClient],
     knowledgebox_writer: str,
@@ -263,7 +258,6 @@ async def test_knowledgebox_file_upload_root_headers(
     assert len(data.read()) == 30472
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_tus_upload_field(writer_api, knowledgebox_writer, resource):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         language = base64.b64encode(b"ca").decode()
@@ -353,7 +347,6 @@ async def test_knowledgebox_file_tus_upload_field(writer_api, knowledgebox_write
     assert len(data.read()) == len(raw_bytes)
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_upload_field_headers(writer_api, knowledgebox_writer, resource):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         filename = "image.jpg"
@@ -397,7 +390,6 @@ async def test_knowledgebox_file_upload_field_headers(writer_api, knowledgebox_w
     assert len(data.read()) == 30472
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_file_upload_field_sync(writer_api, knowledgebox_writer, resource):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         filename = "image.jpg"
@@ -425,7 +417,6 @@ async def test_knowledgebox_file_upload_field_sync(writer_api, knowledgebox_writ
             ) is True
 
 
-@pytest.mark.asyncio
 async def test_file_tus_upload_field_by_slug(writer_api, knowledgebox_writer, resource):
     kb = knowledgebox_writer
     rslug = "resource1"
@@ -515,7 +506,6 @@ async def test_file_tus_upload_field_by_slug(writer_api, knowledgebox_writer, re
     assert len(data.read()) == len(raw_bytes)
 
 
-@pytest.mark.asyncio
 async def test_file_tus_upload_urls_field_by_resource_id(writer_api, knowledgebox_writer, resource):
     kb = knowledgebox_writer
 
@@ -554,7 +544,6 @@ async def test_file_tus_upload_urls_field_by_resource_id(writer_api, knowledgebo
         assert resp.headers["Upload-Offset"] == "0"
 
 
-@pytest.mark.asyncio
 async def test_multiple_tus_file_upload_tries(writer_api, knowledgebox_writer, resource):
     kb = knowledgebox_writer
     rslug = "resource1"
@@ -612,7 +601,6 @@ async def test_multiple_tus_file_upload_tries(writer_api, knowledgebox_writer, r
         assert resp.headers["Tus-Upload-Finished"] == "1"
 
 
-@pytest.mark.asyncio
 async def test_file_upload_by_slug(writer_api, knowledgebox_writer):
     kb = knowledgebox_writer
     rslug = "myslug"
@@ -672,7 +660,6 @@ def test_maybe_b64decode():
     assert maybe_b64decode(something) == something
 
 
-@pytest.mark.asyncio
 async def test_tus_validates_intermediate_chunks_length(writer_api, knowledgebox_writer):
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
         language = base64.b64encode(b"ca").decode()

--- a/nucliadb/tests/writer/test_knowledgebox.py
+++ b/nucliadb/tests/writer/test_knowledgebox.py
@@ -20,7 +20,6 @@
 from typing import Callable
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb.learning_proxy import LearningConfiguration, SemanticConfig, SimilarityFunction
@@ -28,7 +27,6 @@ from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX
 from nucliadb_models.resource import NucliaDBRoles
 
 
-@pytest.mark.asyncio
 async def test_knowledgebox_lifecycle(writer_api):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(

--- a/nucliadb/tests/writer/test_reprocess_file_field.py
+++ b/nucliadb/tests/writer/test_reprocess_file_field.py
@@ -42,7 +42,6 @@ def processing_mock(mocker):
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.asyncio
 async def file_field(writer_api, knowledgebox_writer: str) -> AsyncIterator[tuple[str, str, str]]:
     kbid = knowledgebox_writer
     field_id = "myfile"
@@ -76,7 +75,6 @@ async def file_field(writer_api, knowledgebox_writer: str) -> AsyncIterator[tupl
         assert resp.status_code == 204
 
 
-@pytest.mark.asyncio
 async def test_reprocess_nonexistent_file_field(writer_api, knowledgebox_writer: str, resource: str):
     kbid = knowledgebox_writer
     rid = resource
@@ -89,7 +87,6 @@ async def test_reprocess_nonexistent_file_field(writer_api, knowledgebox_writer:
         assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_reprocess_file_field_with_password(
     writer_api, file_field: tuple[str, str, str], processing_mock
 ):
@@ -108,7 +105,6 @@ async def test_reprocess_file_field_with_password(
     assert processing_mock.send_to_process.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_reprocess_file_field_without_password(
     writer_api, file_field: tuple[str, str, str], processing_mock
 ):

--- a/nucliadb/tests/writer/test_resources.py
+++ b/nucliadb/tests/writer/test_resources.py
@@ -45,7 +45,6 @@ from tests.writer.test_fields import (
 )
 
 
-@pytest.mark.asyncio
 async def test_resource_crud(writer_api: Callable[[list[str]], AsyncClient], knowledgebox_writer: str):
     knowledgebox_id = knowledgebox_writer
     async with writer_api([NucliaDBRoles.WRITER]) as client:
@@ -130,7 +129,6 @@ async def test_resource_crud(writer_api: Callable[[list[str]], AsyncClient], kno
         assert resp.status_code == 204
 
 
-@pytest.mark.asyncio
 async def test_resource_crud_sync(
     writer_api: Callable[[list[str]], AsyncClient], knowledgebox_writer: str
 ):
@@ -226,7 +224,6 @@ async def test_resource_crud_sync(
         ) is False
 
 
-@pytest.mark.asyncio
 async def test_create_resource_async(
     writer_api: Callable[[list[str]], AsyncClient],
     knowledgebox_writer: str,
@@ -281,7 +278,6 @@ async def test_create_resource_async(
         assert spy.call_args.kwargs["wait"] is False
 
 
-@pytest.mark.asyncio
 async def test_reprocess_resource(
     writer_api: Callable[..., AsyncClient],
     test_resource: Resource,
@@ -327,7 +323,6 @@ async def test_reprocess_resource(
         )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "method,endpoint,payload",
     [
@@ -371,7 +366,6 @@ async def test_resource_endpoints_by_slug(
         assert resp.status_code in (200, 202, 204)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "method,endpoint,payload",
     [
@@ -406,7 +400,6 @@ async def test_resource_endpoints_by_slug_404(
         assert resp.json()["detail"] == "Resource does not exist"
 
 
-@pytest.mark.asyncio
 async def test_reindex(writer_api, test_resource):
     rsc = test_resource
     kbid = rsc.kb.kbid
@@ -423,7 +416,6 @@ async def test_reindex(writer_api, test_resource):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
 async def test_paragraph_annotations(writer_api, knowledgebox_writer):
     kbid = knowledgebox_writer
     async with writer_api(roles=[NucliaDBRoles.WRITER]) as client:
@@ -493,7 +485,6 @@ async def test_paragraph_annotations(writer_api, knowledgebox_writer):
         assert body["detail"] == "Paragraph classifications need to be unique"
 
 
-@pytest.mark.asyncio
 async def test_hide_on_creation(
     writer_api: Callable[[list[str]], AsyncClient],
     knowledgebox_writer: str,

--- a/nucliadb/tests/writer/test_service.py
+++ b/nucliadb/tests/writer/test_service.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import pytest
 
 from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX
 from nucliadb_models.entities import CreateEntitiesGroupPayload, Entity
@@ -27,7 +26,6 @@ from nucliadb_protos import knowledgebox_pb2, writer_pb2
 from nucliadb_utils.utilities import get_ingest
 
 
-@pytest.mark.asyncio
 async def test_service_lifecycle_entities(writer_api, entities_manager_mock):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(
@@ -76,7 +74,6 @@ async def test_service_lifecycle_entities(writer_api, entities_manager_mock):
         assert set(result.groups.keys()) == {"0", "1"}
 
 
-@pytest.mark.asyncio
 async def test_entities_custom_field_for_user_defined_groups(writer_api, entities_manager_mock):
     """
     Test description:
@@ -108,7 +105,6 @@ async def test_entities_custom_field_for_user_defined_groups(writer_api, entitie
         assert result.groups["0"].custom is True
 
 
-@pytest.mark.asyncio
 async def test_service_lifecycle_labels(writer_api):
     async with writer_api(roles=[NucliaDBRoles.MANAGER]) as client:
         resp = await client.post(

--- a/nucliadb/tests/writer/test_tus.py
+++ b/nucliadb/tests/writer/test_tus.py
@@ -99,17 +99,14 @@ async def redis_dm(redis):
     settings.dm_enabled = prev
 
 
-@pytest.mark.asyncio
 async def test_s3_driver(redis_dm, s3_storage_tus: S3BlobStore):
     await storage_test(s3_storage_tus, S3FileStorageManager(s3_storage_tus))
 
 
-@pytest.mark.asyncio
 async def test_gcs_driver(redis_dm, gcs_storage_tus: GCloudBlobStore):
     await storage_test(gcs_storage_tus, GCloudFileStorageManager(gcs_storage_tus))
 
 
-@pytest.mark.asyncio
 async def test_local_driver(local_storage_tus: LocalBlobStore):
     settings.dm_enabled = False
     await storage_test(local_storage_tus, LocalFileStorageManager(local_storage_tus))

--- a/nucliadb/tests/writer/unit/api/v1/test_entities.py
+++ b/nucliadb/tests/writer/unit/api/v1/test_entities.py
@@ -40,8 +40,6 @@ from tests.utils.entities import (
     update_entities_group,
 )
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestEntitiesApi:
     @pytest.fixture

--- a/nucliadb/tests/writer/unit/api/v1/test_upload.py
+++ b/nucliadb/tests/writer/unit/api/v1/test_upload.py
@@ -72,7 +72,6 @@ async def kb_config_mock():
         yield mock
 
 
-@pytest.mark.asyncio
 async def test_store_file_on_nucliadb_does_not_store_passwords(
     processing_mock, partitioning_mock, transaction_mock
 ):
@@ -115,7 +114,6 @@ async def test_store_file_on_nucliadb_does_not_store_passwords(
         ("rid", "field", "md5", True, ("rid", "field")),
     ],
 )
-@pytest.mark.asyncio
 async def test_validate_field_upload(rid, field, md5, exists: bool, result):
     mock_uuid = Mock()
     mock_uuid4 = Mock()
@@ -137,7 +135,6 @@ async def test_validate_field_upload(rid, field, md5, exists: bool, result):
                 _, result_rid, result_field = await validate_field_upload("kbid", rid, field, md5)
 
 
-@pytest.mark.asyncio
 async def test_store_file_on_nucliadb_sets_hidden(
     processing_mock, partitioning_mock, transaction_mock, kb_config_mock
 ):

--- a/nucliadb/tests/writer/unit/resources/test_field.py
+++ b/nucliadb/tests/writer/unit/resources/test_field.py
@@ -71,7 +71,6 @@ def storage_mock():
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_parse_file_field_does_not_store_password(processing_mock, file_field):
     field_key = "key"
     kbid = "kbid"
@@ -105,7 +104,6 @@ def get_message(id, who, to, text, attachments=None):
     return msg
 
 
-@pytest.mark.asyncio
 async def test_parse_conversation_field(storage_mock, processing_mock):
     key = "conv"
     kbid = "kbid"

--- a/nucliadb/tests/writer/unit/tus/test_gcs.py
+++ b/nucliadb/tests/writer/unit/tus/test_gcs.py
@@ -19,12 +19,9 @@
 
 from unittest.mock import ANY, MagicMock, patch
 
-import pytest
-
 from nucliadb.writer.tus.gcs import GCloudBlobStore
 
 
-@pytest.mark.asyncio
 @patch("nucliadb.writer.tus.gcs.aiohttp")
 @patch("nucliadb.writer.tus.gcs.ServiceAccountCredentials")
 async def test_tus_gcs(mock_sa, mock_aiohttp):
@@ -51,7 +48,6 @@ async def test_tus_gcs(mock_sa, mock_aiohttp):
     assert await gblobstore.check_exists("test-bucket")
 
 
-@pytest.mark.asyncio
 @patch("nucliadb.writer.tus.gcs.google")
 async def test_tus_gcs_empty_json_credentials(mock_google):
     mock_google.auth.default.return_value = ("credential", "project")

--- a/nucliadb_dataset/src/nucliadb_dataset/tests/fixtures.py
+++ b/nucliadb_dataset/src/nucliadb_dataset/tests/fixtures.py
@@ -315,7 +315,6 @@ def temp_folder():
 
 
 @pytest.fixture
-@pytest.mark.asyncio
 async def ingest_stub(nucliadb) -> AsyncIterator[WriterStub]:
     channel = aio.insecure_channel(f"{nucliadb.host}:{nucliadb.grpc}")
     stub = WriterStub(channel)

--- a/nucliadb_node_binding/tests/integration/test_indexing.py
+++ b/nucliadb_node_binding/tests/integration/test_indexing.py
@@ -78,7 +78,6 @@ def data_path(tmp_path):
     del os.environ["DATA_PATH"]
 
 
-@pytest.mark.asyncio
 async def test_set_and_search(data_path):
     return await _test_set_and_search(ReleaseChannel.STABLE)
 

--- a/nucliadb_sidecar/tests/integration/test_indexing.py
+++ b/nucliadb_sidecar/tests/integration/test_indexing.py
@@ -43,7 +43,6 @@ from tests.fixtures import Reader
 TEST_PARTITION = "111"
 
 
-@pytest.mark.asyncio
 async def test_indexing(worker, shard: str, reader: Reader):
     node = settings.force_host_id
 
@@ -81,7 +80,6 @@ async def test_indexing(worker, shard: str, reader: Reader):
     assert await storage.get_indexing(index) is not None
 
 
-@pytest.mark.asyncio
 async def test_prioritary_indexing_on_one_shard(
     worker,
     shard: str,
@@ -207,7 +205,6 @@ class TestConcurrentIndexingFailureRecovery:
         worker.writer.delete_resource = original_delete_resource
         settings.indexer_delay_after_error = original_delay
 
-    @pytest.mark.asyncio
     async def test(
         self,
         bunch_of_shards: list[str],
@@ -269,7 +266,6 @@ class TestConcurrentIndexingFailureRecovery:
         assert seqids_by_shard == seqids_log
 
 
-@pytest.mark.asyncio
 async def test_indexing_not_found(worker, reader):
     node = settings.force_host_id
     shard = "fake-shard"
@@ -285,7 +281,6 @@ async def test_indexing_not_found(worker, reader):
     await wait_for_indexed_message("kb")
 
 
-@pytest.mark.asyncio
 async def test_indexing_publishes_to_sidecar_index_stream(worker, shard: str, natsd):
     node_id = settings.force_host_id
     assert node_id

--- a/nucliadb_sidecar/tests/unit/test_app.py
+++ b/nucliadb_sidecar/tests/unit/test_app.py
@@ -19,11 +19,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from nucliadb_sidecar import app
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_main():

--- a/nucliadb_sidecar/tests/unit/test_indexed_publisher.py
+++ b/nucliadb_sidecar/tests/unit/test_indexed_publisher.py
@@ -28,7 +28,6 @@ from nucliadb_sidecar.signals import SuccessfulIndexingPayload, successful_index
 
 class TestIndexedPublisher:
     @pytest.fixture
-    @pytest.mark.asyncio
     async def indexed_publisher(self):
         ip = IndexedPublisher()
         await ip.initialize()
@@ -44,7 +43,6 @@ class TestIndexedPublisher:
         ):
             yield pubsub
 
-    @pytest.mark.asyncio
     async def test_listener_registration_in_lifecycle_functions(self):
         with patch("nucliadb_sidecar.listeners.indexed_publisher.signals") as signals:
             ip = IndexedPublisher()
@@ -54,7 +52,6 @@ class TestIndexedPublisher:
             await ip.finalize()
             assert signals.successful_indexing.remove_listener.call_count == 1
 
-    @pytest.mark.asyncio
     async def test_successful_indexing_triggers_notification(self, indexed_publisher, pubsub):
         pb = IndexMessage()
         pb.partition = "1"

--- a/nucliadb_sidecar/tests/unit/test_pull.py
+++ b/nucliadb_sidecar/tests/unit/test_pull.py
@@ -53,17 +53,14 @@ class TestIndexedPublisher:
         delpb.kbid = "kbid"
         return delpb
 
-    @pytest.mark.asyncio
     async def test_initialize(self, publisher, pubsub):
         assert publisher.pubsub == pubsub
 
-    @pytest.mark.asyncio
     async def test_finalize(self, publisher, pubsub):
         await publisher.finalize()
 
         pubsub.finalize.assert_awaited_once()
 
-    @pytest.mark.asyncio
     async def test_indexed(self, publisher, index_message, pubsub):
         await publisher.indexed(index_message)
 
@@ -71,7 +68,6 @@ class TestIndexedPublisher:
         pubsub.publish.assert_awaited_once()
         assert pubsub.publish.call_args[0][0] == channel
 
-    @pytest.mark.asyncio
     async def test_indexed_skips_if_no_partition(self, publisher, index_message, pubsub):
         index_message.ClearField("partition")
 

--- a/nucliadb_telemetry/tests/integration/test_telemetry.py
+++ b/nucliadb_telemetry/tests/integration/test_telemetry.py
@@ -20,7 +20,6 @@
 import asyncio
 import json
 
-import pytest
 from httpx import AsyncClient
 
 from nucliadb_telemetry import grpc_metrics
@@ -50,7 +49,6 @@ def debug_spans(spans):
     )
 
 
-@pytest.mark.asyncio
 async def test_telemetry_dict(http_service: AsyncClient, greeter: Greeter):
     resp = await http_service.get(
         "http://test/",

--- a/nucliadb_telemetry/tests/test_sentry_interceptor.py
+++ b/nucliadb_telemetry/tests/test_sentry_interceptor.py
@@ -70,7 +70,6 @@ async def run_service(telemetry_grpc: GRPCTelemetry, greeter):
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.asyncio
 async def grpc_service(telemetry_grpc: GRPCTelemetry):
     greeter = SimpleGreeter()
     server, port = await run_service(telemetry_grpc, greeter)
@@ -79,7 +78,6 @@ async def grpc_service(telemetry_grpc: GRPCTelemetry):
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.asyncio
 async def faulty_grpc_service(telemetry_grpc: GRPCTelemetry):
     greeter = FaultyGreeter()
     server, port = await run_service(telemetry_grpc, greeter)
@@ -87,7 +85,6 @@ async def faulty_grpc_service(telemetry_grpc: GRPCTelemetry):
     await server.stop(grace=True)
 
 
-@pytest.mark.asyncio
 async def test_sentry_interceptor_without_errors(telemetry_grpc: GRPCTelemetry, grpc_service: int):
     port = grpc_service
     channel = telemetry_grpc.init_client(f"localhost:{port}")
@@ -101,7 +98,6 @@ async def test_sentry_interceptor_without_errors(telemetry_grpc: GRPCTelemetry, 
         assert mock_capture_exception.called is False
 
 
-@pytest.mark.asyncio
 async def test_sentry_interceptor_without_streaming_errors(
     telemetry_grpc: GRPCTelemetry, grpc_service: int
 ):
@@ -117,7 +113,6 @@ async def test_sentry_interceptor_without_streaming_errors(
             assert mock_capture_exception.called is False
 
 
-@pytest.mark.asyncio
 async def test_sentry_interceptor_raises_unhandled_exception(
     telemetry_grpc: GRPCTelemetry, faulty_grpc_service: int
 ):
@@ -135,7 +130,6 @@ async def test_sentry_interceptor_raises_unhandled_exception(
         assert mock_capture_exception.call_count == 1
 
 
-@pytest.mark.asyncio
 async def test_sentry_interceptor_raises_unhandled_exception_stream(
     telemetry_grpc: GRPCTelemetry, faulty_grpc_service: int
 ):

--- a/nucliadb_telemetry/tests/unit/fastapi/test_context.py
+++ b/nucliadb_telemetry/tests/unit/fastapi/test_context.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from unittest.mock import patch
 
-import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -32,7 +31,6 @@ def get_kb(kbid: str):
     return {"kbid": kbid}
 
 
-@pytest.mark.asyncio
 async def test_context_injected():
     app.add_middleware(ContextInjectorMiddleware)
 

--- a/nucliadb_telemetry/tests/unit/test_context.py
+++ b/nucliadb_telemetry/tests/unit/test_context.py
@@ -19,12 +19,9 @@
 
 import asyncio
 
-import pytest
-
 from nucliadb_telemetry import context
 
 
-@pytest.mark.asyncio
 async def test_logger_with_context(caplog):
     context_lvl_1 = {}
     context_lvl_1_after = {}

--- a/nucliadb_telemetry/tests/unit/test_logs.py
+++ b/nucliadb_telemetry/tests/unit/test_logs.py
@@ -23,7 +23,6 @@ from unittest.mock import MagicMock, patch
 
 import orjson
 import pydantic
-import pytest
 from opentelemetry.trace import format_span_id, format_trace_id
 
 from nucliadb_telemetry import context, logs
@@ -193,7 +192,6 @@ def test_logger_with_formatter_and_active_span(caplog):
     assert outputted_records[0]["span_id"] == format_span_id(9999999999999999999999)
 
 
-@pytest.mark.asyncio
 async def test_logger_with_context(caplog):
     logger = logging.getLogger("test.logger4")
     formatter = logs.JSONFormatter()

--- a/nucliadb_telemetry/tests/unit/test_metrics.py
+++ b/nucliadb_telemetry/tests/unit/test_metrics.py
@@ -72,7 +72,6 @@ class TestObserver:
         histogram.observe.assert_called_once()
         counter.labels().inc.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_async_decorator(self, histogram, counter):
         observer = metrics.Observer("my_metric")
 
@@ -101,7 +100,6 @@ class TestObserver:
         assert histogram.observe.call_args[0][0] >= 0.2
         counter.labels().inc.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_async_gen_decorator(self, histogram, counter):
         observer = metrics.Observer("my_metric")
 

--- a/nucliadb_utils/tests/integration/cache/test_cache.py
+++ b/nucliadb_utils/tests/integration/cache/test_cache.py
@@ -18,14 +18,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytest
 
 from nucliadb_utils.cache.nats import NatsPubsub
 from nucliadb_utils.cache.settings import settings
 from nucliadb_utils.utilities import clear_global_cache
 
 
-@pytest.mark.asyncio
 async def test_nats_pubsub(natsd):
     settings.cache_pubsub_nats_url = [natsd]
     second_pubsub = NatsPubsub(hosts=[natsd], name="second")

--- a/nucliadb_utils/tests/integration/storages/test_field_storage.py
+++ b/nucliadb_utils/tests/integration/storages/test_field_storage.py
@@ -19,8 +19,6 @@
 #
 import uuid
 
-import pytest
-
 from nucliadb_protos.resources_pb2 import CloudFile
 from nucliadb_utils.storages.gcs import GCSStorage
 from nucliadb_utils.storages.local import LocalStorage
@@ -28,17 +26,14 @@ from nucliadb_utils.storages.s3 import S3Storage
 from nucliadb_utils.storages.storage import KB_RESOURCE_FIELD, Storage, StorageField
 
 
-@pytest.mark.asyncio
 async def test_s3_driver(s3_storage: S3Storage):
     await storage_field_test(s3_storage)
 
 
-@pytest.mark.asyncio
 async def test_gcs_driver(gcs_storage: GCSStorage):
     await storage_field_test(gcs_storage)
 
 
-@pytest.mark.asyncio
 async def test_local_driver(local_storage: LocalStorage):
     await storage_field_test(local_storage)
 

--- a/nucliadb_utils/tests/integration/storages/test_storage.py
+++ b/nucliadb_utils/tests/integration/storages/test_storage.py
@@ -19,8 +19,6 @@
 #
 from uuid import uuid4
 
-import pytest
-
 from nucliadb_utils.storages.azure import AzureStorage
 from nucliadb_utils.storages.gcs import GCSStorage
 from nucliadb_utils.storages.local import LocalStorage
@@ -28,25 +26,21 @@ from nucliadb_utils.storages.s3 import S3Storage
 from nucliadb_utils.storages.storage import Storage
 
 
-@pytest.mark.asyncio
 async def test_azure_driver(azure_storage: AzureStorage):
     assert isinstance(azure_storage, AzureStorage)
     await storage_test(azure_storage)
 
 
-@pytest.mark.asyncio
 async def test_s3_driver(s3_storage: S3Storage):
     assert isinstance(s3_storage, S3Storage)
     await storage_test(s3_storage)
 
 
-@pytest.mark.asyncio
 async def test_gcs_driver(gcs_storage: GCSStorage):
     assert isinstance(gcs_storage, GCSStorage)
     await storage_test(gcs_storage)
 
 
-@pytest.mark.asyncio
 async def test_local_driver(local_storage: LocalStorage):
     assert isinstance(local_storage, LocalStorage)
     await storage_test(local_storage)

--- a/nucliadb_utils/tests/unit/audit/test_stream.py
+++ b/nucliadb_utils/tests/unit/audit/test_stream.py
@@ -76,7 +76,6 @@ async def wait_until(condition, timeout=1):
             raise Exception("TESTING ERROR: Condition was never reached")
 
 
-@pytest.mark.asyncio
 async def test_lifecycle(audit_storage: StreamAuditStorage, nats):
     nats.jetstream.assert_called_once()
 
@@ -84,7 +83,6 @@ async def test_lifecycle(audit_storage: StreamAuditStorage, nats):
     nats.close.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_publish(audit_storage: StreamAuditStorage, nats):
     await audit_storage.initialize()
     audit_storage.send(AuditRequest())
@@ -92,14 +90,12 @@ async def test_publish(audit_storage: StreamAuditStorage, nats):
     await wait_until(partial(stream_audit_finish_condition, audit_storage, 1))
 
 
-@pytest.mark.asyncio
 async def test_report(audit_storage: StreamAuditStorage, nats):
     audit_storage.report_and_send(kbid="kbid", audit_type=AuditRequest.AuditType.DELETED)
 
     await wait_until(partial(stream_audit_finish_condition, audit_storage, 1))
 
 
-@pytest.mark.asyncio
 async def test_visited(audit_storage: StreamAuditStorage, nats):
     from nucliadb_utils.audit.stream import RequestContext, request_context_var
 
@@ -110,14 +106,12 @@ async def test_visited(audit_storage: StreamAuditStorage, nats):
     await wait_until(partial(stream_audit_finish_condition, audit_storage, 1))
 
 
-@pytest.mark.asyncio
 async def test_delete_kb(audit_storage: StreamAuditStorage, nats):
     audit_storage.delete_kb("kbid")
 
     await wait_until(partial(stream_audit_finish_condition, audit_storage, 1))
 
 
-@pytest.mark.asyncio
 async def test_search(audit_storage: StreamAuditStorage, nats):
     from nucliadb_utils.audit.stream import RequestContext, request_context_var
 
@@ -128,7 +122,6 @@ async def test_search(audit_storage: StreamAuditStorage, nats):
     await wait_until(partial(stream_audit_finish_condition, audit_storage, 2))
 
 
-@pytest.mark.asyncio
 async def test_chat(audit_storage: StreamAuditStorage, nats):
     from nucliadb_utils.audit.stream import RequestContext, request_context_var
 

--- a/nucliadb_utils/tests/unit/cache/test_nats.py
+++ b/nucliadb_utils/tests/unit/cache/test_nats.py
@@ -38,7 +38,6 @@ async def pubsub(nats_conn):
     yield ps
 
 
-@pytest.mark.asyncio
 async def test_unsubscribe_twice_raises_key_error(pubsub: NatsPubsub):
     key = "foobar"
     await pubsub.subscribe(lambda x: None, key, group="", subscription_id=key)

--- a/nucliadb_utils/tests/unit/fastapi/test_run.py
+++ b/nucliadb_utils/tests/unit/fastapi/test_run.py
@@ -19,7 +19,6 @@
 
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
-import pytest
 from fastapi import FastAPI
 from uvicorn.server import Server  # type: ignore
 
@@ -27,7 +26,6 @@ from nucliadb_utils.fastapi import run
 from nucliadb_utils.settings import running_settings
 
 
-@pytest.mark.asyncio
 async def test_run_server_forever():
     server = AsyncMock(install_signal_handlers=MagicMock(), should_exit=False)
     config = MagicMock(loaded=False)
@@ -49,7 +47,6 @@ def test_metrics_app():
     assert config.port == running_settings.metrics_port
 
 
-@pytest.mark.asyncio
 async def test_serve_metrics():
     server = Mock()
     config = Mock()

--- a/nucliadb_utils/tests/unit/nuclia_usage/test_kb_usage_report.py
+++ b/nucliadb_utils/tests/unit/nuclia_usage/test_kb_usage_report.py
@@ -23,8 +23,6 @@ import time
 from functools import partial
 from unittest.mock import AsyncMock, Mock
 
-import pytest
-
 from nucliadb_protos.kb_usage_pb2 import (
     ClientType,
     KBSource,
@@ -63,7 +61,6 @@ async def wait_until(condition, timeout=1):
             raise Exception("TESTING ERROR: Condition was never reached")
 
 
-@pytest.mark.asyncio
 async def test_kb_usage_report():
     nats_stream = Mock(publish=AsyncMock())
     report_util = KbUsageReportUtility(nats_stream=nats_stream, nats_subject="test-stream")

--- a/nucliadb_utils/tests/unit/storages/test_gcs.py
+++ b/nucliadb_utils/tests/unit/storages/test_gcs.py
@@ -79,7 +79,6 @@ async def test_iter_data_reading_content_error_is_not_retried(storage_field):
     storage_field._inner_iter_data.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_delete_kb_errors():
     kbid = "my-kbid"
     storage = GCSStorage(bucket="bucket")

--- a/nucliadb_utils/tests/unit/storages/test_storage.py
+++ b/nucliadb_utils/tests/unit/storages/test_storage.py
@@ -49,7 +49,6 @@ class TestStorageField:
     def storage_field(self, storage, field):
         yield LocalStorageField(storage, "bucket", "fullkey", field)
 
-    @pytest.mark.asyncio
     async def test_delete(self, storage_field: StorageField, storage):
         await storage_field.delete()
         storage.delete_upload.assert_called_once_with("uri", "bucket")
@@ -103,12 +102,10 @@ class TestStorage:
     def storage(self):
         yield StorageTest()
 
-    @pytest.mark.asyncio
     async def test_delete_resource(self, storage: StorageTest):
         await storage.delete_resource("bucket", "uri")
         storage.delete_upload.assert_called_once_with("uri", "bucket")
 
-    @pytest.mark.asyncio
     async def test_indexing(self, storage: StorageTest):
         msg = BrainResource(resource=ResourceID(uuid="uuid"))
         await storage.indexing(msg, 1, "1", "kb", "shard")
@@ -117,7 +114,6 @@ class TestStorage:
             "indexing_bucket", "index/kb/shard/uuid/1", msg.SerializeToString()
         )
 
-    @pytest.mark.asyncio
     async def test_reindexing(self, storage: StorageTest):
         msg = BrainResource(resource=ResourceID(uuid="uuid"))
         await storage.reindexing(msg, "reindex_id", "1", "kb", "shard")
@@ -126,7 +122,6 @@ class TestStorage:
             "indexing_bucket", "index/kb/shard/uuid/reindex_id", msg.SerializeToString()
         )
 
-    @pytest.mark.asyncio
     async def test_get_indexing(self, storage: StorageTest):
         im = IndexMessage()
         im.node = "node"
@@ -134,7 +129,6 @@ class TestStorage:
         im.txid = 0
         assert isinstance(await storage.get_indexing(im), BrainResource)
 
-    @pytest.mark.asyncio
     async def test_get_indexing_storage_key(self, storage: StorageTest):
         im = IndexMessage()
         im.node = "node"
@@ -143,7 +137,6 @@ class TestStorage:
         im.storage_key = "index/kb/uuid/1"
         assert isinstance(await storage.get_indexing(im), BrainResource)
 
-    @pytest.mark.asyncio
     async def test_delete_indexing(self, storage: StorageTest):
         im = IndexMessage()
         im.node = "node"
@@ -155,14 +148,12 @@ class TestStorage:
 
         storage.upload_object.assert_called_once()
 
-    @pytest.mark.asyncio
     async def test_download_pb(self, storage: StorageTest):
         assert isinstance(
             await storage.download_pb(LocalStorageField(storage, "bucket", "fullkey"), BrainResource),
             BrainResource,
         )
 
-    @pytest.mark.asyncio
     async def test_indexing_bucket_none_attributeerrror(self, storage: StorageTest):
         storage.indexing_bucket = None
         msg = BrainResource()

--- a/nucliadb_utils/tests/unit/test_authentication.py
+++ b/nucliadb_utils/tests/unit/test_authentication.py
@@ -36,11 +36,9 @@ class TestNucliaCloudAuthenticationBackend:
     def req(self):
         return Mock(headers={})
 
-    @pytest.mark.asyncio
     async def test_authenticate(self, backend: authentication.NucliaCloudAuthenticationBackend, req):
         assert await backend.authenticate(req) is None
 
-    @pytest.mark.asyncio
     async def test_authenticate_with_user(
         self, backend: authentication.NucliaCloudAuthenticationBackend, req
     ):
@@ -54,7 +52,6 @@ class TestNucliaCloudAuthenticationBackend:
         assert creds.scopes == ["admin"]
         assert user.username == "user"
 
-    @pytest.mark.asyncio
     async def test_authenticate_with_anon(
         self, backend: authentication.NucliaCloudAuthenticationBackend, req
     ):
@@ -94,7 +91,6 @@ class TestRequires:
             resp = authentication.requires(["foobar"], redirect="/foobar")(lambda request: None)(req)
         assert resp.status_code == 303
 
-    @pytest.mark.asyncio
     async def test_requires_async(self):
         req = Request({"type": "http", "auth": Mock(scopes=["admin"])})
 
@@ -102,7 +98,6 @@ class TestRequires:
 
         assert await authentication.requires(["admin"])(noop)(request=req) is None
 
-    @pytest.mark.asyncio
     async def test_requires_async_returns_status(self):
         req = Request({"type": "http", "auth": Mock(scopes=["admin"])})
 
@@ -111,7 +106,6 @@ class TestRequires:
         with pytest.raises(HTTPException):
             assert await authentication.requires(["foobar"])(noop)(request=req)
 
-    @pytest.mark.asyncio
     async def test_requires_async_returns_redirect(self):
         req = Request({"type": "http", "auth": Mock(scopes=["admin"])})
 
@@ -121,7 +115,6 @@ class TestRequires:
             resp = await authentication.requires(["foobar"], redirect="/foobar")(noop)(request=req)
         assert resp.status_code == 303
 
-    @pytest.mark.asyncio
     async def test_requires_ws(self):
         ws = AsyncMock()
         req = WebSocket(
@@ -134,7 +127,6 @@ class TestRequires:
 
         assert await authentication.requires(["admin"])(noop)(req) is None
 
-    @pytest.mark.asyncio
     async def test_requires_ws_fail(self):
         req = WebSocket(
             {"type": "websocket", "auth": Mock(scopes=["admin"])},

--- a/nucliadb_utils/tests/unit/test_run.py
+++ b/nucliadb_utils/tests/unit/test_run.py
@@ -20,11 +20,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from nucliadb_utils import run
-
-pytestmark = pytest.mark.asyncio
 
 
 async def test_run_until_exit():

--- a/nucliadb_utils/tests/unit/test_transaction.py
+++ b/nucliadb_utils/tests/unit/test_transaction.py
@@ -50,7 +50,6 @@ async def txn(pubsub):
         await txn.finalize()
 
 
-@pytest.mark.asyncio
 async def test_wait_for_commited(txn: TransactionUtility, pubsub):
     waiting_for = WaitFor(uuid="foo")
     request_id = "request1"
@@ -68,7 +67,6 @@ async def test_wait_for_commited(txn: TransactionUtility, pubsub):
     await (await txn.wait_for_commited(kbid, waiting_for, request_id=request_id)).wait()
 
 
-@pytest.mark.asyncio
 async def test_wait_for_indexed(txn: TransactionUtility, pubsub):
     waiting_for = WaitFor(uuid="foo")
     request_id = "request1"
@@ -87,7 +85,6 @@ async def test_wait_for_indexed(txn: TransactionUtility, pubsub):
         await (await txn.wait_for_commited(kbid, waiting_for, request_id=request_id)).wait()
 
 
-@pytest.mark.asyncio
 async def test_wait_for_commit_stop_waiting(txn: TransactionUtility, pubsub):
     pubsub.unsubscribe.side_effect = [
         "sub_id",
@@ -107,7 +104,6 @@ async def test_wait_for_commit_stop_waiting(txn: TransactionUtility, pubsub):
         await txn.stop_waiting(kbid, request_id=request_id)
 
 
-@pytest.mark.asyncio
 async def test_commit_timeout(txn: TransactionUtility, pubsub):
     txn.js = mock.AsyncMock()
     bm = BrokerMessage()
@@ -119,7 +115,6 @@ async def test_commit_timeout(txn: TransactionUtility, pubsub):
         await txn.commit(bm, 1, wait=True, target_subject="foo")
 
 
-@pytest.mark.asyncio
 async def test_max_payload_error_handled(txn: TransactionUtility, pubsub):
     txn.js = mock.Mock()
     txn.js.publish = mock.AsyncMock(side_effect=nats.errors.MaxPayloadError)

--- a/nucliadb_utils/tests/unit/test_utilities.py
+++ b/nucliadb_utils/tests/unit/test_utilities.py
@@ -42,7 +42,6 @@ def test_clean_utility():
     assert utilities.get_utility(utilities.Utility.PUBSUB) is None
 
 
-@pytest.mark.asyncio
 async def test_get_storage_s3():
     s3 = AsyncMock()
     with (
@@ -52,7 +51,6 @@ async def test_get_storage_s3():
         assert await utilities.get_storage() == s3
 
 
-@pytest.mark.asyncio
 async def test_get_storage_gcs():
     gcs = AsyncMock()
     with (
@@ -62,7 +60,6 @@ async def test_get_storage_gcs():
         assert await utilities.get_storage() == gcs
 
 
-@pytest.mark.asyncio
 async def test_get_storage_local():
     local = AsyncMock()
     with (
@@ -73,24 +70,20 @@ async def test_get_storage_local():
         assert await utilities.get_storage() == local
 
 
-@pytest.mark.asyncio
 async def test_get_storage_missing():
     with patch.object(utilities.storage_settings, "file_backend", "missing"):
         with pytest.raises(ConfigurationError):
             await utilities.get_storage()
 
 
-@pytest.mark.asyncio
 async def test_get_local_storage():
     assert utilities.get_local_storage() is not None
 
 
-@pytest.mark.asyncio
 async def test_get_nuclia_storage():
     assert await utilities.get_nuclia_storage() is not None
 
 
-@pytest.mark.asyncio
 async def test_get_pubsub():
     from nucliadb_utils.cache.settings import settings
 
@@ -99,7 +92,6 @@ async def test_get_pubsub():
         assert await utilities.get_pubsub() is not None
 
 
-@pytest.mark.asyncio
 async def test_finalize_utilities():
     util = AsyncMock()
     utilities.MAIN["test"] = util
@@ -110,7 +102,6 @@ async def test_finalize_utilities():
     assert len(utilities.MAIN) == 0
 
 
-@pytest.mark.asyncio
 async def test_start_audit_utility():
     with (
         patch("nucliadb_utils.utilities.NatsPubsub", return_value=AsyncMock()),
@@ -121,7 +112,6 @@ async def test_start_audit_utility():
         assert "audit" in utilities.MAIN
 
 
-@pytest.mark.asyncio
 async def test_stop_audit_utility():
     with (
         patch("nucliadb_utils.utilities.NatsPubsub", return_value=AsyncMock()),


### PR DESCRIPTION
### Description
pytest's `asyncio_mode` is always set to `auto`. This means all async fixtures and tests are automatically annotated with `pytest.mark.asyncio` and we don't need to. In addition, fixtures annotated with this mark throw a noisy error on every test execution. 

### How was this PR tested?
Existing test suite
