### PR TITLE
Only choose partition for main ingest consumer

### DIFF
--- a/nucliadb/src/nucliadb/ingest/app.py
+++ b/nucliadb/src/nucliadb/ingest/app.py
@@ -176,7 +176,6 @@ async def main_subscriber_workers():  # pragma: no cover
 
 def setup_configuration():  # pragma: no cover
     setup_logging()
-    assign_partitions(settings)
 
     errors.setup_error_handling(importlib.metadata.distribution("nucliadb").version)
 
@@ -188,9 +187,9 @@ def run_consumer() -> None:  # pragma: no cover
     """
     Running:
         - main consumer
-        - pull worker
     """
     setup_configuration()
+    assign_partitions(settings)
     asyncio.run(main_consumer())
 
 


### PR DESCRIPTION
### Description

Only needed for main/writer ingest. Causes a warning in the rest.

Not needed for the rest of services:
- ingest_processed_consumer
- ingest_orm_grpc
- ingest_subscriber_workers

### How was this PR tested?
Describe how you tested this PR.
