### PR TITLE
Set status to pending on reprocess

### DIFF
--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -564,7 +564,7 @@ class Resource:
                     ),
                     None,
                 )
-                if field_status:
+                if field_status is not None:
                     status.status = field_status
                 # If the field was not found and the message comes from the writer, this implicitly sets the
                 # status to the default value, which is PROCESSING. This covers the case of new field creation.


### PR DESCRIPTION
If `field_status` was set to PENDING (=0) it was not being updated.

The test was not correctly written and didn't completely test the code we wanted to test.