### PR TITLE
Reduce default fuzzy distance

### DIFF
--- a/nidx/nidx_relation/src/graph_query_parser.rs
+++ b/nidx/nidx_relation/src/graph_query_parser.rs
@@ -25,7 +25,7 @@ use tantivy::schema::{Field, IndexRecordOption};
 use crate::schema::Schema;
 use crate::{io_maps, schema};
 
-const DEFAULT_NODE_VALUE_FUZZY_DISTANCE: u8 = 2;
+const DEFAULT_NODE_VALUE_FUZZY_DISTANCE: u8 = 1;
 
 #[derive(Clone)]
 pub struct FuzzyTerm {

--- a/nidx/tests/test_search_relations.rs
+++ b/nidx/tests/test_search_relations.rs
@@ -598,7 +598,7 @@ async fn test_graph_search__fuzzy_node_query(pool: PgPool) -> anyhow::Result<()>
     let relations = friendly_parse(&response);
     assert_eq!(relations.len(), 0);
 
-    // (:~AnXstXsia)
+    // (:~Ansatasia)
     let response = fixture
         .searcher_client
         .graph_search(GraphSearchRequest {
@@ -607,7 +607,7 @@ async fn test_graph_search__fuzzy_node_query(pool: PgPool) -> anyhow::Result<()>
                 path: Some(graph_query::PathQuery {
                     query: Some(path_query::Query::Path(graph_query::Path {
                         source: Some(graph_query::Node {
-                            value: Some("AnXstXsia".to_string()),
+                            value: Some("Ansatasia".to_string()),
                             match_kind: MatchKind::Fuzzy.into(),
                             ..Default::default()
                         }),

--- a/nucliadb/tests/nucliadb/integration/search/graph/test_graph_path_search.py
+++ b/nucliadb/tests/nucliadb/integration/search/graph/test_graph_path_search.py
@@ -188,14 +188,14 @@ async def test_graph_search__fuzzy_node_queries(
     paths = simple_paths(GraphSearchResponse.model_validate(resp.json()).paths)
     assert len(paths) == 0
 
-    # (:~AnXstXsia)
+    # (:~Ansatasia)
     resp = await nucliadb_reader.post(
         f"/kb/{kbid}/graph",
         json={
             "query": {
                 "prop": "path",
                 "source": {
-                    "value": "AnXstXsia",
+                    "value": "Ansatasia",
                     "match": "fuzzy",
                 },
             },


### PR DESCRIPTION
### Description
As fuzzy was using prefix and distance 2, matched entities were too different from queried ones. Reduce fuzzy distance to get closer results

### How was this PR tested?
Describe how you tested this PR.
