### PR TITLE
Address logger deprecation warnings

### DIFF
--- a/nucliadb/src/nucliadb/search/search/pgcatalog.py
+++ b/nucliadb/src/nucliadb/search/search/pgcatalog.py
@@ -188,7 +188,7 @@ async def pgcatalog_search(catalog_query: CatalogQuery) -> Resources:
                     if not (
                         facet.startswith("/n/s") or facet.startswith("/n/i") or facet.startswith("/l")
                     ):
-                        logger.warn(
+                        logger.warning(
                             f"Unexpected facet used at catalog: {facet}, kbid={catalog_query.kbid}"
                         )
 


### PR DESCRIPTION
### Description
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```