### PR TITLE
Use nidx as extracted text storage in augmentor

### DIFF
--- a/nucliadb/src/nucliadb/common/cache.py
+++ b/nucliadb/src/nucliadb/common/cache.py
@@ -28,13 +28,10 @@ from typing import Generic, TypeVar
 
 import backoff
 from async_lru import _LRUCacheWrapper, alru_cache
-from nidx_protos.nidx_pb2 import ExtractedTextsRequest
 from typing_extensions import ParamSpec
 
-from nucliadb.common import datamanagers
 from nucliadb.common.ids import FieldId
 from nucliadb.common.maindb.utils import get_driver
-from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import FieldTypes
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
@@ -125,42 +122,9 @@ class ExtractedTextCache(Cache[[str, FieldId], ExtractedText]):
             if field_id.type != "c" and has_feature(
                 const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": kbid}
             ):
-                async with datamanagers.with_ro_transaction() as txn:
-                    kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
-                    if kb_shards is None:
-                        return None
+                from nucliadb.search.augmentor.fields import get_field_extracted_text_from_nidx
 
-                    resource_shard_id = await datamanagers.resources.get_resource_shard_id(
-                        txn,
-                        kbid=kbid,
-                        rid=field_id.rid,
-                    )
-                    if resource_shard_id is None:
-                        return None
-
-                    nidx_shard_id = None
-                    for shard in kb_shards.shards:
-                        if shard.shard == resource_shard_id:
-                            nidx_shard_id = shard.nidx_shard_id
-                            break
-                    else:
-                        return None
-
-                nidx_searcher = get_nidx_searcher_client()
-                extracted_texts = await nidx_searcher.ExtractedTexts(
-                    ExtractedTextsRequest(
-                        shard_id=nidx_shard_id,
-                        field_ids=[
-                            ExtractedTextsRequest.FieldId(
-                                rid=field_id.rid,
-                                field_type=field_id.type,
-                                field_name=field_id.key,
-                                split=field_id.subfield_id,
-                            )
-                        ],
-                    )
-                )
-                text = extracted_texts.fields.get(field_id.full_without_subfield(), None)
+                text = await get_field_extracted_text_from_nidx(kbid, field_id)
                 if text is None:
                     return None
                 return ExtractedText(text=text)

--- a/nucliadb/src/nucliadb/common/cache.py
+++ b/nucliadb/src/nucliadb/common/cache.py
@@ -37,8 +37,7 @@ from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb_protos.utils_pb2 import ExtractedText
 from nucliadb_telemetry.metrics import Counter, Gauge
-from nucliadb_utils import const
-from nucliadb_utils.utilities import get_storage, has_feature
+from nucliadb_utils.utilities import get_storage
 
 logger = logging.getLogger(__name__)
 
@@ -117,36 +116,23 @@ class ExtractedTextCache(Cache[[str, FieldId], ExtractedText]):
         @alru_cache(maxsize=cache_size)
         @backoff.on_exception(backoff.expo, (Exception,), jitter=backoff.random_jitter, max_tries=3)
         async def _get_extracted_text(kbid: str, field_id: FieldId) -> ExtractedText | None:
-            # we store all splits unordered inside nidx_text, so nidx can't
-            # support yet conversation fields
-            if field_id.type != "c" and has_feature(
-                const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": kbid}
-            ):
-                from nucliadb.search.augmentor.fields import get_field_extracted_text_from_nidx
-
-                text = await get_field_extracted_text_from_nidx(kbid, field_id)
-                if text is None:
-                    return None
-                return ExtractedText(text=text)
-
-            else:
-                storage = await get_storage()
-                try:
-                    sf = storage.file_extracted(
-                        kbid, field_id.rid, field_id.type, field_id.key, FieldTypes.FIELD_TEXT.value
-                    )
-                    return await storage.download_pb(sf, ExtractedText)
-                except Exception:
-                    logger.warning(
-                        "Error getting extracted text for field. Retrying",
-                        exc_info=True,
-                        extra={
-                            "kbid": kbid,
-                            "resource_id": field_id.rid,
-                            "field": f"{field_id.type}/{field_id.key}",
-                        },
-                    )
-                    raise
+            storage = await get_storage()
+            try:
+                sf = storage.file_extracted(
+                    kbid, field_id.rid, field_id.type, field_id.key, FieldTypes.FIELD_TEXT.value
+                )
+                return await storage.download_pb(sf, ExtractedText)
+            except Exception:
+                logger.warning(
+                    "Error getting extracted text for field. Retrying",
+                    exc_info=True,
+                    extra={
+                        "kbid": kbid,
+                        "resource_id": field_id.rid,
+                        "field": f"{field_id.type}/{field_id.key}",
+                    },
+                )
+                raise
 
         self.cache = _get_extracted_text
 

--- a/nucliadb/src/nucliadb/common/cluster/manager.py
+++ b/nucliadb/src/nucliadb/common/cluster/manager.py
@@ -352,24 +352,3 @@ class StandaloneKBShardManager(KBShardManager):
                     await storage.delete_upload(storage_key, storage.indexing_bucket)
             except Exception:
                 pass
-
-
-async def get_resource_nidx_shard_id(kbid: str, rid: str) -> str | None:
-    async with datamanagers.with_ro_transaction() as txn:
-        kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
-        if kb_shards is None:
-            return None
-
-        resource_shard_id = await datamanagers.resources.get_resource_shard_id(txn, kbid=kbid, rid=rid)
-        if resource_shard_id is None:
-            return None
-
-        nidx_shard_id = None
-        for shard in kb_shards.shards:
-            if shard.shard == resource_shard_id:
-                nidx_shard_id = shard.nidx_shard_id
-                break
-        else:
-            return None
-
-    return nidx_shard_id

--- a/nucliadb/src/nucliadb/common/cluster/manager.py
+++ b/nucliadb/src/nucliadb/common/cluster/manager.py
@@ -352,3 +352,24 @@ class StandaloneKBShardManager(KBShardManager):
                     await storage.delete_upload(storage_key, storage.indexing_bucket)
             except Exception:
                 pass
+
+
+async def get_resource_nidx_shard_id(kbid: str, rid: str) -> str | None:
+    async with datamanagers.with_ro_transaction() as txn:
+        kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
+        if kb_shards is None:
+            return None
+
+        resource_shard_id = await datamanagers.resources.get_resource_shard_id(txn, kbid=kbid, rid=rid)
+        if resource_shard_id is None:
+            return None
+
+        nidx_shard_id = None
+        for shard in kb_shards.shards:
+            if shard.shard == resource_shard_id:
+                nidx_shard_id = shard.nidx_shard_id
+                break
+        else:
+            return None
+
+    return nidx_shard_id

--- a/nucliadb/src/nucliadb/search/api/v1/retrieve.py
+++ b/nucliadb/src/nucliadb/search/api/v1/retrieve.py
@@ -28,7 +28,7 @@ from nucliadb.common.external_index_providers.base import TextBlockMatch
 from nucliadb.common.models_utils import to_proto
 from nucliadb.models.internal.augment import Paragraph, ParagraphText
 from nucliadb.search.api.v1.router import KB_PREFIX, api
-from nucliadb.search.augmentor.paragraphs import augment_paragraphs
+from nucliadb.search.augmentor import augment_paragraphs
 from nucliadb.search.search import cache, rerankers
 from nucliadb.search.search.query_parser.parsers.retrieve import parse_retrieve
 from nucliadb.search.search.query_parser.parsers.unit_retrieval import get_rephrased_query

--- a/nucliadb/src/nucliadb/search/augmentor/__init__.py
+++ b/nucliadb/src/nucliadb/search/augmentor/__init__.py
@@ -18,4 +18,4 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from . import fields, paragraphs, resources  # noqa: F401
-from .augmentor import augment  # noqa: F401
+from .augmentor import augment, augment_paragraphs  # noqa: F401

--- a/nucliadb/src/nucliadb/search/augmentor/augmentor.py
+++ b/nucliadb/src/nucliadb/search/augmentor/augmentor.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
-from contextvars import ContextVar
 from typing import cast
 
 from typing_extensions import assert_never
@@ -56,12 +55,10 @@ from nucliadb_models.resource import Resource
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
-from .extracted_text import ExtractedTexts, extracted_texts
+from .extracted_text import extracted_texts, nidx_et_cache
 from .fields import augment_field
 from .paragraphs import augment_paragraph
 from .resources import augment_resource, augment_resource_deep
-
-nidx_et_cache: ContextVar[ExtractedTexts | None] = ContextVar("nidx_et_cache", default=None)
 
 
 @augmentor_observer.wrap({"type": "augment"})

--- a/nucliadb/src/nucliadb/search/augmentor/augmentor.py
+++ b/nucliadb/src/nucliadb/search/augmentor/augmentor.py
@@ -18,11 +18,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
-from typing import Any
+from typing import cast
 
 from typing_extensions import assert_never
 
 import nucliadb_models
