### PR TITLE
Graph strategy filtering

### DIFF
--- a/nidx/nidx_relation/src/reader.rs
+++ b/nidx/nidx_relation/src/reader.rs
@@ -105,10 +105,14 @@ impl RelationsReaderService {
             );
             let source_type_term =
                 TermQuery::new(Term::from_field_u64(self.schema.source_type, node_type), IndexRecordOption::Basic);
-            let source_subtype_term = TermQuery::new(
-                Term::from_field_text(self.schema.source_subtype, node_subtype),
-                IndexRecordOption::Basic,
-            );
+            let source_subtype_term: Box<dyn Query> = if node_subtype.is_empty() {
+                Box::new(AllQuery)
+            } else {
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.schema.source_subtype, node_subtype),
+                    IndexRecordOption::Basic,
+                ))
+            };
             let out_relations_query: Box<dyn Query> = Box::new(BooleanQuery::new(vec![
                 (Occur::Must, Box::new(source_value_term)),
                 (Occur::Must, Box::new(source_type_term)),
@@ -122,10 +126,14 @@ impl RelationsReaderService {
             );
             let target_type_term =
                 TermQuery::new(Term::from_field_u64(self.schema.target_type, node_type), IndexRecordOption::Basic);
-            let target_subtype_term = TermQuery::new(
-                Term::from_field_text(self.schema.target_subtype, node_subtype),
-                IndexRecordOption::Basic,
-            );
+            let target_subtype_term: Box<dyn Query> = if node_subtype.is_empty() {
+                Box::new(AllQuery)
+            } else {
+                Box::new(TermQuery::new(
+                    Term::from_field_text(self.schema.target_subtype, node_subtype),
+                    IndexRecordOption::Basic,
+                ))
+            };
             let in_relations_query: Box<dyn Query> = Box::new(BooleanQuery::new(vec![
                 (Occur::Must, Box::new(target_value_term)),
                 (Occur::Must, Box::new(target_type_term)),

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -50,7 +50,12 @@ from nucliadb_models.search import (
     parse_rephrase_prompt,
 )
 from nucliadb_protos import audit_pb2
-from nucliadb_protos.nodereader_pb2 import RelationSearchResponse, SearchRequest, SearchResponse
+from nucliadb_protos.nodereader_pb2 import (
+    EntitiesSubgraphRequest,
+    RelationSearchResponse,
+    SearchRequest,
+    SearchResponse,
+)
 from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb_telemetry.errors import capture_exception
 from nucliadb_utils.utilities import get_audit
@@ -245,10 +250,16 @@ async def get_relations_results_from_entities(
     timeout: Optional[float] = None,
     only_with_metadata: bool = False,
     only_agentic_relations: bool = False,
+    deleted_entities: set[str] = set(),
 ) -> Relations:
     request = SearchRequest()
     request.relation_subgraph.entry_points.extend(entities)
     request.relation_subgraph.depth = 1
+
+    deleted = EntitiesSubgraphRequest.DeletedEntities()
+    deleted.node_values.extend(deleted_entities)
+    request.relation_subgraph.deleted_entities.append(deleted)
+
     results: list[SearchResponse]
     (
         results,

--- a/nucliadb/src/nucliadb/search/search/graph_strategy.py
+++ b/nucliadb/src/nucliadb/search/search/graph_strategy.py
@@ -365,19 +365,14 @@ async def get_graph_results(
                     timeout=5.0,
                     only_with_metadata=True,
                     only_agentic_relations=graph_strategy.agentic_graph_only,
+                    deleted_entities=explored_entities,
                 )
             except Exception as e:
                 capture_exception(e)
                 logger.exception("Error in getting query relations for graph strategy")
                 new_relations = Relations(entities={})
 
-            # Removing the relations connected to the entities that were already explored
-            # XXX: This could be optimized by implementing a filter in the index
-            # so we don't have to remove them after
-            new_subgraphs = {
-                entity: filter_subgraph(subgraph, explored_entities)
-                for entity, subgraph in new_relations.entities.items()
-            }
+            new_subgraphs = new_relations.entities
 
             explored_entities.update(new_subgraphs.keys())
 
@@ -839,15 +834,6 @@ async def build_graph_response(
         best_matches=best_matches,
         relations=final_relations,
         total=len(text_blocks),
-    )
-
-
-def filter_subgraph(subgraph: EntitySubgraph, entities_to_remove: Collection[str]) -> EntitySubgraph:
-    """
-    Removes the relationships with entities in `entities_to_remove` from the subgraph.
-    """
-    return EntitySubgraph(
-        related_to=[rel for rel in subgraph.related_to if rel.entity not in entities_to_remove]
     )
 
 

--- a/nucliadb/src/nucliadb/search/search/graph_strategy.py
+++ b/nucliadb/src/nucliadb/search/search/graph_strategy.py
@@ -337,7 +337,14 @@ async def get_graph_results(
                     or graph_strategy.query_entity_detection == QueryEntityDetection.PREDICT
                 ):
                     try:
-                        entities_to_explore = await predict.detect_entities(kbid, query)
+                        # Purposely ignore the entity subtype. This is done so we find all entities that match
+                        # the entity by name. e.g: in a query like "2000", predict might detect the number as
+                        # a year entity or as a currency entity. We want graph results for both, so we ignore the
+                        # subtype just in this case.
+                        entities_to_explore = [
+                            RelationNode(ntype=r.ntype, value=r.value, subtype="")
+                            for r in await predict.detect_entities(kbid, query)
+                        ]
                     except Exception as e:
                         capture_exception(e)
                         logger.exception("Error in detecting entities for graph strategy")


### PR DESCRIPTION
1. While exploring the graph we ignore already-seen entities. Move this filter from python to nidx.
2. When getting entities from predict, we get a random subtype depending on the mood of the model. Ignore it for the initial knowledge-graph search.

[sc-11424]