### PR TITLE
Fix config semgrep as using CE edition

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Semgrep
-        run: semgrep ci --junit-xml-output semgrep-results.xml
+        run: semgrep ci --config=auto --junit-xml-output semgrep-results.xml
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/semgrep.yaml` file. The change updates the Semgrep command to automatically use the appropriate configuration.

* [`.github/workflows/semgrep.yaml`](diffhunk://#diff-825415cb1ea250dfa9c8d6e8599c661d3f1eb8cfe9218ad90f072632c7536981L22-R22): Modified the Semgrep command to include the `--config=auto` option for automatic configuration.