### PR TITLE
Rerank using RaBitQ error bounds

### DIFF
--- a/nidx/nidx_vector/src/hnsw.rs
+++ b/nidx/nidx_vector/src/hnsw.rs
@@ -24,8 +24,5 @@ mod params;
 mod ram_hnsw;
 
 pub use disk_hnsw::DiskHnsw;
-pub use ops_hnsw::Cnx;
-pub use ops_hnsw::DataRetriever;
-pub use ops_hnsw::HnswOps;
-pub use ops_hnsw::SearchVector;
+pub use ops_hnsw::{Cnx, DataRetriever, HnswOps, ScoreBound, SearchVector};
 pub use ram_hnsw::RAMHnsw;

--- a/nidx/nidx_vector/src/hnsw.rs
+++ b/nidx/nidx_vector/src/hnsw.rs
@@ -24,5 +24,5 @@ mod params;
 mod ram_hnsw;
 
 pub use disk_hnsw::DiskHnsw;
-pub use ops_hnsw::{Cnx, DataRetriever, HnswOps, ScoreBound, SearchVector};
+pub use ops_hnsw::{Cnx, DataRetriever, EstimatedScore, HnswOps, SearchVector};
 pub use ram_hnsw::RAMHnsw;

--- a/nidx/nidx_vector/src/hnsw/params.rs
+++ b/nidx/nidx_vector/src/hnsw/params.rs
@@ -23,11 +23,11 @@
 
 /// Factor by which the layer distribution should deviate.
 pub fn level_factor() -> f64 {
-    1.0 / (m() as f64).ln()
+    1.0 / (M as f64).ln()
 }
 
 pub const fn m_max_for_layer(layer: usize) -> usize {
-    if layer == 0 { m_max0() } else { m_max() }
+    if layer == 0 { M_MAX_0 } else { M_MAX }
 }
 
 /// M to use when pruning neighbours
@@ -36,21 +36,13 @@ pub const fn prune_m(m: usize) -> usize {
 }
 
 /// Upper limit to the number of out-edges a embedding can have.
-pub const fn m_max0() -> usize {
-    60
-}
+pub const M_MAX_0: usize = 60;
 
 /// Upper limit to the number of out-edges a embedding can have.
-pub const fn m_max() -> usize {
-    30
-}
+pub const M_MAX: usize = 30;
 
 /// Number of bi-directional links created for every new element.
-pub const fn m() -> usize {
-    30
-}
+pub const M: usize = 30;
 
 /// Number of neighbours that are searched for before adding a new embedding.
-pub const fn ef_construction() -> usize {
-    100
-}
+pub const EF_CONSTRUCTION: usize = 100;

--- a/nidx/nidx_vector/src/segment.rs
+++ b/nidx/nidx_vector/src/segment.rs
@@ -352,14 +352,14 @@ impl<DS: DataStore> DataRetriever for Retriever<'_, DS> {
         }
     }
 
