### PR TITLE
NucliaDB shared: Fix S3_ENDPOINT value scope

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -27,7 +27,7 @@ data:
   GCS_PROJECT: {{ .Values.storage.gcs_project }}
   GCS_BUCKET_LABELS: {{ toJson .Values.storage.gcs_bucket_labels | quote }}
 {{- else if eq .Values.storage.file_backend "s3" }}
-{{- if .Values.storage.s3_endpoint }}
+{{- with .Values.storage.s3_endpoint }}
   S3_ENDPOINT: {{ . }}
 {{- end }}
 {{- if .Values.storage.s3_ssl }}


### PR DESCRIPTION
### Description
Fixed S3_ENDPOINT value to be scoped to only .Values.storage.s3_endpoint, not all values.

### How was this PR tested?
helm template ...
