### PR TITLE
Slimmer docker images

### DIFF
--- a/Dockerfile.withbinding
+++ b/Dockerfile.withbinding
@@ -3,6 +3,9 @@
 # It's a copy of `Dockerfile` adding the additional `python_rust` stage.
 #
 
+#
+# Stage to build nidx_binding (with Rust)
+#
 FROM python:3.12 AS python_rust
 
 ARG RUST_BUILD_PROFILE=release
@@ -47,19 +50,21 @@ RUN set -eux; \
 # This is to improve caching, `pdm.lock` changes when our components
 # are updated. The generated requirements.txt does not, so it is
 # more cacheable.
-FROM python:3.12 AS requirements
+FROM python:3.12-slim-bookworm AS requirements
 RUN pip install pdm==2.22.1
 COPY pdm.lock pyproject.toml .
 RUN pdm export --prod --no-hashes | grep -v ^-e | grep -v nidx_protos > requirements.lock.txt
 
-FROM python:3.12
+#
+# This stage builds a virtual env with all dependencies
+#
+FROM python:3.12-slim-bookworm AS builder
 RUN pip install pdm==2.22.1
 
 # Install Python dependencies
 WORKDIR /usr/src/app
 COPY --from=requirements requirements.lock.txt /tmp
-RUN python -m venv .venv && \
-    .venv/bin/pip install -r /tmp/requirements.lock.txt
+RUN python -m venv /app && /app/bin/pip install -r /tmp/requirements.lock.txt
 
 # Copy application
 COPY VERSION pyproject.toml pdm.lock /usr/src/app
@@ -71,12 +76,17 @@ COPY nucliadb /usr/src/app/nucliadb
 COPY nidx /usr/src/app/nidx
 
 # Install our packages to the virtualenv
-RUN pdm sync --prod --no-editable
+RUN pdm use -f /app && pdm sync --prod --no-editable
 
 # make sure to install the built wheel after so it is installed no matter what
 COPY --from=python_rust /nucliadb/nidx/target/wheels/ /wheels/
-RUN /usr/src/app/.venv/bin/pip install /wheels/*.whl --force
+RUN /app/bin/pip install /wheels/*.whl --force
 
+#
+# This is the main image, it just copies the virtual env into the base image
+#
+FROM python:3.12-slim-bookworm
+COPY --from=builder /app /app
 RUN mkdir -p /data
 
 ENV NUA_ZONE=europe-1
@@ -96,5 +106,6 @@ EXPOSE 8060/tcp
 # GRPC - TRAIN
 EXPOSE 8040/tcp
 
-ENV PATH="/usr/src/app/.venv/bin:$PATH"
+ENV PATH="/app/bin:$PATH"
+WORKDIR /app
 CMD ["nucliadb"]


### PR DESCRIPTION
- Use slim base image
- Only copy virtualenv (not source code) into the final image
- Move virtualenv to /app (from /usr/src/app/.venv)