### PR TITLE
Use public app for calling async sbom scanning

### DIFF
--- a/.github/workflows/_build-img-nucliadb.yml
+++ b/.github/workflows/_build-img-nucliadb.yml
@@ -94,5 +94,5 @@ jobs:
           aws-ecr-role: ${{ secrets.AWS_ECR_ROLE }}
           tag-latest: ${{ github.ref == 'refs/heads/main' && 'latest' || 'dev-latest' }}
           push: true
-          ghapp-nuclia-service-bot-id: ${{ vars.GHAPP_NUCLIA_SERVICE_BOT_ID }}
-          ghapp-nuclia-service-bot-pk: ${{ secrets.GHAPP_NUCLIA_SERVICE_BOT_PK }}
+          ghapp-nuclia-service-bot-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
+          ghapp-nuclia-service-bot-pk: ${{ secrets.PK_GHAPP_NUCLIABOT }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration file `.github/workflows/_build-img-nucliadb.yml`. The most important changes involve updating the GitHub App credentials.

Credential updates:

* Updated `ghapp-nuclia-service-bot-id` to use the secret `GHAPP_ID_NUCLIABOT` instead of the variable `GHAPP_NUCLIA_SERVICE_BOT_ID`.
* Updated `ghapp-nuclia-service-bot-pk` to use the secret `PK_GHAPP_NUCLIABOT` instead of the secret `GHAPP_NUCLIA_SERVICE_BOT_PK`.