### PR TITLE
Fix predict proxy streaming. Each chunk should be a line in order to parse it

### DIFF
--- a/nucliadb/src/nucliadb/search/search/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/search/predict_proxy.py
@@ -171,14 +171,13 @@ async def chat_streaming_generator(
     user_query: str,
     is_json: bool,
 ):
-    stream = predict_response.content.iter_any()
     first = True
     status_code = AnswerStatusCode.ERROR.value
     text_answer = ""
     json_object = None
     metrics = AskMetrics()
     with metrics.time(PREDICT_ANSWER_METRIC):
-        async for chunk in stream:
+        async for chunk in predict_response.content:
             if first:
                 metrics.record_first_chunk_yielded()
                 first = False

--- a/nucliadb/tests/search/unit/search/test_predict_proxy.py
+++ b/nucliadb/tests/search/unit/search/test_predict_proxy.py
@@ -44,10 +44,14 @@ def predict_response():
         for i in range(3):
             yield i.to_bytes(i, "big")
 
+    async def iter_lines(_):
+        for i in range(3):
+            yield i.to_bytes(i, "big")
+
     resp = Mock()
     resp.status = 200
     resp.headers = {"Content-Type": "application/json"}
-    resp.content = Mock(iter_any=iter_any)
+    resp.content = Mock(iter_any=iter_any, __aiter__=iter_lines)
     json_answer = {"answer": "foo"}
     resp.json = AsyncMock(return_value=json_answer)
     resp.read = AsyncMock(return_value=json.dumps(json_answer).encode())


### PR DESCRIPTION
### Description

`iter_any()` was cutting chunks at arbitrary places which ended up producing invalid json chunks when trying to parse it. Instread we use the default content iterator which works line by line, which is perfect for parsing ndjson.

### How was this PR tested?
Describe how you tested this PR.
