### PR TITLE
Stop using deprecated utcnow

### DIFF
--- a/nucliadb/src/nucliadb/export_import/datamanager.py
+++ b/nucliadb/src/nucliadb/export_import/datamanager.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import AsyncGenerator, Type, Union, cast
 
 from nucliadb.common.maindb.driver import Driver
@@ -86,7 +86,7 @@ class ExportImportDataManager:
     ):
         metadata.processed = metadata.processed or 0
         metadata.total = metadata.total or 0
-        metadata.modified = datetime.utcnow()
+        metadata.modified = datetime.now(timezone.utc)
         key = self._get_maindb_metadata_key(type, metadata.kbid, metadata.id)
         data = metadata.model_dump_json().encode("utf-8")
         async with self.driver.transaction() as txn:

--- a/nucliadb/src/nucliadb/openapi.py
+++ b/nucliadb/src/nucliadb/openapi.py
@@ -54,7 +54,7 @@ def extract_openapi(application, version, commit_id, app_name):
     document["x-metadata"] = {
         app_name: {
             "commit": commit_id,
-            "last_updated": datetime.datetime.utcnow().isoformat(),
+            "last_updated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         }
     }
     return document

--- a/nucliadb/tests/ingest/fixtures.py
+++ b/nucliadb/tests/ingest/fixtures.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from os.path import dirname, getsize
 from typing import AsyncIterator, Iterable, Optional
 from unittest.mock import AsyncMock, patch
@@ -602,8 +602,8 @@ async def create_resource(storage: Storage, driver: Driver, knowledgebox_ingest:
             field=rpb.FieldID(field_type=rpb.FieldType.TEXT, field="text1"),
         )
         basic.fieldmetadata.append(ufm1)
-        basic.created.FromDatetime(datetime.utcnow())
-        basic.modified.FromDatetime(datetime.utcnow())
+        basic.created.FromDatetime(datetime.now(timezone.utc))
+        basic.modified.FromDatetime(datetime.now(timezone.utc))
 
         await test_resource.set_basic(basic)
 

--- a/nucliadb/tests/ndbfixtures/train.py
+++ b/nucliadb/tests/ndbfixtures/train.py
@@ -20,7 +20,7 @@
 import asyncio
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from time import time
 from typing import AsyncIterator
 from unittest.mock import patch
@@ -194,8 +194,8 @@ def broker_simple_resource(knowledgebox: str, number: int) -> BrokerMessage:
     message1.basic.thumbnail = "doc"
     message1.basic.metadata.useful = True
     message1.basic.metadata.language = "es"
-    message1.basic.created.FromDatetime(datetime.utcnow())
-    message1.basic.modified.FromDatetime(datetime.utcnow())
+    message1.basic.created.FromDatetime(datetime.now(timezone.utc))
+    message1.basic.modified.FromDatetime(datetime.now(timezone.utc))
     message1.texts[
         "field1"
     ].body = "My lovely field with some information from Barcelona. This will be the good field. \n\n And then we will go Manresa."  # noqa

--- a/nucliadb/tests/writer/test_fields.py
+++ b/nucliadb/tests/writer/test_fields.py
@@ -19,7 +19,7 @@
 #
 
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from os.path import dirname
 
 import pytest
@@ -36,7 +36,7 @@ from tests.writer.utils import load_file_as_FileB64_payload
 TEST_FILE = {f"{dirname(__file__)}/orm/"}
 TEST_TEXT_PAYLOAD = {"body": "test1", "format": "PLAIN"}
 TEST_LINK_PAYLOAD = {
-    "added": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "added": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     "headers": {},
     "cookies": {},
     "uri": "http://some-link.com",
@@ -48,7 +48,7 @@ TEST_LINK_PAYLOAD = {
 TEST_CONVERSATION_PAYLOAD = {
     "messages": [
         {
-            "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "who": "Bob",
             "to": ["Alice", "Charlie"],
             "content": {
@@ -77,7 +77,7 @@ TEST_EXTERNAL_FILE_PAYLOAD = {
 
 TEST_CONVERSATION_APPEND_MESSAGES_PAYLOAD = [
     {
-        "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "who": "Bob",
         "to": ["Alice", "Charlie"],
         "content": {

--- a/nucliadb/tests/writer/test_resources.py
+++ b/nucliadb/tests/writer/test_resources.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 from unittest.mock import AsyncMock
 
@@ -85,8 +85,8 @@ async def test_resource_crud(nucliadb_writer: AsyncClient, knowledgebox_writer: 
             "origin": {
                 "source_id": "source_id",
                 "url": "http://some_source",
-                "created": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "modified": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "modified": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "metadata": {"key1": "value1", "key2": "value2"},
                 "tags": ["tag1", "tag2"],
                 "collaborators": ["col1", "col2"],
@@ -169,8 +169,8 @@ async def test_resource_crud_sync(nucliadb_writer: AsyncClient, knowledgebox_wri
             "origin": {
                 "source_id": "source_id",
                 "url": "http://some_source",
-                "created": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "modified": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "modified": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "metadata": {"key1": "value1", "key2": "value2"},
                 "tags": ["tag1", "tag2"],
                 "collaborators": ["col1", "col2"],

--- a/nucliadb_telemetry/src/nucliadb_telemetry/logs.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/logs.py
@@ -17,7 +17,7 @@
 import logging
 import os
 from copy import copy
-from datetime import datetime
+from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from typing import Any, Dict, Optional
 
@@ -99,7 +99,7 @@ class JSONFormatter(logging.Formatter):
 
     def fill_log_data(self, data: Dict[str, Any], record: logging.LogRecord) -> None:
         if "time" not in data:
-            data["time"] = datetime.utcnow()
+            data["time"] = datetime.now(timezone.utc)
 
         if record.exc_info:
             data["exc_info"] = self.formatException(record.exc_info)


### PR DESCRIPTION
### Description

Removing this from nucliadb_telemetry since it generated lots of warnings. Taking the change to cleanup the rest.

### How was this PR tested?
Describe how you tested this PR.
