### PR TITLE
Ditch redis

### DIFF
--- a/nucliadb/tests/ndbfixtures/writer.py
+++ b/nucliadb/tests/ndbfixtures/writer.py
@@ -81,7 +81,7 @@ async def nucliadb_writer_manager(
 @pytest.fixture(scope="function")
 async def writer_api_server(
     disabled_back_pressure,
-    redis,
+    valkey,
     storage: Storage,
     ingest_grpc_server,  # component fixture, shouldn't be used in other modes
     ingest_consumers,

--- a/nucliadb/tests/ndbfixtures/writer.py
+++ b/nucliadb/tests/ndbfixtures/writer.py
@@ -111,12 +111,12 @@ def disabled_back_pressure():
 
 
 @pytest.fixture(scope="function")
-async def tus_manager(redis):
+async def tus_manager(valkey):
     with (
-        patch.object(settings, "dm_redis_host", redis[0]),
-        patch.object(settings, "dm_redis_port", redis[1]),
+        patch.object(settings, "dm_redis_host", valkey[0]),
+        patch.object(settings, "dm_redis_port", valkey[1]),
     ):
-        driver = aioredis.from_url(f"redis://{redis[0]}:{redis[1]}")
+        driver = aioredis.from_url(f"redis://{valkey[0]}:{valkey[1]}")
         await driver.flushall()
 
         yield

--- a/nucliadb/tests/standalone/integration/test_upload_download.py
+++ b/nucliadb/tests/standalone/integration/test_upload_download.py
@@ -32,10 +32,10 @@ from nucliadb_utils.storages.storage import Storage
 
 
 @pytest.fixture(scope="function")
-def configure_redis_dm(redis):
+def configure_redis_dm(valkey):
     writer_settings.dm_enabled = True
-    writer_settings.dm_redis_host = redis[0]
-    writer_settings.dm_redis_port = redis[1]
+    writer_settings.dm_redis_host = valkey[0]
+    writer_settings.dm_redis_port = valkey[1]
     yield
 
 

--- a/nucliadb/tests/writer/test_tus.py
+++ b/nucliadb/tests/writer/test_tus.py
@@ -83,12 +83,12 @@ async def clean_dm():
 
 
 @pytest.fixture(scope="function")
-async def redis_dm(redis):
+async def redis_dm(valkey):
     prev = settings.dm_enabled
 
     settings.dm_enabled = True
-    settings.dm_redis_host = redis[0]
-    settings.dm_redis_port = redis[1]
+    settings.dm_redis_host = valkey[0]
+    settings.dm_redis_port = valkey[1]
 
     dm = get_dm()
 

--- a/nucliadb/tests/writer/unit/tus/test_dm.py
+++ b/nucliadb/tests/writer/unit/tus/test_dm.py
@@ -41,9 +41,7 @@ async def test_file_data_manager_factory(valkey):
     inst = factory()
 
     assert isinstance(inst, RedisFileDataManager)
-    print(inst.redis)
-    print(redis)
-    assert inst.redis == redis
+    assert inst.redis == valkey
 
     await factory.finalize()
 

--- a/nucliadb/tests/writer/unit/tus/test_dm.py
+++ b/nucliadb/tests/writer/unit/tus/test_dm.py
@@ -36,7 +36,7 @@ def redis():
         yield mock
 
 
-async def test_file_data_manager_factory(redis):
+async def test_file_data_manager_factory(valkey):
     factory = RedisFileDataManagerFactory("redis://localhost:6379")
     inst = factory()
 
@@ -55,7 +55,7 @@ async def test_get_file_data_manager():
         assert isinstance(tus.get_dm(), FileDataManager)
 
 
-async def test_get_file_data_manager_redis(redis):
+async def test_get_file_data_manager_redis(valkey):
     await tus.finalize()  # make sure to clear
 
     with patch.object(tus.writer_settings, "dm_enabled", True):

--- a/nucliadb/tests/writer/unit/tus/test_dm.py
+++ b/nucliadb/tests/writer/unit/tus/test_dm.py
@@ -41,6 +41,8 @@ async def test_file_data_manager_factory(valkey):
     inst = factory()
 
     assert isinstance(inst, RedisFileDataManager)
+    print(inst.redis)
+    print(redis)
     assert inst.redis == redis
 
     await factory.finalize()

--- a/nucliadb/tests/writer/unit/tus/test_dm.py
+++ b/nucliadb/tests/writer/unit/tus/test_dm.py
@@ -30,7 +30,7 @@ from nucliadb.writer.tus.dm import (
 
 
 @pytest.fixture()
-def redis():
+def valkey():
     mock = AsyncMock()
     with patch("nucliadb.writer.tus.dm.aioredis.from_url", return_value=mock):
         yield mock
@@ -45,7 +45,7 @@ async def test_file_data_manager_factory(valkey):
 
     await factory.finalize()
 
-    redis.aclose.assert_called_once_with(close_connection_pool=True)
+    valkey.aclose.assert_called_once_with(close_connection_pool=True)
 
 
 async def test_get_file_data_manager():

--- a/uv.lock
+++ b/uv.lock
@@ -3415,14 +3415,17 @@ wheels = [
 
 [[package]]
 name = "pytest-docker-fixtures"
-version = "1.3.19"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker" },
     { name = "pytest" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/6e/cc5395a86f5ef3b71f5bcfcc35cfce734d6010bcc7ea57fcfa704ee94df5/pytest-docker-fixtures-1.3.19.tar.gz", hash = "sha256:016578a1b6a4dfc81e5a09286230cb56e323bdfe3f4dda20a1e7bc2c74492f4a", size = 10518, upload-time = "2024-04-03T14:39:10.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/d2c8d853a51c7d1937e5126d542f23ea6c5c530fe0a6395dc901b68ac82e/pytest_docker_fixtures-1.4.0.tar.gz", hash = "sha256:9d0ac14dbd8ba6e3bd238ef0862093236d83605061147f28292ce1f959bca276", size = 10973, upload-time = "2025-06-25T08:21:38.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/1b/bf7b9635ad7009a820b59a16caede7bf72004614a386b98dd86095116199/pytest_docker_fixtures-1.4.0-py3-none-any.whl", hash = "sha256:5bc31ca1e247a5602c06a3b7c155d941cc1ba12d725a88f4d7c44171cb2db5d0", size = 14210, upload-time = "2025-06-25T08:21:37.418Z" },
+]
 
 [package.optional-dependencies]
 pg = [


### PR DESCRIPTION
### Description
We are switching from redis to valkey, which is api-compatible with redis

### How was this PR tested?
Switching all use of the `redis` fixture to the new `valkey` fixture
