### PR TITLE
nucliadb_models typechecking

### DIFF
--- a/nucliadb/pyproject.toml
+++ b/nucliadb/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
     "pyyaml>=5.1",
 
     "fastapi-versioning>=0.10.0",
-    # At some point FastAPI will drop support for pydantic v1"
     "fastapi>=0.95.2",
     "sentry-sdk>=2.8.0",
     "pyjwt>=2.4.0",

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -176,7 +176,7 @@ class CloudLink(BaseModel):
         return DOWNLOAD_URI.format(**url_params).rstrip("/")
 
     @field_serializer("uri")
-    def serialize_uri(uri):
+    def serialize_uri(self, uri: str):
         return CloudLink.format_reader_download_uri(uri)
 
 

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -88,7 +88,7 @@ class FieldID(BaseModel):
 class File(BaseModel):
     filename: Optional[str] = None
     content_type: str = "application/octet-stream"
-    payload: Optional[str] = Field(None, description="Base64 encoded file content")
+    payload: Optional[str] = Field(default=None, description="Base64 encoded file content")
     md5: Optional[str] = None
     # These are to be used for external files
     uri: Optional[str] = None

--- a/nucliadb_models/src/nucliadb_models/configuration.py
+++ b/nucliadb_models/src/nucliadb_models/configuration.py
@@ -14,7 +14,7 @@
 #
 
 import warnings
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, create_model
 
@@ -38,16 +38,14 @@ class KBConfiguration(BaseModel):
 #
 # Search configurations
 #
+def _model_fields(model: type[BaseModel], skip: list[str]) -> dict[str, Any]:
+    return {
+        name: (field.annotation, field) for name, field in model.model_fields.items() if name not in skip
+    }
+
 
 # FindConfig is a FindConfig without `search_configuration`
-FindConfig = create_model(
-    "FindConfig",
-    **{
-        name: (field.annotation, field)
-        for name, field in FindRequest.model_fields.items()
-        if name not in ("search_configuration")
-    },
-)  # type: ignore[call-overload]
+FindConfig = create_model("FindConfig", **_model_fields(FindRequest, skip=["search_configuration"]))
 
 
 class FindSearchConfiguration(BaseModel):
@@ -58,13 +56,9 @@ class FindSearchConfiguration(BaseModel):
 # AskConfig is an AskRequest where `query` is not mandatory and without `search_configuration`
 AskConfig = create_model(
     "AskConfig",
-    **{
-        name: (field.annotation, field)
-        for name, field in AskRequest.model_fields.items()
-        if name not in ("query", "search_configuration")
-    },
+    **_model_fields(AskRequest, skip=["query", "search_configuration"]),
     query=(Optional[str], None),
-)  # type: ignore[call-overload]
+)
 
 
 class AskSearchConfiguration(BaseModel):

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from nucliadb_models import CloudLink, FieldRef, FileB64
+from nucliadb_models.common import CloudLink, FieldRef, FileB64
 from nucliadb_models.utils import DateTime
 
 # Shared classes

--- a/nucliadb_models/src/nucliadb_models/file.py
+++ b/nucliadb_models/src/nucliadb_models/file.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from nucliadb_models import CloudLink, File
+from nucliadb_models.common import CloudLink, File
 
 # Shared classes
 # - Nothing to see here

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -66,7 +66,7 @@ class Not(BaseModel, Generic[F], extra="forbid"):
 
 
 class FilterProp(BaseModel):
-    prop: str
+    prop: Any
 
     @model_validator(mode="after")
     def set_discriminator(self) -> Self:

--- a/nucliadb_models/src/nucliadb_models/graph/requests.py
+++ b/nucliadb_models/src/nucliadb_models/graph/requests.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 from enum import Enum
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Discriminator, Field, Tag, model_validator
 from typing_extensions import Self
@@ -26,7 +26,7 @@ from nucliadb_models.security import RequestSecurity
 
 
 class GraphProp(BaseModel):
-    prop: str
+    prop: Any
 
     @model_validator(mode="after")
     def set_discriminator(self) -> Self:

--- a/nucliadb_models/src/nucliadb_models/metadata.py
+++ b/nucliadb_models/src/nucliadb_models/metadata.py
@@ -73,7 +73,7 @@ class Relation(BaseModel):
     label: Optional[str] = None
     metadata: Optional[RelationMetadata] = None
 
