### PR TITLE
Use VectorAddr everywhere

### DIFF
--- a/nidx/nidx_vector/src/data_store.rs
+++ b/nidx/nidx_vector/src/data_store.rs
@@ -90,8 +90,8 @@ impl ParagraphRef<'_> {
 
 pub trait DataStore: Sync + Send {
     fn size_bytes(&self) -> usize;
-    fn stored_paragraph_count(&self) -> usize;
-    fn stored_vector_count(&self) -> usize;
+    fn stored_paragraph_count(&self) -> u32;
+    fn stored_vector_count(&self) -> u32;
     fn get_paragraph(&self, id: ParagraphAddr) -> ParagraphRef;
     fn get_vector(&self, id: VectorAddr) -> VectorRef;
     fn will_need(&self, id: VectorAddr);
@@ -99,5 +99,5 @@ pub trait DataStore: Sync + Send {
 }
 
 pub fn iter_paragraphs(data_store: &impl DataStore) -> impl Iterator<Item = ParagraphAddr> {
-    (0..data_store.stored_paragraph_count() as u32).map(ParagraphAddr)
+    (0..data_store.stored_paragraph_count()).map(ParagraphAddr)
 }

--- a/nidx/nidx_vector/src/data_store/v1.rs
+++ b/nidx/nidx_vector/src/data_store/v1.rs
@@ -46,11 +46,11 @@ impl DataStore for DataStoreV1 {
         self.nodes.len()
     }
 
-    fn stored_paragraph_count(&self) -> usize {
-        store::stored_elements(&self.nodes)
+    fn stored_paragraph_count(&self) -> u32 {
+        store::stored_elements(&self.nodes) as u32
     }
 
-    fn stored_vector_count(&self) -> usize {
+    fn stored_vector_count(&self) -> u32 {
         self.stored_paragraph_count()
     }
 

--- a/nidx/nidx_vector/src/data_store/v1/store.rs
+++ b/nidx/nidx_vector/src/data_store/v1/store.rs
@@ -67,7 +67,7 @@ impl<T: AsRef<[u8]>> IntoBuffer for T {
 // O(1)
 // Returns how many elements are in x, alive or deleted.
 pub fn stored_elements(x: &[u8]) -> usize {
-    usize_from_slice_le(&x[..HEADER_LEN])
+    usize_from_slice_le(&x[..USIZE_LEN])
 }
 
 // O(1)
@@ -230,7 +230,7 @@ mod tests {
 
         let buf_map = unsafe { memmap2::Mmap::map(&buf).unwrap() };
         let no_values = stored_elements(&buf_map);
-        assert_eq!(no_values, expected.len());
+        assert_eq!(no_values as usize, expected.len());
         for (id, expected_value) in expected.iter().enumerate() {
             let actual_value = get_value(&buf_map, id);
             assert_eq!(actual_value.key(), expected_value.key);
@@ -275,7 +275,7 @@ mod tests {
             .map(|s| s.key().parse().unwrap())
             .collect();
 
-        assert_eq!(number_of_elements, values.len());
+        assert_eq!(number_of_elements as usize, values.len());
         assert_eq!(values.len(), expected.len());
         assert!(values.iter().all(|i| expected.contains(i)));
     }
@@ -317,7 +317,7 @@ mod tests {
             .map(|s| s.key().parse().unwrap())
             .collect();
 
-        assert_eq!(number_of_elements, values.len());
+        assert_eq!(number_of_elements as usize, values.len());
         assert_eq!(values.len(), expected.len());
         assert!(values.iter().all(|i| expected.contains(i)));
     }
@@ -358,7 +358,7 @@ mod tests {
             .map(|s| s.key().parse().unwrap())
             .collect();
 
-        assert_eq!(number_of_elements, values.len());
+        assert_eq!(number_of_elements as usize, values.len());
         assert_eq!(values.len(), expected.len());
         assert!(values.iter().all(|i| expected.contains(i)));
     }
@@ -399,7 +399,7 @@ mod tests {
             .map(|s| s.key().parse().unwrap())
             .collect();
 
-        assert_eq!(number_of_elements, values.len());
+        assert_eq!(number_of_elements as usize, values.len());
         assert_eq!(values.len(), expected.len());
         assert!(values.iter().all(|i| expected.contains(i)));
     }
@@ -440,7 +440,7 @@ mod tests {
             .map(|s| s.key().parse().unwrap())
             .collect();
 
-        assert_eq!(number_of_elements, values.len());
+        assert_eq!(number_of_elements as usize, values.len());
         assert_eq!(values.len(), expected.len());
         assert!(values.iter().all(|i| expected.contains(i)));
     }
@@ -482,7 +482,7 @@ mod tests {
             .map(|s| s.key().parse().unwrap())
             .collect();
 
-        assert_eq!(number_of_elements, values.len());
+        assert_eq!(number_of_elements as usize, values.len());
         assert_eq!(values.len(), expected.len());
         assert!(values.iter().all(|i| expected.contains(i)));
     }

--- a/nidx/nidx_vector/src/data_store/v2.rs
+++ b/nidx/nidx_vector/src/data_store/v2.rs
@@ -91,11 +91,11 @@ impl DataStore for DataStoreV2 {
         self.vectors.size_bytes() + self.paragraphs.size_bytes()
     }
 
-    fn stored_paragraph_count(&self) -> usize {
+    fn stored_paragraph_count(&self) -> u32 {
         self.paragraphs.stored_elements()
     }
 
-    fn stored_vector_count(&self) -> usize {
+    fn stored_vector_count(&self) -> u32 {
         self.vectors.stored_elements()
     }
 

--- a/nidx/nidx_vector/src/data_store/v2/paragraph_store.rs
+++ b/nidx/nidx_vector/src/data_store/v2/paragraph_store.rs
@@ -106,8 +106,8 @@ impl ParagraphStore {
         self.data.len() + self.pos.len()
     }
 
-    pub fn stored_elements(&self) -> usize {
-        self.pos.len() / U32_LEN
+    pub fn stored_elements(&self) -> u32 {
+        (self.pos.len() / U32_LEN) as u32
     }
 }
 

--- a/nidx/nidx_vector/src/data_store/v2/vector_store.rs
+++ b/nidx/nidx_vector/src/data_store/v2/vector_store.rs
@@ -85,8 +85,8 @@ impl VectorStore {
         self.data.len()
     }
 
-    pub fn stored_elements(&self) -> usize {
-        self.data.len() / (self.record_len_bytes)
+    pub fn stored_elements(&self) -> u32 {
+        (self.data.len() / (self.record_len_bytes)) as u32
     }
 
     fn record_start(&self, VectorAddr(addr): VectorAddr) -> usize {

--- a/nidx/nidx_vector/src/hnsw.rs
+++ b/nidx/nidx_vector/src/hnsw.rs
@@ -28,21 +28,3 @@ pub use ops_hnsw::Cnx;
 pub use ops_hnsw::DataRetriever;
 pub use ops_hnsw::HnswOps;
 pub use ram_hnsw::RAMHnsw;
-
-use crate::VectorAddr;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Address(pub(super) usize);
-
-// VectorAddr and HNSW Address are the same thing with a different data type for serialization purposes
-impl From<Address> for VectorAddr {
-    fn from(value: Address) -> Self {
-        Self(value.0 as u32)
-    }
-}
-
-impl From<VectorAddr> for Address {
-    fn from(value: VectorAddr) -> Self {
-        Self(value.0 as usize)
-    }
-}

--- a/nidx/nidx_vector/src/lib.rs
+++ b/nidx/nidx_vector/src/lib.rs
@@ -51,6 +51,7 @@ pub use request_types::VectorSearchRequest;
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct ParagraphAddr(u32);
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct VectorAddr(u32);
 
 #[derive(Clone, Serialize, Deserialize)]


### PR DESCRIPTION
### Description

We were using VectorAddr and Address for the same concept but with different datatypes. This PR cleans it up, unifying on VectorAddr and changes the serialization code so that usize conversions are used when reading/writing node addresses to disk.

### How was this PR tested?

Unit/integration testing
