### PR TITLE
Query parsing improvements

### DIFF
--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -37,10 +37,8 @@ from nucliadb.search.search import cache
 from nucliadb.search.search.exceptions import InvalidQueryError
 from nucliadb.search.search.merge import merge_results
 from nucliadb.search.search.query import QueryParser
-from nucliadb.search.search.query_parser.old_filters import OldFilterParams
 from nucliadb.search.search.query_parser.parsers.search import parse_search
 from nucliadb.search.search.utils import (
-    filter_hidden_resources,
     min_score_from_payload,
     min_score_from_query_params,
     should_disable_vector_search,
@@ -276,31 +274,10 @@ async def search(
     # We need to query all nodes
     query_parser = QueryParser(
         kbid=kbid,
-        features=item.features,
         query=item.query,
-        filter_expression=item.filter_expression,
-        faceted=item.faceted,
-        sort=item.sort,
-        top_k=item.top_k,
-        min_score=item.min_score,
-        old_filters=OldFilterParams(
-            label_filters=item.filters,
-            keyword_filters=[],
-            range_creation_start=item.range_creation_start,
-            range_creation_end=item.range_creation_end,
-            range_modification_start=item.range_modification_start,
-            range_modification_end=item.range_modification_end,
-            fields=item.fields,
-        ),
         user_vector=item.vector,
         vectorset=item.vectorset,
-        with_duplicates=item.with_duplicates,
-        with_status=with_status,
-        with_synonyms=item.with_synonyms,
-        autofilter=item.autofilter,
-        security=item.security,
         rephrase=item.rephrase,
-        hidden=await filter_hidden_resources(kbid, item.show_hidden),
         rephrase_prompt=item.rephrase_prompt,
         parsed_query=parsed,
     )

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -547,8 +547,7 @@ async def ask(
 
     # Now we build the prompt context
     with metrics.time("context_building"):
-        query_parser.max_tokens = ask_request.max_tokens  # type: ignore
-        max_tokens_context = await query_parser.get_max_tokens_context()
+        max_tokens_context = await query_parser.get_max_tokens_context(ask_request.max_tokens)  # type: ignore
         prompt_context_builder = PromptContextBuilder(
             kbid=kbid,
             ordered_paragraphs=[match.paragraph for match in retrieval_results.best_matches],
@@ -580,7 +579,7 @@ async def ask(
         citations=ask_request.citations,
         citation_threshold=ask_request.citation_threshold,
         generative_model=ask_request.generative_model,
-        max_tokens=query_parser.get_max_tokens_answer(),
+        max_tokens=query_parser.get_max_tokens_answer(ask_request.max_tokens),  # type: ignore
         query_context_images=prompt_context_images,
         json_schema=ask_request.answer_json_schema,
         rerank_context=False,

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -62,7 +62,6 @@ from nucliadb.search.search.exceptions import (
 from nucliadb.search.search.graph_strategy import get_graph_results
 from nucliadb.search.search.metrics import RAGMetrics
 from nucliadb.search.search.query import QueryParser
-from nucliadb.search.search.query_parser.old_filters import OldFilterParams
 from nucliadb.search.utilities import get_predict
 from nucliadb_models.search import (
     AnswerAskResponseItem,
@@ -83,7 +82,6 @@ from nucliadb_models.search import (
     JSONAskResponseItem,
     KnowledgeboxFindResults,
     MetadataAskResponseItem,
-    MinScore,
     NucliaDBClientType,
     PrequeriesAskResponseItem,
     PreQueriesStrategy,
@@ -806,15 +804,7 @@ async def retrieval_in_resource(
             prequeries=None,
             query_parser=QueryParser(
                 kbid=kbid,
-                features=[],
                 query="",
-                filter_expression=ask_request.filter_expression,
-                old_filters=OldFilterParams(
-                    label_filters=ask_request.filters,
-                    keyword_filters=ask_request.keyword_filters,
-                ),
-                top_k=0,
-                min_score=MinScore(),
             ),
             main_query_weight=1.0,
         )

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -63,6 +63,9 @@ from nucliadb.search.search.graph_strategy import get_graph_results
 from nucliadb.search.search.metrics import RAGMetrics
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.parsers.ask import fetcher_for_ask, parse_ask
+from nucliadb.search.search.rerankers import (
+    get_reranker,
+)
 from nucliadb.search.utilities import get_predict
 from nucliadb_models.search import (
     AnswerAskResponseItem,
@@ -752,6 +755,7 @@ async def retrieval_in_kb(
         )
 
         if graph_strategy is not None:
+            reranker = get_reranker(parsed_query.retrieval.reranker)
             graph_results, graph_request = await get_graph_results(
                 kbid=kbid,
                 query=main_query,
@@ -761,6 +765,7 @@ async def retrieval_in_kb(
                 origin=origin,
                 graph_strategy=graph_strategy,
                 metrics=metrics,
+                text_block_reranker=reranker,
             )
 
             if prequeries_results is None:

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -297,7 +297,7 @@ async def get_relations_results_from_entities(
     relations_results: list[RelationSearchResponse] = [result.relation for result in results]
     return await merge_relations_results(
         relations_results,
-        request.relation_subgraph,
+        request.relation_subgraph.entry_points,
         only_with_metadata,
         only_agentic_relations,
         only_entity_to_entity,

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -29,7 +29,7 @@ from nucliadb.search.search.exceptions import IncompleteFindResultsError
 from nucliadb.search.search.find import find
 from nucliadb.search.search.merge import merge_relations_results
 from nucliadb.search.search.metrics import RAGMetrics
-from nucliadb.search.search.query import QueryParser
+from nucliadb.search.search.query_parser.models import ParsedQuery
 from nucliadb.search.settings import settings
 from nucliadb.search.utilities import get_predict
 from nucliadb_models import filters
@@ -93,7 +93,7 @@ async def get_find_results(
     origin: str,
     metrics: RAGMetrics = RAGMetrics(),
     prequeries_strategy: Optional[PreQueriesStrategy] = None,
-) -> tuple[KnowledgeboxFindResults, Optional[list[PreQueryResult]], QueryParser]:
+) -> tuple[KnowledgeboxFindResults, Optional[list[PreQueryResult]], ParsedQuery]:
     prequeries_results = None
     prefilter_queries_results = None
     queries_results = None
@@ -223,10 +223,10 @@ async def run_main_query(
     user: str,
     origin: str,
     metrics: RAGMetrics = RAGMetrics(),
-) -> tuple[KnowledgeboxFindResults, QueryParser]:
+) -> tuple[KnowledgeboxFindResults, ParsedQuery]:
     find_request = find_request_from_ask_request(item, query)
 
-    find_results, incomplete, query_parser = await find(
+    find_results, incomplete, parsed_query = await find(
         kbid,
         find_request,
         ndb_client,
@@ -237,7 +237,7 @@ async def run_main_query(
     )
     if incomplete:
         raise IncompleteFindResultsError()
-    return find_results, query_parser
+    return find_results, parsed_query
 
 
 async def get_relations_results(

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -295,5 +295,6 @@ async def query_parser_from_find_request(
         hidden=hidden,
         rank_fusion=rank_fusion,
         reranker=reranker,
+        parsed_query=parsed,
     )
     return (query_parser, rank_fusion, reranker)

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -260,8 +260,8 @@ async def query_parser_from_find_request(
 
     parsed = await parse_find(kbid, item)
 
-    rank_fusion = get_rank_fusion(parsed.rank_fusion)
-    reranker = get_reranker(parsed.reranker)
+    rank_fusion = get_rank_fusion(parsed.retrieval.rank_fusion)
+    reranker = get_reranker(parsed.retrieval.reranker)
 
     query_parser = QueryParser(
         kbid=kbid,

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -69,7 +69,7 @@ async def find(
     x_forwarded_for: str,
     generative_model: Optional[str] = None,
     metrics: RAGMetrics = RAGMetrics(),
-) -> tuple[KnowledgeboxFindResults, bool, QueryParser]:
+) -> tuple[KnowledgeboxFindResults, bool, ParsedQuery]:
     external_index_manager = await get_external_index_manager(kbid=kbid)
     if external_index_manager is not None:
         return await _external_index_retrieval(
@@ -92,7 +92,7 @@ async def _index_node_retrieval(
     x_forwarded_for: str,
     generative_model: Optional[str] = None,
     metrics: RAGMetrics = RAGMetrics(),
-) -> tuple[KnowledgeboxFindResults, bool, QueryParser]:
+) -> tuple[KnowledgeboxFindResults, bool, ParsedQuery]:
     audit = get_audit()
     start_time = time()
 
@@ -172,7 +172,7 @@ async def _index_node_retrieval(
             },
         )
 
-    return search_results, incomplete_results, query_parser
+    return search_results, incomplete_results, parsed
 
 
 async def _external_index_retrieval(
@@ -180,7 +180,7 @@ async def _external_index_retrieval(
     item: FindRequest,
     external_index_manager: ExternalIndexManager,
     generative_model: Optional[str] = None,
-) -> tuple[KnowledgeboxFindResults, bool, QueryParser]:
+) -> tuple[KnowledgeboxFindResults, bool, ParsedQuery]:
     """
     Parse the query, query the external index, and hydrate the results.
     """
@@ -234,7 +234,7 @@ async def _external_index_retrieval(
         nodes=None,
     )
 
-    return retrieval_results, incomplete_results, query_parser
+    return retrieval_results, incomplete_results, parsed
 
 
 async def query_parser_from_find_request(

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-from dataclasses import dataclass
 from time import time
 from typing import Optional
 
@@ -243,12 +242,6 @@ async def _external_index_retrieval(
     )
 
     return retrieval_results, incomplete_results, query_parser
-
-
-@dataclass
-class ScoredParagraph:
-    id: str
-    score: float
 
 
 async def query_parser_from_find_request(

--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -134,7 +134,9 @@ async def build_find_response(
     )
 
     # build relations graph
-    relations = await merge_relations_results([search_response.relation], relation_subgraph_query)
+    relations = await merge_relations_results(
+        [search_response.relation], relation_subgraph_query.entry_points
+    )
 
     # compose response
     find_resources = compose_find_resources(text_blocks, resources)

--- a/nucliadb/src/nucliadb/search/search/graph_strategy.py
+++ b/nucliadb/src/nucliadb/search/search/graph_strategy.py
@@ -419,7 +419,7 @@ async def get_graph_results(
     # Get the text blocks of the paragraphs that contain the top relations
     with metrics.time("graph_strat_build_response"):
         find_request = find_request_from_ask_request(item, query)
-        query_parser, rank_fusion, reranker = await query_parser_from_find_request(
+        query_parser, _, reranker, _ = await query_parser_from_find_request(
             kbid, find_request, generative_model=generative_model
         )
         find_results = await build_graph_response(

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -219,7 +219,10 @@ class QueryParser:
 
             request, autofilters = convert_retrieval_to_proto(self.parsed_query.retrieval)
             incomplete = is_incomplete(self.parsed_query.retrieval)
-            rephrased_query = await self.parsed_query.fetcher.get_rephrased_query()
+            if self.has_vector_search:
+                rephrased_query = await self.parsed_query.fetcher.get_rephrased_query()
+            else:
+                rephrased_query = None
 
         else:
             # Filter some queries that panic tantivy, better than returning the 500

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -450,20 +450,20 @@ class QueryParser:
     async def get_visual_llm_enabled(self) -> bool:
         return (await self._get_query_information()).visual_llm
 
-    async def get_max_tokens_context(self) -> int:
+    async def get_max_tokens_context(self, max_tokens: Optional[MaxTokens]) -> int:
         model_max = (await self._get_query_information()).max_context
-        if self.max_tokens is not None and self.max_tokens.context is not None:
-            if self.max_tokens.context > model_max:
+        if max_tokens is not None and max_tokens.context is not None:
+            if max_tokens.context > model_max:
                 raise InvalidQueryError(
                     "max_tokens.context",
                     f"Max context tokens is higher than the model's limit of {model_max}",
                 )
-            return self.max_tokens.context
+            return max_tokens.context
         return model_max
 
-    def get_max_tokens_answer(self) -> Optional[int]:
-        if self.max_tokens is not None and self.max_tokens.answer is not None:
-            return self.max_tokens.answer
+    def get_max_tokens_answer(self, max_tokens: Optional[MaxTokens]) -> Optional[int]:
+        if max_tokens is not None and max_tokens.answer is not None:
+            return max_tokens.answer
         return None
 
     async def adjust_page_size(

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -36,7 +36,6 @@ from nucliadb_models.internal.predict import QueryInfo
 from nucliadb_models.labels import LABEL_HIDDEN
 from nucliadb_models.metadata import ResourceProcessingStatus
 from nucliadb_models.search import (
-    MaxTokens,
     SortField,
     SortOrder,
     SuggestOptions,
@@ -123,25 +122,6 @@ class QueryParser:
             rephrased_query = await self.parsed_query.fetcher.get_rephrased_query()
 
         return request, incomplete, autofilters, rephrased_query
-
-    async def get_visual_llm_enabled(self) -> bool:
-        return (await self._get_query_information()).visual_llm
-
-    async def get_max_tokens_context(self, max_tokens: Optional[MaxTokens]) -> int:
-        model_max = (await self._get_query_information()).max_context
-        if max_tokens is not None and max_tokens.context is not None:
-            if max_tokens.context > model_max:
-                raise InvalidQueryError(
-                    "max_tokens.context",
-                    f"Max context tokens is higher than the model's limit of {model_max}",
-                )
-            return max_tokens.context
-        return model_max
-
-    def get_max_tokens_answer(self, max_tokens: Optional[MaxTokens]) -> Optional[int]:
-        if max_tokens is not None and max_tokens.answer is not None:
-            return max_tokens.answer
-        return None
 
 
 async def paragraph_query_to_pb(

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -35,6 +35,7 @@ from nucliadb.search.search.metrics import (
     query_parser_observer,
 )
 from nucliadb.search.search.query_parser.fetcher import Fetcher
+from nucliadb.search.search.query_parser.models import ParsedQuery
 from nucliadb.search.search.rank_fusion import (
     RankFusionAlgorithm,
 )
@@ -114,6 +115,7 @@ class QueryParser:
         hidden: Optional[bool] = None,
         rank_fusion: Optional[RankFusionAlgorithm] = None,
         reranker: Optional[Reranker] = None,
+        parsed_query: Optional[ParsedQuery] = None,
     ):
         self.kbid = kbid
         self.features = features
@@ -140,15 +142,18 @@ class QueryParser:
         self.reranker = reranker
         self.filter_expression = filter_expression
         self.old_filters = old_filters
-        self.fetcher = Fetcher(
-            kbid=kbid,
-            query=query,
-            user_vector=user_vector,
-            vectorset=vectorset,
-            rephrase=rephrase,
-            rephrase_prompt=rephrase_prompt,
-            generative_model=generative_model,
-        )
+        if parsed_query is not None:
+            self.fetcher = parsed_query.fetcher
+        else:
+            self.fetcher = Fetcher(
+                kbid=kbid,
+                query=query,
+                user_vector=user_vector,
+                vectorset=vectorset,
+                rephrase=rephrase,
+                rephrase_prompt=rephrase_prompt,
+                generative_model=generative_model,
+            )
 
     @property
     def has_vector_search(self) -> bool:

--- a/nucliadb/src/nucliadb/search/search/query.py
+++ b/nucliadb/src/nucliadb/search/search/query.py
@@ -111,7 +111,6 @@ class QueryParser:
         generative_model: Optional[str] = None,
         rephrase: bool = False,
         rephrase_prompt: Optional[str] = None,
-        max_tokens: Optional[MaxTokens] = None,
         hidden: Optional[bool] = None,
         rank_fusion: Optional[RankFusionAlgorithm] = None,
         reranker: Optional[Reranker] = None,
@@ -136,7 +135,7 @@ class QueryParser:
         self.rephrase = rephrase
         self.rephrase_prompt = rephrase_prompt
         self.query_endpoint_used = False
-        self.max_tokens = max_tokens
+        self.max_tokens: Optional[MaxTokens] = None
         self.rank_fusion = rank_fusion
         self.reranker = reranker
         self.filter_expression = filter_expression

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -281,10 +281,6 @@ class Fetcher:
             return synonyms
 
     # Generative
-    #
-    # XXX: this methods were in the QueryParser and only used by /ask, maybe it
-    # makes more sense to return a Generation object with all this information
-    # or another thing. Raising invalid query errors here feels kind of late
 
     async def get_visual_llm_enabled(self) -> bool:
         query_info = await self._predict_query_endpoint()

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -205,6 +205,15 @@ class Fetcher:
             return None
         return query_info.rephrased_query
 
+    async def get_semantic_min_score(self) -> Optional[float]:
+        query_info = await self._predict_query_endpoint()
+        if query_info is None:
+            return None
+
+        vectorset = await self.get_vectorset()
+        min_score = query_info.semantic_thresholds.get(vectorset, None)
+        return min_score
+
     # Labels
 
     async def get_classification_labels(self) -> knowledgebox_pb2.Labels:

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -148,9 +148,7 @@ class ParsedQuery:
     fetcher: Fetcher
     retrieval: UnitRetrieval
     generation: Optional[Generation] = None
-
     # TODO: add merge, rank fusion, rerank...
-    # merge: Optional[Merge]
 
 
 ### Catalog

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -112,7 +112,8 @@ class ReciprocalRankFusion(RankFusion):
 # reranking
 
 
-class NoopReranker: ...
+class NoopReranker(BaseModel):
+    pass
 
 
 class PredictReranker(BaseModel):

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -83,7 +83,7 @@ class Filters:
         nodereader_pb2.FilterOperator.AND
     )
 
-    autofilter: bool = False
+    autofilter: Optional[list[utils_pb2.RelationNode]] = None
     facets: list[str] = Field(default_factory=list)
     hidden: Optional[bool] = None
     security: Optional[search_models.RequestSecurity] = None

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, Optional, Union
@@ -27,12 +26,68 @@ from pydantic import (
     Field,
 )
 
+from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb_models import search as search_models
-from nucliadb_protos import nodereader_pb2
+from nucliadb_protos import nodereader_pb2, utils_pb2
 
 ### Retrieval
 
+# query
+
+
+@dataclass
+class _TextQuery:
+    query: str
+    is_synonyms_query: bool
+    min_score: float
+    sort: search_models.SortOrder = search_models.SortOrder.DESC
+    order_by: search_models.SortField = search_models.SortField.SCORE
+
+
+FulltextQuery = _TextQuery
+KeywordQuery = _TextQuery
+
+
+@dataclass
+class SemanticQuery:
+    query: Optional[list[float]]
+    vectorset: str
+    min_score: float
+
+
+@dataclass
+class RelationQuery:
+    detected_entities: list[utils_pb2.RelationNode]
+    # list[subtype]
+    deleted_entity_groups: list[str]
+    # subtype: list[entity]
+    deleted_entities: dict[str, list[str]]
+
+
+@dataclass
+class Query:
+    fulltext: Optional[FulltextQuery] = None
+    keyword: Optional[KeywordQuery] = None
+    semantic: Optional[SemanticQuery] = None
+    relation: Optional[RelationQuery] = None
+
+
 # filters
+
+
+@dataclass
+class Filters:
+    field_expression: Optional[nodereader_pb2.FilterExpression] = None
+    paragraph_expression: Optional[nodereader_pb2.FilterExpression] = None
+    filter_expression_operator: nodereader_pb2.FilterOperator.ValueType = (
+        nodereader_pb2.FilterOperator.AND
+    )
+
+    autofilter: bool = False
+    facets: list[str] = Field(default_factory=list)
+    hidden: Optional[bool] = None
+    security: Optional[search_models.RequestSecurity] = None
+    with_duplicates: bool = False
 
 
 class DateTimeFilter(BaseModel):
@@ -66,14 +121,35 @@ class PredictReranker(BaseModel):
 
 Reranker = Union[NoopReranker, PredictReranker]
 
-# retrieval operation
+# retrieval and generation operations
 
 
 @dataclass
 class UnitRetrieval:
+    query: Query
     top_k: int
+    filters: Filters
+    # TODO: rank fusion depends on the response building, not the retrieval
     rank_fusion: RankFusion
+    # TODO: reranking fusion depends on the response building, not the retrieval
     reranker: Reranker
+
+
+@dataclass
+class Generation:
+    use_visual_llm: bool
+    max_context_tokens: int
+    max_answer_tokens: Optional[int]
+
+
+@dataclass
+class ParsedQuery:
+    fetcher: Fetcher
+    retrieval: UnitRetrieval
+    generation: Optional[Generation] = None
+
+    # TODO: add merge, rank fusion, rerank...
+    # merge: Optional[Merge]
 
 
 ### Catalog

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -57,15 +57,14 @@ class ReciprocalRankFusion(RankFusion):
 # reranking
 
 
-class Reranker(BaseModel): ...
+class NoopReranker: ...
 
 
-class NoopReranker(Reranker): ...
-
-
-class PredictReranker(Reranker):
+class PredictReranker(BaseModel):
     window: int = Field(le=200)
 
+
+Reranker = Union[NoopReranker, PredictReranker]
 
 # retrieval operation
 

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -60,7 +60,7 @@ class RelationQuery:
     detected_entities: list[utils_pb2.RelationNode]
     # list[subtype]
     deleted_entity_groups: list[str]
-    # subtype: list[entity]
+    # subtype -> list[entity]
     deleted_entities: dict[str, list[str]]
 
 

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/ask.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/ask.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from typing import Optional
+
+from nucliadb.search.search.query_parser.fetcher import Fetcher
+from nucliadb.search.search.query_parser.models import (
+    Generation,
+)
+from nucliadb_models.search import AskRequest, MaxTokens
+
+
+async def parse_ask(kbid: str, item: AskRequest, *, fetcher: Optional[Fetcher] = None) -> Generation:
+    fetcher = fetcher or fetcher_for_ask(kbid, item)
+    parser = _AskParser(kbid, item, fetcher)
+    return await parser.parse()
+
+
+def fetcher_for_ask(kbid: str, item: AskRequest) -> Fetcher:
+    return Fetcher(
+        kbid=kbid,
+        query=item.query,
+        user_vector=None,
+        vectorset=item.vectorset,
+        rephrase=item.rephrase,
+        rephrase_prompt=None,
+        generative_model=item.generative_model,
+    )
+
+
+class _AskParser:
+    def __init__(self, kbid: str, item: AskRequest, fetcher: Fetcher):
+        self.kbid = kbid
+        self.item = item
+        self.fetcher = fetcher
+
+    async def parse(self) -> Generation:
+        use_visual_llm = await self.fetcher.get_visual_llm_enabled()
+
+        if self.item.max_tokens is None:
+            max_tokens = None
+        elif isinstance(self.item.max_tokens, int):
+            max_tokens = MaxTokens(
+                context=None,
+                answer=self.item.max_tokens,
+            )
+        elif isinstance(self.item.max_tokens, MaxTokens):
+            max_tokens = self.item.max_tokens
+        else:  # pragma: nocover
+            # This is a trick so mypy generates an error if this branch can be reached,
+            # that is, if we are missing some ifs
+            _a: int = "a"
+
+        max_context_tokens = await self.fetcher.get_max_context_tokens(max_tokens)
+        max_answer_tokens = self.fetcher.get_max_answer_tokens(max_tokens)
+
+        return Generation(
+            use_visual_llm=use_visual_llm,
+            max_context_tokens=max_context_tokens,
+            max_answer_tokens=max_answer_tokens,
+        )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
@@ -155,6 +155,9 @@ async def query_with_synonyms(
     - Query: "What is Foo?"
     - Advanced Query: "What is (Foo OR Bar OR Baz)?"
     """
+    if not query:
+        return None
+
     synonyms = await fetcher.get_synonyms()
     if synonyms is None:
         # No synonyms found

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import re
+import string
+from typing import Optional, Union
+
+from nucliadb.search import logger
+from nucliadb.search.search.query_parser.exceptions import InvalidQueryError
+from nucliadb.search.search.query_parser.fetcher import Fetcher
+from nucliadb.search.search.query_parser.models import (
+    KeywordQuery,
+    SemanticQuery,
+)
+from nucliadb.search.search.utils import should_disable_vector_search
+from nucliadb_models import search as search_models
+
+DEFAULT_GENERIC_SEMANTIC_THRESHOLD = 0.7
+
+# -* is an invalid query in tantivy and it won't return results but if you add some whitespaces
+# between - and *, it will actually trigger a tantivy bug and panic
+INVALID_QUERY = re.compile(r"- +\*")
+
+
+def validate_base_request(item: search_models.BaseSearchRequest):
+    # Filter some queries that panic tantivy, better than returning the 500
+    if INVALID_QUERY.search(item.query):
+        raise InvalidQueryError("query", "Invalid query syntax")
+
+    # synonyms are not compatible with vector/graph search
+    if (
+        item.with_synonyms
+        and item.query
+        and (
+            search_models.SearchOptions.SEMANTIC in item.features
+            or search_models.SearchOptions.RELATIONS in item.features
+        )
+    ):
+        raise InvalidQueryError(
+            "synonyms",
+            "Search with custom synonyms is only supported on paragraph and document search",
+        )
+
+    if search_models.SearchOptions.SEMANTIC in item.features:
+        if should_disable_vector_search(item):
+            item.features.remove(search_models.SearchOptions.SEMANTIC)
+
+
+def parse_top_k(item: search_models.BaseSearchRequest) -> int:
+    assert item.top_k is not None, "top_k must have an int value"
+    top_k = item.top_k
+    return top_k
+
+
+async def parse_keyword_query(
+    item: search_models.BaseSearchRequest,
+    *,
+    fetcher: Fetcher,
+) -> KeywordQuery:
+    query = item.query
+    is_synonyms_query = False
+
+    if item.with_synonyms:
+        synonyms_query = await query_with_synonyms(query, fetcher=fetcher)
+        if synonyms_query is not None:
+            query = synonyms_query
+            is_synonyms_query = True
+
+    min_score = parse_keyword_min_score(item.min_score)
+
+    return KeywordQuery(
+        query=query,
+        is_synonyms_query=is_synonyms_query,
+        min_score=min_score,
+    )
+
+
+async def parse_semantic_query(
+    item: search_models.BaseSearchRequest,
+    *,
+    fetcher: Fetcher,
+) -> SemanticQuery:
+    vectorset = await fetcher.get_vectorset()
+    query = await fetcher.get_query_vector()
+
+    min_score = await parse_semantic_min_score(item.min_score, fetcher=fetcher)
+
+    return SemanticQuery(query=query, vectorset=vectorset, min_score=min_score)
+
+
+def parse_keyword_min_score(
+    min_score: Optional[Union[float, search_models.MinScore]],
+) -> float:
+    # Keep backward compatibility with the deprecated min_score payload
+    # parameter being a float (specifying semantic)
+    if min_score is None or isinstance(min_score, float):
+        return 0.0
+    else:
+        return min_score.bm25
+
+
+async def parse_semantic_min_score(
+    min_score: Optional[Union[float, search_models.MinScore]],
+    *,
+    fetcher: Fetcher,
+):
+    if min_score is None:
+        min_score = None
+    elif isinstance(min_score, float):
+        min_score = min_score
+    else:
+        min_score = min_score.semantic
+
+    if min_score is None:
+        # min score not defined by the user, we'll try to get the default
+        # from Predict API
+        min_score = await fetcher.get_semantic_min_score()
+        if min_score is None:
+            logger.warning(
+                "Semantic threshold not found in query information, using default",
+                extra={"kbid": fetcher.kbid},
+            )
+            min_score = DEFAULT_GENERIC_SEMANTIC_THRESHOLD
+
+    return min_score
+
+
+async def query_with_synonyms(
+    query: str,
+    *,
+    fetcher: Fetcher,
+) -> Optional[str]:
+    """
+    Replace the terms in the query with an expression that will make it match with the configured synonyms.
+    We're using the Tantivy's query language here: https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html
+
+    Example:
+    - Synonyms: Foo -> Bar, Baz
+    - Query: "What is Foo?"
+    - Advanced Query: "What is (Foo OR Bar OR Baz)?"
+    """
+    synonyms = await fetcher.get_synonyms()
+    if synonyms is None:
+        # No synonyms found
+        return None
+
+    # Calculate term variants: 'term' -> '(term OR synonym1 OR synonym2)'
+    variants: dict[str, str] = {}
+    for term, term_synonyms in synonyms.terms.items():
+        if len(term_synonyms.synonyms) > 0:
+            variants[term] = "({})".format(" OR ".join([term] + list(term_synonyms.synonyms)))
+
+    # Split the query into terms
+    query_terms = query.split()
+
+    # Remove punctuation from the query terms
+    clean_query_terms = [term.strip(string.punctuation) for term in query_terms]
+
+    # Replace the original terms with the variants if the cleaned term is in the variants
+    term_with_synonyms_found = False
+    for index, clean_term in enumerate(clean_query_terms):
+        if clean_term in variants:
+            term_with_synonyms_found = True
+            query_terms[index] = query_terms[index].replace(clean_term, variants[clean_term])
+
+    if term_with_synonyms_found:
+        advanced_query = " ".join(query_terms)
+        return advanced_query
+
+    return None

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -206,7 +206,6 @@ class _FindParser:
                 fields=self.item.fields,
                 key_filters=self.item.resource_filters,
             )
-            has_old_filters = False
             field_expr, paragraph_expr = await parse_old_filters(old_filters, self.fetcher)
 
         if self.item.filter_expression is not None:

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -65,13 +65,21 @@ async def parse_find(
     *,
     fetcher: Optional[Fetcher] = None,
 ) -> ParsedQuery:
-    fetcher = fetcher or fetcher_for_find(kbid, item)
+    fetcher = fetcher or fetcher_for_find(kbid, item, generative_model)
     parser = _FindParser(kbid, item, fetcher)
     retrieval = await parser.parse()
     return ParsedQuery(fetcher=fetcher, retrieval=retrieval, generation=None)
 
 
-def fetcher_for_find(kbid: str, item: FindRequest) -> Fetcher:
+# XXX: partial parsing for graph use case, we should avoid this kind of things
+async def parse_reranker(kbid: str, item: FindRequest, generative_model: Optional[str]) -> Reranker:
+    fetcher = fetcher_for_find(kbid, item, generative_model)
+    parser = _FindParser(kbid, item, fetcher)
+    reranker = parser._parse_reranker()
+    return reranker
+
+
+def fetcher_for_find(kbid: str, item: FindRequest, generative_model: Optional[str]) -> Fetcher:
     return Fetcher(
         kbid=kbid,
         query=item.query,
@@ -79,7 +87,7 @@ def fetcher_for_find(kbid: str, item: FindRequest) -> Fetcher:
         vectorset=item.vectorset,
         rephrase=item.rephrase,
         rephrase_prompt=item.rephrase_prompt,
-        generative_model=None,
+        generative_model=generative_model,
     )
 
 

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -71,14 +71,6 @@ async def parse_find(
     return ParsedQuery(fetcher=fetcher, retrieval=retrieval, generation=None)
 
 
-# XXX: partial parsing for graph use case, we should avoid this kind of things
-async def parse_reranker(kbid: str, item: FindRequest, generative_model: Optional[str]) -> Reranker:
-    fetcher = fetcher_for_find(kbid, item, generative_model)
-    parser = _FindParser(kbid, item, fetcher)
-    reranker = parser._parse_reranker()
-    return reranker
-
-
 def fetcher_for_find(kbid: str, item: FindRequest, generative_model: Optional[str]) -> Fetcher:
     return Fetcher(
         kbid=kbid,

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -109,7 +109,7 @@ class _FindParser:
             self._query.semantic = await parse_semantic_query(self.item, fetcher=self.fetcher)
 
         if search_models.SearchOptions.RELATIONS in self.item.features:
-            self._query.relation = await self.parse_relation_query()
+            self._query.relation = await self._parse_relation_query()
 
         # TODO: graph search
 
@@ -139,7 +139,7 @@ class _FindParser:
             reranker=reranker,
         )
 
-    async def parse_relation_query(self) -> RelationQuery:
+    async def _parse_relation_query(self) -> RelationQuery:
         detected_entities = await self._get_detected_entities()
 
         deleted_entity_groups = await self.fetcher.get_deleted_entity_groups()

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
@@ -19,6 +19,7 @@
 #
 from typing import Optional
 
+from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query import expand_entities
 from nucliadb.search.search.query_parser.exceptions import InvalidQueryError
 from nucliadb.search.search.query_parser.fetcher import Fetcher
@@ -53,6 +54,7 @@ INDEX_SORTABLE_FIELDS = [
 ]
 
 
+@query_parser_observer.wrap({"type": "parse_search"})
 async def parse_search(
     kbid: str, item: SearchRequest, *, fetcher: Optional[Fetcher] = None
 ) -> ParsedQuery:

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
@@ -1,0 +1,248 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+from typing import Optional
+
+from nucliadb.search.search.query import expand_entities
+from nucliadb.search.search.query_parser.exceptions import InvalidQueryError
+from nucliadb.search.search.query_parser.fetcher import Fetcher
+from nucliadb.search.search.query_parser.filter_expression import parse_expression
+from nucliadb.search.search.query_parser.models import (
+    Filters,
+    NoopReranker,
+    ParsedQuery,
+    Query,
+    RankFusion,
+    RelationQuery,
+    UnitRetrieval,
+    _TextQuery,
+)
+from nucliadb.search.search.query_parser.old_filters import OldFilterParams, parse_old_filters
+from nucliadb.search.search.utils import filter_hidden_resources
+from nucliadb_models import search as search_models
+from nucliadb_models.filters import FilterExpression
+from nucliadb_models.search import (
+    SearchRequest,
+    SortField,
+    SortOptions,
+    SortOrder,
+)
+from nucliadb_protos import nodereader_pb2, utils_pb2
+
+from .common import parse_keyword_query, parse_semantic_query, parse_top_k, validate_base_request
+
+INDEX_SORTABLE_FIELDS = [
+    SortField.CREATED,
+    SortField.MODIFIED,
+]
+
+
+async def parse_search(
+    kbid: str, item: SearchRequest, *, fetcher: Optional[Fetcher] = None
+) -> ParsedQuery:
+    fetcher = fetcher or fetcher_for_search(kbid, item)
+    parser = _SearchParser(kbid, item, fetcher)
+    retrieval = await parser.parse()
+    return ParsedQuery(fetcher=fetcher, retrieval=retrieval, generation=None)
+
+
+def fetcher_for_search(kbid: str, item: SearchRequest) -> Fetcher:
+    return Fetcher(
+        kbid=kbid,
+        query=item.query,
+        user_vector=item.vector,
+        vectorset=item.vectorset,
+        rephrase=item.rephrase,
+        rephrase_prompt=item.rephrase_prompt,
+        generative_model=None,
+    )
+
+
+class _SearchParser:
+    def __init__(self, kbid: str, item: SearchRequest, fetcher: Fetcher):
+        self.kbid = kbid
+        self.item = item
+        self.fetcher = fetcher
+
+        # cached data while parsing
+        self._query: Optional[Query] = None
+        self._top_k: Optional[int] = None
+
+    async def parse(self) -> UnitRetrieval:
+        validate_base_request(self.item)
+
+        self._top_k = parse_top_k(self.item)
+
+        # parse search types (features)
+
+        self._query = Query()
+
+        if search_models.SearchOptions.KEYWORD in self.item.features:
+            keyword = await self.parse_text_query()
+            self._query.keyword = keyword
+
+        if search_models.SearchOptions.FULLTEXT in self.item.features:
+            # copy from keyword, as everything is the same and we can't search
+            # anything different right now
+            keyword = self._query.keyword or (await self.parse_text_query())
+            self._query.fulltext = keyword
+
+        if search_models.SearchOptions.SEMANTIC in self.item.features:
+            self._query.semantic = await parse_semantic_query(self.item, fetcher=self.fetcher)
+
+        if search_models.SearchOptions.RELATIONS in self.item.features:
+            self._query.relation = await self.parse_relation_query()
+
+        filters = await self._parse_filters()
+
+        return UnitRetrieval(
+            query=self._query,
+            top_k=self._top_k,
+            filters=filters,
+            # TODO: this should be in a post retrieval step
+            rank_fusion=RankFusion(window=self._top_k),
+            reranker=NoopReranker(),
+        )
+
+    async def parse_text_query(self) -> _TextQuery:
+        assert self._top_k is not None, "top_k must be parsed before text query"
+
+        keyword = await parse_keyword_query(self.item, fetcher=self.fetcher)
+        sort, order_by, limit = self.parse_sorting()
+        keyword.sort = sort
+        keyword.order_by = order_by
+        if limit is not None:
+            # sort limit can extend top_k
+            self._top_k = max(self._top_k, limit)
+        return keyword
+
+    async def parse_relation_query(self) -> RelationQuery:
+        detected_entities = await self._get_detected_entities()
+        deleted_entity_groups = await self.fetcher.get_deleted_entity_groups()
+        meta_cache = await self.fetcher.get_entities_meta_cache()
+        deleted_entities = meta_cache.deleted_entities
+        return RelationQuery(
+            detected_entities=detected_entities,
+            deleted_entity_groups=deleted_entity_groups,
+            deleted_entities=deleted_entities,
+        )
+
+    async def _get_detected_entities(self) -> list[utils_pb2.RelationNode]:
+        detected_entities = await self.fetcher.get_detected_entities()
+        meta_cache = await self.fetcher.get_entities_meta_cache()
+        detected_entities = expand_entities(meta_cache, detected_entities)
+        return detected_entities
+
+    def parse_sorting(self) -> tuple[search_models.SortOrder, search_models.SortField, Optional[int]]:
+        sort = self.item.sort
+        if len(self.item.query) == 0:
+            if sort is None:
+                sort = SortOptions(
+                    field=SortField.CREATED,
+                    order=SortOrder.DESC,
+                    limit=None,
+                )
+            elif sort.field not in INDEX_SORTABLE_FIELDS:
+                raise InvalidQueryError(
+                    "sort_field",
+                    f"Empty query can only be sorted by '{SortField.CREATED}' or"
+                    f" '{SortField.MODIFIED}' and sort limit won't be applied",
+                )
+        else:
+            if sort is None:
+                sort = SortOptions(
+                    field=SortField.SCORE,
+                    order=SortOrder.DESC,
+                    limit=None,
+                )
+            elif sort.field not in INDEX_SORTABLE_FIELDS and sort.limit is None:
+                raise InvalidQueryError(
+                    "sort_field",
+                    f"Sort by '{sort.field}' requires setting a sort limit",
+                )
+
+        # We need to ask for all and cut later
+        top_k = None
+        if sort and sort.limit is not None:
+            # As the index can't sort, we have to do it when merging. To
+            # have consistent results, we must limit them
+            top_k = sort.limit
+
+        return (sort.order, sort.field, top_k)
+
+    async def _parse_filters(self) -> Filters:
+        assert self._query is not None, "query must be parsed before filters"
+
+        has_old_filters = (
+            len(self.item.filters) > 0
+            or len(self.item.fields) > 0
+            or self.item.range_creation_start is not None
+            or self.item.range_creation_end is not None
+            or self.item.range_modification_start is not None
+            or self.item.range_modification_end is not None
+        )
+        if self.item.filter_expression is not None and has_old_filters:
+            raise InvalidQueryError("filter_expression", "Cannot mix old filters with filter_expression")
+
+        field_expr = None
+        paragraph_expr = None
+        filter_operator = nodereader_pb2.FilterOperator.AND
+
+        if has_old_filters:
+            old_filters = OldFilterParams(
+                label_filters=self.item.filters,
+                keyword_filters=[],
+                range_creation_start=self.item.range_creation_start,
+                range_creation_end=self.item.range_creation_end,
+                range_modification_start=self.item.range_modification_start,
+                range_modification_end=self.item.range_modification_end,
+                fields=self.item.fields,
+            )
+            has_old_filters = False
+            field_expr, paragraph_expr = await parse_old_filters(old_filters, self.fetcher)
+
+        if self.item.filter_expression is not None:
+            if self.item.filter_expression.field:
+                field_expr = await parse_expression(self.item.filter_expression.field, self.kbid)
+            if self.item.filter_expression.paragraph:
+                paragraph_expr = await parse_expression(self.item.filter_expression.paragraph, self.kbid)
+            if self.item.filter_expression.operator == FilterExpression.Operator.OR:
+                filter_operator = nodereader_pb2.FilterOperator.OR
+            else:
+                filter_operator = nodereader_pb2.FilterOperator.AND
+
+        autofilter = None
+        if self.item.autofilter:
+            if self._query.relation is not None:
+                autofilter = self._query.relation.detected_entities
+            else:
+                autofilter = await self._get_detected_entities()
+
+        hidden = await filter_hidden_resources(self.kbid, self.item.show_hidden)
+
+        return Filters(
+            autofilter=autofilter,
+            facets=self.item.faceted,
+            field_expression=field_expr,
+            paragraph_expression=paragraph_expr,
+            filter_expression_operator=filter_operator,
+            security=self.item.security,
+            hidden=hidden,
+            with_duplicates=self.item.with_duplicates,
+        )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
@@ -216,7 +216,6 @@ class _SearchParser:
                 range_modification_end=self.item.range_modification_end,
                 fields=self.item.fields,
             )
-            has_old_filters = False
             field_expr, paragraph_expr = await parse_old_filters(old_filters, self.fetcher)
 
         if self.item.filter_expression is not None:

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
@@ -23,6 +23,7 @@ from nucliadb.search.search.filters import (
 )
 from nucliadb.search.search.metrics import (
     node_features,
+    query_parser_observer,
 )
 from nucliadb.search.search.query import (
     apply_entities_filter,
@@ -46,6 +47,7 @@ def is_incomplete(retrieval: UnitRetrieval) -> bool:
     return incomplete
 
 
+@query_parser_observer.wrap({"type": "convert_retrieval_to_proto"})
 def convert_retrieval_to_proto(retrieval: UnitRetrieval) -> tuple[SearchRequest, list[str]]:
     request = SearchRequest()
 

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
@@ -28,11 +28,10 @@ from nucliadb.search.search.metrics import (
 from nucliadb.search.search.query import (
     apply_entities_filter,
     get_sort_field_proto,
-    translate_system_to_alias_label,
 )
 from nucliadb.search.search.query_parser.filter_expression import add_and_expression
 from nucliadb.search.search.query_parser.models import PredictReranker, UnitRetrieval
-from nucliadb_models.labels import LABEL_HIDDEN
+from nucliadb_models.labels import LABEL_HIDDEN, translate_system_to_alias_label
 from nucliadb_models.search import (
     SortOrderMap,
 )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from nucliadb.search.search.filters import (
+    translate_label,
+)
+from nucliadb.search.search.metrics import (
+    node_features,
+)
+from nucliadb.search.search.query import get_sort_field_proto
+from nucliadb.search.search.query_parser.filter_expression import add_and_expression
+from nucliadb.search.search.query_parser.models import PredictReranker, UnitRetrieval
+from nucliadb_models.labels import LABEL_HIDDEN
+from nucliadb_models.search import (
+    SortOrderMap,
+)
+from nucliadb_protos import nodereader_pb2, utils_pb2
+from nucliadb_protos.nodereader_pb2 import SearchRequest
+
+
+def is_incomplete(retrieval: UnitRetrieval) -> bool:
+    if retrieval.query.semantic is None:
+        return False
+    incomplete = retrieval.query.semantic.query is None or len(retrieval.query.semantic.query) == 0
+    return incomplete
+
+
+def convert_retrieval_to_proto(retrieval: UnitRetrieval) -> tuple[SearchRequest, list[str]]:
+    request = SearchRequest()
+
+    ## queries
+
+    if retrieval.query.keyword and retrieval.query.fulltext:
+        assert retrieval.query.keyword == retrieval.query.fulltext, (
+            "search proto doesn't support different queries for fulltext and keyword search"
+        )
+
+    if retrieval.query.fulltext:
+        request.document = True
+        node_features.inc({"type": "documents"})
+    if retrieval.query.keyword:
+        request.paragraph = True
+        node_features.inc({"type": "paragraphs"})
+
+    text_query = retrieval.query.keyword or retrieval.query.fulltext
+    if text_query is not None:
+        request.min_score_bm25 = text_query.min_score
+
+        if text_query.is_synonyms_query:
+            request.advanced_query = text_query.query
+        else:
+            request.body = text_query.query
+
+        # sort order
+        sort_field = get_sort_field_proto(text_query.order_by)
+        if sort_field is not None:
+            request.order.sort_by = sort_field
+            request.order.type = SortOrderMap[text_query.sort]  # type: ignore
+
+    if retrieval.query.semantic:
+        node_features.inc({"type": "vectors"})
+
+        request.min_score_semantic = retrieval.query.semantic.min_score
+
+        query_vector = retrieval.query.semantic.query
+        if query_vector is not None:
+            request.vectorset = retrieval.query.semantic.vectorset
+            request.vector.extend(query_vector)
+
+    if retrieval.query.relation:
+        node_features.inc({"type": "relations"})
+
+        request.relation_subgraph.entry_points.extend(retrieval.query.relation.detected_entities)
+        request.relation_subgraph.depth = 1
+        request.relation_subgraph.deleted_groups.extend(retrieval.query.relation.deleted_entity_groups)
+        for group_id, deleted_entities in retrieval.query.relation.deleted_entities.items():
+            request.relation_subgraph.deleted_entities.append(
+                nodereader_pb2.EntitiesSubgraphRequest.DeletedEntities(
+                    node_subtype=group_id, node_values=deleted_entities
+                )
+            )
+
+    # filters
+
+    request.with_duplicates = retrieval.filters.with_duplicates
+
+    request.faceted.labels.extend([translate_label(facet) for facet in retrieval.filters.facets])
+
+    if retrieval.filters.security is not None and len(retrieval.filters.security.groups) > 0:
+        security_pb = utils_pb2.Security()
+        for group_id in retrieval.filters.security.groups:
+            if group_id not in security_pb.access_groups:
+                security_pb.access_groups.append(group_id)
+        request.security.CopyFrom(security_pb)
+
+    if retrieval.filters.field_expression:
+        request.field_filter.CopyFrom(retrieval.filters.field_expression)
+    if retrieval.filters.paragraph_expression:
+        request.paragraph_filter.CopyFrom(retrieval.filters.paragraph_expression)
+    request.filter_operator = retrieval.filters.filter_expression_operator
+
+    autofilters = []
+    if retrieval.filters.autofilter and retrieval.query.relation:
+        from nucliadb.search.search.query import apply_entities_filter, translate_system_to_alias_label
+
+        entity_filters = apply_entities_filter(request, retrieval.query.relation.detected_entities)
+        autofilters.extend([translate_system_to_alias_label(e) for e in entity_filters])
+
+    if retrieval.filters.hidden is not None:
+        expr = nodereader_pb2.FilterExpression()
+        if retrieval.filters.hidden:
+            expr.facet.facet = LABEL_HIDDEN
+        else:
+            expr.bool_not.facet.facet = LABEL_HIDDEN
+
+        add_and_expression(request.field_filter, expr)
+
+    # top_k
+
+    # Adjust requested page size depending on rank fusion and reranking algorithms.
+    #
+    # Some rerankers want more results than the requested by the user so
+    # reranking can have more choices.
+
+    rank_fusion_window = 0
+    if retrieval.rank_fusion is not None:
+        rank_fusion_window = retrieval.rank_fusion.window
+
+    reranker_window = 0
+    if retrieval.reranker is not None and isinstance(retrieval.reranker, PredictReranker):
+        reranker_window = retrieval.reranker.window
+
+    request.result_per_page = max(
+        request.result_per_page,
+        rank_fusion_window,
+        reranker_window,
+    )
+
+    return request, autofilters

--- a/nucliadb/src/nucliadb/search/search/rerankers.py
+++ b/nucliadb/src/nucliadb/search/search/rerankers.py
@@ -178,8 +178,10 @@ def get_reranker(reranker: parser_models.Reranker) -> Reranker:
     elif isinstance(reranker, parser_models.PredictReranker):
         algorithm = PredictReranker(reranker.window)
 
-    else:
-        raise ValueError(f"Unknown reranker requested: {reranker}")
+    else:  # pragma: nocover
+        # This is a trick so mypy generates an error if this branch can be reached,
+        # that is, if we are missing some ifs
+        _a: int = "a"
 
     return algorithm
 

--- a/nucliadb/tests/nucliadb/integration/search/test_search.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search.py
@@ -1053,9 +1053,7 @@ async def test_search_min_score(
     standalone_knowledgebox,
 ):
     # When not specifying the min score on the request, it should default to 0.7
-    resp = await nucliadb_reader.post(
-        f"/kb/{standalone_knowledgebox}/search", json={"query": "dummy", "features": ["semantic"]}
-    )
+    resp = await nucliadb_reader.post(f"/kb/{standalone_knowledgebox}/search", json={"query": "dummy"})
     assert resp.status_code == 200
     assert resp.json()["sentences"]["min_score"] == 0.7
 

--- a/nucliadb/tests/nucliadb/integration/search/test_search.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search.py
@@ -1053,7 +1053,9 @@ async def test_search_min_score(
     standalone_knowledgebox,
 ):
     # When not specifying the min score on the request, it should default to 0.7
-    resp = await nucliadb_reader.post(f"/kb/{standalone_knowledgebox}/search", json={"query": "dummy"})
+    resp = await nucliadb_reader.post(
+        f"/kb/{standalone_knowledgebox}/search", json={"query": "dummy", "features": ["semantic"]}
+    )
     assert resp.status_code == 200
     assert resp.json()["sentences"]["min_score"] == 0.7
 

--- a/nucliadb/tests/nucliadb/integration/search/test_search_sorting.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search_sorting.py
@@ -218,7 +218,7 @@ async def test_list_all_resources_by_creation_and_modification_dates_with_empty_
             resources.update(body["resources"])
             fulltext.extend(body["fulltext"]["results"])
 
-            next_page = body["fulltext"]["next_page"] or body["paragraphs"]["next_page"]
+            next_page = body["fulltext"]["next_page"]
             page_number += 1
 
         assert len(fulltext) == 10

--- a/nucliadb/tests/search/unit/search/test_query_parsing.py
+++ b/nucliadb/tests/search/unit/search/test_query_parsing.py
@@ -66,7 +66,7 @@ async def test_find_query_parsing__rank_fusion(
         reranker=search_models.RerankerName.NOOP,
     )
     parsed = await parse_find("kbid", find)
-    assert parsed.rank_fusion == expected
+    assert parsed.retrieval.rank_fusion == expected
 
 
 # ATENTION: if you're changing this test, make sure public models, private
@@ -117,7 +117,7 @@ async def test_find_query_parsing__reranker(
         reranker=reranker,
     )
     parsed = await parse_find("kbid", find)
-    assert parsed.reranker == expected
+    assert parsed.retrieval.reranker == expected
 
 
 # ATENTION: if you're changing this test, make sure public models, private

--- a/nucliadb/tests/search/unit/search/test_query_parsing.py
+++ b/nucliadb/tests/search/unit/search/test_query_parsing.py
@@ -19,6 +19,7 @@
 
 
 from typing import Union
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -29,12 +30,20 @@ from nucliadb_models import search as search_models
 from nucliadb_models.search import FindRequest
 
 
+@pytest.fixture(scope="function", autouse=True)
+def disable_hidden_resources_check():
+    with patch(
+        "nucliadb.search.search.query_parser.parsers.find.filter_hidden_resources", return_value=False
+    ):
+        yield
+
+
 async def test_find_query_parsing__top_k():
     find = FindRequest(
         top_k=20,
     )
     parsed = await parse_find("kbid", find)
-    assert parsed.top_k == find.top_k
+    assert parsed.retrieval.top_k == find.top_k
 
 
 @pytest.mark.parametrize(
@@ -98,7 +107,7 @@ async def test_find_query_parsing__rank_fusion_limits():
     parsed = await parse_find(
         "kbid", FindRequest(rank_fusion=search_models.ReciprocalRankFusion.model_construct(window=501))
     )
-    assert parsed.rank_fusion.window == 500
+    assert parsed.retrieval.rank_fusion.window == 500
 
 
 @pytest.mark.parametrize(
@@ -140,4 +149,4 @@ async def test_find_query_parsing__reranker_limits():
     parsed = await parse_find(
         "kbid", FindRequest(reranker=search_models.PredictReranker.model_construct(window=201))
     )
-    assert parsed.reranker.window == 200
+    assert parsed.retrieval.reranker.window == 200

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -51,7 +51,7 @@ from nucliadb_protos.nodereader_pb2 import DocumentScored, ParagraphResult
 )
 async def test_get_rank_fusion(rank_fusion, expected_type: Type):
     item = FindRequest(rank_fusion=rank_fusion)
-    algorithm = get_rank_fusion((await parse_find("kbid", item)).rank_fusion)
+    algorithm = get_rank_fusion((await parse_find("kbid", item)).retrieval.rank_fusion)
     assert isinstance(algorithm, expected_type)
 
 

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -26,6 +26,7 @@ This test suite validates different combinations of inputs
 
 import random
 from typing import Optional, Type
+from unittest.mock import patch
 
 import pytest
 
@@ -40,6 +41,14 @@ from nucliadb.search.search.query_parser.parsers import parse_find
 from nucliadb.search.search.rank_fusion import LegacyRankFusion, ReciprocalRankFusion, get_rank_fusion
 from nucliadb_models.search import SCORE_TYPE, FindRequest
 from nucliadb_protos.nodereader_pb2 import DocumentScored, ParagraphResult
+
+
+@pytest.fixture(scope="function", autouse=True)
+def disable_hidden_resources_check():
+    with patch(
+        "nucliadb.search.search.query_parser.parsers.find.filter_hidden_resources", return_value=False
+    ):
+        yield
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Shared query parsing logic across different search endpoints makes some changes harder than it should. This is a step forward towards new query parsers, one per endpoint. Although there's some common logic, using a parser per endpoint makes the code more readable and easier to reason about.


### How was this PR tested?
Existing test suite with some subtle changes that were wrong beforehand (and hopefully, nobody relies upon them)
