### PR TITLE
Inject ApplicationContext to search and train FastAPIs

### DIFF
--- a/nucliadb/src/nucliadb/search/lifecycle.py
+++ b/nucliadb/src/nucliadb/search/lifecycle.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from nucliadb.common.cluster.utils import setup_cluster, teardown_cluster
+from nucliadb.common.context.fastapi import inject_app_context
 from nucliadb.common.maindb.utils import setup_driver
 from nucliadb.common.nidx import start_nidx_utility
 from nucliadb.ingest.utils import start_ingest, stop_ingest
@@ -51,7 +52,8 @@ async def lifespan(app: FastAPI):
 
     await start_audit_utility(SERVICE_NAME)
 
-    yield
+    async with inject_app_context(app):
+        yield
 
     await stop_ingest()
     if get_utility(Utility.PARTITION):

--- a/nucliadb/src/nucliadb/train/lifecycle.py
+++ b/nucliadb/src/nucliadb/train/lifecycle.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from nucliadb.common.context.fastapi import inject_app_context
 from nucliadb.common.nidx import start_nidx_utility, stop_nidx_utility
 from nucliadb.train import SERVICE_NAME
 from nucliadb.train.utils import (
@@ -42,7 +43,8 @@ async def lifespan(app: FastAPI):
     await start_train_grpc(SERVICE_NAME)
     await start_audit_utility(SERVICE_NAME)
 
-    yield
+    async with inject_app_context(app):
+        yield
 
     await stop_audit_utility()
     await stop_train_grpc()


### PR DESCRIPTION
### Description
Search and train weren't injecting application context. On search, this was causing multiple initializations of utilities on the first API call

### How was this PR tested?
Existing tests