### PR TITLE
Predict proxy improvements

### DIFF
--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -322,18 +322,22 @@ def _test_predict_proxy_chat(kbid: str):
     )
     raise_for_status(resp)
     lines = [json.loads(line) for line in resp.iter_lines()]
+    print(f"Response lines:\n{'\n'.join(lines)}")
 
     # Check that the answer is in the response
     text_answer = ""
     for line in lines:
+        if not isinstance(line, dict):
+            continue
+        if "type" not in line:
+            continue
         if line["type"] == "text":
             text_answer += line["text"]
     print(f"Answer: {text_answer}")
     assert "Messi" in text_answer, f"Expected answer not found: {'\n'.join(lines)}"
 
     # Check that the tokens are reported
-    meta = next((line for line in lines if line["type"] == "meta"), None)
-    assert meta is not None, f"Meta line not found: {'\n'.join(lines)}"
+    meta = next(line for line in lines if line["type"] == "meta")
     assert meta["input_tokens"] >= 0
     assert meta["output_tokens"] >= 0
 

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -323,18 +323,24 @@ def _test_predict_proxy_chat(kbid: str):
     lines = [line for line in resp.iter_lines()]
 
     # Check that the answer is in the response
-    text_answer = ""
-    for line in lines:
-        if line["type"] == "text":
-            text_answer += line["text"]
-    print(f"Answer: {text_answer}")
-    assert "Messi" in text_answer, f"Expected answer not found: {'\n'.join(lines)}"
+    try:
+        text_answer = ""
+        for line in lines:
+            if line["type"] == "text":
+                text_answer += line["text"]
+        print(f"Answer: {text_answer}")
+        assert "Messi" in text_answer, f"Expected answer not found: {'\n'.join(lines)}"
 
-    # Check that the tokens are reported
-    meta = next((line for line in lines if line["type"] == "meta"), None)
-    assert meta is not None, f"Meta line not found: {'\n'.join(lines)}"
-    assert meta["input_tokens"] >= 0
-    assert meta["output_tokens"] >= 0
+        # Check that the tokens are reported
+        meta = next((line for line in lines if line["type"] == "meta"), None)
+        assert meta is not None, f"Meta line not found: {'\n'.join(lines)}"
+        assert meta["input_tokens"] >= 0
+        assert meta["output_tokens"] >= 0
+    except Exception:
+        print("Response lines:")
+        for line in lines:
+            print(line)
+        raise
 
 
 def _test_predict_proxy_tokens(kbid: str):

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 import os
 import random
 import time
@@ -320,27 +321,22 @@ def _test_predict_proxy_chat(kbid: str):
         },
     )
     raise_for_status(resp)
-    lines = [line for line in resp.iter_lines()]
+    lines = [json.loads(line) for line in resp.iter_lines()]
 
     # Check that the answer is in the response
-    try:
-        text_answer = ""
-        for line in lines:
-            if line["type"] == "text":
-                text_answer += line["text"]
-        print(f"Answer: {text_answer}")
-        assert "Messi" in text_answer, f"Expected answer not found: {'\n'.join(lines)}"
+    text_answer = ""
+    for line in lines:
+        if line["type"] == "text":
+            text_answer += line["text"]
+    print(f"Answer: {text_answer}")
+    assert "Messi" in text_answer, f"Expected answer not found: {'\n'.join(lines)}"
 
-        # Check that the tokens are reported
-        meta = next((line for line in lines if line["type"] == "meta"), None)
-        assert meta is not None, f"Meta line not found: {'\n'.join(lines)}"
-        assert meta["input_tokens"] >= 0
-        assert meta["output_tokens"] >= 0
-    except Exception:
-        print("Response lines:")
-        for line in lines:
-            print(line)
-        raise
+    # Check that the tokens are reported
+    meta = next((line for line in lines if line["type"] == "meta"), None)
+    assert meta is not None, f"Meta line not found: {'\n'.join(lines)}"
+    assert meta["input_tokens"] >= 0
+    assert meta["output_tokens"] >= 0
+
 
 
 def _test_predict_proxy_tokens(kbid: str):

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -327,17 +327,14 @@ def _test_predict_proxy_chat(kbid: str):
     # Check that the answer is in the response
     text_answer = ""
     for line in lines:
-        if not isinstance(line, dict):
-            continue
-        if "type" not in line:
-            continue
-        if line["type"] == "text":
-            text_answer += line["text"]
+        chunk = line["chunk"]
+        if chunk["type"] == "text":
+            text_answer += chunk["text"]
     print(f"Answer: {text_answer}")
     assert "Messi" in text_answer, f"Expected answer not found: {'\n'.join(lines)}"
 
     # Check that the tokens are reported
