### PR TITLE
Decouple search and find features

### DIFF
--- a/nucliadb/src/nucliadb/search/api/v1/find.py
+++ b/nucliadb/src/nucliadb/search/api/v1/find.py
@@ -40,6 +40,7 @@ from nucliadb_models.configuration import FindConfig
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import (
+    FindOptions,
     FindRequest,
     KnowledgeboxFindResults,
     NucliaDBClientType,
@@ -47,7 +48,6 @@ from nucliadb_models.search import (
     Reranker,
     RerankerName,
     ResourceProperties,
-    SearchOptions,
     SearchParamDefaults,
 )
 from nucliadb_models.security import RequestSecurity
@@ -61,7 +61,7 @@ FIND_EXAMPLES = {
         description="Perform a hybrid search that will return text and semantic results matching the query",
         value={
             "query": "How can I be an effective product manager?",
-            "features": [SearchOptions.KEYWORD, SearchOptions.SEMANTIC],
+            "features": [FindOptions.KEYWORD, FindOptions.SEMANTIC],
         },
     )
 }
@@ -110,11 +110,11 @@ async def find_knowledgebox(
     range_modification_end: Optional[DateTime] = fastapi_query(
         SearchParamDefaults.range_modification_end
     ),
-    features: list[SearchOptions] = fastapi_query(
+    features: list[FindOptions] = fastapi_query(
         SearchParamDefaults.search_features,
         default=[
-            SearchOptions.KEYWORD,
-            SearchOptions.SEMANTIC,
+            FindOptions.KEYWORD,
+            FindOptions.SEMANTIC,
         ],
     ),
     debug: bool = fastapi_query(SearchParamDefaults.debug),

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -39,9 +39,7 @@ from nucliadb.search.search.merge import merge_results
 from nucliadb.search.search.query_parser.parsers.search import parse_search
 from nucliadb.search.search.query_parser.parsers.unit_retrieval import legacy_convert_retrieval_to_proto
 from nucliadb.search.search.utils import (
-    min_score_from_payload,
     min_score_from_query_params,
-    should_disable_vector_search,
 )
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.filters import FilterExpression
@@ -262,12 +260,6 @@ async def search(
 ) -> tuple[KnowledgeboxSearchResults, bool]:
     audit = get_audit()
     start_time = time()
-
-    item.min_score = min_score_from_payload(item.min_score)
-
-    if SearchOptions.SEMANTIC in item.features:
-        if should_disable_vector_search(item):
-            item.features.remove(SearchOptions.SEMANTIC)
 
     parsed = await parse_search(kbid, item)
     pb_query, incomplete_results, autofilters, _ = await legacy_convert_retrieval_to_proto(parsed)

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -80,6 +80,7 @@ from nucliadb_models.search import (
     CitationsAskResponseItem,
     DebugAskResponseItem,
     ErrorAskResponseItem,
+    FindOptions,
     FindParagraph,
     FindRequest,
     GraphStrategy,
@@ -97,7 +98,6 @@ from nucliadb_models.search import (
     Relations,
     RelationsAskResponseItem,
     RetrievalAskResponseItem,
-    SearchOptions,
     StatusAskResponseItem,
     SyncAskMetadata,
     SyncAskResponse,
@@ -955,9 +955,9 @@ def calculate_prequeries_for_json_schema(
     json_schema = ask_request.answer_json_schema or {}
     features = []
     if ChatOptions.SEMANTIC in ask_request.features:
-        features.append(SearchOptions.SEMANTIC)
+        features.append(FindOptions.SEMANTIC)
     if ChatOptions.KEYWORD in ask_request.features:
-        features.append(SearchOptions.KEYWORD)
+        features.append(FindOptions.KEYWORD)
 
     properties = json_schema.get("parameters", {}).get("properties", {})
     if len(properties) == 0:  # pragma: no cover

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -38,6 +38,7 @@ from nucliadb_models.search import (
     AskRequest,
     ChatContextMessage,
     ChatOptions,
+    FindOptions,
     FindRequest,
     KnowledgeboxFindResults,
     NucliaDBClientType,
@@ -48,7 +49,6 @@ from nucliadb_models.search import (
     PromptContextOrder,
     Relations,
     RephraseModel,
-    SearchOptions,
     parse_rephrase_prompt,
 )
 from nucliadb_protos import audit_pb2
@@ -180,11 +180,11 @@ def find_request_from_ask_request(item: AskRequest, query: str) -> FindRequest:
     find_request.resource_filters = item.resource_filters
     find_request.features = []
     if ChatOptions.SEMANTIC in item.features:
-        find_request.features.append(SearchOptions.SEMANTIC)
+        find_request.features.append(FindOptions.SEMANTIC)
     if ChatOptions.KEYWORD in item.features:
-        find_request.features.append(SearchOptions.KEYWORD)
+        find_request.features.append(FindOptions.KEYWORD)
     if ChatOptions.RELATIONS in item.features:
-        find_request.features.append(SearchOptions.RELATIONS)
+        find_request.features.append(FindOptions.RELATIONS)
     find_request.query = query
     find_request.fields = item.fields
     find_request.filters = item.filters

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -53,7 +53,8 @@ from .common import (
     parse_keyword_query,
     parse_semantic_query,
     parse_top_k,
-    validate_base_request,
+    should_disable_vector_search,
+    validate_query_syntax,
 )
 
 
@@ -93,7 +94,7 @@ class _FindParser:
         self._top_k: Optional[int] = None
 
     async def parse(self) -> UnitRetrieval:
-        validate_base_request(self.item)
+        self._validate_request()
 
         self._top_k = parse_top_k(self.item)
 
@@ -101,13 +102,13 @@ class _FindParser:
 
         self._query = Query()
 
-        if search_models.SearchOptions.KEYWORD in self.item.features:
+        if search_models.FindOptions.KEYWORD in self.item.features:
             self._query.keyword = await parse_keyword_query(self.item, fetcher=self.fetcher)
 
-        if search_models.SearchOptions.SEMANTIC in self.item.features:
+        if search_models.FindOptions.SEMANTIC in self.item.features:
             self._query.semantic = await parse_semantic_query(self.item, fetcher=self.fetcher)
 
-        if search_models.SearchOptions.RELATIONS in self.item.features:
+        if search_models.FindOptions.RELATIONS in self.item.features:
             self._query.relation = await self._parse_relation_query()
 
         # TODO: graph search
@@ -138,6 +139,27 @@ class _FindParser:
             reranker=reranker,
         )
         return retrieval
+
+    def _validate_request(self):
+        validate_query_syntax(self.item.query)
+
+        # synonyms are not compatible with vector/graph search
+        if (
+            self.item.with_synonyms
+            and self.item.query
+            and (
+                search_models.FindOptions.SEMANTIC in self.item.features
+                or search_models.FindOptions.RELATIONS in self.item.features
+            )
+        ):
+            raise InvalidQueryError(
+                "synonyms",
+                "Search with custom synonyms is only supported on paragraph and document search",
+            )
+
+        if search_models.FindOptions.SEMANTIC in self.item.features:
+            if should_disable_vector_search(self.item):
+                self.item.features.remove(search_models.FindOptions.SEMANTIC)
 
     async def _parse_relation_query(self) -> RelationQuery:
         detected_entities = await self._get_detected_entities()

--- a/nucliadb/tests/nucliadb/integration/search/test_filters.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters.py
@@ -28,7 +28,7 @@ from nucliadb.export_import.utils import get_processor_bm, get_writer_bm
 from nucliadb.search.search.rank_fusion import ReciprocalRankFusion
 from nucliadb.tests.vectors import V1, V2, Q
 from nucliadb_models.labels import Label, LabelSetKind
-from nucliadb_models.search import MinScore, RerankerName, SearchOptions
+from nucliadb_models.search import FindOptions, MinScore, RerankerName
 from nucliadb_protos.resources_pb2 import (
     Classification,
     ExtractedTextWrapper,
@@ -374,7 +374,7 @@ async def _test_filtering(nucliadb_reader: AsyncClient, kbid: str, filters):
         ):
             request = dict(
                 query="",
-                features=[SearchOptions.KEYWORD, SearchOptions.SEMANTIC],
+                features=[FindOptions.KEYWORD, FindOptions.SEMANTIC],
                 vector=Q,
                 min_score=MinScore(semantic=-1).model_dump(),
                 reranker=RerankerName.NOOP,
@@ -416,7 +416,7 @@ async def test_filtering_field_and_paragraph(app_context, nucliadb_reader: Async
             f"/kb/{kbid}/find",
             json=dict(
                 query="",
-                features=[SearchOptions.KEYWORD, SearchOptions.SEMANTIC],
+                features=[FindOptions.KEYWORD, FindOptions.SEMANTIC],
                 vector=Q,
                 min_score=MinScore(semantic=-1).model_dump(),
                 reranker=RerankerName.NOOP,

--- a/nucliadb/tests/nucliadb/integration/search/test_search.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search.py
@@ -35,7 +35,7 @@ from nucliadb.export_import.utils import get_processor_bm, get_writer_bm
 from nucliadb.ingest.consumer import shard_creator
 from nucliadb.search.predict import SendToPredictError
 from nucliadb.tests.vectors import V1
-from nucliadb_models.search import SearchOptions
+from nucliadb_models.search import FindOptions
 from nucliadb_protos import resources_pb2 as rpb
 from nucliadb_protos.audit_pb2 import AuditRequest, ClientType
 from nucliadb_protos.utils_pb2 import RelationNode
@@ -930,7 +930,7 @@ async def test_search_endpoints_handle_predict_errors(
         resp = await nucliadb_reader.post(
             f"/kb/{kbid}/{endpoint}",
             json={
-                "features": [SearchOptions.SEMANTIC],
+                "features": [FindOptions.SEMANTIC],
                 "query": "something",
             },
         )

--- a/nucliadb/tests/nucliadb/integration/search/test_search_date_ranges_filter.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search_date_ranges_filter.py
@@ -24,7 +24,7 @@ from httpx import AsyncClient
 
 from nucliadb.export_import.utils import get_processor_bm, get_writer_bm
 from nucliadb.tests.vectors import V1
-from nucliadb_models.search import SearchOptions
+from nucliadb_models.search import FindOptions
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from tests.nucliadb.integration.search.test_search import get_resource_with_a_sentence
 from tests.utils import inject_message
@@ -82,8 +82,8 @@ async def resource(nucliadb_ingest_grpc: WriterStub, standalone_knowledgebox):
 @pytest.mark.parametrize(
     "feature",
     [
-        SearchOptions.KEYWORD,
-        SearchOptions.SEMANTIC,
+        FindOptions.KEYWORD,
+        FindOptions.SEMANTIC,
     ],
 )
 @pytest.mark.deploy_modes("standalone")
@@ -140,8 +140,8 @@ async def test_search_with_date_range_filters_nucliadb_dates(
 @pytest.mark.parametrize(
     "feature",
     [
-        SearchOptions.KEYWORD,
-        SearchOptions.SEMANTIC,
+        FindOptions.KEYWORD,
+        FindOptions.SEMANTIC,
     ],
 )
 @pytest.mark.deploy_modes("standalone")
@@ -197,7 +197,7 @@ async def _test_find_date_ranges(
     found,
 ):
     payload = {"query": "Ramon", "features": features}
-    if SearchOptions.SEMANTIC in features:
+    if FindOptions.SEMANTIC in features:
         payload["vector"] = V1
     if creation_start is not None:
         payload["range_creation_start"] = creation_start.isoformat()

--- a/nucliadb/tests/nucliadb/integration/test_deletion.py
+++ b/nucliadb/tests/nucliadb/integration/test_deletion.py
@@ -23,7 +23,7 @@ import pytest
 from httpx import AsyncClient
 
 from nucliadb.common import datamanagers
-from nucliadb_models.search import SearchOptions
+from nucliadb_models.search import FindOptions
 from nucliadb_protos.resources_pb2 import (
     FieldType,
     Paragraph,
@@ -111,7 +111,7 @@ async def test_paragraph_index_deletions(
         f"/kb/{standalone_knowledgebox}/find",
         json={
             "query": "Original",
-            "features": [SearchOptions.KEYWORD],
+            "features": [FindOptions.KEYWORD],
             "min_score": {"bm25": 0.0},
         },
         timeout=None,
@@ -136,7 +136,7 @@ async def test_paragraph_index_deletions(
         f"/kb/{standalone_knowledgebox}/find",
         json={
             "query": "Original",
-            "features": [SearchOptions.KEYWORD],
+            "features": [FindOptions.KEYWORD],
             "min_score": {"bm25": 0.0},
         },
         timeout=None,
@@ -150,7 +150,7 @@ async def test_paragraph_index_deletions(
         f"/kb/{standalone_knowledgebox}/find",
         json={
             "query": "Extracted",
-            "features": [SearchOptions.KEYWORD],
+            "features": [FindOptions.KEYWORD],
         },
         timeout=None,
     )
@@ -196,7 +196,7 @@ async def test_paragraph_index_deletions(
         f"/kb/{standalone_knowledgebox}/find",
         json={
             "query": "Extracted",
-            "features": [SearchOptions.KEYWORD],
+            "features": [FindOptions.KEYWORD],
             "min_score": {"bm25": 0.0},
         },
         timeout=None,
@@ -213,7 +213,7 @@ async def test_paragraph_index_deletions(
         f"/kb/{standalone_knowledgebox}/find",
         json={
             "query": "Modified",
-            "features": [SearchOptions.KEYWORD],
+            "features": [FindOptions.KEYWORD],
         },
         timeout=None,
     )

--- a/nucliadb/tests/nucliadb/integration/test_find.py
+++ b/nucliadb/tests/nucliadb/integration/test_find.py
@@ -27,7 +27,7 @@ from pytest_mock import MockerFixture
 
 from nucliadb.search.predict import DummyPredictEngine
 from nucliadb.search.search.rank_fusion import ReciprocalRankFusion
-from nucliadb_models.search import SearchOptions
+from nucliadb_models.search import FindOptions
 from nucliadb_protos.resources_pb2 import (
     ExtractedTextWrapper,
     ExtractedVectorsWrapper,
@@ -110,25 +110,6 @@ async def test_find_with_label_changes(
     assert resp.status_code == 200
     body = resp.json()
     assert len(body["resources"]) == 1
-
-
-@pytest.mark.deploy_modes("standalone")
-async def test_find_does_not_support_fulltext_search(
-    nucliadb_reader: AsyncClient,
-    standalone_knowledgebox,
-):
-    resp = await nucliadb_reader.get(
-        f"/kb/{standalone_knowledgebox}/find?query=title&features=fulltext&features=keyword",
-    )
-    assert resp.status_code == 422
-    assert "fulltext search not supported" in resp.json()["detail"][0]["msg"]
-
-    resp = await nucliadb_reader.post(
-        f"/kb/{standalone_knowledgebox}/find",
-        json={"query": "title", "features": [SearchOptions.FULLTEXT, SearchOptions.KEYWORD]},
-    )
-    assert resp.status_code == 422
-    assert "fulltext search not supported" in resp.json()["detail"][0]["msg"]
 
 
 @pytest.mark.deploy_modes("standalone")
@@ -263,7 +244,7 @@ async def test_story_7286(
             f"/kb/{standalone_knowledgebox}/find",
             json={
                 "query": "title",
-                "features": [SearchOptions.KEYWORD, SearchOptions.SEMANTIC, SearchOptions.RELATIONS],
+                "features": [FindOptions.KEYWORD, FindOptions.SEMANTIC, FindOptions.RELATIONS],
                 "shards": [],
                 "highlight": True,
                 "autofilter": False,

--- a/nucliadb/tests/search/unit/search/search/chat/test_ask.py
+++ b/nucliadb/tests/search/unit/search/search/chat/test_ask.py
@@ -24,12 +24,12 @@ from nucliadb_models.search import (
     AskRequest,
     ChatOptions,
     FindField,
+    FindOptions,
     FindParagraph,
     FindRequest,
     FindResource,
     KnowledgeboxFindResults,
     PreQuery,
-    SearchOptions,
 )
 
 
@@ -67,7 +67,7 @@ def test_calculate_prequeries_for_json_schema():
     assert prequeries.main_query_weight == 1.0
     for preq in prequeries.queries:
         assert preq.weight == 1.0
-        assert preq.request.features == [SearchOptions.KEYWORD]
+        assert preq.request.features == [FindOptions.KEYWORD]
         assert preq.request.rephrase is False
         assert preq.request.highlight is False
         # Only the top-10 results are requested for each query

--- a/nucliadb/tests/search/unit/search/search/chat/test_query.py
+++ b/nucliadb/tests/search/unit/search/search/chat/test_query.py
@@ -28,10 +28,10 @@ from nucliadb.search.search.chat.query import (
 from nucliadb_models.search import (
     AskRequest,
     ChatOptions,
+    FindOptions,
     KnowledgeboxFindResults,
     MinScore,
     NucliaDBClientType,
-    SearchOptions,
 )
 
 
@@ -47,29 +47,29 @@ def predict():
     [
         (
             None,  # default value will be used
-            [SearchOptions.SEMANTIC, SearchOptions.KEYWORD],
+            [FindOptions.SEMANTIC, FindOptions.KEYWORD],
         ),
         (
             [ChatOptions.KEYWORD, ChatOptions.SEMANTIC, ChatOptions.RELATIONS],
-            [SearchOptions.KEYWORD, SearchOptions.SEMANTIC, SearchOptions.RELATIONS],
+            [FindOptions.KEYWORD, FindOptions.SEMANTIC, FindOptions.RELATIONS],
         ),
         (
             [ChatOptions.KEYWORD, ChatOptions.SEMANTIC],
             [
-                SearchOptions.KEYWORD,
-                SearchOptions.SEMANTIC,
+                FindOptions.KEYWORD,
+                FindOptions.SEMANTIC,
             ],
         ),
         (
             [ChatOptions.SEMANTIC],
             [
-                SearchOptions.SEMANTIC,
+                FindOptions.SEMANTIC,
             ],
         ),
         (
             [ChatOptions.KEYWORD],
             [
-                SearchOptions.KEYWORD,
+                FindOptions.KEYWORD,
             ],
         ),
     ],

--- a/nucliadb/tests/search/unit/search/search/test_common_query_parser.py
+++ b/nucliadb/tests/search/unit/search/search/test_common_query_parser.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from nucliadb.search.search.query_parser.parsers.common import (
+    has_user_vectors,
+    is_empty_query,
+    is_exact_match_only_query,
+    should_disable_vector_search,
+)
+from nucliadb_models.search import SearchRequest
+
+
+@pytest.mark.parametrize(
+    "item,empty",
+    [
+        (SearchRequest(query=""), True),
+        (SearchRequest(query="foo"), False),
+    ],
+)
+def test_is_empty_query(item, empty):
+    assert is_empty_query(item) is empty
+
+
+@pytest.mark.parametrize(
+    "query,exact_match",
+    [
+        ("some", False),
+        ("some query terms", False),
+        ('"something"', True),
+        ('   "something"', True),
+        ('"something"   ', True),
+        ('"something exact"', True),
+        ('"something exact" and something else', False),
+    ],
+)
+def test_is_exact_match_only_query(query, exact_match):
+    item = SearchRequest(query=query)
+    assert is_exact_match_only_query(item) is exact_match
+
+
+@pytest.mark.parametrize(
+    "item,has_vectors",
+    [
+        (SearchRequest(query=""), False),
+        (SearchRequest(vector=[]), False),
+        (SearchRequest(vector=[1.0]), True),
+    ],
+)
+def test_has_user_vectors(item, has_vectors):
+    assert has_user_vectors(item) is has_vectors
+
+
+@pytest.mark.parametrize(
+    "item,disable_vectors",
+    [
+        (SearchRequest(query=""), True),
+        (SearchRequest(query='"exact match"'), True),
+        (SearchRequest(query="foo"), False),
+        (SearchRequest(query="", vector=[1.0, 2.0]), False),
+        (SearchRequest(query='"exact match"', vector=[1.0, 2.0]), False),
+    ],
+)
+def test_should_disable_vectors(item, disable_vectors):
+    assert should_disable_vector_search(item) is disable_vectors

--- a/nucliadb/tests/search/unit/search/search/test_utils.py
+++ b/nucliadb/tests/search/unit/search/search/test_utils.py
@@ -19,70 +19,10 @@
 #
 import unittest
 
-import pytest
-
 from nucliadb.search.search.utils import (
-    has_user_vectors,
-    is_empty_query,
-    is_exact_match_only_query,
     maybe_log_request_payload,
-    should_disable_vector_search,
 )
 from nucliadb_models.search import SearchRequest
-
-
-@pytest.mark.parametrize(
-    "item,empty",
-    [
-        (SearchRequest(query=""), True),
-        (SearchRequest(query="foo"), False),
-    ],
-)
-def test_is_empty_query(item, empty):
-    assert is_empty_query(item) is empty
-
-
-@pytest.mark.parametrize(
-    "query,exact_match",
-    [
-        ("some", False),
-        ("some query terms", False),
-        ('"something"', True),
-        ('   "something"', True),
-        ('"something"   ', True),
-        ('"something exact"', True),
-        ('"something exact" and something else', False),
-    ],
-)
-def test_is_exact_match_only_query(query, exact_match):
-    item = SearchRequest(query=query)
-    assert is_exact_match_only_query(item) is exact_match
-
-
-@pytest.mark.parametrize(
-    "item,has_vectors",
-    [
-        (SearchRequest(query=""), False),
-        (SearchRequest(vector=[]), False),
-        (SearchRequest(vector=[1.0]), True),
-    ],
-)
-def test_has_user_vectors(item, has_vectors):
-    assert has_user_vectors(item) is has_vectors
-
-
-@pytest.mark.parametrize(
-    "item,disable_vectors",
-    [
-        (SearchRequest(query=""), True),
-        (SearchRequest(query='"exact match"'), True),
-        (SearchRequest(query="foo"), False),
-        (SearchRequest(query="", vector=[1.0, 2.0]), False),
-        (SearchRequest(query='"exact match"', vector=[1.0, 2.0]), False),
-    ],
-)
-def test_should_disable_vectors(item, disable_vectors):
-    assert should_disable_vector_search(item) is disable_vectors
 
 
 def test_maybe_log_request_payload():

--- a/nucliadb/tests/search/unit/search/test_query.py
+++ b/nucliadb/tests/search/unit/search/test_query.py
@@ -31,7 +31,7 @@ from nucliadb.search.search.query import (
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.parsers.common import parse_semantic_query, query_with_synonyms
 from nucliadb.tests.vectors import Q
-from nucliadb_models.search import BaseSearchRequest, SearchOptions
+from nucliadb_models.search import FindOptions, FindRequest
 from nucliadb_protos.knowledgebox_pb2 import Synonyms
 from nucliadb_protos.nodereader_pb2 import SearchRequest
 from nucliadb_protos.utils_pb2 import RelationNode
@@ -169,8 +169,8 @@ class TestVectorSetAndMatryoshkaParsing:
             patch("nucliadb.common.datamanagers.vectorsets.get_kv_pb"),
         ):
             semantic_query = await parse_semantic_query(
-                BaseSearchRequest(
-                    features=[SearchOptions.SEMANTIC],
+                FindRequest(
+                    features=[FindOptions.SEMANTIC],
                     vectorset=vectorset,
                 ),
                 fetcher=fetcher,

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -103,7 +103,7 @@ class SearchOptions(str, Enum):
     SEMANTIC = "semantic"
 
 
-class FindOptions(Enum):
+class FindOptions(str, Enum):
     RELATIONS = "relations"
     KEYWORD = "keyword"
     SEMANTIC = "semantic"

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -103,6 +103,12 @@ class SearchOptions(str, Enum):
     SEMANTIC = "semantic"
 
 
+class FindOptions(Enum):
+    RELATIONS = "relations"
+    KEYWORD = "keyword"
+    SEMANTIC = "semantic"
+
+
 class ChatOptions(str, Enum):
     KEYWORD = "keyword"
     RELATIONS = "relations"
@@ -789,13 +795,6 @@ class BaseSearchRequest(AuditMetadataBase):
     range_modification_end: Optional[DateTime] = (
         SearchParamDefaults.range_modification_end.to_pydantic_field()
     )
-    features: list[SearchOptions] = SearchParamDefaults.search_features.to_pydantic_field(
-        default=[
-            SearchOptions.KEYWORD,
-            SearchOptions.FULLTEXT,
-            SearchOptions.SEMANTIC,
-        ]
-    )
     debug: bool = SearchParamDefaults.debug.to_pydantic_field()
     highlight: bool = SearchParamDefaults.highlight.to_pydantic_field()
     show: list[ResourceProperties] = SearchParamDefaults.show.to_pydantic_field()
@@ -853,6 +852,13 @@ Please return ONLY the question without any explanation. Just the rephrased ques
 
 
 class SearchRequest(BaseSearchRequest):
+    features: list[SearchOptions] = SearchParamDefaults.search_features.to_pydantic_field(
+        default=[
+            SearchOptions.KEYWORD,
+            SearchOptions.FULLTEXT,
+            SearchOptions.SEMANTIC,
+        ]
+    )
     faceted: list[str] = SearchParamDefaults.faceted.to_pydantic_field()
     sort: Optional[SortOptions] = SearchParamDefaults.sort.to_pydantic_field()
 
@@ -1718,10 +1724,10 @@ class FindRequest(BaseSearchRequest):
     query_entities: SkipJsonSchema[Optional[list[KnowledgeGraphEntity]]] = Field(
         default=None, title="Query entities", description="Entities to use in a knowledge graph search"
     )
-    features: list[SearchOptions] = SearchParamDefaults.search_features.to_pydantic_field(
+    features: list[FindOptions] = SearchParamDefaults.search_features.to_pydantic_field(
         default=[
-            SearchOptions.KEYWORD,
-            SearchOptions.SEMANTIC,
+            FindOptions.KEYWORD,
+            FindOptions.SEMANTIC,
         ]
     )
     rank_fusion: Union[RankFusionName, RankFusion] = SearchParamDefaults.rank_fusion.to_pydantic_field()
@@ -1751,14 +1757,6 @@ class FindRequest(BaseSearchRequest):
         title="Generative model",
         description="The generative model used to rephrase the query. If not provided, the model configured for the Knowledge Box is used.",
     )
-
-    @field_validator("features", mode="after")
-    @classmethod
-    def fulltext_not_supported(cls, v):
-        # features are already normalized in the BaseSearchRequest model
-        if SearchOptions.FULLTEXT in v or SearchOptions.FULLTEXT == v:
-            raise ValueError("fulltext search not supported")
-        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/nucliadb_models/tests/test_search.py
+++ b/nucliadb_models/tests/test_search.py
@@ -65,6 +65,12 @@ def test_find_request_fulltext_feature_not_allowed():
         search.FindRequest(features=[search.SearchOptions.FULLTEXT])
 
 
+def test_find_supports_search_options():
+    search.FindRequest(features=[search.SearchOptions.KEYWORD])
+    search.FindRequest(features=[search.SearchOptions.SEMANTIC])
+    search.FindRequest(features=[search.SearchOptions.RELATIONS])
+
+
 # Rank fusion
 
 

--- a/nucliadb_sdk/tests/test_request_serialization.py
+++ b/nucliadb_sdk/tests/test_request_serialization.py
@@ -21,7 +21,7 @@ import json
 from unittest.mock import Mock, patch
 
 import nucliadb_sdk
-from nucliadb_models.search import FindRequest, KnowledgeboxFindResults, SearchOptions
+from nucliadb_models.search import FindOptions, FindRequest, KnowledgeboxFindResults
 
 
 def test_find_request_serialization() -> None:
@@ -32,11 +32,11 @@ def test_find_request_serialization() -> None:
         "_request",
         return_value=Mock(content=KnowledgeboxFindResults(resources={}).model_dump_json()),
     ) as spy:
-        req = FindRequest(query="love", features=[SearchOptions.RELATIONS])
+        req = FindRequest(query="love", features=[FindOptions.RELATIONS])
 
         sdk.find(kbid="kbid", content=req)
 
         sent = json.loads(spy.call_args.kwargs["content"])
 
-        assert sent == {"query": "love", "features": [SearchOptions.RELATIONS.value]}
+        assert sent == {"query": "love", "features": [FindOptions.RELATIONS.value]}
         assert sent == req.model_dump(exclude_unset=True)


### PR DESCRIPTION
### Description
Decouple `/search`  and `/find` endpoints `features`. Replace `SearchOptions` for `FindOptions` for `/find`

### How was this PR tested?
Describe how you tested this PR.
