### PR TITLE
Add support for envFrom for nidx chart

### DIFF
--- a/charts/nidx/templates/api-deploy.yaml
+++ b/charts/nidx/templates/api-deploy.yaml
@@ -55,6 +55,10 @@ spec:
       - name: nidx-api
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         command: ["nidx", "api"]
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- include "toEnv" .Values.env | nindent 10 }}
           - name: CONTROL_SOCKET

--- a/charts/nidx/templates/indexer-deploy.yaml
+++ b/charts/nidx/templates/indexer-deploy.yaml
@@ -57,6 +57,10 @@ spec:
       - name: nidx-indexer
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         command: ["nidx", "indexer"]
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- include "toEnv" .Values.env | nindent 10 }}
           - name: WORK_PATH

--- a/charts/nidx/templates/scheduler-deploy.yaml
+++ b/charts/nidx/templates/scheduler-deploy.yaml
@@ -61,6 +61,10 @@ spec:
       - name: nidx-scheduler
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         command: ["nidx", "scheduler"]
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- include "toEnv" .Values.env | nindent 10 }}
           - name: CONTROL_SOCKET

--- a/charts/nidx/templates/searcher-deploy.yaml
+++ b/charts/nidx/templates/searcher-deploy.yaml
@@ -58,6 +58,10 @@ spec:
       - name: nidx-searcher
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         command: ["nidx", "searcher"]
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- include "toEnv" .Values.env | nindent 10 }}
           - name: WORK_PATH

--- a/charts/nidx/templates/worker-deploy.yaml
+++ b/charts/nidx/templates/worker-deploy.yaml
@@ -58,6 +58,10 @@ spec:
       - name: nidx-worker
         image: "{{ .Values.containerRegistry }}/{{ .Values.image }}"
         command: ["nidx", "worker"]
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           {{- include "toEnv" .Values.env | nindent 10 }}
           - name: WORK_PATH

--- a/charts/nidx/values.yaml
+++ b/charts/nidx/values.yaml
@@ -8,6 +8,7 @@ containerRegistry: CONTAINER_REGISTRY_TO_REPLACE
 image: IMAGE_TO_REPLACE
 
 env: {}
+envFrom: {}
 indexer: {}
 scheduler: {}
 worker: {}


### PR DESCRIPTION
This pull request introduces support for `envFrom` in the Helm chart templates for the `nidx` project. It allows environment variables to be sourced from external configurations, improving flexibility in managing deployments. The changes affect multiple deployment templates and the `values.yaml` file.

### Helm template updates for `envFrom`:

* Added support for `envFrom` in the deployment templates for `nidx-api`, `nidx-indexer`, `nidx-scheduler`, `nidx-searcher`, and `nidx-worker`. This uses the `toYaml` function to render the `envFrom` configuration if specified in the `values.yaml` file. (`charts/nidx/templates/api-deploy.yaml` [[1]](diffhunk://#diff-d59bd47f42ba40bf3a931b94f542cd0aac1e3854a1783e5a3c1a8214d4192755R58-R61) `charts/nidx/templates/indexer-deploy.yaml` [[2]](diffhunk://#diff-a298dd342bf9a0313a05d981be9dddb13f046caad471f36a8a5fb709070f9170R60-R63) `charts/nidx/templates/scheduler-deploy.yaml` [[3]](diffhunk://#diff-f2c21abdd865c33ca1c0453dfb63665ad9e11f659eded92e0983179382bba892R64-R67) `charts/nidx/templates/searcher-deploy.yaml` [[4]](diffhunk://#diff-0d6f44d823c7a1faeda54fa5ef42a7f76c2064a3e349c9a5503aec9008fb0c53R61-R64) `charts/nidx/templates/worker-deploy.yaml` [[5]](diffhunk://#diff-790459e5b522c002998a3a335d2ed2cf01c8cf9ff9028503f49d28c05c95db7bR61-R64)

### `values.yaml` update:

* Introduced a new `envFrom` field in the `values.yaml` file to allow users to define external environment variable sources for use in the deployment templates. (`charts/nidx/values.yaml` [charts/nidx/values.yamlR11](diffhunk://#diff-27e9cc266923d087b3a45d52d4bfd0e283837dcb6eb6e6b0c06eb17e724d29edR11))