### PR TITLE
Commit all index updates at once.

### DIFF
--- a/nidx/.sqlx/query-95fe4ef93ee90733db1b67ed7987f80b5aac792f1590b979c68b418d1599eb98.json
+++ b/nidx/.sqlx/query-95fe4ef93ee90733db1b67ed7987f80b5aac792f1590b979c68b418d1599eb98.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE indexes SET updated_at = NOW() WHERE id = ANY($1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "95fe4ef93ee90733db1b67ed7987f80b5aac792f1590b979c68b418d1599eb98"
+}

--- a/nidx/src/metadata/index.rs
+++ b/nidx/src/metadata/index.rs
@@ -164,6 +164,13 @@ impl Index {
         Ok(())
     }
 
+    pub async fn updated_many(meta: impl Executor<'_, Database = Postgres>, index_id: &[IndexId]) -> sqlx::Result<()> {
+        sqlx::query!("UPDATE indexes SET updated_at = NOW() WHERE id = ANY($1)", index_id as &[IndexId])
+            .execute(meta)
+            .await?;
+        Ok(())
+    }
+
     pub async fn recently_updated(
         meta: impl Executor<'_, Database = Postgres>,
         newer_than: PrimitiveDateTime,


### PR DESCRIPTION
Doing it one by one may result in a deadlock if multiple indexers are working on messages for the same index, since they will try to update the indexes in a different order.

Fixes https://nuclia.sentry.io/issues/6126563457/events/a3f02aa9fdcc4342b9127b2baacd5c44/