### PR TITLE
Add security group header

### DIFF
--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -66,6 +66,7 @@ async def ask_knowledgebox_endpoint(
     current_user: NucliaUser = request.user
     # If present, security groups from AuthorizationBackend overrides any
     # security group of the payload
+    print(current_user)
     if current_user.security_groups:
         if item.security is None:
             print(f"item security={item.security}, header security={current_user.security_groups}")

--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -68,9 +68,12 @@ async def ask_knowledgebox_endpoint(
     # security group of the payload
     if current_user.security_groups:
         if item.security is None:
+            print(f"item security={item.security}, header security={current_user.security_groups}")
             item.security = RequestSecurity(groups=current_user.security_groups)
         else:
+            print(f"item security={item.security}, header security={current_user.security_groups}")
             item.security.groups = current_user.security_groups
+    print(f"POST item security={item.security}")
     return await create_ask_response(
         kbid, item, x_nucliadb_user, x_ndb_client, x_forwarded_for, x_synchronous
     )

--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -36,7 +36,8 @@ from nucliadb_models.search import (
     SyncAskResponse,
     parse_max_tokens,
 )
-from nucliadb_utils.authentication import requires
+from nucliadb_models.security import RequestSecurity
+from nucliadb_utils.authentication import NucliaUser, requires
 
 
 @api.post(
@@ -62,6 +63,14 @@ async def ask_knowledgebox_endpoint(
         "This is slower and requires waiting for entire answer to be ready.",
     ),
 ) -> Union[StreamingResponse, HTTPClientError, Response]:
+    current_user: NucliaUser = request.user
+    # If present, security groups from AuthorizationBackend overrides any
+    # security group of the payload
+    if current_user.security_groups:
+        if item.security is None:
+            item.security = RequestSecurity(groups=current_user.security_groups)
+        else:
+            item.security.groups = current_user.security_groups
     return await create_ask_response(
         kbid, item, x_nucliadb_user, x_ndb_client, x_forwarded_for, x_synchronous
     )

--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -66,15 +66,12 @@ async def ask_knowledgebox_endpoint(
     current_user: NucliaUser = request.user
     # If present, security groups from AuthorizationBackend overrides any
     # security group of the payload
-    print(current_user)
     if current_user.security_groups:
         if item.security is None:
-            print(f"item security={item.security}, header security={current_user.security_groups}")
             item.security = RequestSecurity(groups=current_user.security_groups)
         else:
-            print(f"item security={item.security}, header security={current_user.security_groups}")
             item.security.groups = current_user.security_groups
-    print(f"POST item security={item.security}")
+
     return await create_ask_response(
         kbid, item, x_nucliadb_user, x_ndb_client, x_forwarded_for, x_synchronous
     )

--- a/nucliadb/src/nucliadb/standalone/settings.py
+++ b/nucliadb/src/nucliadb/standalone/settings.py
@@ -83,6 +83,10 @@ class Settings(DriverSettings, StorageSettings, ExtendedStorageSettings):
         default="X-NUCLIADB-ROLES",
         description="Only used for `upstream_naive` auth policy.",
     )
+    auth_policy_security_groups_header: str = pydantic.Field(
+        default="X-NUCLIADB-SECURITY_GROUPS",
+        description="Only used for `upstream_naive` auth policy.",
+    )
     auth_policy_user_default_roles: list[NucliaDBRoles] = pydantic.Field(
         default=[NucliaDBRoles.READER, NucliaDBRoles.WRITER, NucliaDBRoles.MANAGER],
         description="Default role to assign to user that is authenticated \

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -215,9 +215,9 @@ async def _test_search_request_with_security(
         )
     elif search_endpoint == "ask_post":
         resp = await nucliadb_reader.post(
-            f"/kb/{kbid}/ask",
-            json=payload,
+            f"/kb/{kbid}/ask", json=payload, headers={"x_synchronous": True}
         )
+        print(resp.text)
     else:
         raise ValueError(f"Unknown search endpoint: {search_endpoint}")
 

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -236,7 +236,7 @@ async def _test_search_request_with_security(
         )
         assert resp.status_code == 200, resp.text
 
-        messages = resp.split("\n")
+        messages = resp.text.split("\n")
         for message in messages:
             json_message = json.loads(message)
             if json_message["type"] == "retrieval":

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -84,7 +84,9 @@ async def test_resource_security_is_updated(
     assert resource["security"]["access_groups"] == []
 
 
-@pytest.mark.parametrize("search_endpoint", ("find_get", "find_post", "search_get", "search_post"))
+@pytest.mark.parametrize(
+    "search_endpoint", ("find_get", "find_post", "search_get", "search_post", "ask_post")
+)
 async def test_resource_security_search(
     nucliadb_reader,
     nucliadb_writer,
@@ -210,6 +212,11 @@ async def _test_search_request_with_security(
         resp = await nucliadb_reader.get(
             f"/kb/{kbid}/search",
             params=params,
+        )
+    elif search_endpoint == "ask_post":
+        resp = await nucliadb_reader.post(
+            f"/kb/{kbid}/ask",
+            json=payload,
         )
     else:
         raise ValueError(f"Unknown search endpoint: {search_endpoint}")

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -215,7 +215,7 @@ async def _test_search_request_with_security(
         )
     elif search_endpoint == "ask_post":
         resp = await nucliadb_reader.post(
-            f"/kb/{kbid}/ask", json=payload, headers={"x_synchronous": True}
+            f"/kb/{kbid}/ask", json=payload, headers={"x_synchronous": "true"}
         )
         print(resp.text)
     else:

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -19,18 +19,12 @@
 #
 import asyncio
 import json
-from enum import Enum
 from typing import Optional
 
 import pytest
 
 PLATFORM_GROUP = "platform"
 DEVELOPERS_GROUP = "developers"
-
-
-class SecurityInjectionType(Enum):
-    PAYLOAD = 0
-    HEADERS = 1
 
 
 @pytest.fixture(scope="function")
@@ -232,9 +226,6 @@ async def _test_search_request_with_security(
     assert set(search_response["resources"]) == set(expected_resources)
 
 
-@pytest.mark.parametrize(
-    "security_injection", (SecurityInjectionType.PAYLOAD, SecurityInjectionType.HEADERS)
-)
 @pytest.mark.parametrize("ask_endpoint", ("ask_post",))
 async def test_resource_security_ask(
     nucliadb_reader,
@@ -242,7 +233,6 @@ async def test_resource_security_ask(
     knowledgebox,
     resource_with_security,
     ask_endpoint,
-    security_injection,
 ):
     kbid = knowledgebox
     resource_id = resource_with_security
@@ -266,7 +256,6 @@ async def test_resource_security_ask(
         query="resource",
         security_groups=None,
         expected_resources=[resource_id],
-        security_injection=security_injection,
     )
 
     # Querying with security groups should return the resource
@@ -286,7 +275,6 @@ async def test_resource_security_ask(
             query="resource",
             security_groups=access_groups,
             expected_resources=[resource_id],
-            security_injection=security_injection,
         )
 
     # Querying with an unknown security group should not return the resource
@@ -297,7 +285,6 @@ async def test_resource_security_ask(
         query="resource",
         security_groups=["some-unknown-group"],
         expected_resources=[],
-        security_injection=security_injection,
     )
 
     # Make it public now
@@ -323,7 +310,6 @@ async def test_resource_security_ask(
         query="resource",
         security_groups=["blah-blah"],
         expected_resources=[resource_id],
-        security_injection=security_injection,
     )
 
 
@@ -334,17 +320,13 @@ async def _test_ask_request_with_security(
     query: str,
     security_groups: Optional[list[str]],
     expected_resources: list[str],
-    security_injection: SecurityInjectionType,
 ):
     payload = {
         "query": query,
     }
     headers = {"x_synchronous": "true"}
-    if security_groups and security_injection is SecurityInjectionType.PAYLOAD:
+    if security_groups:
         payload["security"] = {"groups": security_groups}  # type: ignore
-
-    if security_groups and security_injection is SecurityInjectionType.HEADERS:
-        headers["x-nucliadb-security-groups"] = ";".join(security_groups)
 
     if ask_endpoint == "ask_post":
         resp = await nucliadb_reader.post(f"/kb/{kbid}/ask", json=payload, headers=headers)

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -85,9 +85,7 @@ async def test_resource_security_is_updated(
     assert resource["security"]["access_groups"] == []
 
 
-@pytest.mark.parametrize(
-    "search_endpoint", ("find_get", "find_post", "search_get", "search_post", "ask_post")
-)
+@pytest.mark.parametrize("search_endpoint", ("find_get", "find_post", "search_get", "search_post"))
 async def test_resource_security_search(
     nucliadb_reader,
     nucliadb_writer,

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -335,7 +335,6 @@ async def _test_ask_request_with_security(
         messages = resp.text.split("\n")
         for message in messages:
             json_message = json.loads(message)
-            print(json_message)
             if json_message["item"]["type"] == "retrieval":
                 search_response = json_message["item"]["results"]
                 resource_ids = list(search_response["resources"].keys())

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -239,6 +239,7 @@ async def _test_search_request_with_security(
         messages = resp.text.split("\n")
         for message in messages:
             json_message = json.loads(message)
+            print(json_message)
             if json_message["type"] == "retrieval":
                 search_response = json_message["results"]
                 resource_ids = list(search_response["resources"].keys())

--- a/nucliadb/tests/nucliadb/integration/test_security.py
+++ b/nucliadb/tests/nucliadb/integration/test_security.py
@@ -240,8 +240,8 @@ async def _test_search_request_with_security(
         for message in messages:
             json_message = json.loads(message)
             print(json_message)
-            if json_message["type"] == "retrieval":
-                search_response = json_message["results"]
+            if json_message["item"]["type"] == "retrieval":
+                search_response = json_message["item"]["results"]
                 resource_ids = list(search_response["resources"].keys())
                 break
     else:

--- a/nucliadb/tests/search/integration/api/v1/test_ask_audit.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_audit.py
@@ -18,25 +18,75 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import nats
 from httpx import AsyncClient
-from pytest_mock import MockerFixture
+from nats.aio.client import Client
+from nats.js import JetStreamContext
 
 from nucliadb.search.api.v1.router import KB_PREFIX
+from nucliadb_protos.audit_pb2 import AuditRequest
 
 
-async def test_ask_receives_injected_security_groups(
-    cluster_nucliadb_search: AsyncClient, test_search_resource: str, mocker: MockerFixture
+async def get_audit_messages(sub):
+    msg = await sub.fetch(1)
+    auditreq = AuditRequest()
+    auditreq.ParseFromString(msg[0].data)
+    return auditreq
+
+
+async def test_ask_sends_only_one_audit(
+    cluster_nucliadb_search: AsyncClient, test_search_resource: str, stream_audit
 ) -> None:
-    from nucliadb.search.api.v1 import ask
+    from nucliadb_utils.settings import audit_settings
 
     kbid = test_search_resource
 
-    spy = mocker.spy(ask, "create_ask_response")
+    # Prepare a test audit stream to receive our messages
+    partition = stream_audit.get_partition(kbid)
+    nats_client: Client = await nats.connect(stream_audit.nats_servers)
+    jetstream: JetStreamContext = nats_client.jetstream()
+    if audit_settings.audit_jetstream_target is None:
+        assert False, "Missing jetstream target in audit settings"
+    subject = audit_settings.audit_jetstream_target.format(partition=partition, type="*")
+
+    try:
+        await jetstream.delete_stream(name=audit_settings.audit_stream)
+        await jetstream.delete_stream(name="test_usage")
+    except nats.js.errors.NotFoundError:
+        pass
+
+    await jetstream.add_stream(name=audit_settings.audit_stream, subjects=[subject])
+
+    psub = await jetstream.pull_subscribe(subject, "psub")
 
     resp = await cluster_nucliadb_search.post(
         f"/{KB_PREFIX}/{kbid}/ask",
         json={"query": "title"},
-        headers={"x-nucliadb-security-groups": "group1;group2"},
     )
     assert resp.status_code == 200
-    print(spy.call_args)
+
+    # Testing the middleware integration where it collects audit calls and sends a single message
+    # at requests ends. In this case we expect one seach and one chat sent once
+    stream_audit.search.assert_called_once()
+    stream_audit.chat.assert_called_once()
+    assert stream_audit.js.publish.call_count == 2
+    stream_audit.send.assert_called_once()
+
+    auditreq = await get_audit_messages(psub)
+    assert auditreq.type == AuditRequest.AuditType.CHAT
+    assert auditreq.kbid == kbid
+    assert auditreq.HasField("chat")
+    assert auditreq.HasField("search")
+    assert auditreq.request_time > 0
+    assert auditreq.generative_answer_time > 0
+    assert auditreq.retrieval_time > 0
+    assert (auditreq.generative_answer_time + auditreq.retrieval_time) < auditreq.request_time
+    try:
+        auditreq = await get_audit_messages(psub)
+    except nats.errors.TimeoutError:
+        pass
+    else:
+        assert "There was an unexpected extra audit message in nats"
+    await psub.unsubscribe()
+    await nats_client.flush()
+    await nats_client.close()

--- a/nucliadb/tests/search/integration/api/v1/test_ask_security.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_security.py
@@ -51,7 +51,7 @@ async def test_ask_receives_injected_security_groups(
     # Test security groups only on payload
     resp = await cluster_nucliadb_search.post(
         f"/{KB_PREFIX}/{kbid}/ask",
-        json={"query": "title", "security_groups": ["group1", "group2"]},
+        json={"query": "title", "security": {"groups": ["group1", "group2"]}},
     )
     assert resp.status_code == 200
     spy.assert_called_once()
@@ -65,7 +65,7 @@ async def test_ask_receives_injected_security_groups(
     resp = await cluster_nucliadb_search.post(
         f"/{KB_PREFIX}/{kbid}/ask",
         headers={"x-nucliadb-security-groups": "group1;group2"},
-        json={"query": "title", "security_groups": ["group3", "group4"]},
+        json={"query": "title", "security": {"groups": ["group3", "group4"]}},
     )
     assert resp.status_code == 200
     spy.assert_called_once()

--- a/nucliadb/tests/search/integration/api/v1/test_ask_security.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_security.py
@@ -42,10 +42,7 @@ async def test_ask_receives_injected_security_groups(
     )
     assert resp.status_code == 200
     spy.assert_called_once()
-    print(spy.call_args)
-    print(spy.call_args[0])
-    print(spy.call_args[1])
-    ask_request = spy.call_args[1]
+    ask_request = spy.call_args[0][1]
     assert isinstance(ask_request, AskRequest)
     assert ask_request.security is not None
     assert set(ask_request.security.groups) == {"group1", "group2"}
@@ -58,7 +55,7 @@ async def test_ask_receives_injected_security_groups(
     )
     assert resp.status_code == 200
     spy.assert_called_once()
-    ask_request = spy.call_args[1]
+    ask_request = spy.call_args[0][1]
     assert isinstance(ask_request, AskRequest)
     assert ask_request.security is not None
     assert set(ask_request.security.groups) == {"group1", "group2"}
@@ -72,7 +69,7 @@ async def test_ask_receives_injected_security_groups(
     )
     assert resp.status_code == 200
     spy.assert_called_once()
-    ask_request = spy.call_args[1]
+    ask_request = spy.call_args[0][1]
     assert isinstance(ask_request, AskRequest)
     assert ask_request.security is not None
     assert set(ask_request.security.groups) == {"group1", "group2"}
@@ -85,7 +82,7 @@ async def test_ask_receives_injected_security_groups(
     )
     assert resp.status_code == 200
     spy.assert_called_once()
-    ask_request = spy.call_args[1]
+    ask_request = spy.call_args[0][1]
     assert isinstance(ask_request, AskRequest)
     assert ask_request.security is None
     spy.reset_mock()

--- a/nucliadb/tests/search/integration/api/v1/test_ask_security.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_security.py
@@ -18,75 +18,71 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import nats
 from httpx import AsyncClient
-from nats.aio.client import Client
-from nats.js import JetStreamContext
+from pytest_mock import MockerFixture
 
 from nucliadb.search.api.v1.router import KB_PREFIX
-from nucliadb_protos.audit_pb2 import AuditRequest
 
 
-async def get_audit_messages(sub):
-    msg = await sub.fetch(1)
-    auditreq = AuditRequest()
-    auditreq.ParseFromString(msg[0].data)
-    return auditreq
-
-
-async def test_ask_sends_only_one_audit(
-    cluster_nucliadb_search: AsyncClient, test_search_resource: str, stream_audit
+async def test_ask_receives_injected_security_groups(
+    cluster_nucliadb_search: AsyncClient, test_search_resource: str, mocker: MockerFixture
 ) -> None:
-    from nucliadb_utils.settings import audit_settings
+    from nucliadb.search.api.v1 import ask
+    from nucliadb_models.search import AskRequest
 
     kbid = test_search_resource
 
-    # Prepare a test audit stream to receive our messages
-    partition = stream_audit.get_partition(kbid)
-    nats_client: Client = await nats.connect(stream_audit.nats_servers)
-    jetstream: JetStreamContext = nats_client.jetstream()
-    if audit_settings.audit_jetstream_target is None:
-        assert False, "Missing jetstream target in audit settings"
-    subject = audit_settings.audit_jetstream_target.format(partition=partition, type="*")
+    spy = mocker.spy(ask, "create_ask_response")
 
-    try:
-        await jetstream.delete_stream(name=audit_settings.audit_stream)
-        await jetstream.delete_stream(name="test_usage")
-    except nats.js.errors.NotFoundError:
-        pass
+    # Test security groups only on authorizer headers
+    resp = await cluster_nucliadb_search.post(
+        f"/{KB_PREFIX}/{kbid}/ask",
+        json={"query": "title"},
+        headers={"x-nucliadb-security-groups": "group1;group2"},
+    )
+    assert resp.status_code == 200
+    spy.assert_called_once()
+    ask_request = spy.call_args[1]
+    assert isinstance(ask_request, AskRequest)
+    assert ask_request.security is not None
+    assert set(ask_request.security.groups) == {"group1", "group2"}
+    spy.reset_mock()
 
-    await jetstream.add_stream(name=audit_settings.audit_stream, subjects=[subject])
+    # Test security groups only on payload
+    resp = await cluster_nucliadb_search.post(
+        f"/{KB_PREFIX}/{kbid}/ask",
+        json={"query": "title", "security_groups": ["group1", "group2"]},
+    )
+    assert resp.status_code == 200
+    spy.assert_called_once()
+    ask_request = spy.call_args[1]
+    assert isinstance(ask_request, AskRequest)
+    assert ask_request.security is not None
+    assert set(ask_request.security.groups) == {"group1", "group2"}
+    spy.reset_mock()
 
-    psub = await jetstream.pull_subscribe(subject, "psub")
+    # Test security groups on headers override payload
+    resp = await cluster_nucliadb_search.post(
+        f"/{KB_PREFIX}/{kbid}/ask",
+        headers={"x-nucliadb-security-groups": "group1;group2"},
+        json={"query": "title", "security_groups": ["group3", "group4"]},
+    )
+    assert resp.status_code == 200
+    spy.assert_called_once()
+    ask_request = spy.call_args[1]
+    assert isinstance(ask_request, AskRequest)
+    assert ask_request.security is not None
+    assert set(ask_request.security.groups) == {"group1", "group2"}
+    spy.reset_mock()
 
+    # Test no security groups
     resp = await cluster_nucliadb_search.post(
         f"/{KB_PREFIX}/{kbid}/ask",
         json={"query": "title"},
     )
     assert resp.status_code == 200
-
-    # Testing the middleware integration where it collects audit calls and sends a single message
-    # at requests ends. In this case we expect one seach and one chat sent once
-    stream_audit.search.assert_called_once()
-    stream_audit.chat.assert_called_once()
-    assert stream_audit.js.publish.call_count == 2
-    stream_audit.send.assert_called_once()
-
-    auditreq = await get_audit_messages(psub)
-    assert auditreq.type == AuditRequest.AuditType.CHAT
-    assert auditreq.kbid == kbid
-    assert auditreq.HasField("chat")
-    assert auditreq.HasField("search")
-    assert auditreq.request_time > 0
-    assert auditreq.generative_answer_time > 0
-    assert auditreq.retrieval_time > 0
-    assert (auditreq.generative_answer_time + auditreq.retrieval_time) < auditreq.request_time
-    try:
-        auditreq = await get_audit_messages(psub)
-    except nats.errors.TimeoutError:
-        pass
-    else:
-        assert "There was an unexpected extra audit message in nats"
-    await psub.unsubscribe()
-    await nats_client.flush()
-    await nats_client.close()
+    spy.assert_called_once()
+    ask_request = spy.call_args[1]
+    assert isinstance(ask_request, AskRequest)
+    assert ask_request.security is None
+    spy.reset_mock()

--- a/nucliadb/tests/search/integration/api/v1/test_ask_security.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_security.py
@@ -42,6 +42,9 @@ async def test_ask_receives_injected_security_groups(
     )
     assert resp.status_code == 200
     spy.assert_called_once()
+    print(spy.call_args)
+    print(spy.call_args[0])
+    print(spy.call_args[1])
     ask_request = spy.call_args[1]
     assert isinstance(ask_request, AskRequest)
     assert ask_request.security is not None

--- a/nucliadb/tests/search/integration/api/v1/test_ask_security.py
+++ b/nucliadb/tests/search/integration/api/v1/test_ask_security.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import nats
+from httpx import AsyncClient
+from nats.aio.client import Client
+from nats.js import JetStreamContext
+
+from nucliadb.search.api.v1.router import KB_PREFIX
+from nucliadb_protos.audit_pb2 import AuditRequest
+
+
+async def get_audit_messages(sub):
+    msg = await sub.fetch(1)
+    auditreq = AuditRequest()
+    auditreq.ParseFromString(msg[0].data)
+    return auditreq
+
+
+async def test_ask_sends_only_one_audit(
+    cluster_nucliadb_search: AsyncClient, test_search_resource: str, stream_audit
+) -> None:
+    from nucliadb_utils.settings import audit_settings
+
+    kbid = test_search_resource
+
+    # Prepare a test audit stream to receive our messages
+    partition = stream_audit.get_partition(kbid)
+    nats_client: Client = await nats.connect(stream_audit.nats_servers)
+    jetstream: JetStreamContext = nats_client.jetstream()
+    if audit_settings.audit_jetstream_target is None:
+        assert False, "Missing jetstream target in audit settings"
+    subject = audit_settings.audit_jetstream_target.format(partition=partition, type="*")
+
+    try:
+        await jetstream.delete_stream(name=audit_settings.audit_stream)
+        await jetstream.delete_stream(name="test_usage")
+    except nats.js.errors.NotFoundError:
+        pass
+
+    await jetstream.add_stream(name=audit_settings.audit_stream, subjects=[subject])
+
+    psub = await jetstream.pull_subscribe(subject, "psub")
+
+    resp = await cluster_nucliadb_search.post(
+        f"/{KB_PREFIX}/{kbid}/ask",
+        json={"query": "title"},
+    )
+    assert resp.status_code == 200
+
+    # Testing the middleware integration where it collects audit calls and sends a single message
+    # at requests ends. In this case we expect one seach and one chat sent once
+    stream_audit.search.assert_called_once()
+    stream_audit.chat.assert_called_once()
+    assert stream_audit.js.publish.call_count == 2
+    stream_audit.send.assert_called_once()
+
+    auditreq = await get_audit_messages(psub)
+    assert auditreq.type == AuditRequest.AuditType.CHAT
+    assert auditreq.kbid == kbid
+    assert auditreq.HasField("chat")
+    assert auditreq.HasField("search")
+    assert auditreq.request_time > 0
+    assert auditreq.generative_answer_time > 0
+    assert auditreq.retrieval_time > 0
+    assert (auditreq.generative_answer_time + auditreq.retrieval_time) < auditreq.request_time
+    try:
+        auditreq = await get_audit_messages(psub)
+    except nats.errors.TimeoutError:
+        pass
+    else:
+        assert "There was an unexpected extra audit message in nats"
+    await psub.unsubscribe()
+    await nats_client.flush()
+    await nats_client.close()

--- a/nucliadb_utils/src/nucliadb_utils/authentication.py
+++ b/nucliadb_utils/src/nucliadb_utils/authentication.py
@@ -34,7 +34,7 @@ from starlette.websockets import WebSocket
 class NucliaUser(BaseUser):
     def __init__(self, username: str, security_groups: Optional[list[str]] = None) -> None:
         self.username = username
-        self.security_groups = security_groups
+        self._security_groups = security_groups
 
     @property
     def is_authenticated(self) -> bool:
@@ -43,6 +43,10 @@ class NucliaUser(BaseUser):
     @property
     def display_name(self) -> str:
         return self.username
+
+    @property
+    def security_groups(self) -> Optional[list[str]]:
+        return self._security_groups
 
 
 STFUser = NucliaUser
@@ -69,7 +73,6 @@ class NucliaCloudAuthenticationBackend(AuthenticationBackend):
 
         if self.user_header in request.headers:
             user = request.headers[self.user_header]
-            nuclia_user: NucliaUser = NucliaUser(username=user)
 
             raw_security_groups: Optional[str] = request.headers.get(self.security_groups_header)
 
@@ -77,8 +80,7 @@ class NucliaCloudAuthenticationBackend(AuthenticationBackend):
             if raw_security_groups is not None:
                 security_groups = raw_security_groups.split(";")
 
-            if security_groups:
-                nuclia_user.security_groups = security_groups
+            nuclia_user: NucliaUser = NucliaUser(username=user, security_groups=security_groups)
 
         else:
             nuclia_user = NucliaUser(username="anonymous")

--- a/nucliadb_utils/src/nucliadb_utils/authentication.py
+++ b/nucliadb_utils/src/nucliadb_utils/authentication.py
@@ -32,8 +32,9 @@ from starlette.websockets import WebSocket
 
 
 class NucliaUser(BaseUser):
-    def __init__(self, username: str) -> None:
+    def __init__(self, username: str, security_groups: Optional[list[str]] = None) -> None:
         self.username = username
+        self.security_groups = security_groups
 
     @property
     def is_authenticated(self) -> bool:
@@ -52,9 +53,11 @@ class NucliaCloudAuthenticationBackend(AuthenticationBackend):
         self,
         roles_header: str = "X-NUCLIADB-ROLES",
         user_header: str = "X-NUCLIADB-USER",
+        security_groups_header: str = "X-NUCLIADB-SECURITY-GROUPS",
     ) -> None:
         self.roles_header = roles_header
         self.user_header = user_header
+        self.security_groups_header = security_groups_header
 
     async def authenticate(self, request: HTTPConnection) -> Optional[Tuple[AuthCredentials, BaseUser]]:
         if self.roles_header not in request.headers:
@@ -66,7 +69,16 @@ class NucliaCloudAuthenticationBackend(AuthenticationBackend):
 
         if self.user_header in request.headers:
             user = request.headers[self.user_header]
-            nuclia_user: BaseUser = NucliaUser(username=user)
+            nuclia_user: NucliaUser = NucliaUser(username=user)
+
+            raw_security_groups: Optional[str] = request.headers.get(self.security_groups_header)
+            security_groups: Optional[list[str]] = None
+            if raw_security_groups is not None:
+                security_groups = raw_security_groups.split(";")
+
+            if security_groups:
+                nuclia_user.security_groups = security_groups
+
         else:
             nuclia_user = NucliaUser(username="anonymous")
 

--- a/nucliadb_utils/src/nucliadb_utils/authentication.py
+++ b/nucliadb_utils/src/nucliadb_utils/authentication.py
@@ -71,7 +71,6 @@ class NucliaCloudAuthenticationBackend(AuthenticationBackend):
             user = request.headers[self.user_header]
             nuclia_user: NucliaUser = NucliaUser(username=user)
 
-            print(f"authenticate headers: {request.headers}")
             raw_security_groups: Optional[str] = request.headers.get(self.security_groups_header)
 
             security_groups: Optional[list[str]] = None

--- a/nucliadb_utils/src/nucliadb_utils/authentication.py
+++ b/nucliadb_utils/src/nucliadb_utils/authentication.py
@@ -71,7 +71,9 @@ class NucliaCloudAuthenticationBackend(AuthenticationBackend):
             user = request.headers[self.user_header]
             nuclia_user: NucliaUser = NucliaUser(username=user)
 
+            print(f"authenticate headers: {request.headers}")
             raw_security_groups: Optional[str] = request.headers.get(self.security_groups_header)
+
             security_groups: Optional[list[str]] = None
             if raw_security_groups is not None:
                 security_groups = raw_security_groups.split(";")


### PR DESCRIPTION
### Description
When using the new Temporal service accounts feature, that can have embedded security groups, Authorizer will forward this to nucliad, for now only on the ask endpoint. This ensures that if present, this value is set and maybe overrides the value of the payload

### How was this PR tested?
the existing security tests were done against standalone, that doesn't use the auth backend used in the cloud setup, so a mocked test to ensure the injection is done has ben set at a search component level