### PR TITLE
Fix empty quotes token bug

### DIFF
--- a/nidx/nidx_paragraph/src/query_parser.rs
+++ b/nidx/nidx_paragraph/src/query_parser.rs
@@ -137,6 +137,16 @@ mod tests {
                 // keeps last term even if is a stop word
                 "nuclia database the",
             ),
+            (
+                "nuclia \"is\" a database for the",
+                // keeps last term even if is a stop word
+                "nuclia \"is\" database the",
+            ),
+            (
+                "nuclia \"...\" a database for the",
+                // keeps last term even if is a stop word
+                "nuclia database the",
+            ),
             ("is a for and", "and"),
             ("what does stop is?", "stop is"),
             ("", ""),


### PR DESCRIPTION
### Description
Our new tokenizer removes empty quotes (or full with whitespaces). However, quotes with only special characters can become empty due to tantivy retokenization step. We fix it by checking if we have emptied the token before adding it to the new token list

### How was this PR tested?
New unit tests
