### PR TITLE
Add limits to conversation fields

### DIFF
--- a/nucliadb/src/nucliadb/common/cluster/settings.py
+++ b/nucliadb/src/nucliadb/common/cluster/settings.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
         description="Maximum number of paragraphs to target per shard",
     )
     max_resource_paragraphs: int = Field(
-        default=50_000,
+        default=300_000,
         title="Max paragraphs per resource",
         description="Maximum number of paragraphs allowed on a single resource",
     )

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -25,10 +25,16 @@ from nucliadb_protos.resources_pb2 import CloudFile, FieldConversation
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_utils.storages.storage import StorageField
 
+MAX_CONVERSATION_MESSAGES = 50_000
+
 PAGE_SIZE = 200
 
 CONVERSATION_PAGE_VALUE = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/{page}"
 CONVERSATION_METADATA = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}"
+
+
+class MaxConversationMessagesReached(Exception):
+    pass
 
 
 class PageNotFound(Exception):
@@ -97,6 +103,9 @@ class Conversation(Field[PBConversation]):
         # Increment the metadata total with the number of messages
         messages = list(payload.messages)
         metadata.total += len(messages)
+
+        if metadata.total > MAX_CONVERSATION_MESSAGES:
+            raise MaxConversationMessagesReached()
 
         # Store the messages in pages of PAGE_SIZE messages
         while True:

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -33,10 +33,6 @@ CONVERSATION_PAGE_VALUE = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/{page}"
 CONVERSATION_METADATA = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}"
 
 
-class MaxConversationMessagesReached(Exception):
-    pass
-
-
 class PageNotFound(Exception):
     pass
 
@@ -103,9 +99,6 @@ class Conversation(Field[PBConversation]):
         # Increment the metadata total with the number of messages
         messages = list(payload.messages)
         metadata.total += len(messages)
-
-        if metadata.total > MAX_CONVERSATION_MESSAGES:
-            raise MaxConversationMessagesReached()
 
         # Store the messages in pages of PAGE_SIZE messages
         while True:

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -25,7 +25,7 @@ from nucliadb_protos.resources_pb2 import CloudFile, FieldConversation
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_utils.storages.storage import StorageField
 
-MAX_CONVERSATION_MESSAGES = 50_000
+MAX_CONVERSATION_MESSAGES = 50 * 1024
 
 PAGE_SIZE = 200
 

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -30,7 +30,7 @@ from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR, FIELD_TYPE_STR_TO_PB, FieldId
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.base import Field
-from nucliadb.ingest.fields.conversation import Conversation, MaxConversationMessagesReached
+from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.fields.generic import VALID_GENERIC_FIELDS, Generic
 from nucliadb.ingest.fields.link import Link
@@ -427,21 +427,9 @@ class Resource:
             message_updated_fields.append(fid)
 
         for field, conversation in message.conversations.items():
-            try:
-                fid = FieldID(field_type=FieldType.CONVERSATION, field=field)
-                await self.set_field(fid.field_type, fid.field, conversation)
-                message_updated_fields.append(fid)
-            except MaxConversationMessagesReached:
-                field_key = f"c/{field}"
-                error_message = "Conversation exceeds the maximum number of messages"
-                logger.info(
-                    error_message, extra={"kbid": self.kb.kbid, "rid": self.uuid, "field": field_key}
-                )
-                await self.add_field_error(
-                    field_key,
-                    error_message,
-                    writer_pb2.Error.Severity.ERROR,
-                )
+            fid = FieldID(field_type=FieldType.CONVERSATION, field=field)
+            await self.set_field(fid.field_type, fid.field, conversation)
+            message_updated_fields.append(fid)
 
         for fieldid in message.delete_fields:
             await self.delete_field(fieldid.field_type, fieldid.field)

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Annotated, Callable, Optional, Type, Union
+from typing import TYPE_CHECKING, Annotated, Callable, List, Optional, Type, Union
 
 import pydantic
 from fastapi import HTTPException, Query, Response
@@ -460,7 +460,7 @@ async def append_messages_to_conversation_field_rslug_prefix(
     kbid: str,
     rslug: str,
     field_id: FieldIdString,
-    messages: list[models.InputMessage],
+    messages: List[models.InputMessage],
 ) -> ResourceFieldAdded:
     try:
         field = models.InputConversationField(messages=messages)
@@ -483,7 +483,7 @@ async def append_messages_to_conversation_field_rid_prefix(
     kbid: str,
     rid: str,
     field_id: FieldIdString,
-    messages: list[models.InputMessage],
+    messages: List[models.InputMessage],
 ) -> ResourceFieldAdded:
     try:
         field = models.InputConversationField(messages=messages)

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -433,7 +433,6 @@ async def parse_conversation_field(
     resource_classifications: ResourceClassifications,
 ) -> None:
     # Make sure that the max number of messages is not exceeded
