### PR TITLE
Add variable for s3_kms_key_id on nuclia shared chart

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -36,6 +36,9 @@ data:
   S3_BUCKET_TAGS: {{ toJson .Values.storage.s3_bucket_tags | quote }}
   S3_DEADLETTER_BUCKET: {{ .Values.storage.s3_deadletter_bucket }}
   S3_INDEXING_BUCKET: {{ .Values.storage.s3_indexing_bucket }}
+{{- with .Values.storage.s3_kms_key_id }}
+  S3_KMS_KEY_ID: {{ . }}
+{{- end  }}
 {{- end }}
 {{- if .Values.nuclia.onprem }}
   NUCLIA_SERVICE_ACCOUNT: {{ .Values.nuclia.nuclia_service_account }}


### PR DESCRIPTION
This pull request introduces a small change to the `charts/nucliadb_shared/templates/nucliadb.cm.yaml` file, adding support for specifying an optional S3 KMS key ID in the configuration.

* [`charts/nucliadb_shared/templates/nucliadb.cm.yaml`](diffhunk://#diff-9d2ad27467ea53ab08d32f836e5cc71f1894db2b6898532b483f76cf016393a6R39-R41): Added a conditional block to include the `S3_KMS_KEY_ID` environment variable if `storage.s3_kms_key_id` is defined in the Helm chart values.