-    meta = next(line for line in lines if line["type"] == "meta")
+    meta = next(line["chunk"] for line in lines if line["chunk"]["type"] == "meta")
     assert meta["input_tokens"] >= 0
     assert meta["output_tokens"] >= 0
 

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -304,11 +304,12 @@ def _test_predict_proxy_chat(kbid: str):
     print(f"Answer: {answer}")
     assert "Messi" in answer
 
-    # Test application/x-ndjson content type
+    # Test accepting application/x-ndjson content type
     resp = requests.post(
         os.path.join(BASE_URL, f"api/v1/kb/{kbid}/predict/chat"),
         headers={
-            "content-type": "application/x-ndjson",
+            "Content-type": "application/json",
+            "Accept": "application/x-ndjson",
             "X-NUCLIADB-ROLES": "READER",
             "x-ndb-client": "web",
         },

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -322,7 +322,6 @@ def _test_predict_proxy_chat(kbid: str):
     )
     raise_for_status(resp)
     lines = [json.loads(line) for line in resp.iter_lines()]
-    print(f"Response lines:\n{'\n'.join(lines)}")
 
     # Check that the answer is in the response
     text_answer = ""

--- a/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
@@ -59,6 +59,7 @@ async def predict_proxy_endpoint(
     kbid: str,
     endpoint: PredictProxiedEndpoints,
 ) -> Union[Response, StreamingResponse, HTTPClientError]:
+    breakpoint()
     try:
         payload = await request.json()
     except json.JSONDecodeError:

--- a/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
@@ -21,7 +21,7 @@ import json
 from typing import Union
 
 from fastapi import Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from fastapi_versioning import version
 
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
@@ -58,7 +58,7 @@ async def predict_proxy_endpoint(
     request: Request,
     kbid: str,
     endpoint: PredictProxiedEndpoints,
-) -> Union[JSONResponse, StreamingResponse, HTTPClientError]:
+) -> Union[Response, StreamingResponse, HTTPClientError]:
     try:
         payload = await request.json()
     except json.JSONDecodeError:

--- a/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
@@ -65,7 +65,12 @@ async def predict_proxy_endpoint(
         payload = None
     try:
         return await predict_proxy(
-            kbid, endpoint, request.method, params=request.query_params, json=payload
+            kbid,
+            endpoint,
+            request.method,
+            params=request.query_params,
+            json=payload,
+            headers=dict(request.headers),
         )
     except KnowledgeBoxNotFound:
         return HTTPClientError(status_code=404, detail="Knowledge box not found")

--- a/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
@@ -59,7 +59,6 @@ async def predict_proxy_endpoint(
     kbid: str,
     endpoint: PredictProxiedEndpoints,
 ) -> Union[Response, StreamingResponse, HTTPClientError]:
-    breakpoint()
     try:
         payload = await request.json()
     except json.JSONDecodeError:

--- a/nucliadb/src/nucliadb/search/predict.py
+++ b/nucliadb/src/nucliadb/search/predict.py
@@ -262,7 +262,7 @@ class PredictEngine:
         jitter=backoff.random_jitter,
         max_tries=MAX_TRIES,
     )
-    async def make_request(self, method: str, **request_args):
+    async def make_request(self, method: str, **request_args) -> aiohttp.ClientResponse:
         func = getattr(self.session, method.lower())
         return await func(**request_args)
 
@@ -311,8 +311,8 @@ class PredictEngine:
             timeout=None,
         )
         await self.check_response(kbid, resp, expected_status=200)
-        ident = resp.headers.get(NUCLIA_LEARNING_ID_HEADER)
-        model = resp.headers.get(NUCLIA_LEARNING_MODEL_HEADER)
+        ident = resp.headers.get(NUCLIA_LEARNING_ID_HEADER) or "unknown"
+        model = resp.headers.get(NUCLIA_LEARNING_MODEL_HEADER) or "unknown"
         return ident, model, get_chat_ndjson_generator(resp)
 
     @predict_observer.wrap({"type": "query"})

--- a/nucliadb/src/nucliadb/search/predict.py
+++ b/nucliadb/src/nucliadb/search/predict.py
@@ -471,7 +471,9 @@ class DummyPredictEngine(PredictEngine):
 
     async def make_request(self, method: str, **request_args):
         response = Mock(status=200)
-        response.json = AsyncMock(return_value={"foo": "bar"})
+        json_data = {"foo": "bar"}
+        response.json = AsyncMock(return_value=json_data)
+        response.read = AsyncMock(return_value=json.dumps(json_data).encode("utf-8"))
         response.headers = {NUCLIA_LEARNING_ID_HEADER: DUMMY_LEARNING_ID}
         return response
 

