### PR TITLE
Change testbed bucket to ncl-testbed-gcp-stage-1

### DIFF
--- a/nucliadb_sdk/src/nucliadb_sdk/tests/fixtures.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/tests/fixtures.py
@@ -55,7 +55,7 @@ images.settings["nucliadb"] = {
 }
 
 NUCLIA_DOCS_dataset = (
-    "https://storage.googleapis.com/config.flaps.dev/test_nucliadb/nuclia-datasets.export"
+    "https://storage.googleapis.com/ncl-testbed-gcp-stage-1/test_nucliadb/nuclia-datasets.export"
 )
 
 


### PR DESCRIPTION
This pull request includes a small change to the `nucliadb_sdk/src/nucliadb_sdk/tests/fixtures.py` file. The change updates the URL for the `NUCLIA_DOCS_dataset` to point to a new location.

* [`nucliadb_sdk/src/nucliadb_sdk/tests/fixtures.py`](diffhunk://#diff-9705b08d62aaea7aa1e29071688b5c743825fbab1f8a4c03b4b50703811cef5fL58-R58): Updated the URL for the `NUCLIA_DOCS_dataset` to "https://storage.googleapis.com/ncl-testbed-gcp-stage-1/test_nucliadb/nuclia-datasets.export".