### PR TITLE
Cleanup feature flags

### DIFF
--- a/nucliadb/src/nucliadb/common/cluster/rebalance.py
+++ b/nucliadb/src/nucliadb/common/cluster/rebalance.py
@@ -28,9 +28,7 @@ from nucliadb_protos import nodereader_pb2, noderesources_pb2
 from nucliadb_telemetry import errors
 from nucliadb_telemetry.logs import setup_logging
 from nucliadb_telemetry.utils import setup_telemetry
-from nucliadb_utils import const
 from nucliadb_utils.fastapi.run import serve_metrics
-from nucliadb_utils.utilities import has_feature
 
 from .settings import settings
 from .utils import delete_resource_from_shard, index_resource_to_shard, wait_for_node
@@ -163,9 +161,6 @@ async def move_set_of_kb_resources(
 
 
 async def rebalance_kb(context: ApplicationContext, kbid: str) -> None:
-    if not has_feature(const.Features.REBALANCE_KB, context={"kbid": kbid}):
-        return
-
     await maybe_add_shard(kbid)
 
     shard_paragraphs = await get_shards_paragraphs(kbid)

--- a/nucliadb/src/nucliadb/ingest/consumer/consumer.py
+++ b/nucliadb/src/nucliadb/ingest/consumer/consumer.py
@@ -42,7 +42,6 @@ from nucliadb_utils.cache.pubsub import PubSubDriver
 from nucliadb_utils.nats import MessageProgressUpdater, NatsConnectionManager
 from nucliadb_utils.settings import nats_consumer_settings
 from nucliadb_utils.storages.storage import Storage
-from nucliadb_utils.utilities import has_feature
 
 consumer_observer = metrics.Observer(
     "message_processor",
@@ -89,13 +88,7 @@ class IngestConsumer:
         self.subscription: Optional[JetStreamContext.PullSubscription] = None
 
     async def ack_message(self, msg: Msg, kbid: Optional[str] = None):
-        context = {}
-        if kbid:
-            context["kbid"] = kbid
-        if has_feature(const.Features.NATS_SYNC_ACK, default=False, context=context):
-            await msg.ack_sync(timeout=10)
-        else:
-            await msg.ack()
+        await msg.ack()
 
     async def initialize(self):
         await self.setup_nats_subscription()

--- a/nucliadb/src/nucliadb/ingest/orm/entities.py
+++ b/nucliadb/src/nucliadb/ingest/orm/entities.py
@@ -65,12 +65,10 @@ class EntitiesManager:
         self,
         knowledgebox: KnowledgeBox,
         txn: Transaction,
-        use_read_replica_nodes: bool = False,
     ):
         self.kb = knowledgebox
         self.txn = txn
         self.kbid = self.kb.kbid
-        self.use_read_replica_nodes = use_read_replica_nodes
 
     async def create_entities_group(self, group: str, entities: EntitiesGroup):
         if await self.entities_group_exists(group):
@@ -222,7 +220,6 @@ class EntitiesManager:
             self.kbid,
             do_entities_search,
             settings.relation_search_timeout,
-            use_read_replica_nodes=self.use_read_replica_nodes,
         )
 
         entities = {}
@@ -318,10 +315,7 @@ class EntitiesManager:
                 return {facet.tag.split("/")[-1] for facet in facetresults}
 
         results = await shard_manager.apply_for_all_shards(
-            self.kbid,
-            query_indexed_entities_group_names,
-            settings.relation_types_timeout,
-            use_read_replica_nodes=self.use_read_replica_nodes,
+            self.kbid, query_indexed_entities_group_names, settings.relation_types_timeout
         )
 
         if not results:

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -69,9 +69,7 @@ from nucliadb_protos.resources_pb2 import Origin as PBOrigin
 from nucliadb_protos.resources_pb2 import Relations as PBRelations
 from nucliadb_protos.utils_pb2 import Relation as PBRelation
 from nucliadb_protos.writer_pb2 import BrokerMessage
-from nucliadb_utils import const
 from nucliadb_utils.storages.storage import Storage
-from nucliadb_utils.utilities import has_feature
 
 if TYPE_CHECKING:  # pragma: no cover
     from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
