### PR TITLE
Add configurable Prometheus buckets and request-start logging to nucliadb_telemetry

### DIFF
--- a/nucliadb_telemetry/src/nucliadb_telemetry/fastapi/metrics.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/fastapi/metrics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import logging
 import time
 
 from prometheus_client import Counter, Gauge, Histogram
@@ -21,7 +22,11 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 
+from nucliadb_telemetry.settings import telemetry_settings
+
 from .utils import get_path_template
+
+logger = logging.getLogger(__name__)
 
 try:
     from starlette_prometheus.middleware import (  # type: ignore
@@ -48,6 +53,7 @@ except ImportError:  # pragma: no cover
         "starlette_requests_processing_time_seconds",
         "Histogram of requests processing time by path (in seconds)",
         ["method", "path_template"],
+        buckets=telemetry_settings.prometheus_request_duration_buckets,
     )
     EXCEPTIONS = Counter(
         "starlette_exceptions_total",
@@ -73,6 +79,8 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
 
         REQUESTS_IN_PROGRESS.labels(method=method, path_template=path_template).inc()
         REQUESTS.labels(method=method, path_template=path_template).inc()
+        if telemetry_settings.log_requests_start:
+            logger.info("HTTP Request start: %s %s", method, path_template)
         before_time = time.perf_counter()
         try:
             response = await call_next(request)

--- a/nucliadb_telemetry/src/nucliadb_telemetry/settings.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/settings.py
@@ -32,6 +32,27 @@ class TelemetrySettings(BaseSettings):
         default=False, description="Instrument and observe GC metrics"
     )
 
+    prometheus_request_duration_buckets: list[float] = pydantic.Field(
+        default=[0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
+        description=(
+            "Histogram bucket boundaries (in seconds) for the "
+            "starlette_requests_processing_time_seconds metric. "
+            "Defaults to the standard Prometheus buckets (max 10 s). "
+            "Set this to cover the full latency range of the service, e.g. "
+            "[0.1, 0.5, 1, 2.5, 5, 10, 20, 30, 45, 60, 90, 120]"
+        ),
+    )
+
+    log_requests_start: bool = pydantic.Field(
+        default=False,
+        description=(
+            "Log an INFO entry when each request is received, including the "
+            "HTTP method, path template, and trace ID (when tracing is active). "
+            "FastAPI already logs requests upon completion; this flag adds the "
+            "arrival log that is otherwise missing"
+        ),
+    )
+
     def tracing_enabled(self) -> bool:
         return self.jaeger_enabled or self.otlp_collector_endpoint is not None
 

--- a/nucliadb_telemetry/tests/integration/test_fastapi.py
+++ b/nucliadb_telemetry/tests/integration/test_fastapi.py
@@ -182,6 +182,50 @@ class TestCasePrometheusMiddlewareFilterUnhandledPaths:
         )
 
 
+class TestCasePrometheusMiddlewareLogRequestsStart:
+    @pytest.fixture(scope="class")
+    def app(self):
+        app_ = Starlette()
+        app_.add_middleware(PrometheusMiddleware)
+
+        @app_.route("/foo/")
+        def foo(request):
+            return PlainTextResponse("Foo")
+
+        @app_.route("/foo/{bar}/")
+        def foobar(request):
+            return PlainTextResponse(f"Foo: {request.path_params['bar']}")
+
+        return app_
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app)
+
+    def test_log_requests_start_off_by_default(self, client):
+        with patch("nucliadb_telemetry.fastapi.metrics.logger") as mock_logger:
+            client.get("/foo/")
+        mock_logger.info.assert_not_called()
+
+    def test_log_requests_start_logs_method_and_path(self, client):
+        with (
+            patch("nucliadb_telemetry.fastapi.metrics.telemetry_settings") as mock_settings,
+            patch("nucliadb_telemetry.fastapi.metrics.logger") as mock_logger,
+        ):
+            mock_settings.log_requests_start = True
+            client.get("/foo/")
+        mock_logger.info.assert_called_once_with("HTTP Request start: %s %s", "GET", "/foo/")
+
+    def test_log_requests_start_uses_path_template(self, client):
+        with (
+            patch("nucliadb_telemetry.fastapi.metrics.telemetry_settings") as mock_settings,
+            patch("nucliadb_telemetry.fastapi.metrics.logger") as mock_logger,
+        ):
+            mock_settings.log_requests_start = True
+            client.get("/foo/baz/")
+        mock_logger.info.assert_called_once_with("HTTP Request start: %s %s", "GET", "/foo/{bar}/")
+
+
 class TestCaseCaptureTraceIdMiddleware:
     @pytest.fixture(scope="class")
     def app(self):


### PR DESCRIPTION
### Description
Two small debugability improvements to `nucliadb_telemetry`:

- **Configurable histogram buckets**: The `starlette_requests_processing_time_seconds` histogram previously used Prometheus default buckets (capped at 10 s), making long-running generative requests (up to 120 s) invisible in dashboards. 
Bucket boundaries are now configurable via the `PROMETHEUS_REQUEST_DURATION_BUCKETS` env var in `TelemetrySettings`.
- **Request-start logging**: A new `LOG_REQUESTS_START` toggle (default off) emits an `INFO` log when a request arrives. FastAPI already logs on completion

### How was this PR tested?
Added unit tests covering the request start logging functionality