### PR TITLE
lock pdm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@
 # are updated. The generated requirements.txt does not, so it is
 # more cacheable.
 FROM python:3.12 AS requirements
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 COPY pdm.lock pyproject.toml .
 RUN pdm export --prod --no-hashes | grep -v ^-e | grep -v nidx_protos > requirements.lock.txt
 
 FROM python:3.12
 RUN mkdir -p /usr/src/app
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \

--- a/Dockerfile.node_sidecar
+++ b/Dockerfile.node_sidecar
@@ -3,13 +3,13 @@
 #
 
 FROM python:3.12 AS requirements
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 COPY pdm.lock pyproject.toml .
 RUN pdm export --prod --no-default -G sidecar --no-hashes | grep -v ^-e > requirements.lock.txt
 
 FROM python:3.12
 RUN mkdir -p /usr/src/app
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
@@ -36,7 +36,7 @@ COPY nucliadb_protos /usr/src/app/nucliadb_protos
 COPY nucliadb_sidecar /usr/src/app/nucliadb_sidecar
 
 # Install our packages to the virtualenv
-RUN pdm sync --prod --no-default -G sidecar --no-editable
+RUN pdm sync --prod --no-default -G sidecar --no-editable -v
 
 ENV PATH="/usr/src/app/.venv/bin:$PATH"
 CMD ["node_sidecar"]

--- a/Dockerfile.pipbinding
+++ b/Dockerfile.pipbinding
@@ -7,12 +7,12 @@
 # are updated. The generated requirements.txt does not, so it is
 # more cacheable.
 FROM python:3.12 AS requirements
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 COPY pdm.lock pyproject.toml .
 RUN pdm export --prod --no-hashes | grep -v ^-e | grep -v nidx_protos > requirements.lock.txt
 
 FROM python:3.12
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \

--- a/Dockerfile.withbinding
+++ b/Dockerfile.withbinding
@@ -53,12 +53,12 @@ RUN set -eux; \
 # are updated. The generated requirements.txt does not, so it is
 # more cacheable.
 FROM python:3.12 AS requirements
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 COPY pdm.lock pyproject.toml .
 RUN pdm export --prod --no-hashes | grep -v ^-e | grep -v nidx_protos > requirements.lock.txt
 
 FROM python:3.12
-RUN pip install pdm
+RUN pip install pdm==2.22.1
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \


### PR DESCRIPTION
pdm 2.22.2 includes some changes in editable dependencies that break our dockerfile installs. Locking pdm version for now https://github.com/pdm-project/pdm/pull/3361