### PR TITLE
Fix models discrepancy with protos

### DIFF
--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -813,10 +813,11 @@ async def test_question_answer_annotations(
                 ids_paragraphs=["id1/0", "id2/0"],
             ),
             answers=[
-                common.Answer(
+                common.Answers(
                     ids_paragraphs=["id1/00", "id2/00"],
                     language="catalan",
                     text="My answer 00",
+                    reason="reason 00",
                 )
             ],
         ),

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -263,15 +263,16 @@ class Question(BaseModel):
     ids_paragraphs: List[str]
 
 
-class Answer(BaseModel):
+class Answers(BaseModel):
     text: str
     language: Optional[str] = None
     ids_paragraphs: List[str]
+    reason: str
 
 
 class QuestionAnswer(BaseModel):
     question: Question
-    answers: List[Answer]
+    answers: List[Answers]
 
 
 class QuestionAnswers(BaseModel):


### PR DESCRIPTION
### Description
Adds missing field to pydantic model and aligns name with the protos defined in `resources.proto`

### How was this PR tested?
Describe how you tested this PR.
