### PR TITLE
Fix empty tus uploads on GCS

### DIFF
--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -227,7 +227,7 @@ async def _tus_post(
         size = int(request.headers["upload-length"])
     else:
         if not deferred_length:
-            raise HTTPPreconditionFailed(detail="We need upload-length header")
+            raise HTTPPreconditionFailed(detail="upload-length header is required")
 
     if "tus-resumable" not in request.headers:
         raise HTTPPreconditionFailed(detail="TUS needs a TUS version")

--- a/nucliadb/src/nucliadb/writer/tus/gcs.py
+++ b/nucliadb/src/nucliadb/writer/tus/gcs.py
@@ -354,24 +354,23 @@ class GCloudFileStorageManager(FileStorageManager):
         if dm.size == 0:
             if self.storage.session is None:
                 raise AttributeError()
+            # In case of empty file, we need to send a PUT request with empty body
+            # and Content-Range header set to "bytes */0"
             headers = {
                 "Content-Length": "0",
+                "Content-Range": "bytes */0",
             }
-            if dm.offset != 0:
-                headers["Content-Range"] = "bytes {init}-{chunk}/{total}".format(
-                    init=dm.offset, chunk=dm.offset, total=dm.offset
-                )
-            else:
-                # In case of empty file
-                headers["Content-Range"] = "bytes */0"
             resumable_uri = dm.get("resumable_uri")
             async with self.storage.session.put(
                 resumable_uri,
                 headers=headers,
                 data="",
             ) as call:
-                text = await call.text()  # noqa
                 if call.status not in [200, 201, 308]:
+                    try:
+                        text = await call.text()
+                    except Exception:
+                        text = ""
                     raise GoogleCloudException(f"{call.status}: {text}")
         path = dm.get("path")
         await dm.finish()


### PR DESCRIPTION
### Description
TUS protocol allows for uploading empty files, and our gcs implementation was breaking in that case

### How was this PR tested?
Added an integration test that reproduced the issue, and then fixed it
