### PR TITLE
Trigger semgrep on CI

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Semgrep
-        run: semgrep ci --config=auto --junit-xml-output semgrep-results.xml
+        run: semgrep ci --junit-xml-output semgrep-results.xml
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,17 @@
+name: Semgrep - SAST Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  semgrep-scan:
+    name: Semgrep SAST Scan
+    uses: nuclia/tooling/.github/workflows/semgrep-scan.yaml@main
+    secrets: inherit
+    with:
+      scan-type: ci
+      comment: false
+      update-comment: false

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -7,11 +7,29 @@ on:
       - master
 
 jobs:
-  semgrep-scan:
-    name: Semgrep SAST Scan
-    uses: nuclia/tooling/.github/workflows/semgrep-scan.yaml@main
-    secrets: inherit
-    with:
-      scan-type: ci
-      comment: false
-      update-comment: false
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: semgrep ci --config=auto --junit-xml-output semgrep-results.xml
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: (success() || failure()) && github.event_name == 'pull_request'
+        with:
+          report_paths: 'semgrep-results.xml'
+          job_summary: true
+          comment: false
+          summary: "Semgrep Results"
+          updateComment: false
+          check_name: "Semgrep SAST"
+          detailed_summary: true
+          include_passed: true

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+Dockerfile
+docker-compose.yaml
+config/nginx.conf

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,3 +1,8 @@
 Dockerfile
+Dockerfile.*
 docker-compose.yaml
 config/nginx.conf
+**/docs
+docs/*
+**/migrations
+**/tests


### PR DESCRIPTION
This pull request introduces a new workflow for running Semgrep SAST scans on pull requests and adds a `.semgrepignore` file to exclude certain files from the scan. The most important changes include the addition of a GitHub Actions workflow for Semgrep and the configuration of the `.semgrepignore` file.

New Semgrep SAST scan workflow:

* [`.github/workflows/semgrep.yaml`](diffhunk://#diff-825415cb1ea250dfa9c8d6e8599c661d3f1eb8cfe9218ad90f072632c7536981R1-R35): Added a new GitHub Actions workflow to run Semgrep SAST scans on pull requests targeting the `main` and `master` branches. The workflow uses the `semgrep/semgrep` container and publishes the test report using the `mikepenz/action-junit-report` action.

Exclusion of files from Semgrep scan:

* [`.semgrepignore`](diffhunk://#diff-df422332ec3e07a3f1bc457f724e34ef757229ed5b25c3c587c0d45b06e50392R1-R3): Added a `.semgrepignore` file to exclude `Dockerfile`, `docker-compose.yaml`, and `config/nginx.conf` from the Semgrep scan.