### PR TITLE
More generic rank fusion + WeightedCombSUM algorithm 

### DIFF
--- a/nucliadb/src/nucliadb/common/external_index_providers/base.py
+++ b/nucliadb/src/nucliadb/common/external_index_providers/base.py
@@ -55,16 +55,19 @@ class VectorsetExternalIndex:
     similarity: VectorSimilarity.ValueType
 
 
-class TextBlockMatch(BaseModel):
+class ScoredTextBlock(BaseModel):
+    paragraph_id: ParagraphId
+    score: float
+    score_type: SCORE_TYPE
+
+
+class TextBlockMatch(ScoredTextBlock):
     """
     Model a text block/paragraph retrieved from an external index with all the information
     needed in order to later hydrate retrieval results.
     """
 
-    paragraph_id: ParagraphId
     position: TextPosition
-    score: float
-    score_type: SCORE_TYPE
     order: int
     page_with_visual: bool = False
     fuzzy_search: bool

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -33,6 +33,8 @@ from nuclia_models.predict.generative_responses import (
 from pydantic_core import ValidationError
 
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
+from nucliadb.common.external_index_providers.base import ScoredTextBlock
+from nucliadb.common.ids import ParagraphId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import logger, predict
 from nucliadb.search.predict import (
@@ -63,6 +65,7 @@ from nucliadb.search.search.graph_strategy import get_graph_results
 from nucliadb.search.search.metrics import RAGMetrics
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.parsers.ask import fetcher_for_ask, parse_ask
+from nucliadb.search.search.rank_fusion import WeightedCombSum
 from nucliadb.search.search.rerankers import (
     get_reranker,
 )
@@ -861,6 +864,10 @@ async def retrieval_in_resource(
     )
 
 
+class _FindParagraph(ScoredTextBlock):
+    original: FindParagraph
+
+
 def compute_best_matches(
     main_results: KnowledgeboxFindResults,
     prequeries_results: Optional[list[PreQueryResult]] = None,
@@ -878,42 +885,49 @@ def compute_best_matches(
     `main_query_weight` is the weight given to the paragraphs matching the main query when calculating the final score.
     """
 
-    def iter_paragraphs(results: KnowledgeboxFindResults):
+    def extract_paragraphs(results: KnowledgeboxFindResults) -> list[_FindParagraph]:
+        paragraphs = []
         for resource in results.resources.values():
             for field in resource.fields.values():
                 for paragraph in field.paragraphs.values():
-                    yield paragraph
+                    paragraphs.append(
+                        _FindParagraph(
+                            paragraph_id=ParagraphId.from_string(paragraph.id),
+                            score=paragraph.score,
+                            score_type=paragraph.score_type,
+                            original=paragraph,
+                        )
+                    )
+        return paragraphs
 
-    total_weights = main_query_weight + sum(prequery.weight for prequery, _ in prequeries_results or [])
-    paragraph_id_to_match: dict[str, RetrievalMatch] = {}
-    for paragraph in iter_paragraphs(main_results):
-        normalized_weight = main_query_weight / total_weights
-        rmatch = RetrievalMatch(
-            paragraph=paragraph,
-            weighted_score=paragraph.score * normalized_weight,
+    weights = {
+        "main": main_query_weight,
+    }
+    total_weight = main_query_weight
+    find_results = {
+        "main": extract_paragraphs(main_results),
+    }
+    total_elements = len(find_results["main"])
+    for i, (prequery, prequery_results) in enumerate(prequeries_results or []):
+        weights[f"prequery-{i}"] = prequery.weight
+        total_weight += prequery.weight
+        prequery_paragraphs = extract_paragraphs(prequery_results)
+        find_results[f"prequery-{i}"] = prequery_paragraphs
+        total_elements += len(prequery_paragraphs)
+
+    normalized_weights = {key: value / total_weight for key, value in weights.items()}
+
+    # window does nothing here
+    rank_fusion = WeightedCombSum(window=0, weights=normalized_weights)
+
+    merged = []
+    for item in rank_fusion.fuse(find_results):
+        match = RetrievalMatch(
+            paragraph=item.original,
+            weighted_score=item.score,
         )
-        paragraph_id_to_match[paragraph.id] = rmatch
-
-    for prequery, prequery_results in prequeries_results or []:
-        for paragraph in iter_paragraphs(prequery_results):
-            normalized_weight = prequery.weight / total_weights
-            weighted_score = paragraph.score * normalized_weight
-            if paragraph.id in paragraph_id_to_match:
-                rmatch = paragraph_id_to_match[paragraph.id]
-                # If a paragraph is matched in various prequeries, the final score is the
-                # sum of the weighted scores
-                rmatch.weighted_score += weighted_score
-            else:
-                paragraph_id_to_match[paragraph.id] = RetrievalMatch(
-                    paragraph=paragraph,
-                    weighted_score=weighted_score,
-                )
-
-    return sorted(
-        paragraph_id_to_match.values(),
-        key=lambda match: match.weighted_score,
-        reverse=True,
-    )
+        merged.append(match)
+    return merged
 
 
 def calculate_prequeries_for_json_schema(

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -907,13 +907,10 @@ def compute_best_matches(
     find_results = {
         "main": extract_paragraphs(main_results),
     }
-    total_elements = len(find_results["main"])
     for i, (prequery, prequery_results) in enumerate(prequeries_results or []):
         weights[f"prequery-{i}"] = prequery.weight
         total_weight += prequery.weight
-        prequery_paragraphs = extract_paragraphs(prequery_results)
-        find_results[f"prequery-{i}"] = prequery_paragraphs
-        total_elements += len(prequery_paragraphs)
+        find_results[f"prequery-{i}"] = extract_paragraphs(prequery_results)
 
     normalized_weights = {key: value / total_weight for key, value in weights.items()}
 

--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -42,7 +42,7 @@ from nucliadb.search.search.hydrator import (
 )
 from nucliadb.search.search.merge import merge_relations_results
 from nucliadb.search.search.query_parser.models import UnitRetrieval
-from nucliadb.search.search.rank_fusion import RankFusionAlgorithm
+from nucliadb.search.search.rank_fusion import IndexSource, RankFusionAlgorithm
 from nucliadb.search.search.rerankers import (
     RerankableItem,
     Reranker,
@@ -108,7 +108,13 @@ async def build_find_response(
     )
     graph_results = graph_results_to_text_block_matches(search_response.graph)
 
-    merged_text_blocks = rank_fusion_algorithm.fuse(keyword_results, semantic_results, graph_results)
+    merged_text_blocks = rank_fusion_algorithm.fuse(
+        {
+            IndexSource.KEYWORD: keyword_results,
+            IndexSource.SEMANTIC: semantic_results,
+            IndexSource.GRAPH: graph_results,
+        }
+    )
 
     # cut
     # we assume pagination + predict reranker is forbidden and has been already

--- a/nucliadb/src/nucliadb/search/search/rank_fusion.py
+++ b/nucliadb/src/nucliadb/search/search/rank_fusion.py
@@ -184,7 +184,7 @@ class ReciprocalRankFusion(RankFusionAlgorithm):
         return merged
 
 
-class WeigthedCombSum(RankFusionAlgorithm):
+class WeightedCombSum(RankFusionAlgorithm):
     """Score-based rank fusion algorithm. Multiply each score by a list-specific
     weight (boost). Then adds the retrieval score of documents contained in more
     than one list and sort by score.

--- a/nucliadb/tests/search/unit/search/search/chat/test_ask.py
+++ b/nucliadb/tests/search/unit/search/search/chat/test_ask.py
@@ -184,6 +184,13 @@ def test_compute_best_matches():
     # The last paragraphs come from the main results
     assert best_matches[4].paragraph.id == "main-result/f/f1/0-10"
     assert best_matches[5].paragraph.id == "main-result/f/f1/10-20"
+    # validate score computation
+    assert best_matches[0].weighted_score == best_matches[0].paragraph.score * 90 / 101
+    assert best_matches[1].weighted_score == best_matches[1].paragraph.score * 90 / 101
+    assert best_matches[2].weighted_score == best_matches[2].paragraph.score * 10 / 101
+    assert best_matches[3].weighted_score == best_matches[3].paragraph.score * 10 / 101
+    assert best_matches[4].weighted_score == best_matches[4].paragraph.score * 1 / 101
+    assert best_matches[5].weighted_score == best_matches[5].paragraph.score * 1 / 101
 
     # Test that the main query weight can be set to a huge
     # value so that the main results are always at the beginning
@@ -202,3 +209,10 @@ def test_compute_best_matches():
     assert best_matches[3].paragraph.id == "prequery-2-result/f/f1/10-20"
     assert best_matches[4].paragraph.id == "prequery-1-result/f/f1/0-10"
     assert best_matches[5].paragraph.id == "prequery-1-result/f/f1/10-20"
+    # validate score computation
+    assert best_matches[0].weighted_score == best_matches[0].paragraph.score * 1000 / 1100
+    assert best_matches[1].weighted_score == best_matches[1].paragraph.score * 1000 / 1100
+    assert best_matches[2].weighted_score == best_matches[2].paragraph.score * 90 / 1100
+    assert best_matches[3].weighted_score == best_matches[3].paragraph.score * 90 / 1100
+    assert best_matches[4].weighted_score == best_matches[4].paragraph.score * 10 / 1100
+    assert best_matches[5].weighted_score == best_matches[5].paragraph.score * 10 / 1100

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -43,7 +43,7 @@ from nucliadb.search.search.find_merge import (
 from nucliadb.search.search.query_parser.parsers import parse_find
 from nucliadb.search.search.rank_fusion import (
     ReciprocalRankFusion,
-    WeigthedCombSum,
+    WeightedCombSum,
     get_rank_fusion,
 )
 from nucliadb_models.search import SCORE_TYPE, FindRequest
@@ -433,7 +433,7 @@ def test_weighted_comb_sum_rank_fusion(
     graph: list[TextBlockMatch],
     expected: list[tuple[str, float]],
 ):
-    wcombsum = WeigthedCombSum(
+    wcombsum = WeightedCombSum(
         window=20,
         weights={
             "keyword": 2,

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -41,7 +41,10 @@ from nucliadb.search.search.find_merge import (
     semantic_result_to_text_block_match,
 )
 from nucliadb.search.search.query_parser.parsers import parse_find
-from nucliadb.search.search.rank_fusion import ReciprocalRankFusion, get_rank_fusion
+from nucliadb.search.search.rank_fusion import (
+    ReciprocalRankFusion,
+    get_rank_fusion,
+)
 from nucliadb_models.search import SCORE_TYPE, FindRequest
 from nucliadb_protos.utils_pb2 import RelationMetadata
 
@@ -293,7 +296,7 @@ def test_reciprocal_rank_fusion_algorithm(
     expected: list[tuple[str, float, SCORE_TYPE]],
 ):
     rrf = ReciprocalRankFusion(k=RRF_TEST_K, window=20)
-    merged = rrf.fuse(keyword, semantic, graph)
+    merged = rrf.fuse({"keyword": keyword, "semantic": semantic, "graph": graph})
     results = [(item.paragraph_id.rid, round(item.score, 6), item.score_type) for item in merged]
     assert results == expected
 
@@ -381,7 +384,15 @@ def test_reciprocal_rank_fusion_boosting(
     graph: list[TextBlockMatch],
     expected: list[tuple[str, float]],
 ):
-    rrf = ReciprocalRankFusion(k=RRF_TEST_K, window=20, keyword_weight=2, semantic_weight=0.5)
-    merged = rrf.fuse(keyword, semantic, graph)
+    rrf = ReciprocalRankFusion(
+        k=RRF_TEST_K,
+        window=20,
+        weights={
+            "keyword": 2,
+            "semantic": 0.5,
+        },
+        default_weight=1.0,
+    )
+    merged = rrf.fuse({"keyword": keyword, "semantic": semantic, "graph": graph})
     results = [(item.paragraph_id.rid, round(item.score, 6), item.score_type) for item in merged]
     assert results == expected


### PR DESCRIPTION
### Description
Make rank fusion more generic and add a `WeightedCombSUM` rank fusion algorithm. The algorithm was used to merge prequeries responses. Now it could be used as a rank fusion strategy for search.

### How was this PR tested?
Describe how you tested this PR.
