### PR TITLE
Safer predict utility lifecycle

### DIFF
--- a/nucliadb/src/nucliadb/reader/run.py
+++ b/nucliadb/src/nucliadb/reader/run.py
@@ -31,7 +31,7 @@ def run():
     instrument_app(
         application,
         tracer_provider=get_telemetry(SERVICE_NAME),
-        excluded_urls=["/"],
+        excluded_urls=["/", "/health/alive", "/health/ready"],
         metrics=True,
         trace_id_on_responses=True,
     )

--- a/nucliadb/src/nucliadb/search/lifecycle.py
+++ b/nucliadb/src/nucliadb/search/lifecycle.py
@@ -27,7 +27,7 @@ from nucliadb.common.maindb.utils import setup_driver
 from nucliadb.common.nidx import start_nidx_utility, stop_nidx_utility
 from nucliadb.ingest.utils import start_ingest, stop_ingest
 from nucliadb.search import SERVICE_NAME
-from nucliadb.search.predict import start_predict_engine
+from nucliadb.search.predict import start_predict_engine, stop_predict_engine
 from nucliadb_telemetry.utils import clean_telemetry, setup_telemetry
 from nucliadb_utils.utilities import (
     Utility,
@@ -58,11 +58,8 @@ async def lifespan(app: FastAPI):
     await stop_ingest()
     if get_utility(Utility.PARTITION):
         clean_utility(Utility.PARTITION)
-    predict = get_utility(Utility.PREDICT)
-    if predict:
-        await predict.finalize()
-        clean_utility(Utility.PREDICT)
 
+    await stop_predict_engine()
     await stop_nidx_utility()
 
     await finalize_utilities()

--- a/nucliadb/src/nucliadb/search/lifecycle.py
+++ b/nucliadb/src/nucliadb/search/lifecycle.py
@@ -58,7 +58,9 @@ async def lifespan(app: FastAPI):
     await stop_ingest()
     if get_utility(Utility.PARTITION):
         clean_utility(Utility.PARTITION)
-    if get_utility(Utility.PREDICT):
+    predict = get_utility(Utility.PREDICT)
+    if predict:
+        await predict.finalize()
         clean_utility(Utility.PREDICT)
 
     await stop_nidx_utility()

--- a/nucliadb/src/nucliadb/search/predict.py
+++ b/nucliadb/src/nucliadb/search/predict.py
@@ -62,7 +62,7 @@ from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb_telemetry import errors, metrics
 from nucliadb_utils.exceptions import LimitsExceededError
 from nucliadb_utils.settings import nuclia_settings
-from nucliadb_utils.utilities import Utility, set_utility
+from nucliadb_utils.utilities import Utility, get_utility, set_utility
 
 
 class SendToPredictError(Exception):
@@ -148,6 +148,10 @@ class RephraseResponse:
 
 
 async def start_predict_engine():
+    existing = get_utility(Utility.PREDICT)
+    if existing is not None:
+        return
+
     if nuclia_settings.dummy_predict:
         predict_util = DummyPredictEngine()
     else:

--- a/nucliadb/src/nucliadb/search/predict.py
+++ b/nucliadb/src/nucliadb/search/predict.py
@@ -25,6 +25,7 @@ import random
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from enum import Enum
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import aiohttp
@@ -62,7 +63,7 @@ from nucliadb_protos.utils_pb2 import RelationNode
 from nucliadb_telemetry import errors, metrics
 from nucliadb_utils.exceptions import LimitsExceededError
 from nucliadb_utils.settings import nuclia_settings
-from nucliadb_utils.utilities import Utility, get_utility, set_utility
+from nucliadb_utils.utilities import Utility, clean_utility, get_utility, set_utility
 
 
 class SendToPredictError(Exception):
@@ -147,13 +148,15 @@ class RephraseResponse:
     use_chat_history: bool | None
 
 
-async def start_predict_engine():
+async def start_predict_engine() -> None:
     existing = get_utility(Utility.PREDICT)
     if existing is not None:
         return
 
     if nuclia_settings.dummy_predict:
-        predict_util = DummyPredictEngine()
+        dummy = DummyPredictEngine()
+        await dummy.initialize()
+        set_utility(Utility.PREDICT, dummy)
     else:
         predict_util = PredictEngine(
             nuclia_settings.nuclia_inner_predict_url,
@@ -164,8 +167,16 @@ async def start_predict_engine():
             nuclia_settings.local_predict,
             nuclia_settings.local_predict_headers,
         )
-    await predict_util.initialize()
-    set_utility(Utility.PREDICT, predict_util)
+        await predict_util.initialize()
+        set_utility(Utility.PREDICT, predict_util)
+
+
+async def stop_predict_engine() -> None:
+    predict = get_utility(Utility.PREDICT)
+    if predict is not None:
+        predict = cast(PredictEngine, predict)
+        await predict.finalize()
+        clean_utility(Utility.PREDICT)
 
 
 def convert_relations(data: dict[str, list[dict[str, str]]]) -> list[RelationNode]:

--- a/nucliadb/src/nucliadb/search/run.py
+++ b/nucliadb/src/nucliadb/search/run.py
@@ -31,7 +31,7 @@ def run():
     instrument_app(
         application,
         tracer_provider=get_telemetry(SERVICE_NAME),
-        excluded_urls=["/"],
+        excluded_urls=["/", "/health/alive", "/health/ready"],
         metrics=True,
         trace_id_on_responses=True,
     )

--- a/nucliadb/src/nucliadb/search/utilities.py
+++ b/nucliadb/src/nucliadb/search/utilities.py
@@ -22,4 +22,7 @@ from nucliadb_utils.utilities import Utility, get_utility
 
 
 def get_predict() -> PredictEngine:
-    return get_utility(Utility.PREDICT)  # type: ignore
+    existing = get_utility(Utility.PREDICT)
+    if existing is None:
+        raise ValueError("Predict engine is not initialized")
+    return existing

--- a/nucliadb/src/nucliadb/standalone/run.py
+++ b/nucliadb/src/nucliadb/standalone/run.py
@@ -85,7 +85,7 @@ def run():
     settings = setup()
     run_migrations()
     app, server = get_server(settings)
-    instrument_app(app, excluded_urls=["/"], metrics=True)
+    instrument_app(app, excluded_urls=["/", "/health/alive", "/health/ready"], metrics=True)
 
     if settings.fork:  # pragma: no cover
         pid = os.fork()

--- a/nucliadb/src/nucliadb/train/run.py
+++ b/nucliadb/src/nucliadb/train/run.py
@@ -31,7 +31,7 @@ def run():
     instrument_app(
         application,
         tracer_provider=get_telemetry(SERVICE_NAME),
-        excluded_urls=["/"],
+        excluded_urls=["/", "/health/alive", "/health/ready"],
         metrics=True,
         trace_id_on_responses=True,
     )

--- a/nucliadb/src/nucliadb/writer/run.py
+++ b/nucliadb/src/nucliadb/writer/run.py
@@ -32,7 +32,7 @@ def run():
     instrument_app(
         application,
         tracer_provider=get_telemetry(SERVICE_NAME),
-        excluded_urls=["/"],
+        excluded_urls=["/", "/health/alive", "/health/ready"],
         metrics=True,
         trace_id_on_responses=True,
     )


### PR DESCRIPTION
### Description
Due to the ugly versioned fastapi implementation, it turns out we end up initializing predict engine several times, leaving orphaned sessions.

Also, teardown of the util was not properly done, never calling finalize

### How was this PR tested?
Describe how you tested this PR.
