### PR TITLE
Revive synchronous deletes

### DIFF
--- a/nucliadb/src/nucliadb/export_import/utils.py
+++ b/nucliadb/src/nucliadb/export_import/utils.py
@@ -96,6 +96,7 @@ BM_FIELDS = {
         "delete_question_answers",
         "errors",
         "generated_by",
+        "synchronous_storage_deletion",
     ],
     # No longer used fields
     "deprecated": [

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -490,8 +490,8 @@ class KnowledgeBox:
             except Exception:
                 logger.exception("Error deleting slug")
 
-    async def storage_delete_resource(self, uuid: str):
-        if is_onprem_nucliadb():
+    async def storage_delete_resource(self, uuid: str, synchronous: bool = False):
+        if is_onprem_nucliadb() or synchronous:
             await self.storage.delete_resource(self.kbid, uuid)
         else:
             # Deleting from storage can be slow, so we schedule its deletion and the purge cronjob
@@ -502,11 +502,11 @@ class KnowledgeBox:
         key = RESOURCE_TO_DELETE_STORAGE.format(kbid=kbid, uuid=uuid)
         await self.txn.set(key, b"")
 
-    async def delete_resource(self, uuid: str):
+    async def delete_resource(self, uuid: str, storage_synchronous: bool = False):
         with processor_observer({"type": "delete_resource_maindb"}):
             await self.maindb_delete_resource(uuid)
         with processor_observer({"type": "delete_resource_storage"}):
-            await self.storage_delete_resource(uuid)
+            await self.storage_delete_resource(uuid, synchronous=storage_synchronous)
 
     async def get_resource_uuid_by_slug(self, slug: str) -> str | None:
         return await datamanagers.resources.get_resource_uuid_from_slug(

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -232,7 +232,9 @@ class Processor:
                             shard, uuid, seqid, partition, kbid
                         )
                     try:
-                        await kb.delete_resource(uuid)
+                        await kb.delete_resource(
+                            uuid, storage_synchronous=message.synchronous_storage_deletion
+                        )
                     except Exception as exc:
                         await txn.abort()
                         await self.notify_abort(

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -558,7 +558,7 @@ async def _delete_resource(
         writer.synchronous_storage_deletion = True
 
     parse_audit(writer.audit, request)
-    await transaction.commit(writer, partition, wait=synchronous)
+    await transaction.commit(writer, partition, wait=True)
     processing = get_processing()
     background.add_task(processing.delete_from_processing, kbid=kbid, resource_id=rid)
 

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -81,7 +81,6 @@ from nucliadb_utils.utilities import (
 )
 
 X_SYNCHRONOUS_DELETE_HEADER = Header(
-    default=None,
     description="When set to true, waits for the resource to be fully deleted before returning the response. If set to false, the deletion is asynchronous and the response is returned immediately. When unset, the behavior is determined by the server configuration.",
 )
 

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -81,7 +81,7 @@ from nucliadb_utils.utilities import (
 )
 
 X_SYNCHRONOUS_DELETE_HEADER = Header(
-    description="When set to true, waits for the resource to be fully deleted before returning the response. If set to false, the deletion is asynchronous and the response is returned immediately. When unset, the behavior is determined by the server configuration.",
+    description="When set to true, waits for the resource to be fully deleted before returning the response. Otherwise, some resource metadata is deleted asynchronously."
 )
 
 
@@ -507,9 +507,9 @@ async def delete_resource_rslug_prefix(
     rslug: str,
     background: BackgroundTasks,
     x_synchronous: Annotated[
-        bool | None,
+        bool,
         X_SYNCHRONOUS_DELETE_HEADER,
-    ] = None,
+    ] = False,
 ):
     rid = await get_rid_from_slug_or_raise_error(kbid, rslug)
     return await _delete_resource(request, kbid, rid, background, synchronous=x_synchronous)
@@ -529,15 +529,15 @@ async def delete_resource_rid_prefix(
     rid: str,
     background: BackgroundTasks,
     x_synchronous: Annotated[
-        bool | None,
+        bool,
         X_SYNCHRONOUS_DELETE_HEADER,
-    ] = None,
+    ] = False,
 ):
     return await _delete_resource(request, kbid, rid, background, synchronous=x_synchronous)
 
 
 async def _delete_resource(
-    request: Request, kbid: str, rid: str, background: BackgroundTasks, synchronous: bool | None = None
+    request: Request, kbid: str, rid: str, background: BackgroundTasks, synchronous: bool
 ):
     await validate_rid_exists_or_raise_error(kbid, rid)
 
@@ -550,23 +550,17 @@ async def _delete_resource(
     writer.uuid = rid
     writer.type = BrokerMessage.MessageType.DELETE
 
-    if synchronous is None:
-        # Default server behaviour is waiting for the commit to complete, but delete from storage asynchronously (i.e. at purge time)
-        wait_for_commit = True
-        storage_deletion_synchronous = False
-    elif synchronous is True:
+    if synchronous is True:
         # Wait for the commit to complete and delete from storage during the transaction.
         # This way we avoid having orphaned objects which can cause issues for users that reuse ids on uploads.
-        wait_for_commit = True
         storage_deletion_synchronous = True
     else:
-        # Do not wait for the commit to complete and delete from storage asynchronously (i.e. at purge time)
-        wait_for_commit = False
+        # Default server behaviour is waiting for the commit to complete, but delete from storage asynchronously (i.e. at purge time)
         storage_deletion_synchronous = False
 
     writer.synchronous_storage_deletion = storage_deletion_synchronous
     parse_audit(writer.audit, request)
-    await transaction.commit(writer, partition, wait=wait_for_commit)
+    await transaction.commit(writer, partition, wait=True)
     processing = get_processing()
     background.add_task(processing.delete_from_processing, kbid=kbid, resource_id=rid)
 

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -80,6 +80,11 @@ from nucliadb_utils.utilities import (
     get_storage,
 )
 
+X_SYNCHRONOUS_DELETE_HEADER = Header(
+    default=None,
+    description="When set to true, waits for the resource to be fully deleted before returning the response. If set to false, the deletion is asynchronous and the response is returned immediately. When unset, the behavior is determined by the server configuration.",
+)
+
 
 @api.post(
     f"/{KB_PREFIX}/{{kbid}}/{RESOURCES_PREFIX}",
@@ -503,12 +508,9 @@ async def delete_resource_rslug_prefix(
     rslug: str,
     background: BackgroundTasks,
     x_synchronous: Annotated[
-        bool,
-        Header(
-            default=False,
-            description="When set to true, waits for the resource to be fully deleted before returning the response.",
-        ),
-    ] = False,
+        bool | None,
+        X_SYNCHRONOUS_DELETE_HEADER,
+    ] = None,
 ):
     rid = await get_rid_from_slug_or_raise_error(kbid, rslug)
     return await _delete_resource(request, kbid, rid, background, synchronous=x_synchronous)
@@ -528,18 +530,15 @@ async def delete_resource_rid_prefix(
     rid: str,
     background: BackgroundTasks,
     x_synchronous: Annotated[
-        bool,
-        Header(
-            default=False,
-            description="When set to true, waits for the resource to be fully deleted before returning the response.",
-        ),
-    ] = False,
+        bool | None,
+        X_SYNCHRONOUS_DELETE_HEADER,
+    ] = None,
 ):
     return await _delete_resource(request, kbid, rid, background, synchronous=x_synchronous)
 
 
 async def _delete_resource(
-    request: Request, kbid: str, rid: str, background: BackgroundTasks, synchronous: bool = False
+    request: Request, kbid: str, rid: str, background: BackgroundTasks, synchronous: bool | None = None
 ):
     await validate_rid_exists_or_raise_error(kbid, rid)
 
@@ -552,13 +551,23 @@ async def _delete_resource(
     writer.uuid = rid
     writer.type = BrokerMessage.MessageType.DELETE
 
-    if synchronous:
-        # If synchronous deletion is requested, make sure to delete all objects from the storage during the transaction.
+    if synchronous is None:
+        # Default server behaviour is waiting for the commit to complete, but delete from storage asynchronously (i.e. at purge time)
+        wait_for_commit = True
+        storage_deletion_synchronous = False
+    elif synchronous is True:
+        # Wait for the commit to complete and delete from storage during the transaction.
         # This way we avoid having orphaned objects which can cause issues for users that reuse ids on uploads.
-        writer.synchronous_storage_deletion = True
+        wait_for_commit = True
+        storage_deletion_synchronous = True
+    else:
+        # Do not wait for the commit to complete and delete from storage asynchronously (i.e. at purge time)
+        wait_for_commit = False
+        storage_deletion_synchronous = False
 
+    writer.synchronous_storage_deletion = storage_deletion_synchronous
     parse_audit(writer.audit, request)
-    await transaction.commit(writer, partition, wait=True)
+    await transaction.commit(writer, partition, wait=wait_for_commit)
     processing = get_processing()
     background.add_task(processing.delete_from_processing, kbid=kbid, resource_id=rid)
 

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -23,6 +23,7 @@ from typing import Annotated
 from uuid import uuid4
 
 from fastapi import BackgroundTasks, HTTPException, Query, Response
+from fastapi.params import Header
 from fastapi_versioning import version
 from starlette.requests import Request
 
@@ -497,10 +498,20 @@ async def _reprocess_resource(
 @requires(NucliaDBRoles.WRITER)
 @version(1)
 async def delete_resource_rslug_prefix(
-    request: Request, kbid: str, rslug: str, background: BackgroundTasks
+    request: Request,
+    kbid: str,
+    rslug: str,
+    background: BackgroundTasks,
+    x_synchronous: Annotated[
+        bool,
+        Header(
+            default=False,
+            description="When set to true, waits for the resource to be fully deleted before returning the response.",
+        ),
+    ] = False,
 ):
     rid = await get_rid_from_slug_or_raise_error(kbid, rslug)
-    return await _delete_resource(request, kbid, rid, background)
+    return await _delete_resource(request, kbid, rid, background, synchronous=x_synchronous)
 
 
 @api.delete(
@@ -511,11 +522,25 @@ async def delete_resource_rslug_prefix(
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def delete_resource_rid_prefix(request: Request, kbid: str, rid: str, background: BackgroundTasks):
-    return await _delete_resource(request, kbid, rid, background)
+async def delete_resource_rid_prefix(
+    request: Request,
+    kbid: str,
+    rid: str,
+    background: BackgroundTasks,
+    x_synchronous: Annotated[
+        bool,
+        Header(
+            default=False,
+            description="When set to true, waits for the resource to be fully deleted before returning the response.",
+        ),
+    ] = False,
+):
+    return await _delete_resource(request, kbid, rid, background, synchronous=x_synchronous)
 
 
-async def _delete_resource(request: Request, kbid: str, rid: str, background: BackgroundTasks):
+async def _delete_resource(
+    request: Request, kbid: str, rid: str, background: BackgroundTasks, synchronous: bool = False
+):
     await validate_rid_exists_or_raise_error(kbid, rid)
 
     partitioning = get_partitioning()
@@ -527,8 +552,13 @@ async def _delete_resource(request: Request, kbid: str, rid: str, background: Ba
     writer.uuid = rid
     writer.type = BrokerMessage.MessageType.DELETE
 
+    if synchronous:
+        # If synchronous deletion is requested, make sure to delete all objects from the storage during the transaction.
+        # This way we avoid having orphaned objects which can cause issues for users that reuse ids on uploads.
+        writer.synchronous_storage_deletion = True
+
     parse_audit(writer.audit, request)
-    await transaction.commit(writer, partition)
+    await transaction.commit(writer, partition, wait=synchronous)
     processing = get_processing()
     background.add_task(processing.delete_from_processing, kbid=kbid, resource_id=rid)
 

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import base64
+import hashlib
 import json
 from typing import cast
 from unittest.mock import AsyncMock, patch
@@ -26,6 +27,8 @@ import pydantic
 import pytest
 from httpx import AsyncClient
 
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.fields.base import FieldTypes
 from nucliadb.ingest.processing import DummyProcessingEngine, PushPayload
 from nucliadb.learning_proxy import (
     LearningConfiguration,
@@ -58,6 +61,7 @@ from nucliadb_protos.train_pb2 import GetSentencesRequest, TrainParagraph
 from nucliadb_protos.train_pb2_grpc import TrainStub
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_protos.writer_pb2_grpc import WriterStub
+from nucliadb_utils.storages.storage import Storage
 from tests.utils import broker_resource, inject_message
 from tests.utils.broker_messages import BrokerMessageBuilder
 from tests.utils.dirty_index import mark_dirty, wait_for_sync
@@ -2073,3 +2077,107 @@ async def test_concurrent_patch_operations(
     # At least some classifications should be present
     assert "classifications" in data["usermetadata"]
     assert len(data["usermetadata"]["classifications"]) > 0
+
+
+@pytest.mark.parametrize(
+    "x_synchronous,should_be_deleted_from_storage",
+    [
+        (True, True),
+        (False, False),
+        (None, False),
+    ],
+    ids=["synchronous-true", "synchronous-false", "synchronous-not-set"],
+)
+@pytest.mark.deploy_modes("standalone")
+async def test_delete_resource_x_synchronous_header(
+    nucliadb_writer: AsyncClient,
+    nucliadb_reader: AsyncClient,
+    nucliadb_ingest_grpc: WriterStub,
+    standalone_knowledgebox,
+    maindb_driver: Driver,
+    storage: Storage,
+    hosted_nucliadb,
+    x_synchronous: str | None,
+    should_be_deleted_from_storage: bool,
+):
+    """
+    Test that the x-synchronous header on resource deletion by slug works
+    for all three conditions: true, false, and not set (None).
+    """
+    import random
+
+    kbid = standalone_knowledgebox
+
+    # Create a resource using the /upload endpoint
+    content = random.randbytes(1024)
+    md5 = hashlib.md5(content).hexdigest()
+    filename = "test_sync_delete.txt"
+    encoded_filename = base64.b64encode(filename.encode()).decode("utf-8")
+
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/upload",
+        headers={
+            "X-Filename": encoded_filename,
+            "X-MD5": md5,
+            "Content-Type": "text/plain",
+            "Content-Length": str(len(content)),
+        },
+        content=content,
+    )
+    assert resp.status_code == 201, resp.text
+    rid = resp.json()["uuid"]
+
+    # Set a slug on the resource so we can delete by slug
+    slug = f"sync-delete-test-{x_synchronous if x_synchronous is not None else 'none'}"
+    resp = await nucliadb_writer.patch(
+        f"/kb/{kbid}/resource/{rid}",
+        json={"slug": slug},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Emulate processing: inject extracted text for the file field
+    extracted_text = "This is some test content for synchronous deletion testing"
+    field_id = md5
+    bmb = BrokerMessageBuilder(kbid=kbid, rid=rid, source=BrokerMessage.MessageSource.PROCESSOR)
+    fb = bmb.field_builder(field_id, field_type=FieldType.FILE)
+    fb.with_extracted_text(extracted_text)
+    bm = bmb.build()
+    await inject_message(nucliadb_ingest_grpc, bm)
+
+    et = await _raw_storage_get_extracted_text(storage, kbid, rid, field_id, "f")
+    assert et is not None
+    assert et.text == extracted_text
+
+    # Delete the resource by slug with the appropriate header
+    headers = {}
+    if x_synchronous is not None:
+        headers["X-Synchronous"] = str(x_synchronous)
+
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/{rid}",
+        headers=headers,
+    )
+    assert resp.status_code == 204, resp.text
+
+    # Verify the resource no longer exists
+    resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid}")
+    assert resp.status_code == 404
+
+    # Check that the extracted text has been deleted from storage
+    et = await _raw_storage_get_extracted_text(storage, kbid, rid, field_id, "f")
+    if should_be_deleted_from_storage:
+        assert et is None, "Extracted text should have been deleted from storage but still exists"
+    else:
+        assert et is not None, "Extracted text should not have been deleted from storage but is missing"
+        assert et.text == extracted_text, "Extracted text content does not match expected value"
+
+
+async def _raw_storage_get_extracted_text(
+    storage: Storage,
+    kbid: str,
+    rid: str,
+    field_id: str,
+    field_type: str,
+) -> rpb.ExtractedText | None:
+    sf = storage.file_extracted(kbid, rid, field_type, field_id, FieldTypes.FIELD_TEXT.value)
+    return await storage.download_pb(sf, rpb.ExtractedText)

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -20,6 +20,7 @@
 import base64
 import hashlib
 import json
+import random
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
@@ -2104,7 +2105,6 @@ async def test_delete_resource_x_synchronous_header(
     Test that the x-synchronous header on resource deletion by slug works
     for all three conditions: true, false, and not set (None).
     """
-    import random
 
     kbid = standalone_knowledgebox
 

--- a/nucliadb_protos/writer.proto
+++ b/nucliadb_protos/writer.proto
@@ -155,6 +155,10 @@ message BrokerMessage {
     // Vectors for the relation graph nodes & edges
     repeated resources.SemanticGraphNodeVectors field_semantic_graph_node_vectors = 44;
     repeated resources.SemanticGraphEdgeVectors field_semantic_graph_edge_vectors = 45;
+
+    // Set to true when we want the deletion operation to happen during the transaction.
+    // Otherwise, objects in storage are marked for deletion and deleted by the purge cronjob.
+    bool synchronous_storage_deletion = 46;
 }
 
 message BrokerMessageBlobReference {


### PR DESCRIPTION
### Description
Adds the optional header X-Synchronous to the delete resource request allowing users to wait until the resource has been removed completely from nucliadb (including storage)

[sc-14410]

### How was this PR tested?
Integration tests
