### PR TITLE
Text v2: faster prefiltering

### DIFF
--- a/nidx/Cargo.lock
+++ b/nidx/Cargo.lock
@@ -2153,9 +2153,11 @@ dependencies = [
  "nidx_tantivy",
  "nidx_tests",
  "nidx_types",
+ "serde",
  "tantivy",
  "tempfile",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4752,9 +4754,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
  "serde",

--- a/nidx/nidx_paragraph/tests/reader.rs
+++ b/nidx/nidx_paragraph/tests/reader.rs
@@ -145,7 +145,6 @@ fn create_resource(shard_id: String, timestamp: Timestamp) -> Resource {
         labels: vec!["/l/mylabel_resource".to_string()],
         paragraphs,
         paragraphs_to_delete: vec![],
-        sentences_to_delete: vec![],
         relations: vec![],
         vectors: HashMap::default(),
         vectors_to_delete: HashMap::default(),

--- a/nidx/nidx_text/Cargo.toml
+++ b/nidx/nidx_text/Cargo.toml
@@ -13,6 +13,8 @@ nidx_protos = { version = "0.1.0", path = "../nidx_protos" }
 nidx_tantivy = { version = "0.1.0", path = "../nidx_tantivy" }
 anyhow = "1.0.91"
 tracing = "0.1.40"
+uuid = "1.12.0"
+serde = { version = "1.0.210", features = ["derive"] }
 
 [dev-dependencies]
 nidx_tests = { path = "../nidx_tests" }

--- a/nidx/nidx_text/src/schema.rs
+++ b/nidx/nidx_text/src/schema.rs
@@ -143,3 +143,30 @@ pub fn decode_field_id(data: &[u64]) -> (uuid::Uuid, String) {
     }
     (rid, String::from_utf8(ubytes).unwrap())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_field_id, encode_field_id};
+
+    #[test]
+    fn test_encode_decode_field_id() {
+        // Test with different lengths to ensure it works when crossing block length
+        let testcases = [
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title1"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title12"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title123"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title1234"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title12345"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title123456"),
+            ("03ce0c2cdcc0060069fb8f69c73fa8e2", "/a/title1234567"),
+        ];
+        for t in testcases {
+            let rid = uuid::Uuid::parse_str(t.0).unwrap();
+            let data = encode_field_id(rid, t.1);
+            let (decoded_rid, decoded_fid) = decode_field_id(&data);
+            assert_eq!(decoded_rid.simple().to_string().as_str(), t.0);
+            assert_eq!(decoded_fid, t.1);
+        }
+    }
+}

