### PR TITLE
Remove unused multi txn logic

### DIFF
--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -338,20 +338,14 @@ def has_new_field_metadata(
     field_id: FieldID,
     message: BrokerMessage,
 ) -> bool:
-    for field_metadata in message.field_metadata:
-        if field_metadata.field == field_id:
-            return True
-    return False
+    return any(field_metadata.field == field_id for field_metadata in message.field_metadata)
 
 
 def has_new_extracted_text(
     field_id: FieldID,
     message: BrokerMessage,
 ) -> bool:
-    for extracted_text in message.extracted_text:
-        if extracted_text.field == field_id:
-            return True
-    return False
+    return any(extracted_text.field == field_id for extracted_text in message.extracted_text)
 
 
 def needs_texts_update(
@@ -365,10 +359,7 @@ def needs_vectors_update(
     field_id: FieldID,
     message: BrokerMessage,
 ) -> bool:
-    for field_vectors in message.field_vectors:
-        if field_vectors.field == field_id:
-            return True
-    return False
+    return any(field_vectors.field == field_id for field_vectors in message.field_vectors)
 
 
 def needs_relations_update(

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -158,20 +158,20 @@ class IndexMessageBuilder:
     @observer.wrap({"type": "writer_bm"})
     async def for_writer_bm(
         self,
-        messages: list[BrokerMessage],
+        message: BrokerMessage,
         resource_created: bool,
     ) -> IndexMessage:
         """
-        Builds the index message for the broker messages coming from the writer.
+        Builds the index message for the broker message coming from the writer.
         The writer messages are not adding new vectors to the index.
         """
-        assert all(message.source == BrokerMessage.MessageSource.WRITER for message in messages)
+        assert message.source == BrokerMessage.MessageSource.WRITER
 
-        deleted_fields = get_bm_deleted_fields(messages)
+        deleted_fields = get_bm_deleted_fields(message)
         self._apply_field_deletions(self.brain, deleted_fields)
         await self._apply_resource_index_data(self.brain)
         basic = await self.get_basic()
-        prefilter_update = needs_prefilter_update(messages)
+        prefilter_update = needs_prefilter_update(message)
         if prefilter_update:
             # Changes on some metadata at the resource level that is used for filtering require that we reindex all the fields
             # in the texts index (as it is the one used for prefiltering).
@@ -181,7 +181,7 @@ class IndexMessageBuilder:
             ]
         else:
             # Simply process the fields that are in the message
-            fields_to_index = get_bm_modified_fields(messages)
+            fields_to_index = get_bm_modified_fields(message)
         for fieldid in fields_to_index:
             if fieldid in deleted_fields:
                 continue
@@ -189,8 +189,8 @@ class IndexMessageBuilder:
                 self.brain,
                 fieldid,
                 basic,
-                texts=prefilter_update or needs_texts_update(fieldid, messages),
-                paragraphs=needs_paragraphs_update(fieldid, messages),
+                texts=prefilter_update or needs_texts_update(fieldid, message),
+                paragraphs=needs_paragraphs_update(fieldid, message),
                 relations=False,  # Relations at the field level are not modified by the writer
                 vectors=False,  # Vectors are never added by the writer
                 replace=not resource_created,
@@ -200,18 +200,18 @@ class IndexMessageBuilder:
     @observer.wrap({"type": "processor_bm"})
     async def for_processor_bm(
         self,
-        messages: list[BrokerMessage],
+        message: BrokerMessage,
     ) -> IndexMessage:
         """
         Builds the index message for the broker messages coming from the processor.
         The processor can index new data to any index.
         """
-        assert all(message.source == BrokerMessage.MessageSource.PROCESSOR for message in messages)
-        deleted_fields = get_bm_deleted_fields(messages)
+        assert message.source == BrokerMessage.MessageSource.PROCESSOR
+        deleted_fields = get_bm_deleted_fields(message)
         self._apply_field_deletions(self.brain, deleted_fields)
         await self._apply_resource_index_data(self.brain)
         basic = await self.get_basic()
-        fields_to_index = get_bm_modified_fields(messages)
+        fields_to_index = get_bm_modified_fields(message)
         vectorsets_configs = await self.get_vectorsets_configs()
         for fieldid in fields_to_index:
             if fieldid in deleted_fields:
@@ -220,10 +220,10 @@ class IndexMessageBuilder:
                 self.brain,
                 fieldid,
                 basic,
-                texts=needs_texts_update(fieldid, messages),
-                paragraphs=needs_paragraphs_update(fieldid, messages),
-                relations=needs_relations_update(fieldid, messages),
-                vectors=needs_vectors_update(fieldid, messages),
+                texts=needs_texts_update(fieldid, message),
+                paragraphs=needs_paragraphs_update(fieldid, message),
+                relations=needs_relations_update(fieldid, message),
+                vectors=needs_vectors_update(fieldid, message),
                 replace=True,
                 vectorset_configs=vectorsets_configs,
             )
