### PR TITLE
Use Sequence in recursive filters to make them covariant

### DIFF
--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+from collections.abc import Sequence
 from enum import Enum
 from typing import Any, Generic, Literal, Optional, TypeVar, Union
 from uuid import UUID
@@ -31,7 +32,7 @@ F = TypeVar("F", bound=BaseModel)
 class And(BaseModel, Generic[F], extra="forbid"):
     """AND of other expressions"""
 
-    operands: list[F] = pydantic.Field(
+    operands: Sequence[F] = pydantic.Field(
         serialization_alias="and", validation_alias=AliasChoices("operands", "and"), min_length=1
     )
 
@@ -43,7 +44,7 @@ class And(BaseModel, Generic[F], extra="forbid"):
 class Or(BaseModel, Generic[F], extra="forbid"):
     """OR of other expressions"""
 
-    operands: list[F] = pydantic.Field(
+    operands: Sequence[F] = pydantic.Field(
         serialization_alias="or", validation_alias=AliasChoices("operands", "or"), min_length=1
     )
 


### PR DESCRIPTION
### Description

list are invariant (see https://mypy.readthedocs.io/en/stable/common_issues.html#variance). This is annoying to work with in examples like this:

```python
# This does not work
nodes: list[AnyNode] = [AnyNode()]

nodes_query: GraphNodesQuery = And(operands=nodes)
# error: Argument "operands" to "And" has incompatible type "list[AnyNode]";
# expected "list[Union[And[GraphNodesQuery], Or[GraphNodesQuery], Not[GraphNodesQuery], AnyNode, Generated]]"  [arg-type]
```

Since `And.operands` is a `list` and lists are invariant, `AnyNode` cannot be converted into `GraphNodesQuery` even when that query is `Union[..., AnyNode, ...]`. Calling the query directly works:

```python
# This works
nodes_query: GraphNodesQuery = And(operands=[AnyNode])
```

but anything involving typed function calls or typed variables will fail type-checking. The alternative is to use casts, which are kind of annoying to write:

```python
# This works
nodes: list[AnyNode] = [AnyNode()]

nodes_query: GraphNodesQuery = And(operands=cast(list[GraphNodesQuery], nodes))
```

Or alternatively, make copies:

```python
# This works
nodes: list[AnyNode] = [AnyNode()]

nodes_query: GraphNodesQuery = And(operands=list(nodes))
```

---

One solution is just to define those generic containers (And, Or) as `Sequence` which is covariant (it can automatically upcast the contents).

The downside is that `Sequence` is inmutable (which is precisely why it can be covariant). Which means you can no longer do something like `and_query.operands.append(...)` once assigned to the query. Example:

```python
# This is OK. We work with a list, which autocasts to a sequence when putting it inside the And
operands = []
for i in range(10):
  operands.append(AnyNode())
nodes_query: And[GraphNodesQuery] = And(operands=operands)

# This is not OK, nodes_query.operands is already an inmutable Sequence
nodes_query.operands.append(AnyNode())
```


