### PR TITLE
Serialize default fields on SDK

### DIFF
--- a/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
@@ -548,7 +548,7 @@ def _parse_list_of_pydantic(
     output = []
     for item in data:
         if isinstance(item, BaseModel):
-            output.append(item.model_dump(by_alias=True, exclude_unset=True))
+            output.append(item.model_dump(by_alias=True))
         else:
             output.append(item)
     return orjson.dumps(output).decode("utf-8")
@@ -597,7 +597,7 @@ def prepare_request(
             elif not isinstance(content, request_type):
                 raise TypeError(f"Expected {request_type}, got {type(content)}")
             elif isinstance(content, BaseModel):
-                data = content.model_dump_json(by_alias=True, exclude_unset=True)
+                data = content.model_dump_json(by_alias=True)
             else:
                 raise TypeError(f"Unknown type {type(content)}")
         else:
@@ -607,9 +607,7 @@ def prepare_request(
                 for key in list(kwargs.keys()):
                     if key in request_type.model_fields:
                         content_data[key] = kwargs.pop(key)
-                data = request_type.model_validate(content_data).model_dump_json(
-                    by_alias=True, exclude_unset=True
-                )
+                data = request_type.model_validate(content_data).model_dump_json(by_alias=True)
     elif (
         isinstance(content, str)
         or isinstance(content, dict)

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -77,6 +77,8 @@ def test_ask_on_kb(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
 
 
 def test_ask_on_kb_pydantic(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
+    """This test intends to check that the serialization of the AskRequest
+    is correctly done and compatible with discriminator fields."""
     result: SyncAskResponse = sdk.ask(
         kbid=docs_dataset,
         content=AskRequest(

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -39,6 +39,7 @@ from nucliadb_models.search import (
     RelationDirection,
     Relations,
     RelationsAskResponseItem,
+    RerankerName,
     RetrievalAskResponseItem,
     StatusAskResponseItem,
     SyncAskResponse,
@@ -95,11 +96,12 @@ def test_ask_on_kb_pydantic(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
                 boosting=ReciprocalRankFusionWeights(keyword=0.5, semantic=0.5)
             ),
             rag_strategies=[HierarchyResourceStrategy(count=0)],
+            reranker=RerankerName.NOOP,
         ),
     )
     assert result.learning_id == "00"
     assert result.answer == "valid answer to"
-    assert len(result.retrieval_results.resources) == 7
+    assert len(result.retrieval_results.resources) == 8
     assert result.relations
 
 

--- a/nucliadb_sdk/tests/test_ask.py
+++ b/nucliadb_sdk/tests/test_ask.py
@@ -101,7 +101,7 @@ def test_ask_on_kb_pydantic(docs_dataset, sdk: nucliadb_sdk.NucliaDB):
     )
     assert result.learning_id == "00"
     assert result.answer == "valid answer to"
-    assert len(result.retrieval_results.resources) == 8
+    assert len(result.retrieval_results.resources) == 7
     assert result.relations
 
 


### PR DESCRIPTION
### Description
We were not serializing fields that contained default values. This caused a problem for features like RAG strategies, which use the `name` field as a discriminator (with  a default value set) to determine the specific strategy type. Because the name was not being sent, these strategies could not be used.

### How was this PR tested?
Added additional test