### PR TITLE
Fix PDB selector for ingest nucliadb

### DIFF
--- a/charts/nucliadb_ingest/templates/ingest.pdb.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.pdb.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       app: ingest
-      release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
+      app.kubernetes.io/name: ingest
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
   minAvailable: 1  # simple for now, we can add more complex rules later


### PR DESCRIPTION
This pull request includes changes to the `charts/nucliadb_ingest/templates/ingest.pdb.yaml` file to update the `spec` section for Kubernetes labels. The most important change is the modification of the label format to follow Kubernetes recommended conventions.

Changes to Kubernetes labels:

* [`charts/nucliadb_ingest/templates/ingest.pdb.yaml`](diffhunk://#diff-a2cd0b2612da5528f491887070027fe7c4dfbcbde8400af1234b4512af8ada97L14-R16): Updated the label keys to use the `app.kubernetes.io` standard format.