### PR TITLE
Nidx telemetry tonic client

### DIFF
--- a/nidx/src/control.rs
+++ b/nidx/src/control.rs
@@ -96,7 +96,7 @@ impl ControlServer {
             match socket.accept().await {
                 Ok((stream, _addr)) => {
                     if let Err(e) = self.run_connection(stream).await {
-                        warn!(?e, "Error processing control socket message")
+                        warn!("Error processing control socket message: {e:?}")
                     }
                 }
                 Err(e) => return Err(e.into()),

--- a/nidx/src/indexer.rs
+++ b/nidx/src/indexer.rs
@@ -79,7 +79,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
         let info = match msg.info() {
             Ok(info) => info,
             Err(e) => {
-                error!(?e, "Invalid NATS message, skipping");
+                error!("Invalid NATS message, skipping: {e:?}");
                 let _ = msg.ack().await;
                 continue;
             }
@@ -102,7 +102,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
         let index_message = match IndexMessage::decode(msg.payload) {
             Ok(index_message) => index_message,
             Err(e) => {
-                warn!(?e, "Error decoding index message");
+                warn!("Error decoding index message: {e:?}");
                 continue;
             }
         };
@@ -119,13 +119,13 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
         .await
         {
             INDEXING_COUNTER.get_or_create(&OperationStatusLabels::failure()).inc();
-            error!(?seq, ?e, "Error processing index message");
+            error!(?seq, "Error processing index message: {e:?}");
             continue;
         }
         INDEXING_COUNTER.get_or_create(&OperationStatusLabels::success()).inc();
 
         if let Err(e) = acker.ack().await {
-            warn!(?e, "Error acking index message");
+            warn!("Error acking index message: {e:?}");
             continue;
         }
     }

--- a/nidx/src/metrics.rs
+++ b/nidx/src/metrics.rs
@@ -156,7 +156,11 @@ pub mod searcher {
         SYNC_FAILED_INDEXES: Gauge as "searcher_sync_failed_indexes" ("Number of indexes failing to sync"),
         REFRESH_QUEUE_LEN: Gauge as "searcher_indexes_pending_refresh" ("Number of indexes waiting to be refreshed"),
         INDEX_LOAD_TIME: Family<IndexKindLabels, Histogram>{exponential_buckets(0.001, 2.0, 12)} as "searcher_index_load_time_seconds" ("Time to load index searchers"),
+
         SHARD_SELECTOR_TIME: Histogram[exponential_buckets(0.001, 2.0, 8)] as "searcher_shard_seletor_time_seconds" ("Time to select shards to sync"),
+        ACTIVE_SHARDS: Gauge as "searcher_shards_active" ("Number of active shards in this searcher"),
+        EVICTED_SHARDS: Gauge as "searcher_shards_evicted" ("Number of evicted shards (pending deletion) in this searcher"),
+        DESIRED_SHARDS: Gauge as "searcher_shards_desired" ("Number of shards desired by this searcher"),
     }
 }
 

--- a/nidx/src/scheduler.rs
+++ b/nidx/src/scheduler.rs
@@ -79,7 +79,7 @@ pub async fn run_tasks(
     tasks.spawn(async move {
         loop {
             if let Err(e) = retry_jobs(&meta2).await {
-                warn!(?e, "Error in retry_jobs task");
+                warn!("Error in retry_jobs task: {e:?}");
             }
             sleep(Duration::from_secs(30)).await;
         }
@@ -90,7 +90,7 @@ pub async fn run_tasks(
     tasks.spawn(async move {
         loop {
             if let Err(e) = purge_segments(&meta2, &storage).await {
-                warn!(?e, "Error in purge_segments task");
+                warn!("Error in purge_segments task: {e:?}");
             }
             sleep(Duration::from_secs(60)).await;
         }
@@ -100,7 +100,7 @@ pub async fn run_tasks(
     tasks.spawn(async move {
         loop {
             if let Err(e) = purge_deleted_shards_and_indexes(&meta2).await {
-                warn!(?e, "Error purging deleted shards and indexes");
+                warn!("Error purging deleted shards and indexes: {e:?}");
             }
             sleep(Duration::from_secs(60)).await;
         }
@@ -114,11 +114,11 @@ pub async fn run_tasks(
                 Ok(oldest_confirmed_seq) => {
                     let oldest_pending_seq = oldest_confirmed_seq + 1;
                     if let Err(e) = purge_deletions(&meta2, oldest_pending_seq).await {
-                        warn!(?e, "Error in purge_deletions task");
+                        warn!("Error in purge_deletions task: {e:?}");
                     }
                 }
                 Err(e) => {
-                    warn!(?e, "Error while getting consumer information");
+                    warn!("Error while getting consumer information: {e:?}");
                 }
             }
             sleep(Duration::from_secs(15)).await;
@@ -132,11 +132,11 @@ pub async fn run_tasks(
             match ack_floor.get().await {
                 Ok(oldest_confirmed_seq) => {
                     if let Err(e) = merge_scheduler.schedule_merges(&meta2, Seq::from(oldest_confirmed_seq)).await {
-                        warn!(?e, "Error in schedule_merges task");
+                        warn!("Error in schedule_merges task: {e:?}");
                     }
                 }
                 Err(e) => {
-                    warn!(?e, "Error while getting consumer information");
+                    warn!("Error while getting consumer information: {e:?}");
                 }
             }
             sleep(Duration::from_secs(15)).await;
@@ -147,7 +147,7 @@ pub async fn run_tasks(
     tasks.spawn(async move {
         loop {
             if let Err(e) = metrics_task::update_metrics(&meta2).await {
-                info!(?e, "Error updating scheduler metrics");
+                info!("Error updating scheduler metrics: {e:?}");
             }
             sleep(Duration::from_secs(15)).await;
         }

--- a/nidx/src/scheduler/purge_tasks.rs
+++ b/nidx/src/scheduler/purge_tasks.rs
@@ -41,7 +41,7 @@ pub async fn purge_segments(meta: &NidxMetadata, storage: &Arc<DynObjectStore>) 
             | Err(object_store::Error::NotFound {
                 ..
             }) => deleted.push(segment_id),
-            Err(e) => warn!(?e, "Error deleting segment from storage"),
+            Err(e) => warn!("Error deleting segment from storage: {e:?}"),
         }
     }
     Segment::delete_many(&meta.pool, &deleted).await?;

--- a/nidx/src/searcher.rs
+++ b/nidx/src/searcher.rs
@@ -87,7 +87,7 @@ async fn refresher_task(mut rx: Receiver<IndexId>, index_cache: Arc<IndexCache>)
                     debug!(?index_id, "Index reloaded");
                 }
                 Err(e) => {
-                    error!(?index_id, ?e, "Index failed to reload, might become out of date");
+                    error!(?index_id, "Index failed to reload, might become out of date: {e:?}");
                 }
             }
         }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -49,7 +49,9 @@ impl Interceptor for TelemetryInterceptor {
 }
 #[cfg(not(feature = "telemetry"))]
 impl Interceptor for TelemetryInterceptor {
-    fn call(&mut self, request: tonic::Request<()>) -> std::result::Result<tonic::Request<()>, Status> {}
+    fn call(&mut self, request: tonic::Request<()>) -> std::result::Result<tonic::Request<()>, Status> {
+        Ok(request)
+    }
 }
 
 type SearcherClient = NidxSearcherClient<InterceptedService<Channel, TelemetryInterceptor>>;

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -125,7 +125,7 @@ macro_rules! shard_request {
             match result {
                 Ok(response) => return Ok(response),
                 Err(e) => {
-                    warn!(?e, ?node, ?$shard_id, concat!("Error in ", $name, ", trying with next node"));
+                    warn!(?node, ?$shard_id, concat!("Error in ", $name, ", trying with next node: {:?}"), e);
                     errors.push(e);
                 }
             }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -33,7 +33,6 @@ use tonic::{service::Routes, Request, Response, Result, Status};
 
 use crate::errors::{NidxError, NidxResult};
 use crate::searcher::shard_selector::SearcherNode;
-use crate::telemetry::middleware::add_telemetry_headers;
 
 use super::shard_selector::ShardSelector;
 use super::streams;
@@ -45,7 +44,7 @@ struct TelemetryInterceptor;
 #[cfg(feature = "telemetry")]
 impl Interceptor for TelemetryInterceptor {
     fn call(&mut self, request: tonic::Request<()>) -> std::result::Result<tonic::Request<()>, Status> {
-        add_telemetry_headers(request)
+        crate::telemetry::middleware::add_telemetry_headers(request)
     }
 }
 #[cfg(not(feature = "telemetry"))]

--- a/nidx/src/searcher/sync.rs
+++ b/nidx/src/searcher/sync.rs
@@ -20,6 +20,7 @@
 
 use crate::metadata::{Index, IndexId, IndexKind, SegmentId, Shard};
 use crate::metrics;
+use crate::metrics::searcher::{ACTIVE_SHARDS, DESIRED_SHARDS, EVICTED_SHARDS};
 use crate::settings::SearcherSettings;
 use crate::{segment_store::download_segment, NidxMetadata};
 use anyhow::anyhow;
@@ -547,6 +548,10 @@ impl SyncMetadata {
         if count_evicted_shards > 0 {
             info!(count = count_evicted_shards, "Shards marked for eviction");
         }
+
+        DESIRED_SHARDS.set(shards.len() as i64);
+        ACTIVE_SHARDS.set(shard_metadata.values().filter(|v| !v.is_empty()).count() as i64);
+        EVICTED_SHARDS.set(evicted_shards.len() as i64);
 
         (indexes_to_sync, indexes_to_delete)
     }

--- a/nidx/src/searcher/sync.rs
+++ b/nidx/src/searcher/sync.rs
@@ -115,7 +115,7 @@ pub async fn run_sync(
                 }
 
                 if let Err(e) = delete_index(shard_id, index_id, Arc::clone(&index_metadata), &notifier).await {
-                    warn!(?e, ?index_id, "Could not delete index, some files will be left behind");
+                    warn!(?index_id, "Could not delete index, some files will be left behind: {e:?}");
                 }
             }
 
@@ -165,9 +165,9 @@ pub async fn run_sync(
                     }
                     let retries = failed_indexes.entry(index_id).or_default();
                     if *retries > 2 {
-                        error!(?index_id, ?e, "Index failed to update multiple times, will keep retrying forever")
+                        error!(?index_id, "Index failed to update multiple times, will keep retrying forever: {e:?}")
                     } else {
-                        warn!(?index_id, ?e, "Index failed to update, will retry")
+                        warn!(?index_id, "Index failed to update, will retry: {e:?}")
                     }
                     *retries += 1;
                 } else {
@@ -202,7 +202,7 @@ pub async fn run_sync(
         }
         .await;
         if let Err(e) = sync_result {
-            error!(?e, "Unexpected error while syncing");
+            error!("Unexpected error while syncing: {e:?}");
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
     }
@@ -242,7 +242,7 @@ async fn sync_index(
                     if retries > 3 {
                         return Err(e);
                     } else {
-                        warn!(?e, ?segment_id, "Failure to download a segment, will retry");
+                        warn!(?segment_id, "Failure to download a segment, will retry: {e:?}");
                     }
                     retries += 1;
                 } else {

--- a/nidx/src/worker.rs
+++ b/nidx/src/worker.rs
@@ -78,7 +78,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
                 }
                 Err(e) => {
                     MERGE_COUNTER.get_or_create(&OperationStatusLabels::failure()).inc();
-                    error!(job.id, ?e, "Merge job failed")
+                    error!(job.id, "Merge job failed: {e:?}")
                 }
             }
 


### PR DESCRIPTION
This PR is a bit chaotic. It contains:

- Add telemetry middleware to nidx searcher clients so we can trace when a search goes across multiple nodes.
- Change error handling to show the error in the message. This is so Sentry does not group all exceptions together.
- Some fixes to vector merge algorithm to ensure we don't create too big segments
- Adding a few metrics to track the amount of shards downloaded by each searcher.