### PR TITLE
Include custom graph in graph strategy

### DIFF
--- a/nidx/nidx_text/src/query_io.rs
+++ b/nidx/nidx_text/src/query_io.rs
@@ -32,7 +32,7 @@ pub fn translate_keyword_to_text_query(literal: &str, schema: &TextSchema) -> Bo
         terms.push(Term::from_field_text(schema.text, &token.text));
     }
     // Create a query using the tokenized terms
-    if terms.len() == 0 {
+    if terms.is_empty() {
         // This can happen for empty or non-alphanumeric keywords, fallback to avoid panic'ing
         Box::new(TermQuery::new(
             Term::from_field_text(schema.text, literal),

--- a/nucliadb/src/nucliadb/search/search/chat/query.py
+++ b/nucliadb/src/nucliadb/search/search/chat/query.py
@@ -246,8 +246,6 @@ async def get_relations_results(
     kbid: str,
     text_answer: str,
     timeout: Optional[float] = None,
-    only_with_metadata: bool = False,
-    only_agentic_relations: bool = False,
 ) -> Relations:
     try:
         predict = get_predict()
@@ -257,8 +255,6 @@ async def get_relations_results(
             kbid=kbid,
             entities=detected_entities,
             timeout=timeout,
-            only_with_metadata=only_with_metadata,
-            only_agentic_relations=only_agentic_relations,
         )
     except Exception as exc:
         capture_exception(exc)
@@ -271,9 +267,6 @@ async def get_relations_results_from_entities(
     kbid: str,
     entities: Iterable[RelationNode],
     timeout: Optional[float] = None,
-    only_with_metadata: bool = False,
-    only_agentic_relations: bool = False,
-    only_entity_to_entity: bool = False,
     deleted_entities: set[str] = set(),
 ) -> Relations:
     entry_points = list(entities)
@@ -304,9 +297,6 @@ async def get_relations_results_from_entities(
     return await merge_relations_results(
         relations_results,
         entry_points,
-        only_with_metadata,
-        only_agentic_relations,
-        only_entity_to_entity,
     )
 
 

--- a/nucliadb/src/nucliadb/search/search/graph_strategy.py
+++ b/nucliadb/src/nucliadb/search/search/graph_strategy.py
@@ -970,5 +970,5 @@ async def find_graph_neighbours(
         exclude_processor.facet.facet = "/g"
         graph_query.query.path.bool_and.operands.append(exclude_processor)
 
-    (relations_results, _, _) = await node_query(kbid, Method.GRAPH, graph_query, timeout=5.0)
+    (relations_results, _) = await nidx_query(kbid, Method.GRAPH, graph_query, timeout=5.0)
     return relations_results

--- a/nucliadb/tests/ndbfixtures/resources.py
+++ b/nucliadb/tests/ndbfixtures/resources.py
@@ -37,8 +37,9 @@ from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX
 from nucliadb_models.metadata import RelationEntity, RelationNodeType, RelationType
 from nucliadb_protos import utils_pb2 as upb
 from nucliadb_protos.knowledgebox_pb2 import SemanticModelMetadata
+from nucliadb_protos.resources_pb2 import FieldType
 from nucliadb_protos.utils_pb2 import Relation, RelationMetadata, RelationNode
-from nucliadb_protos.writer_pb2 import BrokerMessage
+from nucliadb_protos.writer_pb2 import BrokerMessage, FieldComputedMetadataWrapper
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from nucliadb_utils.storages.storage import Storage
 from tests.utils import inject_message
@@ -553,7 +554,6 @@ async def graph_resource(nucliadb_writer: AsyncClient, nucliadb_ingest_grpc, sta
             relation_label="starred",
             metadata=RelationMetadata(
                 paragraph_id=rid + "/t/inception3/0-42",
-                data_augmentation_task_id="",
             ),
         ),
         Relation(
@@ -570,7 +570,12 @@ async def graph_resource(nucliadb_writer: AsyncClient, nucliadb_ingest_grpc, sta
     bm = BrokerMessage()
     bm.uuid = rid
     bm.kbid = standalone_knowledgebox
-    bm.user_relations.relations.extend(edges)
+    bm.source = BrokerMessage.MessageSource.PROCESSOR
+    fcmw = FieldComputedMetadataWrapper()
+    fcmw.field.field_type = FieldType.TEXT
+    fcmw.field.field = "inception1"
+    fcmw.metadata.metadata.relations.add(relations=edges)
+    bm.field_metadata.append(fcmw)
     await inject_message(nucliadb_ingest_grpc, bm)
     await wait_for_sync()
     yield rid

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -22,6 +22,7 @@ from enum import Enum
 from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic.aliases import AliasChoices
 from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Annotated, Self
 
@@ -1294,10 +1295,11 @@ Bigger values will discover more intricate relationships but will also take more
         ge=1,
         le=300,
     )
-    agentic_graph_only: bool = Field(
+    exclude_processor_relations: bool = Field(
         default=True,
-        title="Use only the graph extracted by an agent.",
+        title="Do not use relations extracted by processor.",
         description="If set to true, only relationships extracted from a graph extraction agent are considered for context expansion.",
+        validation_alias=AliasChoices("agentic_graph_only", "exclude_processor_relations"),
     )
     relation_text_as_paragraphs: bool = Field(
         default=False,


### PR DESCRIPTION
### Description
- Moves the filtering logic for graph rag strategy to the index, by building an appropriate query in the strategy.
- Renames `agentic_graph_only` to `exclude_processor_relations` (keep an alias to the old name for bw/c). And change its behaviour to also include results from custom user graphs.
