### PR TITLE
Update nidx merge jobs metrics before scheduling more

### DIFF
--- a/nidx/src/scheduler/metrics_task.rs
+++ b/nidx/src/scheduler/metrics_task.rs
@@ -26,12 +26,6 @@ use crate::{
     NidxMetadata,
 };
 
-pub async fn update_metrics(metadb: &NidxMetadata) -> anyhow::Result<()> {
-    update_merge_job_metric(metadb).await?;
-
-    Ok(())
-}
-
 pub async fn update_merge_job_metric(metadb: &NidxMetadata) -> anyhow::Result<()> {
     let job_states = sqlx::query!(
         r#"


### PR DESCRIPTION
The merge jobs metric is noisy because it can vary a lot if it's updated just before a scheduling run or just after it.

This forces the metric to always be updated before scheduling more, so it will only show non-zero if there are pending jobs when we are about to enqueue new ones. This is a bit better for scaling, if there are zero jobs by the time we schedule new ones, we got enough workers.