### PR TITLE
Fix restore

### DIFF
--- a/nucliadb/src/nucliadb/backups/restore.py
+++ b/nucliadb/src/nucliadb/backups/restore.py
@@ -31,7 +31,7 @@ from nucliadb.backups.settings import settings
 from nucliadb.common.context import ApplicationContext
 from nucliadb.export_import.utils import (
     import_binary,
-    import_broker_message,
+    restore_broker_message,
     set_entities_groups,
     set_labels,
 )
@@ -81,7 +81,7 @@ async def restore_resources(context: ApplicationContext, kbid: str, backup_id: s
         start=last_restored,
     ):
         key = object_info.name
-        resource_id = key.split("/")[-1].rstrip(".tar")
+        resource_id = key.split("/")[-1].split(".tar")[0]
         tasks.append(asyncio.create_task(restore_resource(context, kbid, backup_id, resource_id)))
         if len(tasks) > settings.restore_resources_concurrency:
             await asyncio.gather(*tasks)
@@ -235,8 +235,8 @@ async def restore_resource(context: ApplicationContext, kbid: str, backup_id: st
                 extra={"item_type": type(item), kbid: kbid, resource_id: resource_id},
             )
             continue
-
-    await import_broker_message(context, kbid, bm)
+    if bm is not None:
+        await restore_broker_message(context, kbid, bm)
 
 
 async def restore_labels(context: ApplicationContext, kbid: str, backup_id: str):

--- a/nucliadb/src/nucliadb/ingest/service/writer.py
+++ b/nucliadb/src/nucliadb/ingest/service/writer.py
@@ -202,9 +202,9 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
             return DeleteKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.ERROR)
         return DeleteKnowledgeBoxResponse(status=KnowledgeBoxResponseStatus.OK)
 
-    async def ProcessMessage(  # type: ignore
+    async def ProcessMessage(
         self, request_stream: AsyncIterator[BrokerMessage], context=None
-    ):
+    ) -> OpStatusWriter:
         response = OpStatusWriter()
         async for message in request_stream:
             try:

--- a/nucliadb/src/nucliadb/tasks/consumer.py
+++ b/nucliadb/src/nucliadb/tasks/consumer.py
@@ -105,7 +105,7 @@ class NatsTaskConsumer(Generic[MsgType]):
 
     async def _subscription_worker_as_task(self, msg: Msg):
         seqid = int(msg.reply.split(".")[5])
-        task_name = f"NatsTaskConsumer({self.name}, msg={seqid})"
+        task_name = f"NatsTaskConsumer({self.name}, stream={self.stream.name}, subject={self.consumer.subject}, seqid={seqid})"
         task = asyncio.create_task(self.subscription_worker(msg), name=task_name)
         task.add_done_callback(self._running_tasks_remove)
         self.running_tasks.append(task)

