### PR TITLE
Don't use cloudfile uri in backup tar

### DIFF
--- a/nucliadb/src/nucliadb/backups/create.py
+++ b/nucliadb/src/nucliadb/backups/create.py
@@ -170,7 +170,7 @@ async def backup_resource_with_binaries(
         """
         nonlocal total_size
 
-        for cloud_file in get_cloud_files(bm):
+        for index, cloud_file in enumerate(get_cloud_files(bm)):
             if not await exists_cf(context, cloud_file):
                 logger.warning(
                     "Cloud file not found in storage, skipping",
@@ -184,13 +184,13 @@ async def backup_resource_with_binaries(
                 yield serialized_cf
 
             async for chunk in to_tar(
-                name=f"cloud-files/{cloud_file.uri}", size=len(serialized_cf), chunks=cf_iterator()
+                name=f"cloud-files/{index}", size=len(serialized_cf), chunks=cf_iterator()
             ):
                 yield chunk
                 total_size += len(chunk)
 
             async for chunk in to_tar(
-                name=f"binaries/{cloud_file.uri}",
+                name=f"binaries/{index}",
                 size=cloud_file.size,
                 chunks=download_binary(context, cloud_file),
             ):

--- a/nucliadb/src/nucliadb/backups/restore.py
+++ b/nucliadb/src/nucliadb/backups/restore.py
@@ -93,9 +93,7 @@ async def restore_resources(context: ApplicationContext, kbid: str, backup_id: s
         await set_last_restored(context, kbid, backup_id, key)
 
 
-async def get_last_restored(
-    context: ApplicationContext, kbid: str, backup_id: str
-) -> Optional[str]:
+async def get_last_restored(context: ApplicationContext, kbid: str, backup_id: str) -> Optional[str]:
     key = MaindbKeys.LAST_RESTORED.format(kbid=kbid, backup_id=backup_id)
     async with context.kv_driver.transaction(read_only=True) as txn:
         raw = await txn.get(key)
@@ -104,9 +102,7 @@ async def get_last_restored(
         return raw.decode()
 
 
-async def set_last_restored(
-    context: ApplicationContext, kbid: str, backup_id: str, resource_id: str
-):
+async def set_last_restored(context: ApplicationContext, kbid: str, backup_id: str, resource_id: str):
     key = MaindbKeys.LAST_RESTORED.format(kbid=kbid, backup_id=backup_id)
     async with context.kv_driver.transaction() as txn:
         await txn.set(key, resource_id.encode())

--- a/nucliadb/src/nucliadb/backups/restore.py
+++ b/nucliadb/src/nucliadb/backups/restore.py
@@ -69,11 +69,11 @@ async def restore_kb(context: ApplicationContext, kbid: str, backup_id: str):
     await restore_resources(context, kbid, backup_id)
     await restore_labels(context, kbid, backup_id)
     await restore_entities(context, kbid, backup_id)
-    await delete_last_restored_resource_key(context, kbid, backup_id)
+    await delete_last_restored(context, kbid, backup_id)
 
 
 async def restore_resources(context: ApplicationContext, kbid: str, backup_id: str):
-    last_restored = await get_last_restored_resource_key(context, kbid, backup_id)
+    last_restored = await get_last_restored(context, kbid, backup_id)
     tasks = []
     async for object_info in context.blob_storage.iterate_objects(
         bucket=settings.backups_bucket,
@@ -86,14 +86,14 @@ async def restore_resources(context: ApplicationContext, kbid: str, backup_id: s
         if len(tasks) > settings.restore_resources_concurrency:
             await asyncio.gather(*tasks)
             tasks = []
-            await set_last_restored_resource_key(context, kbid, backup_id, key)
+            await set_last_restored(context, kbid, backup_id, key)
     if len(tasks) > 0:
         await asyncio.gather(*tasks)
         tasks = []
-        await set_last_restored_resource_key(context, kbid, backup_id, key)
+        await set_last_restored(context, kbid, backup_id, key)
 
 
-async def get_last_restored_resource_key(
+async def get_last_restored(
     context: ApplicationContext, kbid: str, backup_id: str
 ) -> Optional[str]:
     key = MaindbKeys.LAST_RESTORED.format(kbid=kbid, backup_id=backup_id)
@@ -104,7 +104,7 @@ async def get_last_restored_resource_key(
         return raw.decode()
 
 
-async def set_last_restored_resource_key(
+async def set_last_restored(
     context: ApplicationContext, kbid: str, backup_id: str, resource_id: str
 ):
     key = MaindbKeys.LAST_RESTORED.format(kbid=kbid, backup_id=backup_id)
@@ -113,7 +113,7 @@ async def set_last_restored_resource_key(
         await txn.commit()
 
 
-async def delete_last_restored_resource_key(context: ApplicationContext, kbid: str, backup_id: str):
+async def delete_last_restored(context: ApplicationContext, kbid: str, backup_id: str):
     key = MaindbKeys.LAST_RESTORED.format(kbid=kbid, backup_id=backup_id)
     async with context.kv_driver.transaction() as txn:
         await txn.delete(key)
@@ -134,6 +134,7 @@ class ResourceBackupReader:
     def __init__(self, download_stream: AsyncIterator[bytes]):
         self.download_stream = download_stream
         self.buffer = b""
+        self.cloud_files: dict[int, CloudFile] = {}
 
     async def read(self, size: int) -> bytes:
         while len(self.buffer) < size:
@@ -194,15 +195,18 @@ class ResourceBackupReader:
             bm.ParseFromString(raw_bm)
             return bm
         elif tarinfo.name.startswith("cloud-files"):
+            cf_index = int(tarinfo.name.split("cloud-files/")[-1])
             raw_cf = await self.read_data(tarinfo)
             cf = CloudFile()
             cf.ParseFromString(raw_cf)
+            self.cloud_files[cf_index] = cf
             return cf
         elif tarinfo.name.startswith("binaries"):
-            uri = tarinfo.name.lstrip("binaries/")
+            bin_index = int(tarinfo.name.split("binaries/")[-1])
             size = tarinfo.size
             download_stream = functools.partial(self.iter_data, size)
-            return CloudFileBinary(uri, download_stream)
+            cf = self.cloud_files[bin_index]
+            return CloudFileBinary(cf.uri, download_stream)
         else:  # pragma: no cover
             raise ValueError(f"Unknown tar entry: {tarinfo.name}")
 

--- a/nucliadb/tests/nucliadb/integration/test_backups.py
+++ b/nucliadb/tests/nucliadb/integration/test_backups.py
@@ -29,9 +29,9 @@ from nucliadb.backups.create import backup_kb, get_metadata, set_metadata
 from nucliadb.backups.delete import delete_backup
 from nucliadb.backups.models import BackupMetadata
 from nucliadb.backups.restore import (
-    get_last_restored_resource_key,
+    get_last_restored,
     restore_kb,
-    set_last_restored_resource_key,
+    set_last_restored,
 )
 from nucliadb.backups.settings import BackupSettings
 from nucliadb.backups.settings import settings as backups_settings
@@ -165,7 +165,7 @@ async def test_backup(
     await restore_kb(context, dst_kb, backup_id)
 
     # Make sure that the restore metadata is cleaned up
-    assert await get_last_restored_resource_key(context, dst_kb, backup_id) is None
+    assert await get_last_restored(context, dst_kb, backup_id) is None
 
     await delete_backup(context, backup_id)
 
@@ -264,7 +264,7 @@ async def test_restore_resumed(
     last_restored_key = StorageKeys.RESOURCE.format(
         kbid=src_kb, backup_id=backup_id, resource_id=rids[0]
     )
-    await set_last_restored_resource_key(context, dst_kb, backup_id, last_restored_key)
+    await set_last_restored(context, dst_kb, backup_id, last_restored_key)
 
     await restore_kb(context, dst_kb, backup_id)
 


### PR DESCRIPTION
### Description
Tar headers with filename longer than 100 characters are tricky to parse & craft: Filename is replaced by `././@LongLink` and extra header chunks need to be sent.

See:
https://nuclia.sentry.io/issues/6381091539/
https://stackoverflow.com/questions/2078778/what-exactly-is-the-gnu-tar-longlink-trick

Using ints is simpler and works well for us.

### How was this PR tested?
Describe how you tested this PR.
