### PR TITLE
Fetcher: a new kinda decoupled helper for query parsing

### DIFF
--- a/nucliadb/src/nucliadb/search/search/exceptions.py
+++ b/nucliadb/src/nucliadb/search/search/exceptions.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from nucliadb.search.search.query_parser.exceptions import InvalidQueryError as InvalidQueryError
+
 
 class IncompleteFindResultsError(Exception):
     pass
@@ -24,10 +26,3 @@ class IncompleteFindResultsError(Exception):
 
 class ResourceNotFoundError(Exception):
     pass
-
-
-class InvalidQueryError(Exception):
-    def __init__(self, param: str, reason: str):
-        self.param = param
-        self.reason = reason
-        super().__init__(f"Invalid query. Error in {param}: {reason}")

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -260,7 +260,7 @@ async def query_parser_from_find_request(
     # XXX this is becoming the new /find query parsing, this should be moved to
     # a cleaner abstraction
 
-    parsed = parse_find(item)
+    parsed = await parse_find(kbid, item)
 
     rank_fusion = get_rank_fusion(parsed.rank_fusion)
     reranker = get_reranker(parsed.reranker)

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -25,7 +25,7 @@ from typing import Any, Awaitable, Optional, Union
 
 from nucliadb.common import datamanagers
 from nucliadb.search import logger
-from nucliadb.search.predict import SendToPredictError, convert_relations
+from nucliadb.search.predict import SendToPredictError
 from nucliadb.search.search.filters import (
     convert_to_node_filters,
     flatten_filter_literals,
@@ -373,14 +373,7 @@ class QueryParser:
     async def parse_relation_search(self, request: nodereader_pb2.SearchRequest) -> list[str]:
         autofilters = []
         if self.has_relations_search or self.autofilter:
-            if not self.query_endpoint_used:
-                detected_entities = await self.fetcher.get_detected_entities()
-            else:
-                query_info_result = await self._get_query_information()
-                if query_info_result.entities:
-                    detected_entities = convert_relations(query_info_result.entities.model_dump())
-                else:
-                    detected_entities = []
+            detected_entities = await self.fetcher.get_detected_entities()
             meta_cache = await self.fetcher.get_entities_meta_cache()
             detected_entities = expand_entities(meta_cache, detected_entities)
             if self.has_relations_search:

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -332,18 +332,12 @@ class QueryParser:
         elif self.has_vector_search and not incomplete:
             query_information = await self._get_query_information()
             vectorset = await self.fetcher.get_vectorset()
-            if vectorset is not None:
-                semantic_threshold = query_information.semantic_thresholds.get(vectorset, None)
-                if semantic_threshold is not None:
-                    semantic_min_score = semantic_threshold
-                else:
-                    logger.warning(
-                        "Semantic threshold not found in query information, using default",
-                        extra={"kbid": self.kbid},
-                    )
+            semantic_threshold = query_information.semantic_thresholds.get(vectorset, None)
+            if semantic_threshold is not None:
+                semantic_min_score = semantic_threshold
             else:
                 logger.warning(
-                    "Vectorset unset by user or predict, using default semantic threshold",
+                    "Semantic threshold not found in query information, using default",
                     extra={"kbid": self.kbid},
                 )
         self.min_score.semantic = semantic_min_score

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -86,7 +86,6 @@ class QueryParser:
     """
 
     _query_information_task: Optional[asyncio.Task] = None
-    _get_vectorset_task: Optional[asyncio.Task] = None
     _detected_entities_task: Optional[asyncio.Task] = None
     _entities_meta_cache_task: Optional[asyncio.Task] = None
     _deleted_entities_groups_task: Optional[asyncio.Task] = None

--- a/nucliadb/src/nucliadb/search/search/query_parser/exceptions.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/exceptions.py
@@ -19,4 +19,14 @@
 #
 
 
-class ParserError(ValueError): ...
+class InternalParserError(ValueError):
+    """Raised when parsing fails due to some internal error"""
+
+
+class InvalidQueryError(Exception):
+    """Raised when parsing a query containing an invalid parameter"""
+
+    def __init__(self, param: str, reason: str):
+        self.param = param
+        self.reason = reason
+        super().__init__(f"Invalid query. Error in {param}: {reason}")

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -133,14 +133,14 @@ class Fetcher:
         self.cache.matryoshka_dimension = matryoshka_dimension
         return matryoshka_dimension
 
-    def _get_user_vectorset(self) -> Optional[str]:
+    async def _get_user_vectorset(self) -> Optional[str]:
         """Returns the user's requested vectorset and validates if it does exist
         in the KB.
 
         """
         vectorset = self.user_vectorset
         if not self._validated:
-            self._validate_vectorset()
+            await self._validate_vectorset()
         return vectorset
 
     async def get_vectorset(self) -> str:
@@ -297,7 +297,7 @@ class Fetcher:
 
         # we can't call get_vectorset, as it would do a recirsive loop between
         # functions, so we'll manually parse it
-        vectorset = self._get_user_vectorset()
+        vectorset = await self._get_user_vectorset()
         try:
             query_info = await query_information(
                 self.kbid,

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -1,0 +1,279 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from typing import Optional, TypeVar, Union
+
+from async_lru import alru_cache
+from typing_extensions import TypeIs
+
+from nucliadb.common import datamanagers
+from nucliadb.common.maindb.utils import get_driver
+from nucliadb.search import logger
+from nucliadb.search.predict import SendToPredictError
+from nucliadb.search.search.metrics import (
+    query_parse_dependency_observer,
+)
+from nucliadb.search.search.query_parser.exceptions import InvalidQueryError
+from nucliadb.search.utilities import get_predict
+from nucliadb_models.internal.predict import QueryInfo
+
+
+# We use a class as cache miss marker to allow None values in the cache and to
+# make mypy happy with typing
+class NotCached:
+    pass
+
+
+not_cached = NotCached()
+
+
+T = TypeVar("T")
+
+
+def is_cached(field: Union[T, NotCached]) -> TypeIs[T]:
+    return not isinstance(field, NotCached)
+
+
+class FetcherCache:
+    predict_query_info: Union[Optional[QueryInfo], NotCached] = not_cached
+
+    # semantic search
+    query_vector: Union[Optional[list[float]], NotCached] = not_cached
+    vectorset: Union[str, NotCached] = not_cached
+    matryoshka_dimension: Union[Optional[int], NotCached] = not_cached
+
+
+class Fetcher:
+    """Queries are getting more and more complex and different phases of the
+    query depend on different data, not only from the user but from other parts
+    of the system.
+
+    This class is an encapsulation of data gathering across different parts of
+    the system. Given the user query input, it aims to be as efficient as
+    possible removing redundant expensive calls to other parts of the system. An
+    instance of a fetcher caches it's results and it's thought to be used in the
+    context of a single request. DO NOT use this as a global object!
+
+    """
+
+    def __init__(
+        self,
+        kbid: str,
+        *,
+        query: str,
+        user_vector: Optional[list[float]],
+        vectorset: Optional[str],
+        rephrase: bool,
+        rephrase_prompt: Optional[str],
+        generative_model: Optional[str],
+    ):
+        self.kbid = kbid
+        self.query = query
+        self.user_vector = user_vector
+        self.user_vectorset = vectorset
+        self.rephrase = rephrase
+        self.rephrase_prompt = rephrase_prompt
+        self.generative_model = generative_model
+
+        self.cache = FetcherCache()
+        self._validated = False
+
+    async def initial_validate(self):
+        """Runs a validation on the input parameters. It can raise errors if
+        there's some wrong parameter.
+
+        This function should be always called if validated input for fetching is
+        desired
+        """
+        if self._validated:
+            return
+
+        self._validated = True
+
+    async def _validate_vectorset(self):
+        if self.user_vectorset is not None:
+            await validate_vectorset(self.kbid, self.user_vectorset)
+
+    async def get_matryoshka_dimension(self) -> Optional[int]:
+        if is_cached(self.cache.matryoshka_dimension):
+            return self.cache.matryoshka_dimension
+
+        vectorset = await self.get_vectorset()
+        matryoshka_dimension = await get_matryoshka_dimension_cached(self.kbid, vectorset)
+        self.cache.matryoshka_dimension = matryoshka_dimension
+        return matryoshka_dimension
+
+    def _get_user_vectorset(self) -> Optional[str]:
+        """Returns the user's requested vectorset and validates if it does exist
+        in the KB.
+
+        """
+        vectorset = self.user_vectorset
+        if not self._validated:
+            self._validate_vectorset()
+        return vectorset
+
+    async def get_vectorset(self) -> str:
+        """Get the vectorset to be used in the search. If not specified, by the
+        user, Predict API or the own uses KB will provide a default.
+
+        """
+
+        if is_cached(self.cache.vectorset):
+            return self.cache.vectorset
+
+        if self.user_vectorset:
+            # user explicitly asked for a vectorset
+            self.cache.vectorset = self.user_vectorset
+            return self.user_vectorset
+
+        # when it's not provided, we get the default from Predict API
+        query_info = await self._predict_query_endpoint()
+        if query_info is None:
+            vectorset = None
+        else:
+            if query_info.sentence is None:
+                logger.error(
+                    "Asking for a vectorset but /query didn't return one", extra={"kbid": self.kbid}
+                )
+                vectorset = None
+            else:
+                # vectors field is enforced by the data model to have at least one key
+                for vectorset in query_info.sentence.vectors.keys():
+                    vectorset = vectorset
+                    break
+
+        if vectorset is None:
+            # in case predict don't answer which vectorset to use, fallback to
+            # the first vectorset of the KB
+            async with datamanagers.with_ro_transaction() as txn:
+                async for vectorset, _ in datamanagers.vectorsets.iter(txn, kbid=self.kbid):
+                    break
+            assert vectorset is not None, "All KBs must have at least one vectorset in maindb"
+
+        self.cache.vectorset = vectorset
+        return vectorset
+
+    async def get_query_vector(self) -> Optional[list[float]]:
+        if is_cached(self.cache.query_vector):
+            return self.cache.query_vector
+
+        if self.user_vector is not None:
+            query_vector = self.user_vector
+        else:
+            query_info = await self._predict_query_endpoint()
+            if query_info is None or query_info.sentence is None:
+                self.cache.query_vector = None
+                return None
+
+            vectorset = await self.get_vectorset()
+            if vectorset not in query_info.sentence.vectors:
+                logger.warning(
+                    "Predict is not responding with a valid query nucliadb vectorset",
+                    extra={
+                        "kbid": self.kbid,
+                        "vectorset": vectorset,
+                        "predict_vectorsets": ",".join(query_info.sentence.vectors.keys()),
+                    },
+                )
+                self.cache.query_vector = None
+                return None
+
+            query_vector = query_info.sentence.vectors[vectorset]
+
+        matryoshka_dimension = await self.get_matryoshka_dimension()
+        if matryoshka_dimension is not None:
+            if self.user_vector is not None and len(query_vector) < matryoshka_dimension:
+                raise InvalidQueryError(
+                    "vector",
+                    f"Invalid vector length, please check valid embedding size for {vectorset} model",
+                )
+
+            # KB using a matryoshka embeddings model, cut the query vector
+            # accordingly
+            query_vector = query_vector[:matryoshka_dimension]
+
+        self.cache.query_vector = query_vector
+        return query_vector
+
+    async def _predict_query_endpoint(self) -> Optional[QueryInfo]:
+        if is_cached(self.cache.predict_query_info):
+            return self.cache.predict_query_info
+
+        # we can't call get_vectorset, as it would do a recirsive loop between
+        # functions, so we'll manually parse it
+        vectorset = self._get_user_vectorset()
+        try:
+            print("CALLING Predict API /query endpoint")
+            query_info = await query_information(
+                self.kbid,
+                self.query,
+                vectorset,
+                self.generative_model,
+                self.rephrase,
+                self.rephrase_prompt,
+            )
+        except SendToPredictError:
+            query_info = None
+
+        self.cache.predict_query_info = query_info
+        return query_info
+
+
+async def validate_vectorset(kbid: str, vectorset: str):
+    async with datamanagers.with_ro_transaction() as txn:
+        if not await datamanagers.vectorsets.exists(txn, kbid=kbid, vectorset_id=vectorset):
+            raise InvalidQueryError(
+                "vectorset", f"Vectorset {vectorset} doesn't exist in you Knowledge Box"
+            )
+
+
+@query_parse_dependency_observer.wrap({"type": "query_information"})
+async def query_information(
+    kbid: str,
+    query: str,
+    semantic_model: Optional[str],
+    generative_model: Optional[str] = None,
+    rephrase: bool = False,
+    rephrase_prompt: Optional[str] = None,
+) -> QueryInfo:
+    predict = get_predict()
+    return await predict.query(kbid, query, semantic_model, generative_model, rephrase, rephrase_prompt)
+
+
+@alru_cache(maxsize=None)
+async def get_matryoshka_dimension_cached(kbid: str, vectorset: Optional[str]) -> Optional[int]:
+    # This can be safely cached as the matryoshka dimension is not expected to change
+    return await get_matryoshka_dimension(kbid, vectorset)
+
+
+@query_parse_dependency_observer.wrap({"type": "matryoshka_dimension"})
+async def get_matryoshka_dimension(kbid: str, vectorset: Optional[str]) -> Optional[int]:
+    async with get_driver().transaction(read_only=True) as txn:
+        matryoshka_dimension = None
+        if not vectorset:
+            # XXX this should be migrated once we remove the "default" vectorset
+            # concept
+            matryoshka_dimension = await datamanagers.kb.get_matryoshka_vector_dimension(txn, kbid=kbid)
+        else:
+            vectorset_config = await datamanagers.vectorsets.get(txn, kbid=kbid, vectorset_id=vectorset)
+            if vectorset_config is not None and vectorset_config.vectorset_index_config.vector_dimension:
+                matryoshka_dimension = vectorset_config.vectorset_index_config.vector_dimension
+
+        return matryoshka_dimension

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -220,7 +220,6 @@ class Fetcher:
         # functions, so we'll manually parse it
         vectorset = self._get_user_vectorset()
         try:
-            print("CALLING Predict API /query endpoint")
             query_info = await query_information(
                 self.kbid,
                 self.query,

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -293,7 +293,6 @@ class Fetcher:
         # calling twice should be avoided as query endpoint is a superset of detect entities
         if is_cached(self.cache.predict_detected_entities):
             logger.warning("Fetcher is not being efficient enough and has called predict twice!")
-            raise Exception("Fetcher is not being efficient enough and has called predict twice!")
 
         # we can't call get_vectorset, as it would do a recirsive loop between
         # functions, so we'll manually parse it

--- a/nucliadb/tests/search/unit/search/test_query.py
+++ b/nucliadb/tests/search/unit/search/test_query.py
@@ -38,8 +38,6 @@ from nucliadb_protos.knowledgebox_pb2 import Synonyms
 from nucliadb_protos.nodereader_pb2 import SearchRequest
 from nucliadb_protos.utils_pb2 import RelationNode
 
-QUERY_MODULE = "nucliadb.search.search.query"
-
 
 def test_parse_entities_to_filters():
     detected_entities = [
@@ -65,7 +63,10 @@ def test_parse_entities_to_filters():
 @pytest.fixture()
 def kbdm(read_only_txn):
     kbdm = unittest.mock.AsyncMock()
-    with unittest.mock.patch(f"{QUERY_MODULE}.datamanagers.kb", kbdm):
+    with (
+        unittest.mock.patch(f"nucliadb.search.search.query.datamanagers.kb", kbdm),
+        unittest.mock.patch(f"nucliadb.search.search.query_parser.fetcher.datamanagers.kb", kbdm),
+    ):
         yield kbdm
 
 
@@ -91,7 +92,7 @@ class TestApplySynonymsToRequest:
             min_score=MinScore(semantic=0.5),
             with_synonyms=True,
         )
-        with patch("nucliadb.search.search.query.get_kb_synonyms", get_synonyms):
+        with patch("nucliadb.search.search.query_parser.fetcher.get_kb_synonyms", get_synonyms):
             yield qp
 
     async def test_not_applies_if_empty_body(self, query_parser: QueryParser, get_synonyms):

--- a/nucliadb/tests/search/unit/search/test_query.py
+++ b/nucliadb/tests/search/unit/search/test_query.py
@@ -176,11 +176,11 @@ class TestVectorSetAndMatryoshkaParsing:
 
         with (
             patch(
-                "nucliadb.search.search.query.datamanagers.vectorsets.exists",
+                "nucliadb.search.search.query_parser.fetcher.datamanagers.vectorsets.exists",
                 new=AsyncMock(return_value=(vectorset is not None)),
             ),
             patch(
-                "nucliadb.search.search.query.get_matryoshka_dimension_cached",
+                "nucliadb.search.search.query_parser.fetcher.get_matryoshka_dimension_cached",
                 new=AsyncMock(return_value=matryoshka_dimension),
             ),
             patch("nucliadb.common.datamanagers.utils.get_driver"),

--- a/nucliadb/tests/search/unit/search/test_query_parsing.py
+++ b/nucliadb/tests/search/unit/search/test_query_parsing.py
@@ -94,7 +94,7 @@ async def test_find_query_parsing__rank_fusion_limits():
             }
         )
 
-    parsed = parse_find(
+    parsed = await parse_find(
         "kbid", FindRequest(rank_fusion=search_models.ReciprocalRankFusion.model_construct(window=501))
     )
     assert parsed.rank_fusion.window == 500
@@ -121,7 +121,7 @@ async def test_find_query_parsing__reranker(
 
 # ATENTION: if you're changing this test, make sure public models, private
 # models and parsing are change accordingly!
-def test_find_query_parsing__reranker_limits():
+async def test_find_query_parsing__reranker_limits():
     FindRequest.model_validate(
         {
             "reranker": {
@@ -131,12 +131,12 @@ def test_find_query_parsing__reranker_limits():
         }
     )
 
-    parse_find("kbid", FindRequest(reranker=search_models.PredictReranker(window=200)))
+    await parse_find("kbid", FindRequest(reranker=search_models.PredictReranker(window=200)))
 
     with pytest.raises(ValidationError):
         FindRequest.model_validate({"reranker": {"name": "predict", "window": 201}})
 
-    parsed = parse_find(
+    parsed = await parse_find(
         "kbid", FindRequest(reranker=search_models.PredictReranker.model_construct(window=201))
     )
     assert parsed.reranker.window == 200

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -49,9 +49,9 @@ from nucliadb_protos.nodereader_pb2 import DocumentScored, ParagraphResult
         (search_models.ReciprocalRankFusion(), ReciprocalRankFusion),
     ],
 )
-def test_get_rank_fusion(rank_fusion, expected_type: Type):
+async def test_get_rank_fusion(rank_fusion, expected_type: Type):
     item = FindRequest(rank_fusion=rank_fusion)
-    algorithm = get_rank_fusion(parse_find(item).rank_fusion)
+    algorithm = get_rank_fusion((await parse_find("kbid", item)).rank_fusion)
     assert isinstance(algorithm, expected_type)
 
 


### PR DESCRIPTION
### Description
Our current `QueryParser` class has a bunch of problems:
- all code is shared among search, find and ask endpoints, requiring some parameters that don't apply to all endpoints
- query parsing is coupled to `SearchRequest`, although it is not a problem, an intermediate representation for all search endpoints would be beneficial for code maintainability and potential optimizations
- the class has multiple responsibilities: converting a set of parameters to a SearchRequest and call Predict API or maindb to obtain the query vector, decide a default vectorset, detect entities...

This PR proposes a new class named `Fetcher` which only responsibility is to split the third bullet point above. Given a set of parameters, it provides a clean interface to the parsed values. This decouples query parsing from predict error handling and default conditions.

As this is a proposal, it has only been done for vector search, to show a small demo.

### How was this PR tested?
Existing tests
