### PR TITLE
Add extra permissions for read action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
+  actions: read     # This is required for provenance
 
 env:
   GCP_WORKLOAD_IDENTITY_PROVIDER: "projects/224545243904/locations/global/workloadIdentityPools/gh-nuclia/providers/gh-nuclia-provider"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change adds a new permission for `actions: read`, which is required for provenance.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R18): Added `actions: read` permission to the `permissions` section.