### PR TITLE
Avoid duplicated labelset titles

### DIFF
--- a/nucliadb/src/nucliadb/writer/api/v1/services.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/services.py
@@ -174,14 +174,14 @@ async def delete_entities(request: Request, kbid: str, group: str):
 @requires(NucliaDBRoles.WRITER)
 @version(1)
 async def set_labelset_endpoint(request: Request, kbid: str, labelset: str, item: LabelSet):
+    if item.title is None:
+        item.title = labelset
+
     try:
-        if item.title:
-            labelsets = await datamanagers.atomic.labelset.get_all(kbid=kbid)
-            labelset_titles = [
-                ls.title.lower() for (k, ls) in labelsets.labelset.items() if k != labelset
-            ]
-            if item.title.lower() in labelset_titles:
-                raise HTTPException(status_code=422, detail="Duplicated labelset titles are not allowed")
+        labelsets = await datamanagers.atomic.labelset.get_all(kbid=kbid)
+        labelset_titles = [ls.title.lower() for (k, ls) in labelsets.labelset.items() if k != labelset]
+        if item.title.lower() in labelset_titles:
+            raise HTTPException(status_code=422, detail="Duplicated labelset titles are not allowed")
 
         await set_labelset(kbid, labelset, item)
     except KnowledgeBoxNotFound:

--- a/nucliadb/src/nucliadb/writer/api/v1/services.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/services.py
@@ -175,6 +175,14 @@ async def delete_entities(request: Request, kbid: str, group: str):
 @version(1)
 async def set_labelset_endpoint(request: Request, kbid: str, labelset: str, item: LabelSet):
     try:
+        if item.title:
+            labelsets = await datamanagers.atomic.labelset.get_all(kbid=kbid)
+            labelset_titles = [
+                ls.title.lower() for (k, ls) in labelsets.labelset.items() if k != labelset
+            ]
+            if item.title.lower() in labelset_titles:
+                raise HTTPException(status_code=422, detail="Duplicated labelset titles are not allowed")
+
         await set_labelset(kbid, labelset, item)
     except KnowledgeBoxNotFound:
         raise HTTPException(status_code=404, detail="Knowledge Box does not exist")

--- a/nucliadb/tests/writer/test_service.py
+++ b/nucliadb/tests/writer/test_service.py
@@ -96,8 +96,14 @@ async def test_service_lifecycle_labels(nucliadb_writer: AsyncClient, knowledgeb
 
     ls = LabelSet(title="My labelset", color="#0000000", multiple=False, kind=[LabelSetKind.RESOURCES])
     ls.labels.append(Label(title="asd"))
-    ls.labels.append(Label(title="asd"))
+    ls.labels.append(Label(title="fgh"))
+
     resp = await nucliadb_writer.post(f"/{KB_PREFIX}/{kbid}/labelset/ls1", json=ls.model_dump())
     assert resp.status_code == 200
+
+    resp = await nucliadb_writer.post(f"/{KB_PREFIX}/{kbid}/labelset/ls2", json=ls.model_dump())
+    assert resp.status_code == 422
+
+    ls.title = "My labelset 2"
     resp = await nucliadb_writer.post(f"/{KB_PREFIX}/{kbid}/labelset/ls2", json=ls.model_dump())
     assert resp.status_code == 200

--- a/nucliadb_models/src/nucliadb_models/labels.py
+++ b/nucliadb_models/src/nucliadb_models/labels.py
@@ -108,7 +108,7 @@ class Label(BaseModel):
 
 
 class LabelSet(BaseModel):
-    title: Optional[str] = "no title"
+    title: Optional[str] = None
     color: Optional[str] = "blue"
     multiple: bool = True
     kind: List[LabelSetKind] = []

--- a/nucliadb_models/src/nucliadb_models/labels.py
+++ b/nucliadb_models/src/nucliadb_models/labels.py
@@ -21,7 +21,8 @@
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+from typing_extensions import Self
 
 BASE_LABELS: dict[str, set[str]] = {
     "t": set(),  # doc tags
@@ -112,6 +113,17 @@ class LabelSet(BaseModel):
     multiple: bool = True
     kind: List[LabelSetKind] = []
     labels: List[Label] = []
+
+    @model_validator(mode="after")
+    def check_unique_labels(self) -> Self:
+        label_ids = set()
+        for label in self.labels:
+            label_id = label.title.lower()
+            if label_id in label_ids:
+                raise ValueError(f"Duplicated labels are not allowed: {label.title}")
+            label_ids.add(label_id)
+
+        return self
 
 
 class KnowledgeBoxLabels(BaseModel):


### PR DESCRIPTION
Forbid creating labelsets with duplicate titles to avoid confusion.