### PR TITLE
Wait for server response when acking messages

### DIFF
--- a/nidx/src/indexer.rs
+++ b/nidx/src/indexer.rs
@@ -124,7 +124,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
         }
         INDEXING_COUNTER.get_or_create(&OperationStatusLabels::success()).inc();
 
-        if let Err(e) = acker.ack().await {
+        if let Err(e) = acker.double_ack().await {
             warn!("Error acking index message: {e:?}");
             continue;
         }


### PR DESCRIPTION
### Description

When shutting down an indexer (scale down), sometimes the ACK message does not reach NATS and the message is redelivered. Using `double_ack` should make sure we wait until NATS has received the ACK before exiting.

### How was this PR tested?
Describe how you tested this PR.
