### PR TITLE
Index only appended messages

### DIFF
--- a/nucliadb/src/migrations/0039_backfill_converation_splits_metadata.py
+++ b/nucliadb/src/migrations/0039_backfill_converation_splits_metadata.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Migration #39
+
+Backfill splits metadata on conversation fields
+
+"""
+
+import logging
+from typing import cast
+
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction
+from nucliadb.ingest.fields.conversation import (
+    CONVERSATION_SPLITS_METADATA,
+    Conversation,
+)
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
+from nucliadb.migrator.context import ExecutionContext
+from nucliadb_protos import resources_pb2
+from nucliadb_protos.resources_pb2 import SplitMetadata, SplitsMetadata
+from nucliadb_utils.storages.storage import Storage
+
+logger = logging.getLogger(__name__)
+
+
+async def migrate(context: ExecutionContext) -> None: ...
+
+
+async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
+    BATCH_SIZE = 100
+    async with context.kv_driver.rw_transaction() as txn:
+        txn = cast(PGTransaction, txn)
+        start = ""
+        while True:
+            to_fix: list[tuple[str, str]] = []
+            async with txn.connection.cursor() as cur:
+                # Retrieve a bunch of conversation fields
+                await cur.execute(
+                    """
+                    SELECT key FROM resources
+                    WHERE key ~ ('^/kbs/' || %s || '/r/[^/]*/f/c/[^/]*$')
+                    AND key > %s
+                    ORDER BY key
+                    LIMIT %s""",
+                    (kbid, start, BATCH_SIZE),
+                )
+                rows = await cur.fetchall()
+                if len(rows) == 0:
+                    return
+                for row in rows:
+                    key = row[0]
+                    start = key
+                    rid = key.split("/")[4]
+                    field_id = key.split("/")[7]
+                    to_fix.append((rid, field_id))
+
+            if to_fix:
+                for rid, field_id in to_fix:
+                    async with context.kv_driver.rw_transaction() as txn2:
+                        splits_metadata = await build_splits_metadata(
+                            txn2, context.blob_storage, kbid, rid, field_id
+                        )
+                        splits_metadata_key = CONVERSATION_SPLITS_METADATA.format(
+                            kbid=kbid, uuid=rid, type="c", field=field_id
+                        )
+                        await txn2.set(splits_metadata_key, splits_metadata.SerializeToString())
+                        await txn2.commit()
+
+
+async def build_splits_metadata(
+    txn: Transaction, storage: Storage, kbid: str, rid: str, field_id: str
+) -> SplitsMetadata:
+    splits_metadata = SplitsMetadata()
+    kb_orm = KnowledgeBoxORM(txn, storage, kbid)
+    resource_obj = await kb_orm.get(rid)
+    if resource_obj is None:
+        return splits_metadata
+    field_obj: Conversation = await resource_obj.get_field(
+        field_id, resources_pb2.FieldType.CONVERSATION, load=False
+    )
+    conv_metadata = await field_obj.get_metadata()
+    for i in range(1, conv_metadata.pages + 1):
+        page = await field_obj.get_value(page=i)
+        if page is None:
+            continue
+        for message in page.messages:
+            splits_metadata.metadata.setdefault(message.ident, SplitMetadata())
+    return splits_metadata

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -28,7 +28,7 @@ from nucliadb_utils.storages.storage import StorageField
 PAGE_SIZE = 200
 
 CONVERSATION_PAGE_VALUE = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/{page}"
-CONVERSATION_SPLIT_METADATA = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/split_metadata"
+CONVERSATION_SPLITS_METADATA = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/splits_metadata"
 CONVERSATION_METADATA = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}"
 
 
@@ -212,7 +212,7 @@ class Conversation(Field[PBConversation]):
 
     async def get_splits_metadata(self) -> SplitsMetadata:
         if self._splits_metadata is None:
-            field_key = CONVERSATION_SPLIT_METADATA.format(
+            field_key = CONVERSATION_SPLITS_METADATA.format(
                 kbid=self.kbid,
                 uuid=self.uuid,
                 type=self.type,
@@ -226,7 +226,7 @@ class Conversation(Field[PBConversation]):
         return self._splits_metadata
 
     async def set_splits_metadata(self, payload: SplitsMetadata) -> None:
-        key = CONVERSATION_SPLIT_METADATA.format(
+        key = CONVERSATION_SPLITS_METADATA.format(
             kbid=self.kbid,
             uuid=self.uuid,
             type=self.type,

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -257,7 +257,11 @@ class ResourceBrain:
         paragraph_pages = ParagraphPages(page_positions) if page_positions else None
         # Splits of the field
         for subfield, field_metadata in field_computed_metadata.split_metadata.items():
-            if replace_field is False and append_splits is not None and subfield not in append_splits:
+            if (
+                replace_field is False  # When replacing the whole field, reindex all splits
+                and append_splits is not None
+                and subfield not in append_splits
+            ):
                 # We're only indexing the splits that are appended
                 continue
             if subfield not in extracted_text.split_text:
@@ -509,7 +513,11 @@ class ResourceBrain:
     ):
         fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():
-            if replace_field is False and append_splits is not None and subfield not in append_splits:
+            if (
+                replace_field is False  # When replacing the whole field, reindex all splits
+                and append_splits is not None
+                and subfield not in append_splits
+            ):
                 # We're only indexing the splits that are appended
                 continue
 

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -257,7 +257,7 @@ class ResourceBrain:
         paragraph_pages = ParagraphPages(page_positions) if page_positions else None
         # Splits of the field
         for subfield, field_metadata in field_computed_metadata.split_metadata.items():
-            if append_splits is not None and subfield not in append_splits:
+            if replace_field is False and append_splits is not None and subfield not in append_splits:
                 # We're only indexing the splits that are appended
                 continue
             if subfield not in extracted_text.split_text:
@@ -509,7 +509,7 @@ class ResourceBrain:
     ):
         fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():
-            if append_splits is not None and subfield not in append_splits:
+            if replace_field is False and append_splits is not None and subfield not in append_splits:
                 # We're only indexing the splits that are appended
                 continue
 

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -217,7 +217,7 @@ class ResourceBrain:
         replace_field: bool,
         skip_paragraphs_index: Optional[bool],
         skip_texts_index: Optional[bool],
-        append_splits: Optional[list[str]],
+        append_splits: Optional[list[str]] = None,
     ) -> None:
         # We need to add the extracted text to the texts section of the Resource so that
         # the paragraphs can be indexed
@@ -248,7 +248,7 @@ class ResourceBrain:
         user_field_metadata: Optional[UserFieldMetadata],
         replace_field: bool,
         skip_paragraphs: Optional[bool],
-        append_splits: Optional[list[str]],
+        append_splits: Optional[list[str]] = None,
     ) -> None:
         if skip_paragraphs is not None:
             self.brain.skip_paragraphs = skip_paragraphs

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -217,7 +217,7 @@ class ResourceBrain:
         replace_field: bool,
         skip_paragraphs_index: Optional[bool],
         skip_texts_index: Optional[bool],
-        append_splits: Optional[list[str]] = None,
+        append_splits: Optional[set[str]] = None,
     ) -> None:
         # We need to add the extracted text to the texts section of the Resource so that
         # the paragraphs can be indexed
@@ -248,7 +248,7 @@ class ResourceBrain:
         user_field_metadata: Optional[UserFieldMetadata],
         replace_field: bool,
         skip_paragraphs: Optional[bool],
-        append_splits: Optional[list[str]] = None,
+        append_splits: Optional[set[str]] = None,
     ) -> None:
         if skip_paragraphs is not None:
             self.brain.skip_paragraphs = skip_paragraphs
@@ -504,7 +504,7 @@ class ResourceBrain:
         replace_field: bool = False,
         # cut to specific dimension if specified
         vector_dimension: Optional[int] = None,
-        append_splits: Optional[list[str]] = None,
+        append_splits: Optional[set[str]] = None,
     ):
         fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():
@@ -806,7 +806,7 @@ class ParagraphPages:
 
 
 def should_skip_split_indexing(
-    split: str, replace_field: bool, append_splits: Optional[list[str]]
+    split: str, replace_field: bool, append_splits: Optional[set[str]]
 ) -> bool:
     # When replacing the whole field, reindex all splits. Otherwise, we're only indexing the splits that are appended
     return not replace_field and append_splits is not None and split not in append_splits

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -509,7 +509,7 @@ class ResourceBrain:
         replace_field: bool = False,
         # cut to specific dimension if specified
         vector_dimension: Optional[int] = None,
-        append_splits: Optional[list[str]],
+        append_splits: Optional[list[str]] = None,
     ):
         fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -231,6 +231,7 @@ class IndexMessageBuilder:
                     modified_splits is not None
                     and stored_splits is not None
                     and modified_splits.issubset(stored_splits)
+                    and len(modified_splits) < len(stored_splits)
                 )
                 replace_field = not is_append_messages_op
 

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -222,6 +222,7 @@ class IndexMessageBuilder:
             # For conversation fields, we only replace the full field if it is not an append messages operation.
             # All other fields are always replaced upon modification.
             replace_field = True
+            modified_splits: Optional[list[str]] = None
             if fieldid.field_type == FieldType.CONVERSATION:
                 modified_splits = await get_bm_modified_split_ids(fieldid, message, self.resource)
                 stored_splits = await get_stored_split_ids(fieldid, self.resource)

--- a/nucliadb/tests/ingest/unit/orm/test_brain.py
+++ b/nucliadb/tests/ingest/unit/orm/test_brain.py
@@ -223,7 +223,7 @@ def test_apply_field_paragraphs_populates_page_number():
 
 
 def test_apply_field_paragraphs_append_splits():
-    field_key = "text1"
+    field_key = "t/text1"
     split = "subfield"
     text = "Some text here"
 
@@ -273,6 +273,20 @@ def test_apply_field_paragraphs_append_splits():
         replace_field=False,
         skip_paragraphs=False,
         append_splits=[split],
+    )
+    assert len(br.brain.paragraphs[field_key].paragraphs) == 1
+
+    # When replace=True, all splits are included anyway
+    br = ResourceBrain(rid="foo")
+    br.apply_field_paragraphs(
+        field_key,
+        field_computed_metadata=fcm,
+        page_positions={},
+        extracted_text=extracted_text,
+        user_field_metadata=None,
+        replace_field=True,
+        skip_paragraphs=False,
+        append_splits=["foo"],
     )
     assert len(br.brain.paragraphs[field_key].paragraphs) == 1
 

--- a/nucliadb/tests/ingest/unit/orm/test_brain.py
+++ b/nucliadb/tests/ingest/unit/orm/test_brain.py
@@ -236,7 +236,7 @@ def test_apply_field_paragraphs_append_splits():
     fcm.split_metadata[split].paragraphs.append(p1)
 
     # If no append splits are passed, all splits are included in the index message
-    br = ResourceBrain(rid="foo")
+    br = ResourceBrain(rid="rid")
     br.apply_field_paragraphs(
         field_key,
         field_computed_metadata=fcm,
@@ -248,9 +248,10 @@ def test_apply_field_paragraphs_append_splits():
         append_splits=None,
     )
     assert len(br.brain.paragraphs[field_key].paragraphs) == 1
+    assert br.brain.paragraphs_to_delete == []
 
     # Specifying append splits should be respected
-    br = ResourceBrain(rid="foo")
+    br = ResourceBrain(rid="rid")
     br.apply_field_paragraphs(
         field_key,
         field_computed_metadata=fcm,
@@ -262,8 +263,9 @@ def test_apply_field_paragraphs_append_splits():
         append_splits=["foo"],
     )
     assert len(br.brain.paragraphs[field_key].paragraphs) == 0
+    assert br.brain.paragraphs_to_delete == []
 
-    br = ResourceBrain(rid="foo")
+    br = ResourceBrain(rid="rid")
     br.apply_field_paragraphs(
         field_key,
         field_computed_metadata=fcm,
@@ -275,9 +277,10 @@ def test_apply_field_paragraphs_append_splits():
         append_splits=[split],
     )
     assert len(br.brain.paragraphs[field_key].paragraphs) == 1
+    assert br.brain.paragraphs_to_delete == []
 
     # When replace=True, all splits are included anyway
-    br = ResourceBrain(rid="foo")
+    br = ResourceBrain(rid="rid")
     br.apply_field_paragraphs(
         field_key,
         field_computed_metadata=fcm,
@@ -289,6 +292,7 @@ def test_apply_field_paragraphs_append_splits():
         append_splits=["foo"],
     )
     assert len(br.brain.paragraphs[field_key].paragraphs) == 1
+    assert br.brain.paragraphs_to_delete == [f"rid/{field_key}"]
 
 
 def test_generate_resource_metadata_promotes_origin_dates():

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -508,9 +508,7 @@ async def test_conversation_field_indexing(
 
     # Check counters after appending the message
     counters = await get_counters()
-    assert (
-        counters.sentences == 2 + 1
-    )  # One for each message (the title does not have a vector) + the initial message that has been marked as deleted but not yet merged
+    assert counters.sentences == 2  # One for each message (the title does not have a vector)
     assert counters.paragraphs == 3  # One for each message + the title paragraph
     assert counters.fields == 2  # One conversation field + the title field
     assert counters.resources == 1
@@ -536,7 +534,7 @@ async def test_conversation_field_indexing(
     # Make sure the messages are not searchable anymore
     counters = await get_counters()
     assert (
-        counters.sentences == 3
+        counters.sentences == 2
     )  # The messages are not indexed anymore, but deleted messages still count
     assert counters.paragraphs == 1  # the title
     assert counters.fields == 1  # the title

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import uuid
+from unittest.mock import Mock
+
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.fields.conversation import CONVERSATION_SPLITS_METADATA, Conversation
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.migrator.models import Migration
+from nucliadb_protos import resources_pb2
+from tests.nucliadb.migrations import get_migration
+
+migration: Migration = get_migration(39)
+
+
+async def test_migration_0039(maindb_driver: Driver):
+    execution_context = Mock()
+    execution_context.kv_driver = maindb_driver
+    storage = Mock()
+    execution_context.blob_storage = storage
+
+    kbid = str(uuid.uuid4())
+    rid = str(uuid.uuid4())
+    field_id = "faq"
+
+    # Create a fake conversation field with only one message
+    async with maindb_driver.rw_transaction() as txn:
+        kb_obj = KnowledgeBox(txn, storage, kbid)
+        r_obj = await kb_obj.add_resource(rid, "slug")
+        conv_pb = resources_pb2.Conversation()
+        conv_pb.messages.append(resources_pb2.Message(ident="foo"))
+        await r_obj.set_field(resources_pb2.FieldType.CONVERSATION, field_id, conv_pb)
+        await txn.commit()
+
+    # Delete the key simulating as it wasn't there
+    async with maindb_driver.rw_transaction() as txn:
+        splits_metadata_key = CONVERSATION_SPLITS_METADATA.format(
+            kbid=kbid, uuid=rid, type="c", field=field_id
+        )
+        await txn.delete(splits_metadata_key)
+        await txn.commit()
+
+    await migration.module.migrate_kb(execution_context, kbid)
+
+    # Make sure that the splits metadata has been populated correctly
+    async with maindb_driver.ro_transaction() as txn:
+        kb_obj = KnowledgeBox(txn, storage, kbid)
+        resource_obj = await kb_obj.get(rid)
+        assert resource_obj
+        conv: Conversation = await resource_obj.get_field(
+            field_id, resources_pb2.FieldType.CONVERSATION, load=False
+        )
+        splits_metadata = await conv.get_splits_metadata()
+        assert splits_metadata.metadata["foo"] is not None

--- a/nucliadb_protos/resources.proto
+++ b/nucliadb_protos/resources.proto
@@ -169,6 +169,12 @@ message FieldConversation {
     string split_strategy = 5;
 }
 
+message SplitMetadata {}
+
+message SplitsMetadata {
+    map<string, SplitMetadata> metadata = 1;
+}
+
 message NestedPosition {
     int64 start = 1;
     int64 end = 2;


### PR DESCRIPTION
### Description

When appending messages to a conversation, we were reindexing the whole field always in all indexes (fulltext, relations, paragraphs and vectors).

This PR improves the logic so at least we don't reindex the paragraphs and vectors for all messages every time a new message is appended.

[sc-12775]

### How was this PR tested?
Existing tests modified
