### PR TITLE
Standalone: Update promotion component name to match common naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
               "components": [
                 {
                   "chart-version": "${{ steps.version_step.outputs.helm_version }}",
-                  "component": "nucliadb_standalone",
+                  "component": "nucliadb-standalone",
                   "component-type": "regional"
                 }
               ],


### PR DESCRIPTION
### Description
This change reflects changes to the promotion/deployment naming with the goal of unifying naming convention across all applications.

### How was this PR tested?
N/A