+import nucliadb_models.resource
 from nucliadb.common import datamanagers
 from nucliadb.common.ids import FIELD_TYPE_NAME_TO_STR, FieldId, ParagraphId
 from nucliadb.models.internal.augment import (
@@ -31,6 +32,19 @@ from nucliadb.models.internal.augment import (
     AugmentedField,
     AugmentedParagraph,
     AugmentedResource,
+    ConversationAugment,
+    ConversationProp,
+    DeepResourceAugment,
+    FieldAugment,
+    FieldProp,
+    FileAugment,
+    FileProp,
+    Metadata,
+    ParagraphAugment,
+    ParagraphProp,
+    ParagraphText,
+    ResourceAugment,
+    ResourceProp,
 )
 from nucliadb.search.augmentor.metrics import augmentor_observer
 from nucliadb.search.augmentor.utils import limited_concurrency
@@ -52,183 +66,227 @@ async def augment(
 ) -> Augmented:
     """Process multiple augmentations concurrently and return the augmented content.
 
-    This is a heavy operation that can lead to many I/O operations with maindb
-    and/or blob storage. For improved performance, make sure this is called
-    inside the context of `nucliadb.search.search.cache` `request_caches`
+    This is a heavy operation that can lead to many I/O operations involving
+    maindb blob storage and/or nidx. For improved performance, make sure this is
+    called inside the context of `nucliadb.search.search.cache` `request_caches`
 
     """
-    augments: dict[str, Any] = {
-        "resources": {},
-        "resources.deep": {},
-        "fields": {},
-        "paragraphs": {},
-    }
-    for augmentation in augmentations:
-        if augmentation.from_ == "resources":
-            for id in augmentation.given:
-                if isinstance(id, str):
-                    rid = id
-                elif isinstance(id, FieldId):
-                    rid = id.rid
-                elif isinstance(id, ParagraphId):
-                    rid = id.rid
-                else:  # pragma: no cover
-                    assert_never(id)
+    ops = AugmentorOps(kbid)
+    await ops.parse(augmentations)
+    return await ops.run(concurrency_control=concurrency_control)
 
-                augments["resources"].setdefault(rid, []).extend(augmentation.select)
 
-        elif augmentation.from_ == "resources.deep":
-            for rid in augmentation.given:
-                opts = augments["resources.deep"].setdefault(rid, ResourceHydrationOptions())
-                opts.show.extend(augmentation.show)
-                opts.extracted.extend(augmentation.extracted)
-                opts.field_type_filter.extend(augmentation.field_type_filter)
+class AugmentorOps:
+    def __init__(self, kbid: str):
+        self.kbid = kbid
 
-        elif augmentation.from_ == "fields":
-            unfiltered_field_ids: list[FieldId] = []
-            for id in augmentation.given:
-                if isinstance(id, str):
-                    # augmenting resource fields
-                    rid = id
-                    all_field_ids = await datamanagers.atomic.resources.get_all_field_ids(
-                        kbid=kbid, rid=rid, for_update=False
-                    )
-                    if all_field_ids is None:
-                        continue
+        # augments
+        self.resource_augments: dict[str, list[ResourceProp]] = {}
+        self.deep_resource_augments: dict[str, ResourceHydrationOptions] = {}
+        self.field_augments: dict[FieldId, list[FieldProp | FileProp | ConversationProp]] = {}
+        self.paragraph_augments: dict[ParagraphId, tuple[list[ParagraphProp], Metadata | None]] = {}
 
-                    unfiltered_field_ids.extend(
-                        FieldId.from_pb(
-                            rid=rid, field_type=field_id_pb.field_type, key=field_id_pb.field
-                        )
-                        for field_id_pb in all_field_ids.fields
-                    )
+        # extracted texts
+        self.field_texts: set[FieldId] = set()
+        self.paragraph_texts: set[ParagraphId] = set()
 
-                elif isinstance(id, FieldId):
-                    unfiltered_field_ids.append(id)
+    async def parse(self, augmentations: list[Augment]):
+        for augmentation in augmentations:
+            if augmentation.from_ == "resources":
+                self._parse_resource(augmentation)
 
-                elif isinstance(id, ParagraphId):
-                    unfiltered_field_ids.append(id.field_id)
+            elif augmentation.from_ == "resources.deep":
+                self._parse_deep_resource(augmentation)
 
-                else:  # pragma: no cover
-                    assert_never(id)
+            elif augmentation.from_ == "fields":
+                await self._parse_field(augmentation)
 
-            if not augmentation.filter:
-                field_ids = unfiltered_field_ids
-            else:
-                field_ids = []
-                for field_id in unfiltered_field_ids:
-                    for filter in augmentation.filter:
-                        if isinstance(filter, nucliadb_models.filters.Field):
-                            if filter.type == field_id.type_name and (
-                                filter.name is None or filter.name == field_id.key
-                            ):
-                                field_ids.append(field_id)
+            elif augmentation.from_ == "files":
+                self._parse_file_field(augmentation)
 
-                        elif isinstance(filter, nucliadb_models.filters.Generated):
-                            # generated fields are always text fields starting with "da-"
-                            if field_id.type == FIELD_TYPE_NAME_TO_STR[FieldTypeName.TEXT] and (
-                                filter.da_task is None
-                                or field_id.key.startswith(f"da-{filter.da_task}-")
-                            ):
-                                field_ids.append(field_id)
+            elif augmentation.from_ == "conversations":
+                self._parse_conversation_field(augmentation)
 
-                        else:  # pragma: no cover
-                            assert_never(filter)
+            elif augmentation.from_ == "paragraphs":
+                self._parse_paragraph(augmentation)
 
-            for field_id in field_ids:
-                augments["fields"].setdefault(field_id, []).extend(augmentation.select)
+            else:  # pragma: no cover
+                assert_never(augmentation.from_)
 
-        elif augmentation.from_ == "files" or augmentation.from_ == "conversations":
-            for id in augmentation.given:
-                if isinstance(id, FieldId):
-                    field_id = id
-                elif isinstance(id, ParagraphId):
-                    field_id = id.field_id
-                else:  # pragma: no cover
-                    assert_never(id)
+    def _parse_resource(self, augmentation: ResourceAugment) -> None:
+        for id in augmentation.given:
+            if isinstance(id, str):
+                rid = id
+            elif isinstance(id, FieldId):
+                rid = id.rid
+            elif isinstance(id, ParagraphId):
+                rid = id.rid
+            else:  # pragma: no cover
+                assert_never(id)
 
-                augments["fields"].setdefault(field_id, []).extend(augmentation.select)
+            self.resource_augments.setdefault(rid, []).extend(augmentation.select)
 
-        elif augmentation.from_ == "paragraphs":
-            for paragraph in augmentation.given:
-                select, metadata = augments["paragraphs"].setdefault(paragraph.id, ([], None))
-                select.extend(augmentation.select)
-                # we keep the first metadata object we see
-                metadata = metadata or paragraph.metadata
-                augments["paragraphs"][paragraph.id] = (select, metadata)
+    def _parse_deep_resource(self, augmentation: DeepResourceAugment) -> None:
+        for rid in augmentation.given:
+            opts = self.deep_resource_augments.setdefault(rid, ResourceHydrationOptions())
+            opts.show.extend(augmentation.show)
+            opts.extracted.extend(augmentation.extracted)
+            opts.field_type_filter.extend(augmentation.field_type_filter)
 
-        else:  # pragma: no cover
-            assert_never(augmentation.from_)
+    async def _parse_field(self, augmentation: FieldAugment) -> None:
+        unfiltered_field_ids: list[FieldId] = []
+        for id in augmentation.given:
+            if isinstance(id, str):
+                # augmenting resource fields
+                rid = id
+                all_field_ids = await datamanagers.atomic.resources.get_all_field_ids(
+                    kbid=self.kbid, rid=rid, for_update=False
+                )
+                if all_field_ids is None:
+                    continue
 
-    ops = {  # type: ignore[var-annotated]
-        "resources": [],
-        "resources.deep": [],
-        "fields": [],
-        "paragraphs": [],
-    }
-    for rid, select in augments["resources"].items():
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_resource(  # type: ignore[arg-type]
-                    kbid, rid, select
-                ),
-                max_ops=concurrency_control,
+                unfiltered_field_ids.extend(
+                    FieldId.from_pb(rid=rid, field_type=field_id_pb.field_type, key=field_id_pb.field)
+                    for field_id_pb in all_field_ids.fields
+                )
+
+            elif isinstance(id, FieldId):
+                unfiltered_field_ids.append(id)
+
+            elif isinstance(id, ParagraphId):
+                unfiltered_field_ids.append(id.field_id)
+
+            else:  # pragma: no cover
+                assert_never(id)
+
+        if not augmentation.filter:
+            field_ids = unfiltered_field_ids
+        else:
+            field_ids = []
+            for field_id in unfiltered_field_ids:
+                for filter in augmentation.filter:
+                    if isinstance(filter, nucliadb_models.filters.Field):
+                        if filter.type == field_id.type_name and (
+                            filter.name is None or filter.name == field_id.key
+                        ):
+                            field_ids.append(field_id)
+
+                    elif isinstance(filter, nucliadb_models.filters.Generated):
+                        # generated fields are always text fields starting with "da-"
+                        if field_id.type == FIELD_TYPE_NAME_TO_STR[FieldTypeName.TEXT] and (
+                            filter.da_task is None or field_id.key.startswith(f"da-{filter.da_task}-")
+                        ):
+                            field_ids.append(field_id)
+
+                    else:  # pragma: no cover
+                        assert_never(filter)
+
+        for field_id in field_ids:
+            self.field_augments.setdefault(field_id, []).extend(augmentation.select)
+
+    def _parse_file_field(self, augmentation: FileAugment) -> None:
+        for id in augmentation.given:
+            if isinstance(id, FieldId):
+                field_id = id
+            elif isinstance(id, ParagraphId):
+                field_id = id.field_id
+            else:  # pragma: no cover
+                assert_never(id)
+
+            self.field_augments.setdefault(field_id, []).extend(augmentation.select)
+            self.field_texts.add(field_id)
+
+    def _parse_conversation_field(self, augmentation: ConversationAugment) -> None:
+        for id in augmentation.given:
+            if isinstance(id, FieldId):
+                field_id = id
+            elif isinstance(id, ParagraphId):
+                field_id = id.field_id
+            else:  # pragma: no cover
+                assert_never(id)
+
+            self.field_augments.setdefault(field_id, []).extend(augmentation.select)
+
+    def _parse_paragraph(self, augmentation: ParagraphAugment) -> None:
+        for paragraph in augmentation.given:
+            if any((isinstance(prop, ParagraphText) for prop in augmentation.select)):
+                self.paragraph_texts.add(paragraph.id)
+
+            select, metadata = self.paragraph_augments.setdefault(paragraph.id, ([], None))
+            select.extend(augmentation.select)
+            # we keep the first metadata object we see
+            metadata = metadata or paragraph.metadata
+            self.paragraph_augments[paragraph.id] = (select, metadata)
+
+    async def run(
+        self,
+        *,
+        concurrency_control: asyncio.Semaphore | None = None,
+    ) -> Augmented:
+        resource_ops = []
+        deep_resource_ops = []
+        field_ops = []
+        paragraph_ops = []
+
+        for rid, resource_select in self.resource_augments.items():
+            task = asyncio.create_task(
+                limited_concurrency(  # type: ignore[arg-type]
+                    augment_resource(self.kbid, rid, resource_select),
+                    max_ops=concurrency_control,
+                )
             )
-        )
-        ops["resources"].append(task)
+            resource_ops.append(task)
 