-    breakpoint()
     current_message_count = await get_current_conversation_message_count(kbid, uuid, key)
     if len(conversation_field.messages) + current_message_count > MAX_CONVERSATION_MESSAGES:
         raise HTTPException(

--- a/nucliadb/tests/writer/unit/resources/test_field.py
+++ b/nucliadb/tests/writer/unit/resources/test_field.py
@@ -108,7 +108,13 @@ def get_message(id, who, to, text, attachments=None):
     return msg
 
 
-async def test_parse_conversation_field(storage_mock, processing_mock):
+@pytest.fixture()
+def conv_messages_count():
+    with mock.patch(f"{FIELD_MODULE}.get_current_conversation_message_count", return_value=0):
+        yield
+
+
+async def test_parse_conversation_field(storage_mock, processing_mock, conv_messages_count):
     key = "conv"
     kbid = "kbid"
     uuid = "uuid"

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -21,8 +21,6 @@ from pydantic import BaseModel, Field, field_validator
 from nucliadb_models.common import CloudLink, FieldRef, FileB64
 from nucliadb_models.utils import DateTime
 
-KB = 1024 * 1024
-
 # Shared classes
 
 
@@ -88,7 +86,7 @@ class FieldConversation(BaseModel):
 
 
 class InputMessageContent(BaseModel):
-    text: str = Field(max_length=1 * KB)
+    text: str = Field(max_length=1024)
     format: MessageFormat = MessageFormat.PLAIN
     attachments: List[FileB64] = Field(default=[], max_length=50)
     attachments_fields: List[FieldRef] = Field(default=[], max_length=50)
@@ -130,8 +128,8 @@ class InputMessage(BaseModel):
 class InputConversationField(BaseModel):
     messages: List[InputMessage] = Field(
         default_factory=list,
-        description="List of messages in the conversation field. Each message must have a unique ident. The maximum number of messages a conversation can have is 50.000",
-        max_length=2_000,
+        description="List of messages in the conversation field. Each message must have a unique ident. A single conversation can contain up to 51,200 messages. You can add up to 1,024 messages per request.",
+        max_length=1024,
     )
     extract_strategy: Optional[str] = Field(
         default=None,

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -21,6 +21,8 @@ from pydantic import BaseModel, Field, field_validator
 from nucliadb_models.common import CloudLink, FieldRef, FileB64
 from nucliadb_models.utils import DateTime
 
+KB = 1024 * 1024
+
 # Shared classes
 
 
@@ -86,10 +88,10 @@ class FieldConversation(BaseModel):
 
 
 class InputMessageContent(BaseModel):
-    text: str
+    text: str = Field(max_length=1 * KB)
     format: MessageFormat = MessageFormat.PLAIN
-    attachments: List[FileB64] = []
-    attachments_fields: List[FieldRef] = []
+    attachments: List[FileB64] = Field(default=[], max_length=50)
+    attachments_fields: List[FieldRef] = Field(default=[], max_length=50)
 
 
 class InputMessage(BaseModel):
@@ -102,10 +104,12 @@ class InputMessage(BaseModel):
     to: List[str] = Field(
         default_factory=list,
         description="List of recipients of the message, e.g. ['assistant'] or ['user']",
+        max_length=100,
     )
     content: InputMessageContent
     ident: str = Field(
-        description="Unique identifier for the message. Must be unique within the conversation."
+        description="Unique identifier for the message. Must be unique within the conversation.",
+        max_length=128,
     )
     type_: Optional[MessageType] = Field(None, alias="type")
 
@@ -126,7 +130,8 @@ class InputMessage(BaseModel):
 class InputConversationField(BaseModel):
     messages: List[InputMessage] = Field(
         default_factory=list,
-        description="List of messages in the conversation field. Each message must have a unique ident.",
+        description="List of messages in the conversation field. Each message must have a unique ident. The maximum number of messages a conversation can have is 50.000",
+        max_length=2_000,
     )
     extract_strategy: Optional[str] = Field(
         default=None,

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -129,7 +129,7 @@ class InputConversationField(BaseModel):
     messages: List[InputMessage] = Field(
         default_factory=list,
         description="List of messages in the conversation field. Each message must have a unique ident. A single conversation can contain up to 51,200 messages. You can add up to 1,024 messages per request.",
-        max_length=1024,
+        max_length=2048,
     )
     extract_strategy: Optional[str] = Field(
         default=None,

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -128,7 +128,7 @@ class InputMessage(BaseModel):
 class InputConversationField(BaseModel):
     messages: List[InputMessage] = Field(
         default_factory=list,
-        description="List of messages in the conversation field. Each message must have a unique ident. A single conversation can contain up to 51,200 messages. You can add up to 1,024 messages per request.",
+        description="List of messages in the conversation field. Each message must have a unique ident. A single conversation can contain up to 51,200 messages. You can add up to 2,048 messages per request.",
         max_length=2048,
     )
     extract_strategy: Optional[str] = Field(


### PR DESCRIPTION
### Description
- Max number of messages (50k)
- Max messages in a request (2k)
- Max message size (1k)

That makes that, in the worst case, we can have conversations that have 50MB of text, in batches of 2M at most. I think this is enough for now.

Other limits added:

- Max number of recipients of a message (100)
- Max number of attachments (50)
- Max length for ident (128)

### How was this PR tested?
Integration tests