### PR TITLE
Remove Istio annotations from chart values

### DIFF
--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -40,9 +40,7 @@ affinity: {}
 nodeSelector: {}
 tolerations: []
 topologySpreadConstraints: []
-podAnnotations:
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
-  traffic.sidecar.istio.io/excludeOutboundPorts: '5432,4222'
+podAnnotations: {}
 replicaCount: 2
 revisionHistoryLimit: 2
 debug: False
@@ -92,9 +90,7 @@ ingest_orm_grpc_autoscaling:
         target:
           type: Utilization
           averageUtilization: 75
-ingest_orm_grpc_podAnnotations:
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
-  traffic.sidecar.istio.io/excludeOutboundPorts: '5432,4222'
+ingest_orm_grpc_podAnnotations: {}
 
 # ingest-processed-consumer settings
 ingest_processed_consumer_resources:
@@ -112,9 +108,7 @@ ingest_processed_consumer_autoscaling:
         target:
           type: Utilization
           averageUtilization: 75
-ingest_processed_consumer_podAnnotations:
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
-  traffic.sidecar.istio.io/excludeOutboundPorts: '5432,4222'
+ingest_processed_consumer_podAnnotations: {}
 
 # ingest-subscriber-workers settings
 ingest_subscriber_workers_resources:
@@ -132,29 +126,22 @@ ingest_subscriber_workers_autoscaling:
         target:
           type: Utilization
           averageUtilization: 75
-ingest_subscriber_workers_podAnnotations:
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
-  traffic.sidecar.istio.io/excludeOutboundPorts: '5432,4222'
+ingest_subscriber_workers_podAnnotations: {}
 
 exporter:
   # serviceAccount: default
-  podAnnotations:
-    traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
-    traffic.sidecar.istio.io/excludeOutboundPorts: '5432,4222'
+  podAnnotations: {}
 
 # migrator settings
 migrator:
   # serviceAccount: default
-  podAnnotations:
-    traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
-    traffic.sidecar.istio.io/excludeOutboundPorts: '5432,4222'
+  podAnnotations: {}
 
 # extra_pod_annotations:
 #   what: "add annotations"
 #   where: "in the pods"
 
-extra_cronjob_pod_annotations:
-  sidecar.istio.io/inject: "false"
+extra_cronjob_pod_annotations: {}
 
 tracing:
   enabled: false

--- a/charts/nucliadb_reader/values.yaml
+++ b/charts/nucliadb_reader/values.yaml
@@ -78,9 +78,7 @@ serviceMonitor:
 tracing:
   enabled: false
 
-extra_pod_annotations:
-  traffic.sidecar.istio.io/excludeOutboundPorts: "5432,4222"
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
+extra_pod_annotations: {}
 
 autoscaling:
   minReplicas: 2

--- a/charts/nucliadb_search/values.yaml
+++ b/charts/nucliadb_search/values.yaml
@@ -74,9 +74,7 @@ zone:
 tracing:
   enabled: false
 
-extra_pod_annotations:
-  traffic.sidecar.istio.io/excludeOutboundPorts: "5432,4222"
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
+extra_pod_annotations: {}
 
 autoscaling:
   minReplicas: 2

--- a/charts/nucliadb_train/values.yaml
+++ b/charts/nucliadb_train/values.yaml
@@ -72,9 +72,7 @@ vs:
 
 zone:
 
-extra_pod_annotations:
-  traffic.sidecar.istio.io/excludeOutboundPorts: "5432,4222"
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
+extra_pod_annotations: {}
 
 autoscaling:
   minReplicas: 2

--- a/charts/nucliadb_writer/values.yaml
+++ b/charts/nucliadb_writer/values.yaml
@@ -75,9 +75,7 @@ serviceMonitor:
 tracing:
   enabled: false
 
-extra_pod_annotations:
-  traffic.sidecar.istio.io/excludeOutboundPorts: "6379,5432,4222"
-  traffic.sidecar.istio.io/excludeInboundPorts: *metricsPort
+extra_pod_annotations: {}
 
 autoscaling:
   minReplicas: 2


### PR DESCRIPTION
This pull request simplifies the Helm chart configuration for multiple NucliaDB components by removing default Istio-related pod annotations from the values files. Now, pod annotations are set to empty objects by default, making the charts more generic and easier to customize for different environments.

Key changes by theme:

Helm values simplification (all files):

* Removed default Istio sidecar pod annotations (such as `traffic.sidecar.istio.io/excludeInboundPorts` and `traffic.sidecar.istio.io/excludeOutboundPorts`) from `podAnnotations` and `extra_pod_annotations` fields, replacing them with empty objects for easier customization. [[1]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L43-R43) [[2]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L95-R93) [[3]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L115-R111) [[4]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L135-R144) [[5]](diffhunk://#diff-84fc862633cb1f9b1e42b1a313b969f217e01aa9a4dedf9a93e2d8b98adedf80L81-R81) [[6]](diffhunk://#diff-a6b387b0e33a05c38e6af3418e50f1a269b6df8fdbb9751bc8d49d8444d07288L77-R77) [[7]](diffhunk://#diff-025d186b0bc0d449a4200fd0e1e3f4c42db569897c205d6d7a6219b6e14f3c54L75-R75) [[8]](diffhunk://#diff-5f2cebb62aa74594ab0d7681f1e005f100138db7884b658abf02aa0288929319L78-R78)

Component-specific updates:

* Updated `charts/nucliadb_ingest/values.yaml` to clear Istio pod annotations for main pods, autoscaled components, exporter, migrator, and cronjobs. [[1]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L43-R43) [[2]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L95-R93) [[3]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L115-R111) [[4]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5L135-R144)
* Updated `charts/nucliadb_reader/values.yaml`, `charts/nucliadb_search/values.yaml`, `charts/nucliadb_train/values.yaml`, and `charts/nucliadb_writer/values.yaml` to set `extra_pod_annotations` to empty objects, removing Istio-specific defaults. [[1]](diffhunk://#diff-84fc862633cb1f9b1e42b1a313b969f217e01aa9a4dedf9a93e2d8b98adedf80L81-R81) [[2]](diffhunk://#diff-a6b387b0e33a05c38e6af3418e50f1a269b6df8fdbb9751bc8d49d8444d07288L77-R77) [[3]](diffhunk://#diff-025d186b0bc0d449a4200fd0e1e3f4c42db569897c205d6d7a6219b6e14f3c54L75-R75) [[4]](diffhunk://#diff-5f2cebb62aa74594ab0d7681f1e005f100138db7884b658abf02aa0288929319L78-R78)### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
Helm template