-    for rid, opts in augments["resources.deep"].items():
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_resource_deep(  # type: ignore[arg-type]
-                    kbid, rid, opts
-                ),
-                max_ops=concurrency_control,
+        for rid, opts in self.deep_resource_augments.items():
+            task = asyncio.create_task(
+                limited_concurrency(
+                    augment_resource_deep(  # type: ignore[arg-type]
+                        self.kbid, rid, opts
+                    ),
+                    max_ops=concurrency_control,
+                )
             )
-        )
-        ops["resources.deep"].append(task)
+            deep_resource_ops.append(task)
 
-    for field_id, select in augments["fields"].items():
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_field(  # type: ignore[arg-type]
-                    kbid, field_id, select
-                ),
-                max_ops=concurrency_control,
+        for field_id, field_select in self.field_augments.items():
+            task = asyncio.create_task(
+                limited_concurrency(
+                    augment_field(  # type: ignore[arg-type]
+                        self.kbid, field_id, field_select
+                    ),
+                    max_ops=concurrency_control,
+                )
             )
-        )
-        ops["fields"].append(task)
+            field_ops.append(task)
 
-    for paragraph_id, (select, metadata) in augments["paragraphs"].items():
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_paragraph(  # type: ignore[arg-type]
-                    kbid, paragraph_id, select, metadata
-                ),
-                max_ops=concurrency_control,
+        for paragraph_id, (paragraph_select, metadata) in self.paragraph_augments.items():
+            task = asyncio.create_task(
+                limited_concurrency(
+                    augment_paragraph(  # type: ignore[arg-type]
+                        self.kbid, paragraph_id, paragraph_select, metadata
+                    ),
+                    max_ops=concurrency_control,
+                )
             )
+            paragraph_ops.append(task)
+
+        results = await asyncio.gather(*resource_ops, *deep_resource_ops, *field_ops, *paragraph_ops)
+
+        resources = cast(list[AugmentedResource | None], results[: len(resource_ops)])
+        del results[: len(resource_ops)]
+        resources_deep = cast(list[Resource | None], results[: len(deep_resource_ops)])
+        del results[: len(deep_resource_ops)]
+        fields = cast(list[AugmentedField | None], results[: len(field_ops)])
+        del results[: len(field_ops)]
+        paragraphs = cast(list[AugmentedParagraph | None], results[: len(paragraph_ops)])
+
+        return Augmented(
+            resources={resource.id: resource for resource in resources if resource is not None},
+            resources_deep={
+                resource_deep.id: resource_deep
+                for resource_deep in resources_deep
+                if resource_deep is not None
+            },
+            fields={field.id: field for field in fields if field is not None},
+            paragraphs={paragraph.id: paragraph for paragraph in paragraphs if paragraph is not None},
         )
-        ops["paragraphs"].append(task)
-
-    results = await asyncio.gather(
-        *ops["resources"], *ops["resources.deep"], *ops["fields"], *ops["paragraphs"]
-    )
-
-    resources: list[AugmentedResource] = results[: len(ops["resources"])]
-    del results[: len(ops["resources"])]
-    resources_deep: list[Resource] = results[: len(ops["resources.deep"])]
-    del results[: len(ops["resources.deep"])]
-    fields: list[AugmentedField] = results[: len(ops["fields"])]
-    del results[: len(ops["fields"])]
-    paragraphs: list[AugmentedParagraph] = results[: len(ops["paragraphs"])]
-
-    return Augmented(
-        resources={resource.id: resource for resource in resources if resource is not None},
-        resources_deep={
-            resource_deep.id: resource_deep
-            for resource_deep in resources_deep
-            if resource_deep is not None
-        },
-        fields={field.id: field for field in fields if field is not None},
-        paragraphs={paragraph.id: paragraph for paragraph in paragraphs if paragraph is not None},
-    )

--- a/nucliadb/src/nucliadb/search/augmentor/augmentor.py
+++ b/nucliadb/src/nucliadb/search/augmentor/augmentor.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
+from contextvars import ContextVar
 from typing import cast
 
 from typing_extensions import assert_never
@@ -52,10 +53,15 @@ from nucliadb.search.augmentor.utils import limited_concurrency
 from nucliadb.search.search.hydrator import ResourceHydrationOptions
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import Resource
+from nucliadb_utils import const
+from nucliadb_utils.utilities import has_feature
 
+from .extracted_text import ExtractedTexts, extracted_texts
 from .fields import augment_field
 from .paragraphs import augment_paragraph
 from .resources import augment_resource, augment_resource_deep
+
+nidx_et_cache: ContextVar[ExtractedTexts | None] = ContextVar("nidx_et_cache", default=None)
 
 
 @augmentor_observer.wrap({"type": "augment"})
@@ -201,6 +207,7 @@ class AugmentorOps:
 
         for field_id in field_ids:
             self.field_augments.setdefault(field_id, []).extend(augmentation.select)
+            self.field_texts.add(field_id)
 
     def _parse_file_field(self, augmentation: FileAugment) -> None:
         for id in augmentation.given:
