### PR TITLE
Fix Graph API boolean models using rebuild

### DIFF
--- a/nucliadb_models/src/nucliadb_models/graph/requests.py
+++ b/nucliadb_models/src/nucliadb_models/graph/requests.py
@@ -207,3 +207,15 @@ class GraphRelationsSearchRequest(BaseGraphSearchRequest):
 GraphSearchRequest.model_rebuild()
 GraphNodesSearchRequest.model_rebuild()
 GraphRelationsSearchRequest.model_rebuild()
+
+And["GraphPathQuery"].model_rebuild()
+Or["GraphPathQuery"].model_rebuild()
+Not["GraphPathQuery"].model_rebuild()
+
+And["GraphNodesQuery"].model_rebuild()
+Or["GraphNodesQuery"].model_rebuild()
+Not["GraphNodesQuery"].model_rebuild()
+
+And["GraphRelationsQuery"].model_rebuild()
+Or["GraphRelationsQuery"].model_rebuild()
+Not["GraphRelationsQuery"].model_rebuild()


### PR DESCRIPTION
### Description
Without the model rebuild, nested boolean operators were not capable of serializing themselves

### How was this PR tested?
Added a new test with a complex boolean expression using the models
