### PR TITLE
charts: Add readiness probe to ingest sts

### DIFF
--- a/charts/nucliadb_ingest/templates/ingest.sts.yaml
+++ b/charts/nucliadb_ingest/templates/ingest.sts.yaml
@@ -72,6 +72,13 @@ spec:
           periodSeconds: 120
           timeoutSeconds: 10
           failureThreshold: 10
+        readinessProbe:
+          grpc:
+            port: {{ .Values.serving.grpc }}
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         command: ["nucliadb-ingest"]
         envFrom:
           - configMapRef:


### PR DESCRIPTION
This pull request introduces a readiness probe to the `ingest.sts.yaml` file to enhance the health monitoring of the NucliaDB ingest service.

**Health Monitoring Enhancements:**

* [`charts/nucliadb_ingest/templates/ingest.sts.yaml`](diffhunk://#diff-f777bbd5f53d486385e1b850f5860f37ee80b71b9a5096dadd6681d9aec7f2f5R75-R81): Added a `readinessProbe` configuration with gRPC settings, including port, initial delay, period, timeout, and failure threshold, to ensure the service is ready before accepting traffic.