### PR TITLE
Change default scan keys to be unlimited

### DIFF
--- a/nucliadb/src/migrations/0018_purge_orphan_kbslugs.py
+++ b/nucliadb/src/migrations/0018_purge_orphan_kbslugs.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 async def migrate(context: ExecutionContext) -> None:
     async with context.kv_driver.transaction() as txn:
-        async for key in txn.keys(KB_SLUGS_BASE, count=-1):
+        async for key in txn.keys(KB_SLUGS_BASE):
             slug = key.replace(KB_SLUGS_BASE, "")
             value = await txn.get(key, for_update=False)
             if value is None:

--- a/nucliadb/src/nucliadb/common/datamanagers/entities.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/entities.py
@@ -87,7 +87,7 @@ async def set_entities_group(
 
 async def iterate_entities_groups(txn: Transaction, *, kbid: str) -> AsyncGenerator[str, None]:
     entities_key = KB_ENTITIES.format(kbid=kbid)
-    async for key in txn.keys(entities_key, count=-1):
+    async for key in txn.keys(entities_key):
         group = key.split("/")[-1]
         yield group
 

--- a/nucliadb/src/nucliadb/common/datamanagers/kb.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 async def get_kbs(txn: Transaction, *, prefix: str = "") -> AsyncIterator[tuple[str, str]]:
-    async for key in txn.keys(KB_SLUGS.format(slug=prefix), count=-1):
+    async for key in txn.keys(KB_SLUGS.format(slug=prefix)):
         slug = key.replace(KB_SLUGS_BASE, "")
         uuid = await get_kb_uuid(txn, slug=slug)
         if uuid is None:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -227,7 +227,7 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncGenerator[str, None]:
 @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
 async def _iter_resource_slugs(*, kbid: str) -> AsyncGenerator[str, None]:
     async with with_ro_transaction() as txn:
-        async for key in txn.keys(match=KB_RESOURCE_SLUG_BASE.format(kbid=kbid), count=-1):
+        async for key in txn.keys(match=KB_RESOURCE_SLUG_BASE.format(kbid=kbid)):
             yield key.split("/")[-1]
 
 

--- a/nucliadb/src/nucliadb/common/datamanagers/rollover.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/rollover.py
@@ -93,7 +93,7 @@ async def add_batch_to_index(txn: Transaction, *, kbid: str, batch: list[str]) -
 
 async def get_to_index(txn: Transaction, *, kbid: str) -> Optional[str]:
     key = KB_ROLLOVER_RESOURCES_TO_INDEX.format(kbid=kbid, resource="")
-    found = [key async for key in txn.keys(key, count=1)]
+    found = [key async for key in txn.keys(key)]
     if found:
         return found[0].split("/")[-1]
     return None
@@ -145,7 +145,7 @@ async def iter_indexed_keys(*, kbid: str) -> AsyncGenerator[str, None]:
     """
     start_key = KB_ROLLOVER_RESOURCES_INDEXED.format(kbid=kbid, resource="")
     async with with_ro_transaction() as txn:
-        async for key in txn.keys(match=start_key, count=-1):
+        async for key in txn.keys(match=start_key):
             yield key.split("/")[-1]
 
 

--- a/nucliadb/src/nucliadb/common/maindb/driver.py
+++ b/nucliadb/src/nucliadb/common/maindb/driver.py
@@ -23,7 +23,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional
 
-DEFAULT_SCAN_LIMIT = 10
+DEFAULT_SCAN_LIMIT = -1
 DEFAULT_BATCH_SCAN_LIMIT = 500
 
 

--- a/nucliadb/src/nucliadb/common/maindb/local.py
+++ b/nucliadb/src/nucliadb/common/maindb/local.py
@@ -202,7 +202,7 @@ class LocalTransaction(Transaction):
 
     async def count(self, match: str) -> int:
         value = 0
-        async for _ in self.keys(match, count=-1):
+        async for _ in self.keys(match):
             value += 1
         return value
 

--- a/nucliadb/src/nucliadb/ingest/orm/entities.py
+++ b/nucliadb/src/nucliadb/ingest/orm/entities.py
@@ -286,7 +286,7 @@ class EntitiesManager:
 
         # stored groups
         entities_key = KB_ENTITIES.format(kbid=self.kbid)
-        async for key in self.txn.keys(entities_key, count=-1):
+        async for key in self.txn.keys(entities_key):
             group = key.split("/")[-1]
             if exclude_deleted and group in deleted_groups:
                 continue

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -462,7 +462,7 @@ class KnowledgeBox:
 
     async def iterate_resources(self) -> AsyncGenerator[Resource, None]:
         base = KB_RESOURCE_SLUG_BASE.format(kbid=self.kbid)
-        async for key in self.txn.keys(match=base, count=-1):
+        async for key in self.txn.keys(match=base):
             slug = key.split("/")[-1]
             uuid = await self.get_resource_uuid_by_slug(slug)
             if uuid is not None:

--- a/nucliadb/src/nucliadb/purge/__init__.py
+++ b/nucliadb/src/nucliadb/purge/__init__.py
@@ -42,7 +42,7 @@ from nucliadb_utils.utilities import get_storage
 
 async def _iter_keys(driver: Driver, match: str) -> AsyncGenerator[str, None]:
     async with driver.transaction(read_only=True) as keys_txn:
-        async for key in keys_txn.keys(match=match, count=-1):
+        async for key in keys_txn.keys(match=match):
             yield key
 
 

--- a/nucliadb/src/nucliadb/train/nodes.py
+++ b/nucliadb/src/nucliadb/train/nodes.py
@@ -126,7 +126,7 @@ class TrainShardManager(manager.KBShardManager):
         async with self.driver.transaction() as txn:
             kb = KnowledgeBox(txn, self.storage, request.kb.uuid)
             base = KB_RESOURCE_SLUG_BASE.format(kbid=request.kb.uuid)
-            async for key in txn.keys(match=base, count=-1):
+            async for key in txn.keys(match=base):
                 # Fetch and Add wanted item
                 rid = await txn.get(key, for_update=False)
                 if rid is not None:

--- a/nucliadb/tests/ndbfixtures/maindb.py
+++ b/nucliadb/tests/ndbfixtures/maindb.py
@@ -68,7 +68,7 @@ async def cleanup_maindb(driver: Driver):
     if not driver.initialized:
         return
     async with driver.transaction() as txn:
-        all_keys = [k async for k in txn.keys("", count=-1)]
+        all_keys = [k async for k in txn.keys("")]
         for key in all_keys:
             await txn.delete(key)
         await txn.commit()


### PR DESCRIPTION
The default limit was 10 and was used in two places:
- Resource deletion (only the 10 first fields will be deleted)
- KB rollover (only 10 KBs would be rolled over)

It makes more sense to default to scanning everything.