### PR TITLE
Cleanup some default vectorset stuff

### DIFF
--- a/nucliadb/tests/ingest/integration/servicer/test_reindex.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_reindex.py
@@ -50,7 +50,7 @@ async def test_reindex_resource(dummy_nidx_utility, nucliadb_ingest_grpc: Writer
 
     # Create a resource with a field and some vectors
     bm = BrokerMessage()
-    rid = "test1"
+    rid = str(uuid4())
     field_id = "text1"
     field_type = FieldType.TEXT
     bm.uuid = rid

--- a/nucliadb/tests/ingest/integration/servicer/test_reindex.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_reindex.py
@@ -26,6 +26,7 @@ from nucliadb_protos.resources_pb2 import ExtractedVectorsWrapper, FieldType
 from nucliadb_protos.utils_pb2 import Vector
 from nucliadb_protos.writer_pb2 import BrokerMessage, IndexResource
 from nucliadb_protos.writer_pb2_grpc import WriterStub
+from tests.utils import inject_message
 
 
 @pytest.mark.deploy_modes("component")
@@ -65,7 +66,7 @@ async def test_reindex_resource(dummy_nidx_utility, nucliadb_ingest_grpc: Writer
     evw.field.field_type = field_type
     bm.field_vectors.append(evw)
 
-    await nucliadb_ingest_grpc.ProcessMessage([bm])  # type: ignore
+    await inject_message(nucliadb_ingest_grpc, bm)
 
     # Reindex it along with its vectors
     req = IndexResource(kbid=kbid, rid=rid, reindex_vectors=True)

--- a/nucliadb/tests/nucliadb/integration/search/test_filters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters.py
@@ -163,6 +163,12 @@ def broker_message_with_labels(kbid):
     level (resource, field and paragraph).
     """
     bm = broker_resource(kbid=kbid)
+    # XXX remove title and summary info, as the test don't take them into
+    # account, but the rest is expected for indexing.....
+    bm.basic.ClearField("fieldmetadata")
+    bm.ClearField("field_metadata")
+    bm.ClearField("extracted_text")
+
     field_id = "text"
     field = FieldID()
     field.field = field_id

--- a/nucliadb/tests/nucliadb/integration/test_deletion.py
+++ b/nucliadb/tests/nucliadb/integration/test_deletion.py
@@ -274,5 +274,4 @@ def prepare_broker_message(
 
     bm = bmb.build()
 
-    print(bm)
     return bm

--- a/nucliadb/tests/nucliadb/integration/test_matryoshka_embeddings.py
+++ b/nucliadb/tests/nucliadb/integration/test_matryoshka_embeddings.py
@@ -112,7 +112,7 @@ async def test_matryoshka_embeddings(
                 vector=[(i + 1)] * vector_dimension,
             )
         )
-    text_field.with_extracted_vectors(vectors)
+    text_field.with_extracted_vectors(vectors, vectorset="my-semantic-model")
 
     bmb.add_field_builder(text_field)
 

--- a/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
+++ b/nucliadb/tests/nucliadb/integration/test_pinecone_kb.py
@@ -43,11 +43,11 @@ from nucliadb_protos.writer_pb2 import (
     BrokerMessage,
     NewKnowledgeBoxV2Request,
     NewKnowledgeBoxV2Response,
-    OpStatusWriter,
 )
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from nucliadb_utils.aiopynecone.models import IndexDescription, IndexStats, IndexStatus, QueryResponse
 from nucliadb_utils.utilities import get_endecryptor
+from tests.utils import inject_message
 
 PINECONE_MODULE = "nucliadb.common.external_index_providers.pinecone"
 
@@ -358,8 +358,7 @@ async def _inject_broker_message(nucliadb_grpc: WriterStub, kbid: str, rid: str,
     bm.field_vectors.append(ev)
     bm.source = BrokerMessage.MessageSource.PROCESSOR
 
-    response = await nucliadb_grpc.ProcessMessage([bm], timeout=None)  # type: ignore
-    assert response.status == OpStatusWriter.Status.OK
+    await inject_message(nucliadb_grpc, bm)
 
 
 async def test_ingestion_on_pinecone_kb(

--- a/nucliadb/tests/nucliadb/integration/test_suggest.py
+++ b/nucliadb/tests/nucliadb/integration/test_suggest.py
@@ -22,8 +22,9 @@ import pytest
 from httpx import AsyncClient
 
 from nucliadb_protos.resources_pb2 import LinkExtractedData
-from nucliadb_protos.writer_pb2 import BrokerMessage, OpStatusWriter
+from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_protos.writer_pb2_grpc import WriterStub
+from tests.utils import inject_message
 
 
 async def test_suggest_paragraphs(
@@ -290,8 +291,7 @@ async def test_suggestion_on_link_computed_titles_sc6088(
     led.title = extracted_title
     bm.link_extracted_data.append(led)
 
-    resp = await nucliadb_grpc.ProcessMessage([bm])
-    assert resp.status == OpStatusWriter.Status.OK
+    await inject_message(nucliadb_grpc, bm)
 
     # Check that the resource title changed
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid}")

--- a/nucliadb/tests/train/test_image_classification.py
+++ b/nucliadb/tests/train/test_image_classification.py
@@ -39,9 +39,10 @@ from nucliadb_protos.resources_pb2 import (
     PageStructurePage,
     PageStructureToken,
 )
-from nucliadb_protos.writer_pb2 import BrokerMessage, OpStatusWriter
+from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from tests.train.utils import get_batches_from_train_response_stream
+from tests.utils import inject_message
 from tests.utils.dirty_index import wait_for_sync
 
 _dir = os.path.dirname(__file__)
@@ -131,11 +132,8 @@ async def image_classification_resource(
         patch("nucliadb.ingest.fields.file.File.set_file_extracted_data", new=mock_set) as _,
         patch("nucliadb.ingest.fields.file.File.get_file_extracted_data", new=mock_get) as _,
     ):
-        response = await nucliadb_ingest_grpc.ProcessMessage(  # type: ignore
-            iter([broker_message]), timeout=10, wait_for_ready=True
-        )
+        await inject_message(nucliadb_ingest_grpc, broker_message, timeout=10, wait_for_ready=True)
         await wait_for_sync()
-        assert response.status == OpStatusWriter.Status.OK
         yield
 
 

--- a/nucliadb/tests/utils/__init__.py
+++ b/nucliadb/tests/utils/__init__.py
@@ -19,6 +19,7 @@
 #
 import uuid
 from datetime import datetime
+from typing import Optional
 
 from nucliadb_protos import resources_pb2 as rpb
 from nucliadb_protos.writer_pb2 import BrokerMessage, OpStatusWriter
@@ -118,7 +119,12 @@ def broker_resource_with_title_paragraph(
     return bm
 
 
-async def inject_message(writer: WriterStub, message: BrokerMessage):
+async def inject_message(
+    writer: WriterStub,
+    message: BrokerMessage,
+    timeout: Optional[float] = None,
+    wait_for_ready: Optional[bool] = None,
+):
     await mark_dirty()
-    resp = await writer.ProcessMessage([message])  # type: ignore
+    resp = await writer.ProcessMessage([message], timeout=timeout, wait_for_ready=wait_for_ready)  # type: ignore
     assert resp.status == OpStatusWriter.Status.OK

--- a/nucliadb/tests/utils/__init__.py
+++ b/nucliadb/tests/utils/__init__.py
@@ -73,6 +73,7 @@ async def inject_message(
     timeout: Optional[float] = None,
     wait_for_ready: Optional[bool] = None,
 ):
+    # We should be able to enable this once all tests have been migrated
     # for ev in message.field_vectors:
     #     assert ev.vectorset_id, "Vectorset ID must be set in ExtractedVectorsWrapper!"
     #     assert len(ev.vectorset_id) > 0, "Vectorset ID must be set in ExtractedVectorsWrapper!"

--- a/nucliadb/tests/utils/__init__.py
+++ b/nucliadb/tests/utils/__init__.py
@@ -18,104 +18,52 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import uuid
-from datetime import datetime
 from typing import Optional
 
 from nucliadb_protos import resources_pb2 as rpb
 from nucliadb_protos.writer_pb2 import BrokerMessage, OpStatusWriter
 from nucliadb_protos.writer_pb2_grpc import WriterStub
+from tests.utils.broker_messages import BrokerMessageBuilder
 from tests.utils.dirty_index import mark_dirty
 
 
-def broker_resource(kbid: str, rid=None, slug=None, title=None, summary=None) -> BrokerMessage:
-    """
-    Returns a broker resource with barebones metadata.
-    """
-    rid = rid or str(uuid.uuid4()).replace("-", "")
-    slug = slug or f"{rid}slug1"
-    bm: BrokerMessage = BrokerMessage(
-        kbid=kbid,
-        uuid=rid,
-        slug=slug,
-        type=BrokerMessage.AUTOCOMMIT,
-    )
-    title = title or "Title Resource"
-    summary = summary or "Summary of document"
-    bm.basic.icon = "text/plain"
-    bm.basic.title = title
-    bm.basic.summary = summary
-    bm.basic.thumbnail = "doc"
-    bm.basic.metadata.useful = True
-    bm.basic.metadata.language = "es"
-    bm.basic.created.FromDatetime(datetime.now())
-    bm.basic.modified.FromDatetime(datetime.now())
-    bm.origin.source = rpb.Origin.Source.WEB
-
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = title
-    etw.field.field = "title"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
-
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = summary
-    etw.field.field = "summary"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
-
-    bm.source = BrokerMessage.MessageSource.WRITER
-    return bm
-
-
-def broker_resource_with_title_paragraph(
-    kbid: str, rid=None, slug=None, title=None, summary=None
+def broker_resource(
+    kbid: str,
+    rid: Optional[str] = None,
+    slug: Optional[str] = None,
 ) -> BrokerMessage:
     """
     Returns a broker resource with barebones metadata.
     """
     rid = rid or str(uuid.uuid4()).replace("-", "")
     slug = slug or f"{rid}slug1"
-    bm: BrokerMessage = BrokerMessage(
-        kbid=kbid,
-        uuid=rid,
-        slug=slug,
-        type=BrokerMessage.AUTOCOMMIT,
-    )
-    title = title or "Title Resource"
-    summary = summary or "Summary of document"
-    bm.basic.icon = "text/plain"
-    bm.basic.title = title
-    bm.basic.summary = summary
-    bm.basic.thumbnail = "doc"
-    bm.basic.metadata.useful = True
-    bm.basic.metadata.language = "es"
-    bm.basic.created.FromDatetime(datetime.now())
-    bm.basic.modified.FromDatetime(datetime.now())
-    bm.origin.source = rpb.Origin.Source.WEB
 
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = title
-    etw.field.field = "title"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
+    bmb = BrokerMessageBuilder(kbid=kbid, rid=rid, slug=slug)
+    bmb.with_title("Title Resource")
+    bmb.with_summary("Summary of document")
+    bm = bmb.build()
+    return bm
 
-    fcm = rpb.FieldComputedMetadataWrapper()
-    fcm.field.field = "title"
-    fcm.field.field_type = rpb.FieldType.GENERIC
-    p1 = rpb.Paragraph(
-        start=0,
-        end=5,
-    )
-    fcm.metadata.metadata.paragraphs.append(p1)
-    bm.field_metadata.append(fcm)
 
-    etw = rpb.ExtractedTextWrapper()
-    etw.body.text = summary
-    etw.field.field = "summary"
-    etw.field.field_type = rpb.FieldType.GENERIC
-    bm.extracted_text.append(etw)
+def broker_resource_with_title_paragraph(
+    kbid: str,
+    rid: Optional[str] = None,
+    slug: Optional[str] = None,
+) -> BrokerMessage:
+    """
+    Returns a broker resource with barebones metadata.
+    """
+    rid = rid or str(uuid.uuid4()).replace("-", "")
+    slug = slug or f"{rid}slug1"
 
-    bm.source = BrokerMessage.MessageSource.WRITER
+    bmb = BrokerMessageBuilder(kbid=kbid, rid=rid, slug=slug)
+
+    title_builder = bmb.with_title("Title Resource")
+    title_builder.with_extracted_paragraph_metadata(rpb.Paragraph(start=0, end=5))
+
+    bmb.with_summary("Summary of document")
+
+    bm = bmb.build()
     return bm
 
 
@@ -125,6 +73,10 @@ async def inject_message(
     timeout: Optional[float] = None,
     wait_for_ready: Optional[bool] = None,
 ):
+    # for ev in message.field_vectors:
+    #     assert ev.vectorset_id, "Vectorset ID must be set in ExtractedVectorsWrapper!"
+    #     assert len(ev.vectorset_id) > 0, "Vectorset ID must be set in ExtractedVectorsWrapper!"
+
     await mark_dirty()
     resp = await writer.ProcessMessage([message], timeout=timeout, wait_for_ready=wait_for_ready)  # type: ignore
     assert resp.status == OpStatusWriter.Status.OK

--- a/nucliadb/tests/utils/broker_messages/__init__.py
+++ b/nucliadb/tests/utils/broker_messages/__init__.py
@@ -77,7 +77,7 @@ class BrokerMessageBuilder:
     def field_builder(self, field_id: str, field_type: rpb.FieldType.ValueType) -> FieldBuilder:
         return self.fields[(field_id, field_type)]
 
-    def with_title(self, title: str):
+    def with_title(self, title: str) -> FieldBuilder:
         title_builder = FieldBuilder("title", rpb.FieldType.GENERIC)
         title_builder.with_extracted_text(title)
         # we do this to writer BMs in write resource API endpoint
@@ -90,8 +90,9 @@ class BrokerMessageBuilder:
         )
         self.bm.basic.title = title
         self.add_field_builder(title_builder)
+        return title_builder
 
-    def with_summary(self, summary: str):
+    def with_summary(self, summary: str) -> FieldBuilder:
         summary_builder = FieldBuilder("summary", rpb.FieldType.GENERIC)
         summary_builder.with_extracted_text(summary)
         # we do this to writer BMs in write resource API endpoint
@@ -104,6 +105,7 @@ class BrokerMessageBuilder:
         )
         self.bm.basic.summary = summary
         self.add_field_builder(summary_builder)
+        return summary_builder
 
     def with_resource_labels(self, labelset: str, labels: list[str]):
         classifications = labels_to_classifications(labelset, labels)
@@ -114,13 +116,17 @@ class BrokerMessageBuilder:
         self.bm.basic.thumbnail = "doc"
         self.bm.basic.metadata.useful = True
         self.bm.basic.metadata.language = "en"
-        self.bm.basic.metadata.status = rpb.Metadata.Status.PROCESSED
+
+        if self.bm.source == wpb.BrokerMessage.MessageSource.WRITER:
+            self.bm.basic.metadata.status = rpb.Metadata.Status.PENDING
+        elif self.bm.source == wpb.BrokerMessage.MessageSource.PROCESSOR:
+            self.bm.basic.metadata.status = rpb.Metadata.Status.PROCESSED
+        else:
+            raise ValueError(f"Unknown broker message source: {self.bm.source}")
+
         self.bm.basic.metadata.metadata["key"] = "value"
         self.bm.basic.created.FromDatetime(datetime.now())
         self.bm.basic.modified.FromDatetime(datetime.now())
-
-        self.with_title("Default test resource title")
-        self.with_summary("Default test resource summary")
 
     def _default_origin(self):
         self.bm.origin.source = rpb.Origin.Source.API
@@ -140,11 +146,14 @@ class BrokerMessageBuilder:
             field = field_builder.build()
 
             if field.id.field_type == rpb.FieldType.GENERIC:
+                # we don't need to do anything else
                 pass
+
             elif field.id.field_type == rpb.FieldType.FILE:
                 file_field = self.bm.files[field.id.field]
                 file_field.added.FromDatetime(datetime.now())
                 file_field.file.source = rpb.CloudFile.Source.EXTERNAL
+
             elif (
                 field.id.field_type == rpb.FieldType.LINK
                 and self.bm.source == wpb.BrokerMessage.MessageSource.PROCESSOR

--- a/nucliadb/tests/utils/broker_messages/__init__.py
+++ b/nucliadb/tests/utils/broker_messages/__init__.py
@@ -73,6 +73,7 @@ class BrokerMessageBuilder:
 
     def add_field_builder(self, field: FieldBuilder):
         self.fields[(field.id.field, field.id.field_type)] = field
+        return field
 
     def field_builder(self, field_id: str, field_type: rpb.FieldType.ValueType) -> FieldBuilder:
         return self.fields[(field_id, field_type)]
@@ -149,6 +150,11 @@ class BrokerMessageBuilder:
                 # we don't need to do anything else
                 pass
 
+            elif field.id.field_type == rpb.FieldType.TEXT:
+                assert (
+                    field.extracted.text is not None
+                ), "only text fields with extracted data are supported nowadays"
+
             elif field.id.field_type == rpb.FieldType.FILE:
                 file_field = self.bm.files[field.id.field]
                 file_field.added.FromDatetime(datetime.now())
@@ -160,8 +166,9 @@ class BrokerMessageBuilder:
             ):
                 # we don't need to do anything else
                 pass
+
             else:
-                raise Exception("Unsupported field type")
+                raise Exception("Unsupported field type: {field.id.field_type}")
 
             if field.user.metadata is not None:
                 self.bm.basic.fieldmetadata.append(field.user.metadata)

--- a/nucliadb/tests/utils/broker_messages/fields.py
+++ b/nucliadb/tests/utils/broker_messages/fields.py
@@ -131,7 +131,7 @@ class FieldBuilder:
     def with_extracted_text(self, text: str):
         self._extracted_text.body.text = text
 
-    def with_extracted_vectors(self, vectors: list[utils_pb2.Vector], vectorset: str = ""):
+    def with_extracted_vectors(self, vectors: list[utils_pb2.Vector], vectorset: str):
         self._extracted_vectors(vectorset).vectors.vectors.vectors.extend(vectors)
 
     def with_extracted_paragraph_metadata(self, paragraph: rpb.Paragraph):


### PR DESCRIPTION
### Description
- More usage of broker message builder
- All nucliadb/ tests use inject_message to send to process (so everyone is properly marking nidx dirty)
- Enforce vectorset_id in some tests (left work to do here)
- Broker message builder now requires vectorset_id for vectors

### How was this PR tested?
Describe how you tested this PR.
