### PR TITLE
nidx: Add NATS to readiness check

### DIFF
--- a/nidx/nidx_protos/pyproject.toml
+++ b/nidx/nidx_protos/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "pdm-backend",
     # Pin grpio-tools so `make protos` compile with the version we want
     # To use grpc stubs, you need a newer dependency than what was used to build this module
-    "grpcio-tools>=1.71.0,<1.72.0",
+    "grpcio-tools>=1.71.0,==1.71.0,<1.72.0",
     "mypy-protobuf>=3.6.0",
 ]
 build-backend = "pdm.backend"
@@ -13,7 +13,7 @@ name = "nidx_protos"
 version = "6.6.1"
 license = "AGPL-3.0-or-later"
 description = "Protobuf definitions for nucliadb/nidx"
-authors = [ { name = "Nuclia", email = "nucliadb@nuclia.com" }]
+authors = [{ name = "Nuclia", email = "nucliadb@nuclia.com" }]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",

--- a/nidx/src/main.rs
+++ b/nidx/src/main.rs
@@ -23,7 +23,7 @@ use nidx::{
     Settings, api,
     control::{ControlRequest, ControlServer, control_client},
     indexer, metrics, scheduler, searcher,
-    settings::EnvSettings,
+    settings::{EnvSettings, IndexerSettings},
     telemetry,
     tool::{ToolCommand, run_tool},
     worker,
@@ -116,8 +116,12 @@ async fn do_main(env_settings: EnvSettings, components: Vec<Component>) -> anyho
         .iter()
         .any(|c| matches!(c, Component::Indexer | Component::Scheduler));
     let nats_client = if needs_nats {
-        if let Some(indexer_settings) = settings.indexer.as_ref() {
-            Some(async_nats::connect(&indexer_settings.nats_server.as_ref().unwrap()).await?)
+        if let Some(IndexerSettings {
+            nats_server: Some(nats_server),
+            ..
+        }) = settings.indexer.as_ref()
+        {
+            Some(async_nats::connect(&nats_server).await?)
         } else {
             None
         }

--- a/nucliadb_protos/pyproject.toml
+++ b/nucliadb_protos/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "pdm-backend",
     # Pin grpio-tools so `make protos` compile with the version we want
     # To use grpc stubs, you need a newer dependency than what was used to build this module
-    "grpcio-tools>=1.71.0,<1.72.0",
+    "grpcio-tools>=1.71.0,==1.71.0,<1.72.0",
     "mypy-protobuf>=3.6.0",
 ]
 build-backend = "pdm.backend"


### PR DESCRIPTION
### Description
Add NATS connection to readiness check, so if the pod loses connection to NATS it is eventually restarted. 

This tries to fix the problem where an indexer gets stuck and doesn't process new messages that occasionally happens in stage. I previously tried to fix [updating the nats client](https://github.com/nuclia/nucliadb/pull/3198) since there were some problems related to that, but it's still happening, so better to have some control on our side.