--- a/nidx/nidx_text/src/schema.rs
+++ b/nidx/nidx_text/src/schema.rs
@@ -18,6 +18,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+use std::cmp::min;
+
 use tantivy::{
     schema::{FacetOptions, Field, NumericOptions, Schema, FAST, INDEXED, STORED, TEXT},
     DateOptions, DateTime,
@@ -42,6 +44,8 @@ pub struct TextSchema {
     // Security
     pub groups_public: Field,
     pub groups_with_access: Field,
+
+    pub encoded_field_id: Option<Field>,
 }
 
 pub fn timestamp_to_datetime_utc(timestamp: &nidx_protos::prost_types::Timestamp) -> DateTime {
@@ -49,7 +53,7 @@ pub fn timestamp_to_datetime_utc(timestamp: &nidx_protos::prost_types::Timestamp
 }
 
 impl TextSchema {
-    pub fn new() -> Self {
+    pub fn new(version: u64) -> Self {
         let mut sb = Schema::builder();
         let num_options: NumericOptions = NumericOptions::default().set_indexed().set_fast();
 
@@ -76,6 +80,15 @@ impl TextSchema {
         let groups_public = sb.add_u64_field("groups_public", num_options);
         let groups_with_access = sb.add_facet_field("groups_with_access", facet_options);
 
+        // v2: Field ID encoded as array of u64 for faster retrieval during prefilter
+        // Using a bytes field is slow due to tantivy's implementation being slow with many unique values.
+        // A better implementation is tracked in https://github.com/quickwit-oss/tantivy/issues/2090
+        let encoded_field_id = if version >= 2 {
+            Some(sb.add_u64_field("encoded_field_id", FAST))
+        } else {
+            None
+        };
+
         let schema = sb.build();
 
         TextSchema {
@@ -89,12 +102,44 @@ impl TextSchema {
             field,
             groups_public,
             groups_with_access,
+            encoded_field_id,
         }
     }
 }
 
-impl Default for TextSchema {
-    fn default() -> Self {
-        Self::new()
+/// Encodes a resource and field id as a series of u64
+/// This is stored in the fast field `encoded_field_id`
+/// We convert to bytes, batch them in sets of 8, and store
+/// as an array of u64
+pub fn encode_field_id(rid: uuid::Uuid, fid: &str) -> Vec<u64> {
+    let (r1, r2) = rid.as_u64_pair();
+    let mut out = vec![r1, r2];
+    let bb = fid.as_bytes();
+    let mut slice = bb;
+    while !slice.is_empty() {
+        let take = min(8, slice.len());
+        let mut data = [0; 8];
+        data[..take].copy_from_slice(&slice[..take]);
+        slice = &slice[take..];
+        out.push(u64::from_le_bytes(data));
     }
+
+    out
+}
+
+/// Decodes a resource and field id from a series of u64
+/// This is retrieved from the fast field `encoded_field_id`
+/// and used for faster loading in the prefilter Collector
+pub fn decode_field_id(data: &[u64]) -> (uuid::Uuid, String) {
+    let rid = uuid::Uuid::from_u64_pair(data[0], data[1]);
+    let mut ubytes = Vec::with_capacity((data.len() - 2) * 8);
+    for word in &data[2..] {
+        let wb = word.to_le_bytes();
+        let mut i = 7;
+        while wb[i] == 0 {
+            i -= 1;
+        }
+        ubytes.extend_from_slice(&wb[0..=i]);
+    }
+    (rid, String::from_utf8(ubytes).unwrap())
 }

--- a/nidx/nidx_text/src/search_query.rs
+++ b/nidx/nidx_text/src/search_query.rs
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_stream_filter_query_per_tag() {
-        let schema = TextSchema::new();
+        let schema = TextSchema::new(2);
 
         let filter = StreamFilter::default();
         let queries = create_stream_filter_queries(&schema, &filter);
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_default_stream_filter_queries_creation() {
-        let schema = TextSchema::new();
+        let schema = TextSchema::new(2);
         let filter = StreamFilter {
             labels: vec!["/A".to_string(), "/B".to_string()],
             ..Default::default()
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_and_stream_filter_queries_creation() {
-        let schema = TextSchema::new();
+        let schema = TextSchema::new(2);
         let filter = StreamFilter {
             labels: vec!["/A".to_string(), "/B".to_string()],
             conjunction: Conjunction::And.into(),
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_or_stream_filter_queries_creation() {
-        let schema = TextSchema::new();
+        let schema = TextSchema::new(2);
         let filter = StreamFilter {
             labels: vec!["/A".to_string(), "/B".to_string()],
             conjunction: Conjunction::Or.into(),
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_not_stream_filter_queries_creation() {
-        let schema = TextSchema::new();
+        let schema = TextSchema::new(2);
         let filter = StreamFilter {
             labels: vec!["/A".to_string(), "/B".to_string()],
             conjunction: Conjunction::Not.into(),

--- a/nidx/nidx_text/tests/common/mod.rs
+++ b/nidx/nidx_text/tests/common/mod.rs
@@ -26,7 +26,7 @@ use std::time::SystemTime;
 use nidx_protos::prost_types::Timestamp;
 use nidx_protos::{Resource, ResourceId};
 use nidx_tantivy::{TantivyMeta, TantivySegmentMetadata};
-use nidx_text::{TextIndexer, TextSearcher};
+use nidx_text::{TextConfig, TextIndexer, TextSearcher};
 use nidx_types::{OpenIndexMetadata, Seq};
 use tempfile::TempDir;
 
@@ -57,9 +57,9 @@ impl OpenIndexMetadata<TantivyMeta> for TestOpener {
 pub fn test_reader() -> TextSearcher {
     let dir = TempDir::new().unwrap();
     let resource = create_resource("shard".to_string());
-    let segment_meta = TextIndexer.index_resource(dir.path(), &resource).unwrap().unwrap();
+    let segment_meta = TextIndexer.index_resource(dir.path(), TextConfig::default(), &resource).unwrap().unwrap();
 
-    TextSearcher::open(TestOpener::new(vec![(segment_meta, 1i64.into())], vec![])).unwrap()
+    TextSearcher::open(TextConfig::default(), TestOpener::new(vec![(segment_meta, 1i64.into())], vec![])).unwrap()
 }
 
 pub fn create_resource(shard_id: String) -> Resource {
@@ -106,7 +106,6 @@ pub fn create_resource(shard_id: String) -> Resource {
         labels: vec![],
         paragraphs: HashMap::new(),
         paragraphs_to_delete: vec![],
-        sentences_to_delete: vec![],
         relations: vec![],
         vectors: HashMap::default(),
         vectors_to_delete: HashMap::default(),

--- a/nidx/nidx_vector/src/indexer.rs
+++ b/nidx/nidx_vector/src/indexer.rs
@@ -20,7 +20,6 @@
 use crate::config::VectorConfig;
 use crate::data_point::{self, Elem, LabelDictionary};
 use crate::{utils, VectorSegmentMetadata};
-use anyhow::anyhow;
 use nidx_protos::{noderesources, prost::*};
 use std::collections::HashMap;
 use std::path::Path;

--- a/nidx/src/indexer.rs
+++ b/nidx/src/indexer.rs
@@ -255,7 +255,9 @@ fn index_resource_to_index(
         IndexKind::Vector => nidx_vector::VectorIndexer
             .index_resource(output_dir, &index.config()?, resource, &index.name, single_vector_index)?
             .map(|x| x.into()),
-        IndexKind::Text => nidx_text::TextIndexer.index_resource(output_dir, resource)?.map(|x| x.into()),
+        IndexKind::Text => {
+            nidx_text::TextIndexer.index_resource(output_dir, index.config()?, resource)?.map(|x| x.into())
+        }
         IndexKind::Paragraph => {
             nidx_paragraph::ParagraphIndexer.index_resource(output_dir, resource)?.map(|x| x.into())
         }

--- a/nidx/src/searcher/index_cache.rs
+++ b/nidx/src/searcher/index_cache.rs
@@ -193,7 +193,7 @@ impl IndexCache {
         };
 
         let searcher = match meta.index.kind {
-            IndexKind::Text => IndexSearcher::Text(TextSearcher::open(open_index)?),
+            IndexKind::Text => IndexSearcher::Text(TextSearcher::open(meta.index.config()?, open_index)?),
             IndexKind::Paragraph => IndexSearcher::Paragraph(ParagraphSearcher::open(open_index)?),
             IndexKind::Vector => IndexSearcher::Vector(VectorSearcher::open(meta.index.config()?, open_index)?),
             IndexKind::Relation => IndexSearcher::Relation(RelationSearcher::open(open_index)?),

--- a/nidx/src/worker.rs
+++ b/nidx/src/worker.rs
@@ -160,14 +160,14 @@ pub async fn run_job(
 
     let work_dir = tempfile::tempdir_in(work_path)?;
     let work_path = work_dir.path().to_path_buf();
-    let vector_config = index.config();
     let span = Span::current();
+    let index2 = index.clone();
     let merged: NewSegment = tokio::task::spawn_blocking(move || {
         span.in_scope(|| match index.kind {
             IndexKind::Vector => {
-                VectorIndexer.merge(&work_path, vector_config.unwrap(), merge_inputs).map(|x| x.into())
+                VectorIndexer.merge(&work_path, index2.config().unwrap(), merge_inputs).map(|x| x.into())
             }
-            IndexKind::Text => TextIndexer.merge(&work_path, merge_inputs).map(|x| x.into()),
+            IndexKind::Text => TextIndexer.merge(&work_path, index2.config().unwrap(), merge_inputs).map(|x| x.into()),
             IndexKind::Paragraph => ParagraphIndexer.merge(&work_path, merge_inputs).map(|x| x.into()),
             IndexKind::Relation => RelationIndexer.merge(&work_path, merge_inputs).map(|x| x.into()),
         })

--- a/nidx/tests/test_date_range_search.rs
+++ b/nidx/tests/test_date_range_search.rs
@@ -34,7 +34,7 @@ use tonic::Request;
 use uuid::Uuid;
 
 async fn populate(fixture: &mut NidxFixture, shard_id: String, metadata: IndexMetadata) {
-    let raw_resource_id = Uuid::new_v4().to_string();
+    let raw_resource_id = Uuid::new_v4().simple().to_string();
     let field_id = "f/body".to_string();
 
     let resource_id = ResourceId {


### PR DESCRIPTION
### Description
Tantivy 0.20 rewrote the columnar store to use sstables. This is generally good but it's slow when using bytes field with unique values. The problem is tracked on tantivy here:
https://github.com/quickwit-oss/tantivy/issues/2090
https://github.com/quickwit-oss/tantivy/pull/2075

The effect for us is that prefiltering is significantly slower. As a workaround, this PR uses a field type that is not subject to the same issues, an array of u64. This basically stores the same information as before, but grouping the `[u8]`s into `[u64]`s before storing in tantivy. It makes prefilter around 20x faster, basically matching the performance we had with Tantivy 0.17 (in the node).

Also adding a bit of metadata to track the version of the index. This implies reindexing in order to benefit from the faster speed, but the code remains compatible with the current version, so we can do an smooth rollover.