@@ -271,129 +271,116 @@ class IndexMessageBuilder:
 
 
 def get_bm_deleted_fields(
-    messages: list[BrokerMessage],
+    message: BrokerMessage,
 ) -> list[FieldID]:
-    deleted = []
-    for message in messages:
-        for field in message.delete_fields:
-            if field not in deleted:
-                deleted.append(field)
-    return deleted
+    return list(message.delete_fields)
 
 
-def get_bm_modified_fields(messages: list[BrokerMessage]) -> list[FieldID]:
-    message_source = get_messages_source(messages)
+def get_bm_modified_fields(message: BrokerMessage) -> list[FieldID]:
+    message_source = get_message_source(message)
     modified = set()
-    for message in messages:
-        # Added or modified fields need indexing
-        for link in message.links:
-            modified.add((link, FieldType.LINK))
-        for file in message.files:
-            modified.add((file, FieldType.FILE))
-        for conv in message.conversations:
-            modified.add((conv, FieldType.CONVERSATION))
-        for text in message.texts:
-            modified.add((text, FieldType.TEXT))
+    # Added or modified fields need indexing
+    for link in message.links:
+        modified.add((link, FieldType.LINK))
+    for file in message.files:
+        modified.add((file, FieldType.FILE))
+    for conv in message.conversations:
+        modified.add((conv, FieldType.CONVERSATION))
+    for text in message.texts:
+        modified.add((text, FieldType.TEXT))
+    if message.HasField("basic"):
+        # Add title and summary only if they have changed
+        if message.basic.title != "":
+            modified.add(("title", FieldType.GENERIC))
+        if message.basic.summary != "":
+            modified.add(("summary", FieldType.GENERIC))
+
+    if message_source == BrokerMessage.MessageSource.PROCESSOR:
+        # Messages with field metadata, extracted text or field vectors need indexing
+        for fm in message.field_metadata:
+            modified.add((fm.field.field, fm.field.field_type))
+        for et in message.extracted_text:
+            modified.add((et.field.field, et.field.field_type))
+        for fv in message.field_vectors:
+            modified.add((fv.field.field, fv.field.field_type))
+
+    if message_source == BrokerMessage.MessageSource.WRITER:
+        # Any field that has fieldmetadata annotations should be considered as modified
+        # and needs to be reindexed
         if message.HasField("basic"):
-            # Add title and summary only if they have changed
-            if message.basic.title != "":
-                modified.add(("title", FieldType.GENERIC))
-            if message.basic.summary != "":
-                modified.add(("summary", FieldType.GENERIC))
-
-        if message_source == BrokerMessage.MessageSource.PROCESSOR:
-            # Messages with field metadata, extracted text or field vectors need indexing
-            for fm in message.field_metadata:
-                modified.add((fm.field.field, fm.field.field_type))
-            for et in message.extracted_text:
-                modified.add((et.field.field, et.field.field_type))
-            for fv in message.field_vectors:
-                modified.add((fv.field.field, fv.field.field_type))
-
-        if message_source == BrokerMessage.MessageSource.WRITER:
-            # Any field that has fieldmetadata annotations should be considered as modified
-            # and needs to be reindexed
-            if message.HasField("basic"):
-                for ufm in message.basic.fieldmetadata:
-                    modified.add((ufm.field.field, ufm.field.field_type))
+            for ufm in message.basic.fieldmetadata:
+                modified.add((ufm.field.field, ufm.field.field_type))
     return [FieldID(field=field, field_type=field_type) for field, field_type in modified]
 
 
