### PR TITLE
Push docs to AWS

### DIFF
--- a/.github/workflows/public_release.yml
+++ b/.github/workflows/public_release.yml
@@ -173,16 +173,11 @@ jobs:
       - name: Install nucliadb
         run: uv sync --no-editable --no-group nidx
 
-      - name: Authenticate to Google Cloud
-        id: gcp-auth
-        uses: google-github-actions/auth@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          workload_identity_provider: "${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
-          service_account: "${{ env.GCP_SERVICE_ACCOUNT }}"
-          token_format: access_token
-
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v2"
+          role-to-assume: ${{ secrets.AWS_DOCS_SYNC_ROLE }}
+          aws-region: ${{ secrets.AWS_DOCS_SYNC_REGION }}
 
       - name: Upload docs
         run: |
@@ -190,10 +185,10 @@ jobs:
           source .venv/bin/activate
           nucliadb-extract-openapi-reader /tmp/openapi/nucliadb-reader.json $API_VERSION $GITHUB_SHA
           nucliadb-extract-openapi-writer /tmp/openapi/nucliadb-writer.json $API_VERSION $GITHUB_SHA
-          nucliadb-extract-openapi-search /tmp/openapi/nucliadb-search.json $API_VERSION $GITHUB_SHA
-          gsutil copy /tmp/openapi/nucliadb-reader.json gs://ncl-docs-gcp-global-stage-1/api/nucliadb/v$API_VERSION/nucliadb-reader/spec.json
-          gsutil copy /tmp/openapi/nucliadb-writer.json gs://ncl-docs-gcp-global-stage-1/api/nucliadb/v$API_VERSION/nucliadb-writer/spec.json
-          gsutil copy /tmp/openapi/nucliadb-search.json gs://ncl-docs-gcp-global-stage-1/api/nucliadb/v$API_VERSION/nucliadb-search/spec.json
+          nucliadb-extract-openapi-search /tmp/openapi/nucliadb-search.json $API_VERSION $GITHUB_SHA 
+          aws s3 cp /tmp/openapi/nucliadb-reader.json s3://nuclia-docs-aws-global-stage-1/api/nucliadb/v$API_VERSION/nucliadb-reader/spec.json
+          aws s3 cp /tmp/openapi/nucliadb-writer.json s3://nuclia-docs-aws-global-stage-1/api/nucliadb/v$API_VERSION/nucliadb-writer/spec.json
+          aws s3 cp /tmp/openapi/nucliadb-search.json s3://nuclia-docs-aws-global-stage-1/api/nucliadb/v$API_VERSION/nucliadb-search/spec.json
 
       - name: Trigger doc update
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
This pull request updates the documentation upload workflow to use AWS instead of Google Cloud Platform (GCP) for storing OpenAPI specification files. The changes focus on authentication and file upload steps in the `.github/workflows/public_release.yml` file.

**Cloud provider migration:**

* Replaced GCP authentication and `gsutil` commands with AWS credentials configuration and `aws s3 cp` commands for uploading OpenAPI spec files to an S3 bucket instead of a GCS bucket. [[1]](diffhunk://#diff-dbc9c5e3f17abd1a7b2f02532688e09d627ad61033c4ce5a11ae7217af6cf63bL176-R180) [[2]](diffhunk://#diff-dbc9c5e3f17abd1a7b2f02532688e09d627ad61033c4ce5a11ae7217af6cf63bL194-R191)