--- a/nucliadb/src/nucliadb/search/search/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/search/predict_proxy.py
@@ -60,7 +60,7 @@ async def predict_proxy(
 
     predict: PredictEngine = get_predict()
     predict_headers = predict.get_predict_headers(kbid)
-    allowed_headers = {k: v for k, v in headers.items() if k.capitalize() in ALLOWED_HEADERS}
+    user_headers = {k: v for k, v in headers.items() if k.capitalize() in ALLOWED_HEADERS}
 
     # Proxy the request to predict API
     predict_response = await predict.make_request(
@@ -68,7 +68,7 @@ async def predict_proxy(
         url=predict.get_predict_url(endpoint, kbid),
         json=json,
         params=params,
-        headers={**allowed_headers, **predict_headers},
+        headers={**user_headers, **predict_headers},
     )
 
     # Proxy the response back to the client

--- a/nucliadb/src/nucliadb/search/search/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/search/predict_proxy.py
@@ -43,7 +43,7 @@ class PredictProxiedEndpoints(str, Enum):
 
 
 ALLOWED_HEADERS = [
-    "Accept",
+    "Accept",  # To allow 'application/x-ndjson' on the /chat endpoint
 ]
 
 

--- a/nucliadb/src/nucliadb/search/search/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/search/predict_proxy.py
@@ -48,6 +48,7 @@ async def predict_proxy(
     method: str,
     params: QueryParams,
     json: Optional[Any] = None,
+    headers: dict[str, str] = {},
 ) -> Union[JSONResponse, StreamingResponse]:
     if not await exists_kb(kbid=kbid):
         raise datamanagers.exceptions.KnowledgeBoxNotFound()
@@ -55,7 +56,7 @@ async def predict_proxy(
     predict: PredictEngine = get_predict()
 
     # Add KB configuration headers
-    headers = predict.get_predict_headers(kbid)
+    predict_headers = predict.get_predict_headers(kbid)
 
     # Proxy the request to predict API
     predict_response = await predict.make_request(
@@ -63,7 +64,7 @@ async def predict_proxy(
         url=predict.get_predict_url(endpoint, kbid),
         json=json,
         params=params,
-        headers=headers,
+        headers={**headers, **predict_headers},
     )
 
     # Proxy the response back to the client

--- a/nucliadb/src/nucliadb/search/search/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/search/predict_proxy.py
@@ -42,6 +42,11 @@ class PredictProxiedEndpoints(str, Enum):
     REMI = "remi"
 
 
+ALLOWED_HEADERS = [
+    "Accept",
+]
+
+
 async def predict_proxy(
     kbid: str,
     endpoint: PredictProxiedEndpoints,
@@ -54,9 +59,8 @@ async def predict_proxy(
         raise datamanagers.exceptions.KnowledgeBoxNotFound()
 
     predict: PredictEngine = get_predict()
-
-    # Add KB configuration headers
     predict_headers = predict.get_predict_headers(kbid)
+    allowed_headers = {k: v for k, v in headers.items() if k.capitalize() in ALLOWED_HEADERS}
 
     # Proxy the request to predict API
     predict_response = await predict.make_request(
@@ -64,7 +68,7 @@ async def predict_proxy(
         url=predict.get_predict_url(endpoint, kbid),
         json=json,
         params=params,
-        headers={**headers, **predict_headers},
+        headers={**allowed_headers, **predict_headers},
     )
 
     # Proxy the response back to the client

--- a/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
+++ b/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
@@ -24,14 +24,15 @@ from httpx import AsyncClient
 
 
 @pytest.mark.parametrize(
-    "method,endpoint,params,payload",
+    "method,endpoint,params,payload,headers",
     [
-        ("GET", "tokens", {"text": "foo"}, None),
+        ("GET", "tokens", {"text": "foo"}, None, {"foo": "bar"}),
         (
             "POST",
             "chat",
             None,
             {"question": "foo", "query_context": ["foobar"], "user_id": "foo"},
+            {"foo": "bar"},
         ),
         (
             "POST",
@@ -42,6 +43,7 @@ from httpx import AsyncClient
                 "chat_histoy": [{"author": "USER", "text": "foo"}],
                 "user_id": "bar",
             },
+            {"foo": "bar"},
         ),
     ],
 )
@@ -53,10 +55,11 @@ async def test_predict_proxy(
     endpoint: str,
     params,
     payload,
+    headers: dict[str, str],
 ):
     kbid = standalone_knowledgebox
     http_func = getattr(nucliadb_reader, method.lower())
-    http_func_kwargs = {"params": params}
+    http_func_kwargs = {"params": params, "headers": headers}
     if method == "POST":
         http_func_kwargs["json"] = payload
     resp = await http_func(


### PR DESCRIPTION
### Description
- Allow to proxy Accept header so that predict/chat endpoint can be used in x-ndjson format
- Properly handle non-json responses, which fixes SEARCH-YZ

### How was this PR tested?
Describe how you tested this PR.