--- a/nucliadb/tests/nucliadb/integration/test_backups.py
+++ b/nucliadb/tests/nucliadb/integration/test_backups.py
@@ -148,7 +148,6 @@ async def context(nucliadb_reader: AsyncClient, settings: BackupSettings):
     await context.finalize()
 
 
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.deploy_modes("standalone")
 async def test_backup(
     nucliadb_reader: AsyncClient,
@@ -214,7 +213,6 @@ async def check_resources(nucliadb_reader: AsyncClient, kbid: str):
         assert base64.b64decode(resp.content) == b"Test for /upload endpoint"
 
 
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.deploy_modes("standalone")
 async def test_backup_resumed(
     nucliadb_reader: AsyncClient,
@@ -248,7 +246,6 @@ async def test_backup_resumed(
     assert sorted([r["id"] for r in resources]) == rids[1:]
 
 
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.deploy_modes("standalone")
 async def test_restore_resumed(
     nucliadb_reader: AsyncClient,

--- a/nucliadb/tests/nucliadb/integration/test_backups.py
+++ b/nucliadb/tests/nucliadb/integration/test_backups.py
@@ -25,12 +25,17 @@ import pytest
 from httpx import AsyncClient
 
 from nucliadb.backups.const import StorageKeys
-from nucliadb.backups.create import backup_kb, get_metadata, set_metadata
-from nucliadb.backups.delete import delete_backup
-from nucliadb.backups.models import BackupMetadata
+from nucliadb.backups.create import backup_kb_task, get_metadata, set_metadata
+from nucliadb.backups.delete import delete_backup_task
+from nucliadb.backups.models import (
+    BackupMetadata,
+    CreateBackupRequest,
+    DeleteBackupRequest,
+    RestoreBackupRequest,
+)
 from nucliadb.backups.restore import (
     get_last_restored,
-    restore_kb,
+    restore_kb_task,
     set_last_restored,
 )
 from nucliadb.backups.settings import BackupSettings
@@ -155,21 +160,17 @@ async def test_backup(
     backup_id = str(uuid.uuid4())
     assert await exists_backup(context.blob_storage, backup_id) is False
 
-    await backup_kb(context, src_kb, backup_id)
+    await backup_kb_task(context, CreateBackupRequest(kb_id=src_kb, backup_id=backup_id))
 
     assert await exists_backup(context.blob_storage, backup_id) is True
 
     # Make sure that the backup metadata is cleaned up
     assert await get_metadata(context, src_kb, backup_id) is None
 
-    await restore_kb(context, dst_kb, backup_id)
+    await restore_kb_task(context, RestoreBackupRequest(kb_id=dst_kb, backup_id=backup_id))
 
     # Make sure that the restore metadata is cleaned up
     assert await get_last_restored(context, dst_kb, backup_id) is None
-
-    await delete_backup(context, backup_id)
-
-    assert await exists_backup(context.blob_storage, backup_id) is False
 
     # Check that the resources were restored
     await check_resources(nucliadb_reader, src_kb)
@@ -184,6 +185,11 @@ async def test_backup(
     resp = await nucliadb_reader.get(f"/kb/{dst_kb}/labelset/foo")
     assert resp.status_code == 200
     assert len(resp.json()["labels"]) == 1
+
+    # Delete the backup
+    await delete_backup_task(context, DeleteBackupRequest(backup_id=backup_id))
+
+    assert await exists_backup(context.blob_storage, backup_id) is False
 
 
 async def check_resources(nucliadb_reader: AsyncClient, kbid: str):
@@ -230,15 +236,15 @@ async def test_backup_resumed(
     )
     await set_metadata(context, src_kb, backup_id, metadata)
 
-    await backup_kb(context, src_kb, backup_id)
+    await backup_kb_task(context, CreateBackupRequest(kb_id=src_kb, backup_id=backup_id))
 
-    await restore_kb(context, dst_kb, backup_id)
+    await restore_kb_task(context, RestoreBackupRequest(kb_id=dst_kb, backup_id=backup_id))
 
     # Check that the resources were restored
     resp = await nucliadb_reader.get(f"/kb/{dst_kb}/resources")
     assert resp.status_code == 200
     resources = resp.json()["resources"]
-    assert len(resources) == 9
+    assert len(resources) == N_RESOURCES - 1
     assert sorted([r["id"] for r in resources]) == rids[1:]
 
 
@@ -258,7 +264,7 @@ async def test_restore_resumed(
     assert resp.status_code == 200
     rids = sorted([r["id"] for r in resp.json()["resources"]])
 
-    await backup_kb(context, src_kb, backup_id)
+    await backup_kb_task(context, CreateBackupRequest(kb_id=src_kb, backup_id=backup_id))
 
     # Set the last restored resource id as if the restore was interrupted right after restoring the first resource
     last_restored_key = StorageKeys.RESOURCE.format(
@@ -266,7 +272,7 @@ async def test_restore_resumed(
     )
     await set_last_restored(context, dst_kb, backup_id, last_restored_key)
 
-    await restore_kb(context, dst_kb, backup_id)
+    await restore_kb_task(context, RestoreBackupRequest(kb_id=dst_kb, backup_id=backup_id))
 
     # Check that the correct resources were restored
     resp = await nucliadb_reader.get(f"/kb/{dst_kb}/resources")


### PR DESCRIPTION
### Description
rstrip was messing up occasionally if the resource_id was finishing with the 'a' character...
also improve the way we're ingesting restored resources

### How was this PR tested?
existing tests were flaky, now they are not!