### PR TITLE
Avoid panic with 0-tokens keyword

### DIFF
--- a/nidx/nidx_text/src/query_io.rs
+++ b/nidx/nidx_text/src/query_io.rs
@@ -32,7 +32,13 @@ pub fn translate_keyword_to_text_query(literal: &str, schema: &TextSchema) -> Bo
         terms.push(Term::from_field_text(schema.text, &token.text));
     }
     // Create a query using the tokenized terms
-    if terms.len() == 1 {
+    if terms.len() == 0 {
+        // This can happen for empty or non-alphanumeric keywords, fallback to avoid panic'ing
+        Box::new(TermQuery::new(
+            Term::from_field_text(schema.text, literal),
+            IndexRecordOption::Basic,
+        ))
+    } else if terms.len() == 1 {
         Box::new(TermQuery::new(terms[0].clone(), IndexRecordOption::Basic))
     } else {
         Box::new(PhraseQuery::new(terms))

--- a/nidx/nidx_text/tests/test_search.rs
+++ b/nidx/nidx_text/tests/test_search.rs
@@ -173,6 +173,19 @@ fn test_keywords_prefilter_search() {
         panic!("Response is not on the right variant");
     };
     assert_eq!(fields.len(), 1);
+
+    let request = PreFilterRequest {
+        security: None,
+        filter_expression: Some(FilterExpression {
+            expr: Some(nidx_protos::filter_expression::Expr::Keyword(KeywordFilter {
+                keyword: "%".into(),
+            })),
+        }),
+    };
+    let response = reader.prefilter(&request).unwrap();
+    let PrefilterResult::None = response else {
+        panic!("Response is not on the right variant");
+    };
 }
 
 #[test]

--- a/nucliadb/src/nucliadb/search/api/v1/catalog.py
+++ b/nucliadb/src/nucliadb/search/api/v1/catalog.py
@@ -184,7 +184,8 @@ async def catalog(
         return HTTPClientError(status_code=exc.status_code, detail=exc.detail)
     finally:
         duration = time() - start_time
-        if duration > 2:  # pragma: no cover
+        max_time = 5 if item.faceted else 2
+        if duration > max_time:  # pragma: no cover
             logger.warning(
                 "Slow catalog request",
                 extra={


### PR DESCRIPTION
### Description

When searching for a keyword which returns 0 tokens when tokenized (e.g: `%`), we panic. This PR avoids the panic, even if the results will likely not be what's expected.

### How was this PR tested?
Describe how you tested this PR.