-def get_messages_source(messages: list[BrokerMessage]) -> BrokerMessage.MessageSource.ValueType:
-    assert len(set(message.source for message in messages)) == 1
-    return messages[0].source
+def get_message_source(message: BrokerMessage) -> BrokerMessage.MessageSource.ValueType:
+    return message.source
 
 
-def needs_prefilter_update(messages: list[BrokerMessage]) -> bool:
-    return any(message.reindex for message in messages)
+def needs_prefilter_update(message: BrokerMessage) -> bool:
+    return message.reindex
 
 
-def needs_paragraphs_update(field_id: FieldID, messages: list[BrokerMessage]) -> bool:
+def needs_paragraphs_update(field_id: FieldID, message: BrokerMessage) -> bool:
     return (
-        has_paragraph_annotations(field_id, messages)
-        or has_new_extracted_text(field_id, messages)
-        or has_new_field_metadata(field_id, messages)
+        has_paragraph_annotations(field_id, message)
+        or has_new_extracted_text(field_id, message)
+        or has_new_field_metadata(field_id, message)
     )
 
 
-def has_paragraph_annotations(field_id: FieldID, messages: list[BrokerMessage]) -> bool:
-    for message in messages:
-        ufm = next(
-            (fm for fm in message.basic.fieldmetadata if fm.field == field_id),
-            None,
-        )
-        if ufm is None:
-            continue
-        if len(ufm.paragraphs) > 0:
-            return True
-    return False
+def has_paragraph_annotations(field_id: FieldID, message: BrokerMessage) -> bool:
+    ufm = next(
+        (fm for fm in message.basic.fieldmetadata if fm.field == field_id),
+        None,
+    )
+    if ufm is None:
+        return False
+    return len(ufm.paragraphs) > 0
 
 
 def has_new_field_metadata(
     field_id: FieldID,
-    messages: list[BrokerMessage],
+    message: BrokerMessage,
 ) -> bool:
-    for message in messages:
-        for field_metadata in message.field_metadata:
-            if field_metadata.field == field_id:
-                return True
+    for field_metadata in message.field_metadata:
+        if field_metadata.field == field_id:
+            return True
     return False
 
 
 def has_new_extracted_text(
     field_id: FieldID,
-    messages: list[BrokerMessage],
+    message: BrokerMessage,
 ) -> bool:
-    for message in messages:
-        for extracted_text in message.extracted_text:
-            if extracted_text.field == field_id:
-                return True
+    for extracted_text in message.extracted_text:
+        if extracted_text.field == field_id:
+            return True
     return False
 
 
 def needs_texts_update(
     field_id: FieldID,
-    messages: list[BrokerMessage],
+    message: BrokerMessage,
 ) -> bool:
-    return has_new_extracted_text(field_id, messages) or has_new_field_metadata(field_id, messages)
+    return has_new_extracted_text(field_id, message) or has_new_field_metadata(field_id, message)
 
 
 def needs_vectors_update(
     field_id: FieldID,
-    messages: list[BrokerMessage],
+    message: BrokerMessage,
 ) -> bool:
-    for message in messages:
-        for field_vectors in message.field_vectors:
-            if field_vectors.field == field_id:
-                return True
+    for field_vectors in message.field_vectors:
+        if field_vectors.field == field_id:
+            return True
     return False
 
 
 def needs_relations_update(
     field_id: FieldID,
-    messages: list[BrokerMessage],
+    message: BrokerMessage,
 ) -> bool:
-    return has_new_field_metadata(field_id, messages) or has_new_extracted_text(field_id, messages)
+    return has_new_field_metadata(field_id, message) or has_new_extracted_text(field_id, message)
 
 
 async def get_resource_index_message(

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -277,7 +277,6 @@ def get_bm_deleted_fields(
 
 
 def get_bm_modified_fields(message: BrokerMessage) -> list[FieldID]:
-    message_source = get_message_source(message)
     modified = set()
     # Added or modified fields need indexing
     for link in message.links:
@@ -295,7 +294,7 @@ def get_bm_modified_fields(message: BrokerMessage) -> list[FieldID]:
         if message.basic.summary != "":
             modified.add(("summary", FieldType.GENERIC))
 
-    if message_source == BrokerMessage.MessageSource.PROCESSOR:
+    if message.source == BrokerMessage.MessageSource.PROCESSOR:
         # Messages with field metadata, extracted text or field vectors need indexing
         for fm in message.field_metadata:
             modified.add((fm.field.field, fm.field.field_type))
@@ -304,17 +303,13 @@ def get_bm_modified_fields(message: BrokerMessage) -> list[FieldID]:
         for fv in message.field_vectors:
             modified.add((fv.field.field, fv.field.field_type))
 
-    if message_source == BrokerMessage.MessageSource.WRITER:
+    if message.source == BrokerMessage.MessageSource.WRITER:
         # Any field that has fieldmetadata annotations should be considered as modified
         # and needs to be reindexed
         if message.HasField("basic"):
             for ufm in message.basic.fieldmetadata:
                 modified.add((ufm.field.field, ufm.field.field_type))
     return [FieldID(field=field, field_type=field_type) for field, field_type in modified]
-
-
-def get_message_source(message: BrokerMessage) -> BrokerMessage.MessageSource.ValueType:
-    return message.source
 
 
 def needs_prefilter_update(message: BrokerMessage) -> bool:

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -340,7 +340,7 @@ class Processor:
                             seqid=seqid,
                             partition=partition,
                             kb=kb,
-                            source=get_message_source(message),
+                            source=to_index_message_source(message),
                         )
                         # Save indexing warnings
                         for field_id, warning in warnings:
@@ -501,13 +501,12 @@ class Processor:
         resource_created: bool,
     ) -> PBBrainResource:
         builder = IndexMessageBuilder(resource)
