### PR TITLE
Bump upload/download artifact action

### DIFF
--- a/.github/workflows/nidx_binding_release.yml
+++ b/.github/workflows/nidx_binding_release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - run: twine check dist/*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pypi_files
           path: dist
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: get dist artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pypi_files
           path: dist
@@ -111,7 +111,7 @@ jobs:
       - run: pip install -U twine
 
       - name: get dist artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pypi_files
           path: dist


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow file `.github/workflows/nidx_binding_release.yml` to use the latest versions of certain actions. The most important changes are as follows:

* Updated the `upload-artifact` action to version 4. (`[.github/workflows/nidx_binding_release.ymlL76-R76](diffhunk://#diff-24ec545d23fba6dde75e6c17c5fd4da6eac2d2d53f1d8fce958e42e3ec956602L76-R76)`)
* Updated the `download-artifact` action to version 4 in two places. (`[[1]](diffhunk://#diff-24ec545d23fba6dde75e6c17c5fd4da6eac2d2d53f1d8fce958e42e3ec956602L90-R90)`, `[[2]](diffhunk://#diff-24ec545d23fba6dde75e6c17c5fd4da6eac2d2d53f1d8fce958e42e3ec956602L114-R114)`)