-    fn similarity_upper_bound(&self, x: VectorAddr, y: &SearchVector) -> ScoreBound {
+    fn similarity_upper_bound(&self, x: VectorAddr, y: &SearchVector) -> EstimatedScore {
         match y {
             SearchVector::RabitQ(query) => {
                 let x = self.data_store.get_quantized_vector(x);
                 let (est, err) = query.similarity(x);
-                ScoreBound::new_with_error(est, err)
+                EstimatedScore::new_with_error(est, err)
             }
-            _ => ScoreBound::new_exact(self.similarity(x, y)),
+            _ => EstimatedScore::new_exact(self.similarity(x, y)),
         }
     }
 

--- a/nidx/nidx_vector/src/vector_types/rabitq.rs
+++ b/nidx/nidx_vector/src/vector_types/rabitq.rs
@@ -18,11 +18,27 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+use std::{cmp::Reverse, collections::BinaryHeap};
+
 use simsimd::SpatialSimilarity;
 
-use crate::config::VectorType;
+use crate::{
+    VectorAddr,
+    config::VectorType,
+    hnsw::{Cnx, DataRetriever, ScoreBound, SearchVector},
+};
 
+/// Constant to adjust the error bound of the estimated similarity.
+// The paper recommends 1.9, reasonable values are from 0.0 to 4.0
+// Higher numbers give more error bound so we need to load more raw
+// vectors but provide slightly better recall.
 const EPSILON: f32 = 1.9;
+
+/// How many vectors to evaluate per each expected result.
+/// This is multiplied by top_k to get the number of vectors to search for.
+pub const RERANKING_FACTOR: usize = 100;
+/// The maximum number of vectors to evaluate during reranking.
+pub const RERANKING_LIMIT: usize = 2000;
 
 pub struct EncodedVector<'a> {
     data: &'a [u8],
@@ -205,6 +221,31 @@ impl QueryVector {
 
         (estimate, error)
     }
+}
+
+/// Rerank results from RabitQ search using the raw vectors. Uses the error bound to know when to stop reranking
+pub fn rerank_top(
+    candidates: Vec<(VectorAddr, ScoreBound)>,
+    top_k: usize,
+    retriever: &impl DataRetriever,
+    query: &SearchVector,
+) -> BinaryHeap<Reverse<Cnx>> {
+    let mut best = BinaryHeap::new();
+    let mut best_k = 0.0;
+    for (addr, ScoreBound { upper_bound, .. }) in candidates {
+        if best.len() < top_k || best_k < upper_bound {
+            // If the candidate score could be better than what we have so far, calculate the accurate similarity
+            let real_score = retriever.similarity(addr, query);
+            if best.len() < top_k || best_k < real_score {
+                best.push(Reverse(Cnx(addr, real_score)));
+                if best.len() > top_k {
+                    best.pop();
+                }
+                best_k = best.peek().unwrap().0.1;
+            }
+        }
+    }
+    best
 }
 
 #[cfg(test)]

--- a/nidx/nidx_vector/src/vector_types/rabitq.rs
+++ b/nidx/nidx_vector/src/vector_types/rabitq.rs
@@ -25,7 +25,7 @@ use simsimd::SpatialSimilarity;
 use crate::{
     VectorAddr,
     config::VectorType,
-    hnsw::{Cnx, DataRetriever, ScoreBound, SearchVector},
+    hnsw::{Cnx, DataRetriever, EstimatedScore, SearchVector},
 };
 
 /// Constant to adjust the error bound of the estimated similarity.
@@ -225,14 +225,14 @@ impl QueryVector {
 
 /// Rerank results from RabitQ search using the raw vectors. Uses the error bound to know when to stop reranking
 pub fn rerank_top(
-    candidates: Vec<(VectorAddr, ScoreBound)>,
+    candidates: Vec<(VectorAddr, EstimatedScore)>,
     top_k: usize,
     retriever: &impl DataRetriever,
     query: &SearchVector,
 ) -> BinaryHeap<Reverse<Cnx>> {
     let mut best = BinaryHeap::new();
     let mut best_k = 0.0;
-    for (addr, ScoreBound { upper_bound, .. }) in candidates {
+    for (addr, EstimatedScore { upper_bound, .. }) in candidates {
         if best.len() < top_k || best_k < upper_bound {
             // If the candidate score could be better than what we have so far, calculate the accurate similarity
             let real_score = retriever.similarity(addr, query);


### PR DESCRIPTION
### Description

RaBitQ provides error bound that can be used to stop reranking vectors early. If the upper bound of the score estimate is worse than the best reranked vector so far, we can skip calculating the actual similarity score. This reduces the number of raw vectors loaded from disk significantly. In a quick experiment with the current setting this reduces the loaded vectors by ~50% while keeping the exact same results.

### How was this PR tested?
Describe how you tested this PR.