-    from_: Optional[RelationEntity] = Field(None, alias="from")
+    from_: Optional[RelationEntity] = Field(default=None, alias="from")
     to: RelationEntity
 
     @model_validator(mode="after")

--- a/nucliadb_models/src/nucliadb_models/notifications.py
+++ b/nucliadb_models/src/nucliadb_models/notifications.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -29,7 +30,7 @@ class Notification(BaseModel):
         title="Notification Type",
         description="Type of notification.",
     )
-    data: BaseModel = Field(
+    data: Any = Field(
         ...,
         title="Notification Data",
         description="Notification data.",

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -1100,7 +1100,7 @@ class ImageRagStrategyName:
 
 
 class RagStrategy(BaseModel):
-    name: str
+    name: Any
 
     @model_validator(mode="after")
     def set_discriminator(self) -> Self:
@@ -1110,7 +1110,7 @@ class RagStrategy(BaseModel):
 
 
 class ImageRagStrategy(BaseModel):
-    name: str
+    name: Any
 
     @model_validator(mode="after")
     def set_discriminator(self) -> Self:

--- a/nucliadb_models/tests/test_metadata.py
+++ b/nucliadb_models/tests/test_metadata.py
@@ -27,7 +27,7 @@ def test_relation_validator():
     )
 
     with pytest.raises(ValidationError):
-        metadata.UserMetadata(relations=["my-wrong-relation"])
+        metadata.UserMetadata(relations=["my-wrong-relation"])  # type: ignore
 
 
 def test_relation_entity_model_validator():

--- a/nucliadb_models/tests/test_search.py
+++ b/nucliadb_models/tests/test_search.py
@@ -30,40 +30,40 @@ def test_filter_model_validator():
 def test_field_extension_strategy_fields_field_validator():
     search.FieldExtensionStrategy(
         name="field_extension",
-        fields={"f/myfield"},
+        fields=["f/myfield"],
     )
 
     # not a set of fields
     with pytest.raises(ValidationError):
         search.FieldExtensionStrategy(
             name="field_extension",
-            fields=0,
+            fields=0,  # type: ignore
         )
 
     # fields must be in the format {field_type}/{field_name}
     with pytest.raises(ValidationError):
         search.FieldExtensionStrategy(
             name="field_extension",
-            fields={"myfield"},
+            fields=["myfield"],
         )
 
     # not an allowed field
     with pytest.raises(ValidationError):
         search.FieldExtensionStrategy(
             name="field_extension",
-            fields={"z/myfield"},
+            fields=["z/myfield"],
         )
 
 
 def test_find_request_fulltext_feature_not_allowed():
     with pytest.raises(ValidationError):
-        search.FindRequest(features=[search.SearchOptions.FULLTEXT])
+        search.FindRequest(features=[search.SearchOptions.FULLTEXT])  # type: ignore
 
 
 def test_find_supports_search_options():
-    search.FindRequest(features=[search.SearchOptions.KEYWORD])
-    search.FindRequest(features=[search.SearchOptions.SEMANTIC])
-    search.FindRequest(features=[search.SearchOptions.RELATIONS])
+    search.FindRequest(features=[search.FindOptions.KEYWORD])
+    search.FindRequest(features=[search.FindOptions.SEMANTIC])
+    search.FindRequest(features=[search.FindOptions.RELATIONS])
 
 
 # Rank fusion
@@ -86,13 +86,13 @@ def test_rank_fusion(rank_fusion, expected):
 
 def test_rank_fusion_errors():
     with pytest.raises(ValueError):
-        search.FindRequest(rank_fusion="unknown")
+        search.FindRequest(rank_fusion="unknown")  # type: ignore
     with pytest.raises(ValueError):
-        search.AskRequest(query="q", rank_fusion="unknown")
+        search.AskRequest(query="q", rank_fusion="unknown")  # type: ignore
 
 
 def test_legacy_rank_fusion_fix():
-    req = search.FindRequest(rank_fusion="legacy")
+    req = search.FindRequest(rank_fusion="legacy")  # type: ignore
     assert req.rank_fusion == "rrf"
 
     req = search.FindRequest.model_validate({"rank_fusion": "legacy"})


### PR DESCRIPTION
Make nucliadb_models pass typechecking with pyright & ty, fixing all typechecking warnings. This uncovered some actual bugs that could trigger when using the SDK.