@@ -602,12 +600,6 @@ class Resource:
 
     @processor_observer.wrap({"type": "apply_extracted"})
     async def apply_extracted(self, message: BrokerMessage):
-        if not has_feature(const.Features.FIELD_STATUS):
-            field_obj: Field
-            for error in message.errors:
-                field_obj = await self.get_field(error.field, error.field_type, load=False)
-                await field_obj.set_error(error)
-
         await self.get_basic()
         if self.basic is None:
             raise KeyError("Resource Not Found")
@@ -628,15 +620,9 @@ class Resource:
 
         # Update field and resource status depending on processing results
         await self.apply_fields_status(message, self._modified_extracted_text)
-        if has_feature(const.Features.FIELD_STATUS):
-            # Compute resource status based on all fields statuses
-            await self.update_status()
-        else:
-            # Old code path, compute resource status based on the presence of errors in this BrokerMessage
-            if message.errors:
-                self.basic.metadata.status = PBMetadata.Status.ERROR
-            elif message.source is message.MessageSource.PROCESSOR:
-                self.basic.metadata.status = PBMetadata.Status.PROCESSED
+
+        # Compute resource status based on all fields statuses
+        await self.update_status()
 
         extracted_languages = []
 

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -52,8 +52,7 @@ from nucliadb_models.resource import (
 from nucliadb_models.search import ResourceProperties
 from nucliadb_models.security import ResourceSecurity
 from nucliadb_protos.writer_pb2 import FieldStatus
-from nucliadb_utils import const
-from nucliadb_utils.utilities import get_storage, has_feature
+from nucliadb_utils.utilities import get_storage
 
 
 async def set_resource_field_extracted_data(
@@ -154,32 +153,22 @@ async def serialize_field_errors(
         TextFieldData, FileFieldData, LinkFieldData, ConversationFieldData, GenericFieldData
     ],
 ):
-    if has_feature(const.Features.FIELD_STATUS):
-        status = await field.get_status()
-        if status is None:
-            status = FieldStatus()
-        serialized.status = status.Status.Name(status.status)
-        if status.errors:
-            serialized.errors = []
-            for error in status.errors:
-                serialized.errors.append(
-                    Error(
-                        body=error.source_error.error,
-                        code=error.source_error.code,
-                        code_str=error.source_error.ErrorCode.Name(error.source_error.code),
-                        created=error.created.ToDatetime(),
-                    )
+    status = await field.get_status()
+    if status is None:
+        status = FieldStatus()
+    serialized.status = status.Status.Name(status.status)
+    if status.errors:
+        serialized.errors = []
+        for error in status.errors:
+            serialized.errors.append(
+                Error(
+                    body=error.source_error.error,
+                    code=error.source_error.code,
+                    code_str=error.source_error.ErrorCode.Name(error.source_error.code),
+                    created=error.created.ToDatetime(),
                 )
-            serialized.error = serialized.errors[-1]
-    else:
-        field_error = await field.get_error()
-        if field_error is not None:
-            serialized.error = Error(
-                body=field_error.error,
-                code=field_error.code,
-                code_str=field_error.ErrorCode.Name(field_error.code),
-                created=None,
             )
+        serialized.error = serialized.errors[-1]
 
 
 async def managed_serialize(

--- a/nucliadb/src/nucliadb/ingest/service/writer.py
+++ b/nucliadb/src/nucliadb/ingest/service/writer.py
@@ -272,7 +272,7 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
                 response.status = ListEntitiesGroupsResponse.Status.NOTFOUND
                 return response
 
-            entities_manager = EntitiesManager(kbobj, txn, use_read_replica_nodes=True)
+            entities_manager = EntitiesManager(kbobj, txn)
             try:
                 entities_groups = await entities_manager.list_entities_groups()
             except Exception as e:

--- a/nucliadb/src/nucliadb/search/api/v1/catalog.py
+++ b/nucliadb/src/nucliadb/search/api/v1/catalog.py
@@ -79,7 +79,6 @@ async def catalog_get(
     sort_order: SortOrder = fastapi_query(SearchParamDefaults.sort_order),
     page_number: int = fastapi_query(SearchParamDefaults.catalog_page_number),
     page_size: int = fastapi_query(SearchParamDefaults.catalog_page_size),
-    shards: list[str] = fastapi_query(SearchParamDefaults.shards, deprecated=True),
     with_status: Optional[ResourceProcessingStatus] = fastapi_query(
         SearchParamDefaults.with_status, deprecated="Use filters instead"
     ),
@@ -100,7 +99,6 @@ async def catalog_get(
         faceted=faceted,
         page_number=page_number,
         page_size=page_size,
-        shards=shards,
         debug=debug,
         with_status=with_status,
         range_creation_start=range_creation_start,

--- a/nucliadb/src/nucliadb/search/api/v1/resource/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/search.py
@@ -76,7 +76,6 @@ async def resource_search(
     highlight: bool = fastapi_query(SearchParamDefaults.highlight),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     debug: bool = fastapi_query(SearchParamDefaults.debug),
-    shards: list[str] = fastapi_query(SearchParamDefaults.shards),
 ) -> Union[ResourceSearchResults, HTTPClientError]:
     top_k = top_k or SearchParamDefaults.top_k  # type: ignore
     top_k = cast(int, top_k)
@@ -101,9 +100,7 @@ async def resource_search(
         except InvalidQueryError as exc:
             return HTTPClientError(status_code=412, detail=str(exc))
 
-        results, incomplete_results, queried_nodes = await node_query(
-            kbid, Method.SEARCH, pb_query, shards
-        )
+        results, incomplete_results, queried_nodes = await node_query(kbid, Method.SEARCH, pb_query)
 
         # We need to merge
         search_results = await merge_paragraphs_results(

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -146,7 +146,6 @@ async def search_knowledgebox(
         SearchParamDefaults.field_type_filter, alias="field_type"
     ),
     extracted: list[ExtractedDataTypeName] = fastapi_query(SearchParamDefaults.extracted),
-    shards: list[str] = fastapi_query(SearchParamDefaults.shards),
     with_duplicates: bool = fastapi_query(SearchParamDefaults.with_duplicates),
     with_synonyms: bool = fastapi_query(SearchParamDefaults.with_synonyms),
     autofilter: bool = fastapi_query(SearchParamDefaults.autofilter),
@@ -183,7 +182,6 @@ async def search_knowledgebox(
             show=show,
             field_type_filter=field_type_filter,
             extracted=extracted,
-            shards=shards,
             with_duplicates=with_duplicates,
             with_synonyms=with_synonyms,
             autofilter=autofilter,

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -295,9 +295,7 @@ async def search(
     )
     pb_query, incomplete_results, autofilters, _ = await query_parser.parse()
 
-    results, query_incomplete_results, queried_nodes = await node_query(
-        kbid, Method.SEARCH, pb_query, target_shard_replicas=item.shards
-    )
+    results, query_incomplete_results, queried_nodes = await node_query(kbid, Method.SEARCH, pb_query)
 
     incomplete_results = incomplete_results or query_incomplete_results
 

--- a/nucliadb/src/nucliadb/search/predict.py
+++ b/nucliadb/src/nucliadb/search/predict.py
@@ -49,10 +49,9 @@ from nucliadb_models.search import (
 )
 from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb_telemetry import errors, metrics
-from nucliadb_utils.const import Features
 from nucliadb_utils.exceptions import LimitsExceededError
 from nucliadb_utils.settings import nuclia_settings
-from nucliadb_utils.utilities import Utility, has_feature, set_utility
+from nucliadb_utils.utilities import Utility, set_utility
 
 
 class SendToPredictError(Exception):
@@ -89,7 +88,6 @@ DUMMY_LEARNING_MODEL = "chatgpt"
 
 PUBLIC_PREDICT = "/api/v1/predict"
 PRIVATE_PREDICT = "/api/internal/predict"
-VERSIONED_PRIVATE_PREDICT = "/api/v1/internal/predict"
 SENTENCE = "/sentence"
 TOKENS = "/tokens"
 QUERY = "/query"
@@ -199,10 +197,7 @@ class PredictEngine:
             # /api/v1/predict/rephrase/{kbid}
             return f"{self.public_url}{PUBLIC_PREDICT}{endpoint}/{kbid}"
         else:
-            if has_feature(Features.VERSIONED_PRIVATE_PREDICT):
-                return f"{self.cluster_url}{VERSIONED_PRIVATE_PREDICT}{endpoint}"
-            else:
-                return f"{self.cluster_url}{PRIVATE_PREDICT}{endpoint}"
+            return f"{self.cluster_url}{PRIVATE_PREDICT}{endpoint}"
 
     def get_predict_headers(self, kbid: str) -> dict[str, str]:
         if self.onprem:

--- a/nucliadb/src/nucliadb/search/requesters/utils.py
+++ b/nucliadb/src/nucliadb/search/requesters/utils.py
@@ -71,10 +71,7 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: SuggestRequest,
-    target_shard_replicas: Optional[list[str]] = None,
-    use_read_replica_nodes: bool = True,
     timeout: Optional[float] = None,
-    retry_on_primary: bool = True,
 ) -> tuple[list[SuggestResponse], bool, list[tuple[AbstractIndexNode, str]]]: ...
 
 
@@ -83,10 +80,7 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: SearchRequest,
-    target_shard_replicas: Optional[list[str]] = None,
-    use_read_replica_nodes: bool = True,
     timeout: Optional[float] = None,
-    retry_on_primary: bool = True,
 ) -> tuple[list[SearchResponse], bool, list[tuple[AbstractIndexNode, str]]]: ...
 
 
@@ -94,10 +88,7 @@ async def node_query(
     kbid: str,
     method: Method,
     pb_query: REQUEST_TYPE,
-    target_shard_replicas: Optional[list[str]] = None,
-    use_read_replica_nodes: bool = True,
     timeout: Optional[float] = None,
-    retry_on_primary: bool = True,
 ) -> tuple[Sequence[Union[T, BaseException]], bool, list[tuple[AbstractIndexNode, str]]]:
     timeout = timeout or settings.search_timeout
     shard_manager = get_shard_manager()
@@ -115,11 +106,7 @@ async def node_query(
 
     for shard_obj in shard_groups:
         try:
-            node, shard_id = cluster_manager.choose_node(
-                shard_obj,
-                use_read_replica_nodes=use_read_replica_nodes,
-                target_shard_replicas=target_shard_replicas,
-            )
+            node, shard_id = cluster_manager.choose_node(shard_obj)
         except KeyError:
             incomplete_results = True
         else:
@@ -160,29 +147,6 @@ async def node_query(
                 "query": json.dumps(query_dict),
             },
         )
-        if (
-            error.status_code >= 500
-            and use_read_replica_nodes
-            and any([node.is_read_replica() for node, _ in queried_nodes])
-            and retry_on_primary
-        ):
-            # We had an error querying a secondary node, instead of raising an
-            # error directly, retry query to primaries and hope it works
-            logger.warning(
-                "Query to read replica failed. Trying again with primary",
-                extra={"nodes": debug_nodes_info(queried_nodes)},
-            )
-
-            results, incomplete_results, primary_queried_nodes = await node_query(  # type: ignore
-                kbid,
-                method,
-                pb_query,
-                target_shard_replicas,
-                use_read_replica_nodes=False,
-            )
-            queried_nodes.extend(primary_queried_nodes)
-            return results, incomplete_results, queried_nodes
-
         raise error
 
     return results, incomplete_results, queried_nodes

--- a/nucliadb/src/nucliadb/search/requesters/utils.py
+++ b/nucliadb/src/nucliadb/search/requesters/utils.py
@@ -45,8 +45,6 @@ from nucliadb_protos.nodereader_pb2 import (
 )
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from nucliadb_telemetry import errors
-from nucliadb_utils import const
-from nucliadb_utils.utilities import has_feature
 
 
 class Method(Enum):
@@ -102,10 +100,6 @@ async def node_query(
     retry_on_primary: bool = True,
 ) -> tuple[Sequence[Union[T, BaseException]], bool, list[tuple[AbstractIndexNode, str]]]:
     timeout = timeout or settings.search_timeout
-    use_read_replica_nodes = use_read_replica_nodes and has_feature(
-        const.Features.READ_REPLICA_SEARCHES, context={"kbid": kbid}
-    )
-
     shard_manager = get_shard_manager()
     try:
         shard_groups: list[PBShardObject] = await shard_manager.get_shards_by_kbid(kbid)

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -740,7 +740,6 @@ async def retrieval_in_kb(
                 origin=origin,
                 graph_strategy=graph_strategy,
                 metrics=metrics,
-                shards=ask_request.shards,
             )
 
             if prequeries_results is None:

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -383,7 +383,6 @@ class AskResult:
                 self._relations = await get_relations_results(
                     kbid=self.kbid,
                     text_answer=self._answer_text,
-                    target_shard_replicas=self.ask_request.shards,
                     timeout=5.0,
                 )
         return self._relations

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -219,7 +219,6 @@ async def get_relations_results(
     *,
     kbid: str,
     text_answer: str,
-    target_shard_replicas: Optional[list[str]],
     timeout: Optional[float] = None,
     only_with_metadata: bool = False,
     only_agentic_relations: bool = False,
@@ -231,7 +230,6 @@ async def get_relations_results(
         return await get_relations_results_from_entities(
             kbid=kbid,
             entities=detected_entities,
-            target_shard_replicas=target_shard_replicas,
             timeout=timeout,
             only_with_metadata=only_with_metadata,
             only_agentic_relations=only_agentic_relations,
@@ -246,7 +244,6 @@ async def get_relations_results_from_entities(
     *,
     kbid: str,
     entities: Iterable[RelationNode],
-    target_shard_replicas: Optional[list[str]],
     timeout: Optional[float] = None,
     only_with_metadata: bool = False,
     only_agentic_relations: bool = False,
@@ -269,10 +266,7 @@ async def get_relations_results_from_entities(
         kbid,
         Method.SEARCH,
         request,
-        target_shard_replicas=target_shard_replicas,
         timeout=timeout,
-        use_read_replica_nodes=True,
-        retry_on_primary=False,
     )
     relations_results: list[RelationSearchResponse] = [result.relation for result in results]
     return await merge_relations_results(

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -173,7 +173,6 @@ def find_request_from_ask_request(item: AskRequest, query: str) -> FindRequest:
     find_request.range_modification_end = item.range_modification_end
     find_request.show = item.show
     find_request.extracted = item.extracted
-    find_request.shards = item.shards
     find_request.autofilter = item.autofilter
     find_request.highlight = item.highlight
     find_request.security = item.security

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -110,7 +110,7 @@ async def _index_node_retrieval(
 
     with metrics.time("node_query"):
         results, query_incomplete_results, queried_nodes = await node_query(
-            kbid, Method.SEARCH, pb_query, target_shard_replicas=item.shards
+            kbid, Method.SEARCH, pb_query
         )
     incomplete_results = incomplete_results or query_incomplete_results
 

--- a/nucliadb/src/nucliadb/search/search/graph_strategy.py
+++ b/nucliadb/src/nucliadb/search/search/graph_strategy.py
@@ -368,7 +368,6 @@ async def get_graph_results(
                 new_relations = await get_relations_results_from_entities(
                     kbid=kbid,
                     entities=entities_to_explore,
-                    target_shard_replicas=shards,
                     timeout=5.0,
                     only_with_metadata=True,
                     only_agentic_relations=graph_strategy.agentic_graph_only,
@@ -455,8 +454,6 @@ async def fuzzy_search_entities(
             kbid,
             Method.SEARCH,
             request,
-            use_read_replica_nodes=True,
-            retry_on_primary=False,
         )
         return merge_relation_prefix_results(results)
     except Exception as e:

--- a/nucliadb/tests/search/unit/test_predict.py
+++ b/nucliadb/tests/search/unit/test_predict.py
@@ -74,7 +74,7 @@ async def test_dummy_predict_engine():
             "X-STF-NUAKEY",
             "Bearer {service_account}",
         ),
-        (False, "{cluster}/api/v1/internal/predict/tokens", "X-STF-KBID", "{kbid}"),
+        (False, "{cluster}/api/internal/predict/tokens", "X-STF-KBID", "{kbid}"),
     ],
 )
 async def test_detect_entities_ok(onprem, expected_url, expected_header, expected_header_value):
@@ -194,7 +194,7 @@ async def test_rephrase():
     assert rephrased_query == "rephrased"
 
     pe.session.post.assert_awaited_once_with(
-        url="cluster/api/v1/internal/predict/rephrase",
+        url="cluster/api/internal/predict/rephrase",
         json=item.model_dump(),
         headers={"X-STF-KBID": "kbid"},
     )
@@ -245,7 +245,7 @@ async def test_parse_rephrase_response(content, exception):
 async def test_check_response_error():
     response = aiohttp.ClientResponse(
         "GET",
-        URL("http://predict:8080/api/v1/chat"),
+        URL("http://predict:8080/api/chat"),
         writer=None,
         continue100=Mock(),
         timer=Mock(),
@@ -285,7 +285,7 @@ async def test_summarize():
     assert summarize_response == summarized
 
     pe.session.post.assert_awaited_once_with(
-        url="cluster/api/v1/internal/predict/summarize",
+        url="cluster/api/internal/predict/summarize",
         json=item.model_dump(),
         headers={"X-STF-KBID": "kbid"},
         timeout=None,

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -472,11 +472,6 @@ class SearchParamDefaults:
         description="The query to get a generative answer for",
         max_items=20_000,
     )
-    shards = ParamDefault(
-        default=[],
-        title="Shards",
-        description="The list of shard replicas to search in. If empty, random replicas will be selected.",
-    )
     catalog_page_number = ParamDefault(
         default=0,
         title="Page number",
@@ -675,7 +670,6 @@ class CatalogRequest(BaseModel):
     sort: Optional[SortOptions] = SearchParamDefaults.sort.to_pydantic_field()
     page_number: int = SearchParamDefaults.catalog_page_number.to_pydantic_field()
     page_size: int = SearchParamDefaults.catalog_page_size.to_pydantic_field()
-    shards: list[str] = SearchParamDefaults.shards.to_pydantic_field(deprecated=True)
     debug: SkipJsonSchema[bool] = SearchParamDefaults.debug.to_pydantic_field()
     with_status: Optional[ResourceProcessingStatus] = Field(
         default=None,
@@ -777,7 +771,6 @@ class BaseSearchRequest(AuditMetadataBase):
     show: list[ResourceProperties] = SearchParamDefaults.show.to_pydantic_field()
     field_type_filter: list[FieldTypeName] = SearchParamDefaults.field_type_filter.to_pydantic_field()
     extracted: list[ExtractedDataTypeName] = SearchParamDefaults.extracted.to_pydantic_field()
-    shards: list[str] = SearchParamDefaults.shards.to_pydantic_field()
     vector: Optional[list[float]] = SearchParamDefaults.vector.to_pydantic_field()
     vectorset: Optional[str] = SearchParamDefaults.vectorset.to_pydantic_field()
     with_duplicates: bool = SearchParamDefaults.with_duplicates.to_pydantic_field()
@@ -1418,7 +1411,6 @@ class AskRequest(AuditMetadataBase):
     show: list[ResourceProperties] = SearchParamDefaults.show.to_pydantic_field()
     field_type_filter: list[FieldTypeName] = SearchParamDefaults.field_type_filter.to_pydantic_field()
     extracted: list[ExtractedDataTypeName] = SearchParamDefaults.extracted.to_pydantic_field()
-    shards: list[str] = SearchParamDefaults.shards.to_pydantic_field()
     context: Optional[list[ChatContextMessage]] = SearchParamDefaults.chat_context.to_pydantic_field()
     extra_context: Optional[list[str]] = Field(
         default=None,

--- a/nucliadb_utils/src/nucliadb_utils/const.py
+++ b/nucliadb_utils/src/nucliadb_utils/const.py
@@ -71,13 +71,6 @@ class Streams:
 
 
 class Features:
-    WAIT_FOR_INDEX = "nucliadb_wait_for_resource_index"
-    READ_REPLICA_SEARCHES = "nucliadb_read_replica_searches"
-    VERSIONED_PRIVATE_PREDICT = "nucliadb_versioned_private_predict"
-    REBALANCE_KB = "nucliadb_rebalance_kb"
     SKIP_EXTERNAL_INDEX = "nucliadb_skip_external_index"
-    NATS_SYNC_ACK = "nucliadb_nats_sync_ack"
     LOG_REQUEST_PAYLOADS = "nucliadb_log_request_payloads"
     IGNORE_EXTRACTED_IN_SEARCH = "nucliadb_ignore_extracted_in_search"
-    NIDX_READS = "nucliadb_nidx_reads"
-    FIELD_STATUS = "nucliadb_field_status"

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -33,43 +33,15 @@ class Settings(pydantic_settings.BaseSettings):
 
 DEFAULT_FLAG_DATA: dict[str, Any] = {
     # These are just defaults to use for local dev and tests
-    const.Features.WAIT_FOR_INDEX: {
-        "rollout": 0,
-        "variants": {"environment": ["none"]},
-    },
-    const.Features.READ_REPLICA_SEARCHES: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
-    },
-    const.Features.VERSIONED_PRIVATE_PREDICT: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
-    },
-    const.Features.REBALANCE_KB: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
-    },
     const.Features.SKIP_EXTERNAL_INDEX: {
         "rollout": 0,
         "variants": {"environment": ["none"]},
-    },
-    const.Features.NATS_SYNC_ACK: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
     },
     const.Features.LOG_REQUEST_PAYLOADS: {
         "rollout": 0,
         "variants": {"environment": ["none"]},
     },
     const.Features.IGNORE_EXTRACTED_IN_SEARCH: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
-    },
-    const.Features.NIDX_READS: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
-    },
-    const.Features.FIELD_STATUS: {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },

--- a/nucliadb_utils/src/nucliadb_utils/transaction.py
+++ b/nucliadb_utils/src/nucliadb_utils/transaction.py
@@ -39,7 +39,7 @@ from nucliadb_telemetry.jetstream import JetStreamContextTelemetry
 from nucliadb_utils import const, logger
 from nucliadb_utils.cache.pubsub import PubSubDriver
 from nucliadb_utils.nats import get_traced_jetstream
-from nucliadb_utils.utilities import get_pubsub, has_feature
+from nucliadb_utils.utilities import get_pubsub
 
 
 class WaitFor:
@@ -128,8 +128,6 @@ class TransactionUtility:
         )
 
     def _get_notification_action_type(self):
-        if has_feature(const.Features.WAIT_FOR_INDEX):
-            return Notification.Action.INDEXED
         return Notification.Action.COMMIT  # currently do not handle ABORT!
 
     async def wait_for_commited(

--- a/nucliadb_utils/tests/unit/test_transaction.py
+++ b/nucliadb_utils/tests/unit/test_transaction.py
@@ -67,24 +67,6 @@ async def test_wait_for_commited(txn: TransactionUtility, pubsub):
     await (await txn.wait_for_commited(kbid, waiting_for, request_id=request_id)).wait()
 
 
-async def test_wait_for_indexed(txn: TransactionUtility, pubsub):
-    waiting_for = WaitFor(uuid="foo")
-    request_id = "request1"
-    kbid = "kbid"
-    notification = Notification()
-    notification.uuid = waiting_for.uuid
-    notification.action = Notification.Action.INDEXED
-
-    async def _subscribe(handler, key, subscription_id):
-        # call it immediately
-        handler(mock.Mock(data=notification.SerializeToString()))
-
-    pubsub.subscribe.side_effect = _subscribe
-
-    with mock.patch("nucliadb_utils.transaction.has_feature", return_value=True):
-        await (await txn.wait_for_commited(kbid, waiting_for, request_id=request_id)).wait()
-
-
 async def test_wait_for_commit_stop_waiting(txn: TransactionUtility, pubsub):
     pubsub.unsubscribe.side_effect = [
         "sub_id",


### PR DESCRIPTION
### Description
- rebalance flag: already implemented long time go
- nats sync ack: not needed -- was just part of a debugging session
- wait for index: not used since > a year
- nidx_reads: already implemented
- field statsu: already implemented 
- versioned private predict: not needed anymore. learning stayed unversioned in the end
- read replica searches, no longer needed after nidx

### How was this PR tested?
existing tests
