### PR TITLE
Add missing setting for kms encryption

### DIFF
--- a/nucliadb_utils/src/nucliadb_utils/utilities.py
+++ b/nucliadb_utils/src/nucliadb_utils/utilities.py
@@ -146,6 +146,7 @@ async def _create_storage(gcs_scopes: Optional[List[str]] = None) -> Storage:
             max_pool_connections=storage_settings.s3_max_pool_connections,
             bucket=storage_settings.s3_bucket,
             bucket_tags=storage_settings.s3_bucket_tags,
+            kms_key_id=storage_settings.s3_kms_key_id,
         )
         logger.info("Configuring S3 Storage")
         await s3util.initialize()


### PR DESCRIPTION
This pull request introduces a small but significant change to the S3 storage configuration in the `nucliadb_utils` library. The change adds support for specifying a KMS (Key Management Service) key ID.

* [`nucliadb_utils/src/nucliadb_utils/utilities.py`](diffhunk://#diff-13c90f125ac9300526e7c42d281281528137ac7b1069dd2122d84603771ee3a3R149): Added `kms_key_id` parameter to the S3 storage configuration, enabling encryption of objects using a specified KMS key.