@@ -237,6 +244,27 @@ class AugmentorOps:
             self.paragraph_augments[paragraph.id] = (select, metadata)
 
     async def run(
+        self,
+        *,
+        concurrency_control: asyncio.Semaphore | None = None,
+    ) -> Augmented:
+        nidx_extracted_texts = None
+        if has_feature(const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": self.kbid}):
+            nidx_extracted_texts = await extracted_texts(
+                self.kbid, self.field_texts, self.paragraph_texts
+            )
+
+        # we don't care here if nidx has been available or not as the fallback
+        # is on the augmentors logic (paragraph and fields)
+        token = nidx_et_cache.set(nidx_extracted_texts)
+        try:
+            augmented = await self._run_augmentations(concurrency_control=concurrency_control)
+        finally:
+            nidx_et_cache.reset(token)
+
+        return augmented
+
+    async def _run_augmentations(
         self,
         *,
         concurrency_control: asyncio.Semaphore | None = None,

--- a/nucliadb/src/nucliadb/search/augmentor/augmentor.py
+++ b/nucliadb/src/nucliadb/search/augmentor/augmentor.py
@@ -40,6 +40,7 @@ from nucliadb.models.internal.augment import (
     FileAugment,
     FileProp,
     Metadata,
+    Paragraph,
     ParagraphAugment,
     ParagraphProp,
     ParagraphText,
@@ -74,6 +75,23 @@ async def augment(
     ops = AugmentorOps(kbid)
     await ops.parse(augmentations)
     return await ops.run(concurrency_control=concurrency_control)
+
+
+async def augment_paragraphs(
+    kbid: str,
+    given: list[Paragraph],
+    select: list[ParagraphProp],
+    *,
+    concurrency_control: asyncio.Semaphore | None = None,
+) -> dict[ParagraphId, AugmentedParagraph]:
+    """Augment a list of paragraphs following an augmentation. Paragraphs that
+    can't be augmented are not returned.
+
+    """
+    augmented = await augment(
+        kbid, [ParagraphAugment(given=given, select=select)], concurrency_control=concurrency_control
+    )
+    return augmented.paragraphs
 
 
 class AugmentorOps:

--- a/nucliadb/src/nucliadb/search/augmentor/extracted_text.py
+++ b/nucliadb/src/nucliadb/search/augmentor/extracted_text.py
@@ -25,6 +25,7 @@ from nidx_protos.nidx_pb2_grpc import NidxSearcherStub
 from nucliadb.common import datamanagers
 from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.common.nidx import get_nidx_searcher_client
+from nucliadb.search import logger
 from nucliadb.search.augmentor.metrics import augmentor_observer
 
 
@@ -94,9 +95,15 @@ async def _build_requests(
                     txn, kbid=kbid, rid=rid
                 )
                 if resource_shard_id is None:
-                    return None
+                    # Resource not in DB, either a dirty read (reading a delete)
+                    # or a user requesting a deleted or wrong resource. Skip
+                    continue
                 nidx_shard_id = logical_to_nidx_shard.get(resource_shard_id)
                 if nidx_shard_id is None:
+                    logger.warning(
+                        "nidx shard not found for resource shard",
+                        extra={"kbid": kbid, "resource_shard_id": resource_shard_id},
+                    )
                     return None
 
                 resource_nidx_shard[rid] = nidx_shard_id
@@ -120,9 +127,15 @@ async def _build_requests(
                     txn, kbid=kbid, rid=rid
                 )
                 if resource_shard_id is None:
-                    return None
+                    # Resource not in DB, either a dirty read (reading a delete)
+                    # or a user requesting a deleted or wrong resource. Skip
+                    continue
                 nidx_shard_id = logical_to_nidx_shard.get(resource_shard_id)
                 if nidx_shard_id is None:
+                    logger.warning(
+                        "nidx shard not found for resource shard",
+                        extra={"kbid": kbid, "resource_shard_id": resource_shard_id},
+                    )
                     return None
 
                 resource_nidx_shard[rid] = nidx_shard_id

--- a/nucliadb/src/nucliadb/search/augmentor/extracted_text.py
+++ b/nucliadb/src/nucliadb/search/augmentor/extracted_text.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
+from contextvars import ContextVar
 
 from nidx_protos.nidx_pb2 import ExtractedTextsRequest, ExtractedTextsResponse
 from nidx_protos.nidx_pb2_grpc import NidxSearcherStub
@@ -48,6 +49,9 @@ class ExtractedTexts:
             if text:
                 break
         return text
+
+
+nidx_et_cache: ContextVar[ExtractedTexts | None] = ContextVar("nidx_et_cache", default=None)
 
 
 @augmentor_observer.wrap({"type": "nidx_extracted_texts"})

--- a/nucliadb/src/nucliadb/search/augmentor/extracted_text.py
+++ b/nucliadb/src/nucliadb/search/augmentor/extracted_text.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import asyncio
+
+from nidx_protos.nidx_pb2 import ExtractedTextsRequest, ExtractedTextsResponse
+from nidx_protos.nidx_pb2_grpc import NidxSearcherStub
+
+from nucliadb.common import datamanagers
+from nucliadb.common.ids import FieldId, ParagraphId
+from nucliadb.common.nidx import get_nidx_searcher_client
+from nucliadb.search.augmentor.metrics import augmentor_observer
+
+
+class ExtractedTexts:
+    def __init__(self, nidx_responses: list[ExtractedTextsResponse]):
+        self.responses = nidx_responses
+
+    def get_field_text(self, id: FieldId) -> str | None:
+        text = None
+        for response in self.responses:
+            text = response.fields.get(id.full_without_subfield())
+            if text:
+                break
+        return text or None
+
+    def get_paragraph_text(self, id: ParagraphId) -> str | None:
+        text = None
+        for response in self.responses:
+            text = response.paragraphs.get(id.full())
+            if text:
+                break
+        return text
+
+
+@augmentor_observer.wrap({"type": "nidx_extracted_texts"})
+async def extracted_texts(
+    kbid: str, fields: set[FieldId], paragraphs: set[ParagraphId]
+) -> ExtractedTexts | None:
+    nidx_searcher = get_nidx_searcher_client()
+    requests = await _build_requests(kbid, fields, paragraphs)
+    if requests is None:
+        return None
+
+    ops = [asyncio.create_task(_extracted_texts(nidx_searcher, request)) for request in requests]
+    responses = await asyncio.gather(*ops)
+    return ExtractedTexts(responses)
+
+
+async def _extracted_texts(
+    nidx_searcher: NidxSearcherStub, request: ExtractedTextsRequest
+) -> ExtractedTextsResponse:
+    # wrapper to help recognize the gRPC call as a coroutine
+    return await nidx_searcher.ExtractedTexts(request)
+
+
+async def _build_requests(
+    kbid: str, fields: set[FieldId], paragraphs: set[ParagraphId]
+) -> list[ExtractedTextsRequest] | None:
+    # shard_id -> nidx gRPC request
+    nidx_requests: dict[str, ExtractedTextsRequest] = {}
+
+    async with datamanagers.with_ro_transaction() as txn:
+        kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
+        if kb_shards is None:
+            return None
+
+        logical_to_nidx_shard = {}
+        for shard in kb_shards.shards:
+            logical_to_nidx_shard[shard.shard] = shard.nidx_shard_id
+
+        resource_nidx_shard = {}
+
+        for field_id in fields:
+            rid = field_id.rid
+            if rid not in resource_nidx_shard:
+                resource_shard_id = await datamanagers.resources.get_resource_shard_id(
+                    txn, kbid=kbid, rid=rid
+                )
+                if resource_shard_id is None:
+                    return None
+                nidx_shard_id = logical_to_nidx_shard.get(resource_shard_id)
+                if nidx_shard_id is None:
+                    return None
+
+                resource_nidx_shard[rid] = nidx_shard_id
+
+            nidx_shard_id = resource_nidx_shard[rid]
+            request = nidx_requests.setdefault(nidx_shard_id, ExtractedTextsRequest())
+            request.shard_id = nidx_shard_id
+            request.field_ids.append(
+                ExtractedTextsRequest.FieldId(
+                    rid=field_id.rid,
+                    field_type=field_id.type,
+                    field_name=field_id.key,
+                    split=field_id.subfield_id,
+                )
+            )
+
+        for paragraph_id in paragraphs:
+            rid = paragraph_id.rid
+            if rid not in resource_nidx_shard:
+                resource_shard_id = await datamanagers.resources.get_resource_shard_id(
+                    txn, kbid=kbid, rid=rid
+                )
+                if resource_shard_id is None:
+                    return None
+                nidx_shard_id = logical_to_nidx_shard.get(resource_shard_id)
+                if nidx_shard_id is None:
+                    return None
+
+                resource_nidx_shard[rid] = nidx_shard_id
+
+            nidx_shard_id = resource_nidx_shard[rid]
+            request = nidx_requests.setdefault(nidx_shard_id, ExtractedTextsRequest())
+            request.shard_id = nidx_shard_id
+            request.paragraph_ids.append(
+                ExtractedTextsRequest.ParagraphId(
+                    rid=paragraph_id.field_id.rid,
+                    field_type=paragraph_id.field_id.type,
+                    field_name=paragraph_id.field_id.key,
+                    split=paragraph_id.field_id.subfield_id,
+                    paragraph_start=paragraph_id.paragraph_start,
+                    paragraph_end=paragraph_id.paragraph_end,
+                )
+            )
+
+    return list(nidx_requests.values())

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -330,7 +330,7 @@ async def db_augment_conversation_field(
                     selector = FullSelector()
 
             # gather the text from each message matching the selector
-            extracted_text_pb = await cache.get_field_extracted_text(field)
+            extracted_text_pb = await cache.get_field_extracted_text_pb(field)
             async for page, index, message in conversation_selector(field, field_id, selector):
                 augmented_message = messages.setdefault(
                     (page, index), AugmentedConversationMessage(ident=message.ident)
@@ -460,7 +460,7 @@ async def get_field_extracted_text_from_nidx(kbid: str, id: FieldId) -> str | No
 
 @augmentor_observer.wrap({"type": "field_text:storage"})
 async def get_field_extracted_text_from_storage(id: FieldId, field: Field) -> str | None:
-    extracted_text_pb = await cache.get_field_extracted_text(field)
+    extracted_text_pb = await cache.get_field_extracted_text_pb(field)
     if extracted_text_pb is None:  # pragma: no cover
         return None
 

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -68,6 +68,8 @@ from nucliadb_utils import const
 from nucliadb_utils.storages.storage import STORAGE_FILE_EXTRACTED
 from nucliadb_utils.utilities import has_feature
 
+from .extracted_text import nidx_et_cache
+
 # Number of messages to pull after a match in a message
 # The hope here is it will be enough to get the answer to the question.
 CONVERSATION_MESSAGE_CONTEXT_EXPANSION = 15
@@ -386,8 +388,6 @@ async def db_augment_generic_field(
 
 @augmentor_observer.wrap({"type": "field_text"})
 async def get_field_extracted_text(id: FieldId, field: Field) -> str | None:
-    from .augmentor import nidx_et_cache
-
     # we store all splits unordered inside nidx_text, so nidx can't support yet
     # conversation fields
     if field.type != Conversation.type and has_feature(
@@ -408,8 +408,6 @@ async def get_field_extracted_text(id: FieldId, field: Field) -> str | None:
 
 
 async def get_field_extracted_text_from_nidx(kbid: str, id: FieldId) -> str | None:
-    from .augmentor import nidx_et_cache
-
     nidx_extracted_texts = nidx_et_cache.get()
     assert nidx_extracted_texts is not None, "this function must be called with the nidx texts cache set"
     return nidx_extracted_texts.get_field_text(id)

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import asyncio
 from collections import deque
 from collections.abc import AsyncIterator, Sequence
 from typing import Deque, cast
@@ -65,7 +64,6 @@ from nucliadb.models.internal.augment import (
 )
 from nucliadb.search.augmentor.metrics import augmentor_observer
 from nucliadb.search.augmentor.resources import get_basic
-from nucliadb.search.augmentor.utils import limited_concurrency
 from nucliadb.search.search import cache
 from nucliadb_models.common import FieldTypeName
 from nucliadb_protos import resources_pb2
@@ -76,33 +74,6 @@ from nucliadb_utils.utilities import has_feature
 # Number of messages to pull after a match in a message
 # The hope here is it will be enough to get the answer to the question.
 CONVERSATION_MESSAGE_CONTEXT_EXPANSION = 15
-
-
-async def augment_fields(
-    kbid: str,
-    given: list[FieldId],
-    select: list[FieldProp | ConversationProp],
-    *,
-    concurrency_control: asyncio.Semaphore | None = None,
-) -> dict[FieldId, AugmentedField | None]:
-    """Augment a list of fields following an augmentation"""
-
-    ops = []
-    for field_id in given:
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_field(kbid, field_id, select),
-                max_ops=concurrency_control,
-            )
-        )
-        ops.append(task)
-    results: list[AugmentedField | None] = await asyncio.gather(*ops)
-
-    augmented = {}
-    for field_id, augmentation in zip(given, results):
-        augmented[field_id] = augmentation
-
-    return augmented
 
 
 @augmentor_observer.wrap({"type": "field"})

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -22,10 +22,13 @@ from collections import deque
 from collections.abc import AsyncIterator, Sequence
 from typing import Deque, cast
 
+from nidx_protos.nidx_pb2 import ExtractedTextsRequest
 from typing_extensions import assert_never
 
+from nucliadb.common.cluster.manager import get_resource_nidx_shard_id
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, FieldId
 from nucliadb.common.models_utils import from_proto
+from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.fields.file import File
@@ -66,7 +69,9 @@ from nucliadb.search.augmentor.utils import limited_concurrency
 from nucliadb.search.search import cache
 from nucliadb_models.common import FieldTypeName
 from nucliadb_protos import resources_pb2
+from nucliadb_utils import const
 from nucliadb_utils.storages.storage import STORAGE_FILE_EXTRACTED
+from nucliadb_utils.utilities import has_feature
 
 # Number of messages to pull after a match in a message
 # The hope here is it will be enough to get the answer to the question.
@@ -413,6 +418,48 @@ async def db_augment_generic_field(
 
 @augmentor_observer.wrap({"type": "field_text"})
 async def get_field_extracted_text(id: FieldId, field: Field) -> str | None:
+    # we store all splits unordered inside nidx_text, so nidx can't support yet
+    # conversation fields
+    if field.type != Conversation.type and has_feature(
+        const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": field.kbid}
+    ):
+        text = await get_field_extracted_text_from_nidx(field.kbid, id)
+    else:
+        text = await get_field_extracted_text_from_storage(id, field)
+
+    return text
+
+
+@augmentor_observer.wrap({"type": "field_text:nidx"})
+async def get_field_extracted_text_from_nidx(kbid: str, id: FieldId) -> str | None:
+    assert id.type != Conversation.type, "conversation extracted text not supported in nidx"
+
+    nidx_shard_id = await get_resource_nidx_shard_id(kbid=kbid, rid=id.rid)
+    if nidx_shard_id is None:
+        return None
+
+    nidx_searcher = get_nidx_searcher_client()
+    # TODO(nidx-as-extracted-text-storage): minimize the number of calls to nidx
+    # with a shared batch or something similar
+    extracted_texts = await nidx_searcher.ExtractedTexts(
+        ExtractedTextsRequest(
+            shard_id=nidx_shard_id,
+            field_ids=[
+                ExtractedTextsRequest.FieldId(
+                    rid=id.rid,
+                    field_type=id.type,
+                    field_name=id.key,
+                    split=id.subfield_id,
+                )
+            ],
+        )
+    )
+    text = extracted_texts.fields.get(id.full_without_subfield(), None)
+    return text
+
+
+@augmentor_observer.wrap({"type": "field_text:storage"})
+async def get_field_extracted_text_from_storage(id: FieldId, field: Field) -> str | None:
     extracted_text_pb = await cache.get_field_extracted_text(field)
     if extracted_text_pb is None:  # pragma: no cover
         return None

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -21,13 +21,10 @@ from collections import deque
 from collections.abc import AsyncIterator, Sequence
 from typing import Deque, cast
 
-from nidx_protos.nidx_pb2 import ExtractedTextsRequest
 from typing_extensions import assert_never
 
-from nucliadb.common.cluster.manager import get_resource_nidx_shard_id
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, FieldId
 from nucliadb.common.models_utils import from_proto
-from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.fields.file import File
@@ -389,44 +386,33 @@ async def db_augment_generic_field(
 
 @augmentor_observer.wrap({"type": "field_text"})
 async def get_field_extracted_text(id: FieldId, field: Field) -> str | None:
+    from .augmentor import nidx_et_cache
+
     # we store all splits unordered inside nidx_text, so nidx can't support yet
     # conversation fields
     if field.type != Conversation.type and has_feature(
         const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": field.kbid}
     ):
-        text = await get_field_extracted_text_from_nidx(field.kbid, id)
+        nidx_extracted_texts = nidx_et_cache.get()
+        if nidx_extracted_texts is not None:
+            text = await get_field_extracted_text_from_nidx(field.kbid, id)
+        else:
+            # nidx texts not available, either we are not calling from augmentor
+            # or something went wrong. In any case, fallback to object storage
+            text = await get_field_extracted_text_from_storage(id, field)
+
     else:
         text = await get_field_extracted_text_from_storage(id, field)
 
     return text
 
 
-@augmentor_observer.wrap({"type": "field_text:nidx"})
 async def get_field_extracted_text_from_nidx(kbid: str, id: FieldId) -> str | None:
-    assert id.type != Conversation.type, "conversation extracted text not supported in nidx"
+    from .augmentor import nidx_et_cache
 
-    nidx_shard_id = await get_resource_nidx_shard_id(kbid=kbid, rid=id.rid)
-    if nidx_shard_id is None:
-        return None
-
-    nidx_searcher = get_nidx_searcher_client()
-    # TODO(nidx-as-extracted-text-storage): minimize the number of calls to nidx
-    # with a shared batch or something similar
-    extracted_texts = await nidx_searcher.ExtractedTexts(
-        ExtractedTextsRequest(
-            shard_id=nidx_shard_id,
-            field_ids=[
-                ExtractedTextsRequest.FieldId(
-                    rid=id.rid,
-                    field_type=id.type,
-                    field_name=id.key,
-                    split=id.subfield_id,
-                )
-            ],
-        )
-    )
-    text = extracted_texts.fields.get(id.full_without_subfield(), None)
-    return text
+    nidx_extracted_texts = nidx_et_cache.get()
+    assert nidx_extracted_texts is not None, "this function must be called with the nidx texts cache set"
+    return nidx_extracted_texts.get_field_text(id)
 
 
 @augmentor_observer.wrap({"type": "field_text:storage"})

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -109,7 +109,7 @@ async def augment_fields(
 async def augment_field(
     kbid: str,
     field_id: FieldId,
-    select: Sequence[FieldProp | ConversationProp],
+    select: Sequence[FieldProp | FileProp | ConversationProp],
 ) -> AugmentedField | None:
     rid = field_id.rid
     resource = await cache.get_resource(kbid, rid)

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import asyncio
 import bisect
 from collections.abc import Sequence
 from typing import cast
@@ -35,7 +34,6 @@ from nucliadb.models.internal.augment import (
     AugmentedParagraph,
     AugmentedRelatedParagraphs,
     Metadata,
-    Paragraph,
     ParagraphImage,
     ParagraphPage,
     ParagraphPosition,
@@ -46,39 +44,11 @@ from nucliadb.models.internal.augment import (
 )
 from nucliadb.search import logger
 from nucliadb.search.augmentor.metrics import augmentor_observer
-from nucliadb.search.augmentor.utils import limited_concurrency
 from nucliadb.search.search import cache
 from nucliadb_models.search import TextPosition
 from nucliadb_protos import resources_pb2
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
-
-
-async def augment_paragraphs(
-    kbid: str,
-    given: list[Paragraph],
-    select: list[ParagraphProp],
-    *,
-    concurrency_control: asyncio.Semaphore | None = None,
-) -> dict[ParagraphId, AugmentedParagraph | None]:
-    """Augment a list of paragraphs following an augmentation"""
-
-    ops = []
-    for paragraph in given:
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_paragraph(kbid, paragraph.id, select, paragraph.metadata),
-                max_ops=concurrency_control,
-            )
-        )
-        ops.append(task)
-    results: list[AugmentedParagraph | None] = await asyncio.gather(*ops)
-
-    augmented = {}
-    for paragraph, augmentation in zip(given, results):
-        augmented[paragraph.id] = augmentation
-
-    return augmented
 
 
 @augmentor_observer.wrap({"type": "paragraph"})

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -348,7 +348,7 @@ async def get_paragraph_text_from_storage(field: Field, paragraph_id: ParagraphI
     extracted text from object storage and then slicing it.
 
     """
-    extracted_text = await cache.get_field_extracted_text(field)
+    extracted_text = await cache.get_field_extracted_text_pb(field)
     if extracted_text is None:
         # NucliaDB doesn't enforce read commited isolation with the index, i.e.
         # we can observe dirty reads.

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -278,7 +278,7 @@ async def get_paragraph_text(field: Field, paragraph_id: ParagraphId) -> str | N
     return text or None
 
 
-async def get_paragraph_text_from_nidx(paragraph_id: ParagraphId) -> str | None:
+async def get_paragraph_text_from_nidx(id: ParagraphId) -> str | None:
     """Obtain a paragraph from the field extracted text.
 
     This is an expensive operation that requires a gRPC request to nidx to get
@@ -293,7 +293,7 @@ async def get_paragraph_text_from_nidx(paragraph_id: ParagraphId) -> str | None:
 
     nidx_extracted_texts = nidx_et_cache.get()
     assert nidx_extracted_texts is not None, "this function must be called with the nidx texts cache set"
-    return nidx_extracted_texts.get_paragraph_text(paragraph_id)
+    return nidx_extracted_texts.get_paragraph_text(id)
 
 
 @augmentor_observer.wrap({"type": "paragraph_text:storage"})

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -22,10 +22,14 @@ import bisect
 from collections.abc import Sequence
 from typing import cast
 
+from nidx_protos.nidx_pb2 import ExtractedTextsRequest
 from typing_extensions import assert_never
 
+from nucliadb.common import datamanagers
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, ParagraphId
+from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import Field
+from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.resource import Resource
 from nucliadb.models.internal.augment import (
     AugmentedParagraph,
@@ -40,12 +44,14 @@ from nucliadb.models.internal.augment import (
     ParagraphText,
     RelatedParagraphs,
 )
+from nucliadb.search import logger
 from nucliadb.search.augmentor.metrics import augmentor_observer
 from nucliadb.search.augmentor.utils import limited_concurrency
 from nucliadb.search.search import cache
-from nucliadb.search.search.paragraphs import get_paragraph_from_full_text
 from nucliadb_models.search import TextPosition
 from nucliadb_protos import resources_pb2
+from nucliadb_utils import const
+from nucliadb_utils.utilities import has_feature
 
 
 async def augment_paragraphs(
@@ -283,16 +289,103 @@ def _find_paragraph(
 
 @augmentor_observer.wrap({"type": "paragraph_text"})
 async def get_paragraph_text(field: Field, paragraph_id: ParagraphId) -> str | None:
-    text = await get_paragraph_from_full_text(
-        field=field,
-        start=paragraph_id.paragraph_start,
-        end=paragraph_id.paragraph_end,
-        split=paragraph_id.field_id.subfield_id,
-        log_on_missing_field=True,
-    )
-    # we want to be explicit with not having the paragraph text but the function
-    # above returns an empty string if it can't find it
+    # we store all splits unordered inside nidx_text, so nidx can't support yet
+    # conversation fields
+    if field.type != Conversation.type and has_feature(
+        const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": field.kbid}
+    ):
+        text = await get_paragraph_text_from_nidx(field, paragraph_id)
+    else:
+        text = await get_paragraph_text_from_storage(field, paragraph_id)
+
+    # we want to be explicit with not having the paragraph text but the
+    # functions above returns an empty string if it can't find it
     return text or None
+
+
+@augmentor_observer.wrap({"type": "paragraph_text:nidx"})
+async def get_paragraph_text_from_nidx(field: Field, paragraph_id: ParagraphId) -> str | None:
+    """Obtain a paragraph from the field extracted text.
+
+    This is an expensive operation that requires a gRPC request to nidx to get
+    the paragraph text. However, this is faster than getting the text from
+    object storage alternative.
+
+    """
+    kbid = field.kbid
+    field_id = paragraph_id.field_id
+
+    async with datamanagers.with_ro_transaction() as txn:
+        kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
+        if kb_shards is None:
+            return ""
+
+        resource_shard_id = await datamanagers.resources.get_resource_shard_id(
+            txn, kbid=field.kbid, rid=field_id.rid
+        )
+        if resource_shard_id is None:
+            return ""
+
+        nidx_shard_id = None
+        for shard in kb_shards.shards:
+            if shard.shard == resource_shard_id:
+                nidx_shard_id = shard.nidx_shard_id
+                break
+        else:
+            return ""
+
+    nidx_searcher = get_nidx_searcher_client()
+    # TODO(nidx-as-extracted-text-storage): minimize the number of calls to nidx
+    # with a shared batch or something similar
+    extracted_texts = await nidx_searcher.ExtractedTexts(
+        ExtractedTextsRequest(
+            shard_id=nidx_shard_id,
+            paragraph_ids=[
+                ExtractedTextsRequest.ParagraphId(
+                    rid=field_id.rid,
+                    field_type=field_id.type,
+                    field_name=field_id.key,
+                    split=field_id.subfield_id,
+                    paragraph_start=paragraph_id.paragraph_start,
+                    paragraph_end=paragraph_id.paragraph_end,
+                )
+            ],
+        )
+    )
+    text = extracted_texts.paragraphs.get(paragraph_id.full(), "")
+    return text
+
+
+@augmentor_observer.wrap({"type": "paragraph_text:storage"})
+async def get_paragraph_text_from_storage(
+    field: Field, paragraph_id: ParagraphId, *, log_on_missing_field: bool = True
+) -> str | None:
+    """Obtain a paragraph from the field extracted text.
+
+    This is an expensive operation that requires downloading the whole field
+    extracted text from object storage and then slicing it.
+
+    """
+    extracted_text = await cache.get_field_extracted_text(field)
+    if extracted_text is None:
+        if log_on_missing_field:
+            logger.warning(
+                "Extracted text for field does not exist on DB. This should not happen.",
+                extra={
+                    "kbid": field.kbid,
+                    "field_id": field.resource_unique_id,
+                },
+            )
+        return ""
+
+    split = paragraph_id.field_id.subfield_id
+    start = paragraph_id.paragraph_start
+    end = paragraph_id.paragraph_end
+    if split not in (None, ""):
+        text = extracted_text.split_text[split]  # type: ignore
+        return text[start:end]
+    else:
+        return extracted_text.text[start:end]
 
 
 async def get_paragraph_position(field: Field, paragraph_id: ParagraphId) -> TextPosition | None:

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -357,9 +357,7 @@ async def get_paragraph_text_from_nidx(field: Field, paragraph_id: ParagraphId) 
 
 
 @augmentor_observer.wrap({"type": "paragraph_text:storage"})
-async def get_paragraph_text_from_storage(
-    field: Field, paragraph_id: ParagraphId, *, log_on_missing_field: bool = True
-) -> str | None:
+async def get_paragraph_text_from_storage(field: Field, paragraph_id: ParagraphId) -> str | None:
     """Obtain a paragraph from the field extracted text.
 
     This is an expensive operation that requires downloading the whole field
@@ -368,22 +366,32 @@ async def get_paragraph_text_from_storage(
     """
     extracted_text = await cache.get_field_extracted_text(field)
     if extracted_text is None:
-        if log_on_missing_field:
-            logger.warning(
-                "Extracted text for field does not exist on DB. This should not happen.",
-                extra={
-                    "kbid": field.kbid,
-                    "field_id": field.resource_unique_id,
-                },
-            )
-        return ""
+        # NucliaDB doesn't enforce read commited isolation with the index, i.e.
+        # we can observe dirty reads.
+        #
+        # In this case, it's possible to match a paragraph on the index that's
+        # being deleted. As the delete order is first maindb and second nidx, it
+        # can happen that we get from the index a resource that is being deleted
+        # and it's no longer in maindb.
+        #
+        # This should be a transient issue and we should only see this for
+        # deletes and searches done in a small window of time. Otherwise, it may
+        # be a persistent consistency issue.
+        logger.warning(
+            "Dirty read: extracted text for field does not exist on DB. This should be temporal.",
+            extra={
+                "kbid": field.kbid,
+                "field_id": field.resource_unique_id,
+            },
+        )
+        return None
 
     split = paragraph_id.field_id.subfield_id
     start = paragraph_id.paragraph_start
     end = paragraph_id.paragraph_end
-    if split not in (None, ""):
-        text = extracted_text.split_text[split]  # type: ignore
-        return text[start:end]
+
+    if split:
+        return extracted_text.split_text[split][start:end]
     else:
         return extracted_text.text[start:end]
 

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -47,6 +47,8 @@ from nucliadb_protos import resources_pb2
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
+from .extracted_text import nidx_et_cache
+
 
 @augmentor_observer.wrap({"type": "paragraph"})
 async def augment_paragraph(
@@ -256,8 +258,6 @@ def _find_paragraph(
 
 @augmentor_observer.wrap({"type": "paragraph_text"})
 async def get_paragraph_text(field: Field, paragraph_id: ParagraphId) -> str | None:
-    from .augmentor import nidx_et_cache
-
     # we store all splits unordered inside nidx_text, so nidx can't support yet
     # conversation fields
     if field.type != Conversation.type and has_feature(
@@ -289,8 +289,6 @@ async def get_paragraph_text_from_nidx(id: ParagraphId) -> str | None:
     the index.
 
     """
-    from .augmentor import nidx_et_cache
-
     nidx_extracted_texts = nidx_et_cache.get()
     assert nidx_extracted_texts is not None, "this function must be called with the nidx texts cache set"
     return nidx_extracted_texts.get_paragraph_text(id)

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -25,7 +25,7 @@ from typing import cast
 from nidx_protos.nidx_pb2 import ExtractedTextsRequest
 from typing_extensions import assert_never
 
-from nucliadb.common import datamanagers
+from nucliadb.common.cluster.manager import get_resource_nidx_shard_id
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, ParagraphId
 from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import Field
@@ -312,27 +312,11 @@ async def get_paragraph_text_from_nidx(field: Field, paragraph_id: ParagraphId) 
     object storage alternative.
 
     """
-    kbid = field.kbid
     field_id = paragraph_id.field_id
 
-    async with datamanagers.with_ro_transaction() as txn:
-        kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
-        if kb_shards is None:
-            return ""
-
-        resource_shard_id = await datamanagers.resources.get_resource_shard_id(
-            txn, kbid=field.kbid, rid=field_id.rid
-        )
-        if resource_shard_id is None:
-            return ""
-
-        nidx_shard_id = None
-        for shard in kb_shards.shards:
-            if shard.shard == resource_shard_id:
-                nidx_shard_id = shard.nidx_shard_id
-                break
-        else:
-            return ""
+    nidx_shard_id = await get_resource_nidx_shard_id(kbid=field.kbid, rid=field_id.rid)
+    if nidx_shard_id is None:
+        return None
 
     nidx_searcher = get_nidx_searcher_client()
     # TODO(nidx-as-extracted-text-storage): minimize the number of calls to nidx
@@ -352,7 +336,7 @@ async def get_paragraph_text_from_nidx(field: Field, paragraph_id: ParagraphId) 
             ],
         )
     )
-    text = extracted_texts.paragraphs.get(paragraph_id.full(), "")
+    text = extracted_texts.paragraphs.get(paragraph_id.full(), None)
     return text
 
 

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -21,12 +21,9 @@ import bisect
 from collections.abc import Sequence
 from typing import cast
 
-from nidx_protos.nidx_pb2 import ExtractedTextsRequest
 from typing_extensions import assert_never
 
-from nucliadb.common.cluster.manager import get_resource_nidx_shard_id
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, ParagraphId
-from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.resource import Resource
@@ -259,12 +256,20 @@ def _find_paragraph(
 
 @augmentor_observer.wrap({"type": "paragraph_text"})
 async def get_paragraph_text(field: Field, paragraph_id: ParagraphId) -> str | None:
+    from .augmentor import nidx_et_cache
+
     # we store all splits unordered inside nidx_text, so nidx can't support yet
     # conversation fields
     if field.type != Conversation.type and has_feature(
         const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": field.kbid}
     ):
-        text = await get_paragraph_text_from_nidx(field, paragraph_id)
+        nidx_extracted_texts = nidx_et_cache.get()
+        if nidx_extracted_texts is not None:
+            text = await get_paragraph_text_from_nidx(paragraph_id)
+        else:
+            # nidx texts not available, either we are not calling from augmentor
+            # or something went wrong. In any case, fallback to object storage
+            text = await get_paragraph_text_from_storage(field, paragraph_id)
     else:
         text = await get_paragraph_text_from_storage(field, paragraph_id)
 
@@ -273,41 +278,22 @@ async def get_paragraph_text(field: Field, paragraph_id: ParagraphId) -> str | N
     return text or None
 
 
-@augmentor_observer.wrap({"type": "paragraph_text:nidx"})
-async def get_paragraph_text_from_nidx(field: Field, paragraph_id: ParagraphId) -> str | None:
+async def get_paragraph_text_from_nidx(paragraph_id: ParagraphId) -> str | None:
     """Obtain a paragraph from the field extracted text.
 
     This is an expensive operation that requires a gRPC request to nidx to get
     the paragraph text. However, this is faster than getting the text from
     object storage alternative.
 
+    It uses a shared cache across the augmentor to avoid too many round trips to
+    the index.
+
     """
-    field_id = paragraph_id.field_id
+    from .augmentor import nidx_et_cache
 
-    nidx_shard_id = await get_resource_nidx_shard_id(kbid=field.kbid, rid=field_id.rid)
-    if nidx_shard_id is None:
-        return None
-
-    nidx_searcher = get_nidx_searcher_client()
-    # TODO(nidx-as-extracted-text-storage): minimize the number of calls to nidx
-    # with a shared batch or something similar
-    extracted_texts = await nidx_searcher.ExtractedTexts(
-        ExtractedTextsRequest(
-            shard_id=nidx_shard_id,
-            paragraph_ids=[
-                ExtractedTextsRequest.ParagraphId(
-                    rid=field_id.rid,
-                    field_type=field_id.type,
-                    field_name=field_id.key,
-                    split=field_id.subfield_id,
-                    paragraph_start=paragraph_id.paragraph_start,
-                    paragraph_end=paragraph_id.paragraph_end,
-                )
-            ],
-        )
-    )
-    text = extracted_texts.paragraphs.get(paragraph_id.full(), None)
-    return text
+    nidx_extracted_texts = nidx_et_cache.get()
+    assert nidx_extracted_texts is not None, "this function must be called with the nidx texts cache set"
+    return nidx_extracted_texts.get_paragraph_text(paragraph_id)
 
 
 @augmentor_observer.wrap({"type": "paragraph_text:storage"})

--- a/nucliadb/src/nucliadb/search/search/cache.py
+++ b/nucliadb/src/nucliadb/search/search/cache.py
@@ -66,7 +66,7 @@ async def get_field(kbid: str, field_id: FieldId) -> Field | None:
     return field_obj
 
 
-async def get_field_extracted_text(field: Field) -> ExtractedText | None:
+async def get_field_extracted_text_pb(field: Field) -> ExtractedText | None:
     if field.extracted_text is not None:
         return field.extracted_text
 

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -36,6 +36,7 @@ from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
 from nucliadb.search import logger
+from nucliadb.search.augmentor.fields import get_field_extracted_text
 from nucliadb.search.search import cache
 from nucliadb.search.search.chat.images import (
     get_file_thumbnail_image,
@@ -1365,11 +1366,8 @@ async def hydrate_field_text(
     if field is None:  # pragma: no cover
         return None
 
-    extracted_text_pb = await cache.get_field_extracted_text_pb(field)
-    if extracted_text_pb is None:  # pragma: no cover
+    text = await get_field_extracted_text(field_id, field)
+    if text is None:
         return None
 
-    if field_id.subfield_id:
-        return field_id, extracted_text_pb.split_text[field_id.subfield_id]
-    else:
-        return field_id, extracted_text_pb.text
+    return field_id, text

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -1365,7 +1365,7 @@ async def hydrate_field_text(
     if field is None:  # pragma: no cover
         return None
 
-    extracted_text_pb = await cache.get_field_extracted_text(field)
+    extracted_text_pb = await cache.get_field_extracted_text_pb(field)
     if extracted_text_pb is None:  # pragma: no cover
         return None
 

--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -25,7 +25,7 @@ from nidx_protos.nodereader_pb2 import GraphSearchResponse, SearchResponse
 from nucliadb.common.external_index_providers.base import TextBlockMatch
 from nucliadb.common.ids import ParagraphId
 from nucliadb.models.internal.augment import AugmentedParagraph, Paragraph, ParagraphText
-from nucliadb.search.augmentor.paragraphs import augment_paragraphs
+from nucliadb.search.augmentor import augment_paragraphs
 from nucliadb.search.augmentor.resources import augment_resources_deep
 from nucliadb.search.search.cut import cut_page
 from nucliadb.search.search.hydrator import (

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -24,6 +24,7 @@ import string
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, ParagraphId
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
+from nucliadb.search.augmentor.paragraphs import get_paragraph_text as _augmentor_get_paragraph_text
 from nucliadb.search.search import cache
 from nucliadb_telemetry import errors
 
@@ -44,12 +45,10 @@ async def get_paragraph_from_full_text(
 
     This requires downloading the full text and then slicing it.
     """
-    from nucliadb.search.augmentor.paragraphs import get_paragraph_text
-
     field_id = field.field_id
     field_id.subfield_id = split
     paragraph_id = field_id.paragraph_id(start, end)
-    return await get_paragraph_text(field, paragraph_id) or ""
+    return await _augmentor_get_paragraph_text(field, paragraph_id) or ""
 
 
 async def get_paragraph_text(

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -21,17 +21,11 @@ import logging
 import re
 import string
 
-from nidx_protos.nidx_pb2 import ExtractedTextsRequest
-
-from nucliadb.common import datamanagers
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, ParagraphId
-from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.search.search import cache
 from nucliadb_telemetry import errors, metrics
-from nucliadb_utils import const
-from nucliadb_utils.utilities import has_feature
 
 logger = logging.getLogger(__name__)
 PRE_WORD = string.punctuation + " "
@@ -71,70 +65,12 @@ async def get_paragraph_from_full_text(
 
     This requires downloading the full text and then slicing it.
     """
-    # we store all splits unordered inside nidx_text, so nidx can't support yet
-    # conversation fields
-    if split is None and has_feature(
-        const.Features.NIDX_AS_EXTRACTED_TEXT_STORAGE, context={"kbid": field.kbid}
-    ):
-        kbid = field.kbid
-        field_id = field.field_id
-        field_id.subfield_id = split
+    from nucliadb.search.augmentor.paragraphs import get_paragraph_text
 
-        async with datamanagers.with_ro_transaction() as txn:
-            kb_shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
-            if kb_shards is None:
-                return ""
-
-            resource_shard_id = await datamanagers.resources.get_resource_shard_id(
-                txn, kbid=field.kbid, rid=field_id.rid
-            )
-            if resource_shard_id is None:
-                return ""
-
-            nidx_shard_id = None
-            for shard in kb_shards.shards:
-                if shard.shard == resource_shard_id:
-                    nidx_shard_id = shard.nidx_shard_id
-                    break
-            else:
-                return ""
-
-        nidx_searcher = get_nidx_searcher_client()
-        extracted_texts = await nidx_searcher.ExtractedTexts(
-            ExtractedTextsRequest(
-                shard_id=nidx_shard_id,
-                paragraph_ids=[
-                    ExtractedTextsRequest.ParagraphId(
-                        rid=field_id.rid,
-                        field_type=field_id.type,
-                        field_name=field_id.key,
-                        split=field_id.subfield_id,
-                        paragraph_start=start,
-                        paragraph_end=end,
-                    )
-                ],
-            )
-        )
-        text = extracted_texts.paragraphs.get(field_id.paragraph_id(start, end).full(), "")
-        return text
-    else:
-        extracted_text = await cache.get_field_extracted_text(field)
-        if extracted_text is None:
-            if log_on_missing_field:
-                logger.warning(
-                    "Extracted_text for field does not exist on DB. This should not happen.",
-                    extra={
-                        "field_id": field.resource_unique_id,
-                        "kbid": field.kbid,
-                    },
-                )
-            return ""
-
-        if split not in (None, ""):
-            text = extracted_text.split_text[split]  # type: ignore
-            return text[start:end]
-        else:
-            return extracted_text.text[start:end]
+    field_id = field.field_id
+    field_id.subfield_id = split
+    paragraph_id = field_id.paragraph_id(start, end)
+    return await get_paragraph_text(field, paragraph_id) or ""
 
 
 async def get_paragraph_text(

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -25,33 +25,12 @@ from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, ParagraphId
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.search.search import cache
-from nucliadb_telemetry import errors, metrics
+from nucliadb_telemetry import errors
 
 logger = logging.getLogger(__name__)
 PRE_WORD = string.punctuation + " "
 
-GET_PARAGRAPH_LATENCY = metrics.Observer(
-    "nucliadb_get_paragraph",
-    buckets=[
-        0.001,
-        0.005,
-        0.01,
-        0.025,
-        0.05,
-        0.075,
-        0.1,
-        0.25,
-        0.5,
-        0.75,
-        1.0,
-        2.5,
-        metrics.INF,
-    ],
-    labels={"type": "full"},
-)
 
-
-@GET_PARAGRAPH_LATENCY.wrap({"type": "full"})
 async def get_paragraph_from_full_text(
     *,
     field: Field,

--- a/nucliadb/tests/search/unit/search/test_augmentor.py
+++ b/nucliadb/tests/search/unit/search/test_augmentor.py
@@ -31,7 +31,7 @@ MODULE = "nucliadb.search.augmentor"
 
 async def test_augment_text():
     with (
-        patch(f"{MODULE}.paragraphs.get_paragraph_from_full_text", return_value="some text"),
+        patch(f"{MODULE}.paragraphs.get_paragraph_text", return_value="some text"),
     ):
         resource = Mock()
         field = Mock()

--- a/nucliadb/tests/search/unit/search/test_paragraphs.py
+++ b/nucliadb/tests/search/unit/search/test_paragraphs.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from nucliadb.common.ids import ParagraphId
+from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.search.search import paragraphs
 from nucliadb.search.search.cache import extracted_text_cache
 from nucliadb_protos.utils_pb2 import ExtractedText
@@ -41,6 +41,7 @@ def extracted_text():
 def field(extracted_text):
     mock = MagicMock()
     mock.kbid = "kbid"
+    mock.field_id = FieldId(rid="rid", type="f", key="myfile")
     mock.extracted_text = None
     mock.get_extracted_text = AsyncMock(return_value=extracted_text)
     yield mock
@@ -71,10 +72,7 @@ class TestGetParagraphText:
     def orm_resource(self, field):
         mock = AsyncMock()
         mock.get_field.return_value = field
-        with patch(
-            "nucliadb.search.search.paragraphs.cache.get_resource",
-            return_value=mock,
-        ):
+        with patch("nucliadb.search.search.paragraphs.cache.get_resource", return_value=mock):
             yield mock
 
     async def test_get_paragraph_text(self, orm_resource):

--- a/nucliadb/tests/search/unit/search/test_paragraphs.py
+++ b/nucliadb/tests/search/unit/search/test_paragraphs.py
@@ -113,7 +113,7 @@ async def test_get_field_extracted_text_is_cached(field, fake_download_pb):
 
     # Run 10 times in parallel to check that the cache is working
     with extracted_text_cache(10):
-        futures = [paragraphs.cache.get_field_extracted_text(field) for _ in range(10)]
+        futures = [paragraphs.cache.get_field_extracted_text_pb(field) for _ in range(10)]
         await asyncio.gather(*futures)
 
         fake_download_pb.assert_awaited_once()
@@ -123,7 +123,7 @@ async def test_get_field_extracted_text_is_not_cached_when_none(field, fake_down
     fake_download_pb.side_effect = lambda _a, _b: None
 
     with extracted_text_cache(10):
-        await paragraphs.cache.get_field_extracted_text(field)
-        await paragraphs.cache.get_field_extracted_text(field)
+        await paragraphs.cache.get_field_extracted_text_pb(field)
+        await paragraphs.cache.get_field_extracted_text_pb(field)
 
     assert fake_download_pb.await_count == 2

--- a/nucliadb/tests/search/unit/test_find_post_index.py
+++ b/nucliadb/tests/search/unit/test_find_post_index.py
@@ -185,6 +185,7 @@ async def test_find_post_index_search(expected_find_response: dict[str, Any], pr
             "nucliadb.search.augmentor.augmentor.augment_paragraph",
             side_effect=mock_augment_paragraph,
         ),
+        patch("nucliadb.search.augmentor.augmentor.extracted_texts"),
         patch.object(predict_mock, "rerank", AsyncMock(side_effect=fake_reranking)),
     ):
         resource_hydration_options = ResourceHydrationOptions(

--- a/nucliadb/tests/search/unit/test_find_post_index.py
+++ b/nucliadb/tests/search/unit/test_find_post_index.py
@@ -182,7 +182,7 @@ async def test_find_post_index_search(expected_find_response: dict[str, Any], pr
             side_effect=mock_augment_resources,
         ),
         patch(
-            "nucliadb.search.augmentor.paragraphs.augment_paragraph",
+            "nucliadb.search.augmentor.augmentor.augment_paragraph",
             side_effect=mock_augment_paragraph,
         ),
         patch.object(predict_mock, "rerank", AsyncMock(side_effect=fake_reranking)),


### PR DESCRIPTION
### Description
- Use nidx as extracted text storage in augmentor
- Implements an augmentor cache that groups requests to nidx in order to optimize the amount of requests done
- Conversation fields are still out of scope for nidx. In this case (and any problem with nidx), we fallback to object storage

### How was this PR tested?
Existing test suite with nidx as extracted text storage enabled