### PR TITLE
Enable new docker build pipeline with provenance and sbom scanning

### DIFF
--- a/.github/workflows/_build-img-nucliadb.yml
+++ b/.github/workflows/_build-img-nucliadb.yml
@@ -35,6 +35,7 @@ on:
 permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
+  actions: read     # This is required for provenance
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: "projects/224545243904/locations/global/workloadIdentityPools/gh-nuclia/providers/gh-nuclia-provider"
@@ -93,3 +94,5 @@ jobs:
           aws-ecr-role: ${{ secrets.AWS_ECR_ROLE }}
           tag-latest: ${{ github.ref == 'refs/heads/main' && 'latest' || 'dev-latest' }}
           push: true
+          ghapp-nuclia-service-bot-id: ${{ vars.GHAPP_NUCLIA_SERVICE_BOT_ID }}
+          ghapp-nuclia-service-bot-pk: ${{ secrets.GHAPP_NUCLIA_SERVICE_BOT_PK }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration file `.github/workflows/_build-img-nucliadb.yml` to enhance security and functionality. The most important changes include adding permissions required for provenance and introducing new environment variables for GitHub App authentication.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/_build-img-nucliadb.yml`](diffhunk://#diff-88c861d3545b5b87c5d70f5c09b938955fb589a9d2f1b53921c437ebfa86e07dR38): Added `actions: read` permission to the `permissions` section to support provenance.
* [`.github/workflows/_build-img-nucliadb.yml`](diffhunk://#diff-88c861d3545b5b87c5d70f5c09b938955fb589a9d2f1b53921c437ebfa86e07dR97-R98): Introduced new environment variables `ghapp-nuclia-service-bot-id` and `ghapp-nuclia-service-bot-pk` for GitHub App authentication.