### PR TITLE
Fix orphan shard purge for new shards

### DIFF
--- a/nucliadb/src/nucliadb/common/datamanagers/cluster.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/cluster.py
@@ -38,6 +38,16 @@ async def get_kb_shards(
     return await get_kv_pb(txn, key, writer_pb2.Shards, for_update=for_update)
 
 
+async def is_kb_shard(txn: Transaction, *, kbid: str, shard_id: str, for_update: bool = False) -> bool:
+    shards = await get_kb_shards(txn, kbid=kbid, for_update=for_update)
+    if shards is None:
+        return False
+    for shard in shards.shards:
+        if shard.shard == shard_id:
+            return True
+    return False
+
+
 async def update_kb_shards(txn: Transaction, *, kbid: str, shards: writer_pb2.Shards) -> None:
     key = KB_SHARDS.format(kbid=kbid)
     await txn.set(key, shards.SerializeToString())

--- a/nucliadb/src/nucliadb/purge/orphan_shards.py
+++ b/nucliadb/src/nucliadb/purge/orphan_shards.py
@@ -78,6 +78,19 @@ async def detect_orphan_shards(driver: Driver) -> dict[str, ShardLocation]:
     node = manager.get_nidx_fake_node()
     for shard_id in orphan_shard_ids:
         kbid = await _get_kbid(node, shard_id) or UNKNOWN_KB
+        # Shards with knwon KB ids can be checked and ignore those comming from
+        # an ongoing migration/rollover (ongoing or finished)
+        if kbid != UNKNOWN_KB:
+            async with datamanagers.with_ro_transaction() as txn:
+                skip = await datamanagers.rollover.is_rollover_shard(
+                    txn, kbid=kbid, shard_id=shard_id
+                ) or await datamanagers.cluster.is_kb_shard(txn, kbid=kbid, shard_id=shard_id)
+                if skip:
+                    continue
+        orphan_shards[shard_id] = ShardLocation(kbid=kbid, node_id="nidx")
+
+    for shard_id in orphan_shard_ids:
+        kbid = await _get_kbid(node, shard_id) or UNKNOWN_KB
         orphan_shards[shard_id] = ShardLocation(kbid=kbid, node_id="nidx")
     return orphan_shards
 
@@ -93,22 +106,13 @@ async def _get_stored_shards(driver: Driver) -> dict[str, ShardLocation]:
 
     async with driver.transaction(read_only=True) as txn:
         async for kbid, _ in datamanagers.kb.get_kbs(txn):
-            # we first lookup the rollover shards as otherwise, a cutover from
-            # the migration could make us miss a shard
-
-            rollover_shards = await datamanagers.rollover.get_kb_rollover_shards(txn, kbid=kbid)
-            if rollover_shards is not None:
-                for shard_object_pb in rollover_shards.shards:
-                    stored_shards[shard_object_pb.nidx_shard_id] = ShardLocation(
-                        kbid=kbid, node_id="nidx"
-                    )
-
             kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
-            if kb_shards is not None:
-                for shard_object_pb in kb_shards.shards:
-                    stored_shards[shard_object_pb.nidx_shard_id] = ShardLocation(
-                        kbid=kbid, node_id="nidx"
-                    )
+            if kb_shards is None:
+                logger.warning("KB not found while looking for orphan shards", extra={"kbid": kbid})
+                continue
+
+            for shard_object_pb in kb_shards.shards:
+                stored_shards[shard_object_pb.nidx_shard_id] = ShardLocation(kbid=kbid, node_id="nidx")
 
     return stored_shards
 


### PR DESCRIPTION
### Description
Between index and maindb scans, new shards can be added. For every orphan shard, we check whether it comes from a rollover to skip its removal.

The issue is that we are only checking if it's a rollover shard but not if it was at scan time. An unfortunate situation like the following can happen:
- A migration creates a rollover shard
- Orphan shard detector scans nidx and maindb
- Migrator swaps the shards (it's no longer a rollover shard, but a KB shard)
- Orphan shard detector considers this shard as orphan, check if it's from a rollover and it's not (anymore). 
- Orphan shard detector wrongly removes the shard

To fix this, we add an extra validation to see if at check time, it's a rollover or a KB shard.

### How was this PR tested?
Describe how you tested this PR.