-        message_source = get_message_source(message)
-        if message_source == nodewriter_pb2.IndexMessageSource.WRITER:
+        if message.source == writer_pb2.BrokerMessage.MessageSource.WRITER:
             return await builder.for_writer_bm(message, resource_created)
-        elif message_source == nodewriter_pb2.IndexMessageSource.PROCESSOR:
+        elif message.source == writer_pb2.BrokerMessage.MessageSource.PROCESSOR:
             return await builder.for_processor_bm(message)
         else:  # pragma: no cover
-            raise InvalidBrokerMessage(f"Unknown broker message source: {message_source}")
+            raise InvalidBrokerMessage(f"Unknown broker message source: {message.source}")
 
     async def external_index_delete_resource(
         self, external_index_manager: ExternalIndexManager, resource_uuid: str
@@ -708,7 +707,7 @@ class Processor:
         return kbobj
 
 
-def get_message_source(message: writer_pb2.BrokerMessage):
+def to_index_message_source(message: writer_pb2.BrokerMessage):
     if message.source == writer_pb2.BrokerMessage.MessageSource.WRITER:
         return nodewriter_pb2.IndexMessageSource.WRITER
     elif message.source == writer_pb2.BrokerMessage.MessageSource.PROCESSOR:

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -284,6 +284,8 @@ class Processor:
             try:
                 kb = KnowledgeBox(txn, self.storage, kbid)
                 uuid = await self.get_resource_uuid(kb, message)
+
+                resource: Optional[Resource] = None
                 handled_exception = None
                 created = False
 
@@ -301,9 +303,14 @@ class Processor:
                     resource = await kb.get(uuid)
                     if resource is None:
                         logger.info(
-                            f"Secondary message for resource {message.uuid} and resource does not exist, ignoring"
+                            f"Processor message for resource received but the resource does not exist, ignoring.",
+                            extra={
+                                "kbid": kbid,
+                                "rid": uuid,
+                                "seqid": seqid,
+                            },
                         )
-                        return
+                        return None
                     else:
                         # It's an update from processor for an existing resource
                         ...

--- a/nucliadb/tests/ingest/integration/orm/test_index_message.py
+++ b/nucliadb/tests/ingest/integration/orm/test_index_message.py
@@ -66,7 +66,7 @@ async def test_for_writer_bm_with_prefilter_update(
             reindex=True,
         )
 
-        im = await IndexMessageBuilder(resource).for_writer_bm([writer_bm], resource_created=False)
+        im = await IndexMessageBuilder(resource).for_writer_bm(writer_bm, resource_created=False)
 
         # title, summary, file, link, conv and text
         total_fields = 6

--- a/nucliadb_protos/writer.proto
+++ b/nucliadb_protos/writer.proto
@@ -71,10 +71,12 @@ message BrokerMessage {
 
     enum MessageType {
         AUTOCOMMIT = 0;
+        DELETE = 4;
+
+        // Deprecated, multi-commit transactions have never worked. Not implemented.
         MULTI = 1;
         COMMIT = 2;
         ROLLBACK = 3;
-        DELETE = 4;
     }
 
     enum MessageSource {


### PR DESCRIPTION
### Description

The multi-txn logic is not used by processing, it does not have tests and the current implementation is not working.
As we have to evolve the logic around indexing to nidx, having multi-transactions increases the complexity across the processor layer. So it's better to remove it at this point.

Related ticket: [sc-12775]

### How was this PR tested?
Existing tests
