### PR TITLE
Do not index the full extracted text of a conversation

### DIFF
--- a/nidx/nidx_paragraph/src/resource_indexer.rs
+++ b/nidx/nidx_paragraph/src/resource_indexer.rs
@@ -82,10 +82,9 @@ pub fn index_paragraphs(
             let split = &p.split;
 
             // The text of the paragraph can be specified in the paragraph message, otherwise slice it from the full field text.
-            let text: String;
-            let text_ref: &str;
+            let text_ref: String;
             if let Some(t) = &p.text {
-                text_ref = t;
+                text_ref = t.to_string();
             } else {
                 let lower_bound = std::cmp::min(start_pos as usize, chars.len());
                 let upper_bound = std::cmp::min(end_pos as usize, chars.len());
@@ -93,8 +92,8 @@ pub fn index_paragraphs(
                     warn!("Skipping paragraph with wrong start and end positions");
                     continue;
                 }
-                text = chars[lower_bound..upper_bound].iter().collect();
-                text_ref = &text;
+                let slice = &chars[lower_bound..upper_bound];
+                text_ref = slice.iter().collect();
             }
             let facet_field = format!("/{field}");
             let paragraph_labels = p

--- a/nidx/nidx_paragraph/src/resource_indexer.rs
+++ b/nidx/nidx_paragraph/src/resource_indexer.rs
@@ -79,9 +79,18 @@ pub fn index_paragraphs(
             let end_pos = p.end as u64;
             let index = p.index;
             let split = &p.split;
-            let lower_bound = std::cmp::min(start_pos as usize, chars.len());
-            let upper_bound = std::cmp::min(end_pos as usize, chars.len());
-            let text: String = chars[lower_bound..upper_bound].iter().collect();
+
+            // The text of the paragraph can be specified in the paragraph message, otherwise slice it from the full field text.
+            let text: String;
+            let text_ref: &str;
+            if let Some(t) = &p.text {
+                text_ref = t;
+            } else {
+                let lower_bound = std::cmp::min(start_pos as usize, chars.len());
+                let upper_bound = std::cmp::min(end_pos as usize, chars.len());
+                text = chars[lower_bound..upper_bound].iter().collect();
+                text_ref = &text;
+            }
             let facet_field = format!("/{field}");
             let paragraph_labels = p
                 .labels
@@ -109,7 +118,7 @@ pub fn index_paragraphs(
                 .for_each(|facet| doc.add_facet(schema.facets, facet));
             doc.add_facet(schema.field, Facet::from(&facet_field));
             doc.add_text(schema.paragraph, paragraph_id.clone());
-            doc.add_text(schema.text, &text);
+            doc.add_text(schema.text, text_ref);
             doc.add_u64(schema.start_pos, start_pos);
             doc.add_u64(schema.end_pos, end_pos);
             doc.add_u64(schema.index, index);

--- a/nidx/nidx_paragraph/src/resource_indexer.rs
+++ b/nidx/nidx_paragraph/src/resource_indexer.rs
@@ -28,6 +28,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use tantivy::doc;
 use tantivy::schema::Facet;
+use tracing::warn;
 
 lazy_static::lazy_static! {
     static ref REGEX: Regex = Regex::new(r"\\[a-zA-Z0-9]").unwrap();
@@ -88,6 +89,10 @@ pub fn index_paragraphs(
             } else {
                 let lower_bound = std::cmp::min(start_pos as usize, chars.len());
                 let upper_bound = std::cmp::min(end_pos as usize, chars.len());
+                if lower_bound >= upper_bound {
+                    warn!("Skipping paragraph with wrong start and end positions");
+                    continue;
+                }
                 text = chars[lower_bound..upper_bound].iter().collect();
                 text_ref = &text;
             }

--- a/nidx/nidx_paragraph/tests/reader.rs
+++ b/nidx/nidx_paragraph/tests/reader.rs
@@ -547,7 +547,7 @@ fn create_resource_with_paragraphs_text_in_paragraph(shard_id: String) -> (Strin
             field: field_id.to_string(),
             start: 0,
             end: paragraph_text.len() as i32,
-            index: 0 as u64,
+            index: 0,
             labels: vec![],
             text: Some(paragraph_text.clone()), // Add the text in the paragraph message instead of the text information.
             ..Default::default()

--- a/nidx/nidx_paragraph/tests/reader.rs
+++ b/nidx/nidx_paragraph/tests/reader.rs
@@ -508,12 +508,6 @@ fn test_query_parsing_weird_stuff() -> anyhow::Result<()> {
 
 fn create_resource_with_paragraphs_text_in_paragraph(shard_id: String) -> (String, Resource) {
     let rid = "5cfcbf5a-0a69-4431-8c9b-2cb7c6532c19".to_string();
-    let fields = vec![Field {
-        field_id: "title",
-        paragraphs: vec![("What is the meaning of life?", vec![])],
-        labels: vec![],
-    }];
-
     let resource_id = ResourceId {
         shard_id: shard_id.clone(),
         uuid: rid.clone(),

--- a/nidx/nidx_protos/noderesources.proto
+++ b/nidx/nidx_protos/noderesources.proto
@@ -120,6 +120,10 @@ message IndexParagraph {
     uint64 index = 7;
     bool repeated_in_field = 8;
     ParagraphMetadata metadata = 9;
+
+    // This is to be used for conversational fields where we don't index the fulltext, thus we want the individual text of each paragraph
+    // to be included in the paragraph message instead of depending on the texts part of the index message payload.
+    optional string text = 11;
 }
 
 message VectorSetID {

--- a/nidx/nidx_vector/src/searcher.rs
+++ b/nidx/nidx_vector/src/searcher.rs
@@ -461,6 +461,7 @@ mod tests {
             split: "".to_string(),
             repeated_in_field: false,
             metadata: None,
+            ..Default::default()
         };
         let paragraphs = IndexParagraphs {
             paragraphs: HashMap::from([("6c5fc1f7a69042d4b24b7f18ea354b4a/f/field1".to_string(), paragraph)]),
@@ -557,6 +558,7 @@ mod tests {
             split: "".to_string(),
             repeated_in_field: false,
             metadata: None,
+            ..Default::default()
         };
         let paragraphs = IndexParagraphs {
             paragraphs: HashMap::from([("DOC/KEY/1".to_string(), paragraph)]),
@@ -667,6 +669,7 @@ mod tests {
             split: "".to_string(),
             repeated_in_field: false,
             metadata: None,
+            ..Default::default()
         };
         let paragraphs = IndexParagraphs {
             paragraphs: HashMap::from([("9cb39c75f8d9498d8f82d92b173011f5/f/field/0-100".to_string(), paragraph)]),

--- a/nidx/tests/test_date_range_search.rs
+++ b/nidx/tests/test_date_range_search.rs
@@ -74,6 +74,7 @@ async fn populate(fixture: &mut NidxFixture, shard_id: String, metadata: IndexMe
         split: "".to_string(),
         repeated_in_field: false,
         metadata: None,
+        ..Default::default()
     };
     let paragraphs = IndexParagraphs {
         paragraphs: HashMap::from([(format!("{raw_resource_id}/{field_id}/1"), paragraph)]),

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -515,6 +515,13 @@ async def test_conversation_field_indexing(
     assert counters.fields == 2  # One conversation field + the title field
     assert counters.resources == 1
 
+    # Make sure that fulltext search is not working for conversations
+    resp = await nucliadb_reader.post(
+        f"/kb/{kbid}/search", json={"query": "meaning of life", "features": ["fulltext"]}
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["fulltext"]["results"]) == 0
+
     # Make sure the messages are searchable
     question_text_block_id = f"{rid}/c/faq/1/0-{len(question)}"
     results = await search_message(query=question)


### PR DESCRIPTION
### Description

Conversational fields can grow to a very large number of messages, being each message potentially as big as a regular field (text, file, link).

Right now, we were appending all the extracted texts of all messages into a single tantivy document on the texts index. This definitely does not scale, so we decided to not index the fulltext of the conversation fields, with the only caveat of not being able to do keyword filtering on these. For keyword filtering to work, we would need to rework the prefiltering on nidx to be done with the paragraphs index, for instance. 

All other filters will work normally as despite not indexing the fulltext, we are indexing the labels on the texts index.

[sc-12775]

### How was this PR tested?
Existing tests + extended conversation integration tests
