### PR TITLE
Faster RRF

### DIFF
--- a/nucliadb/src/nucliadb/common/ids.py
+++ b/nucliadb/src/nucliadb/common/ids.py
@@ -154,7 +154,7 @@ class FieldId:
         return f"FieldId({self.full()})"
 
     def __hash__(self) -> int:
-        return hash(self.full())
+        return hash((self.rid, self.type, self.key, self.subfield_id))
 
     @staticmethod
     def _parse_field_type(_type: str) -> str:
@@ -215,7 +215,16 @@ class ParagraphId:
         return f"ParagraphId({self.full()})"
 
     def __hash__(self) -> int:
-        return hash(self.full())
+        return hash(
+            (
+                self.field_id.rid,
+                self.field_id.type,
+                self.field_id.key,
+                self.field_id.subfield_id,
+                self.paragraph_start,
+                self.paragraph_end,
+            )
+        )
 
 
 @dataclass
@@ -265,7 +274,17 @@ class VectorId:
         return f"VectorId({self.full()})"
 
     def __hash__(self) -> int:
-        return hash(self.full())
+        return hash(
+            (
+                self.field_id.rid,
+                self.field_id.type,
+                self.field_id.key,
+                self.field_id.subfield_id,
+                self.index,
+                self.vector_start,
+                self.vector_end,
+            )
+        )
 
 
 def extract_data_augmentation_id(generated_field_id: str) -> str | None:

--- a/nucliadb/src/nucliadb/search/search/rank_fusion.py
+++ b/nucliadb/src/nucliadb/search/search/rank_fusion.py
@@ -146,9 +146,7 @@ class ReciprocalRankFusion(RankFusionAlgorithm):
         sources: dict[str, list[ScoredItem]],
     ) -> list[ScoredItem]:
         # accumulated scores per paragraph
-        scores: dict[ParagraphId, tuple[float, SCORE_TYPE, list[Score]]] = {}
-        # pointers from paragraph to the original source
-        match_positions: dict[ParagraphId, list[tuple[int, int]]] = {}
+        scores: dict[ParagraphId, tuple[RrfScore, ScoredItem]] = {}
 
         # sort results by it's score before fusing them, as we need the rank
         sources = {
@@ -162,26 +160,22 @@ class ReciprocalRankFusion(RankFusionAlgorithm):
         for i, (ranking, weight) in enumerate(rankings):
             for rank, item in enumerate(ranking):
                 id = item.paragraph_id
-                score, score_type, history = scores.setdefault(id, (0, item.score_type, []))
-                score += 1 / (self._k + rank) * weight
-                history.append(item.current_score)
-                if {score_type, item.score_type} == {SCORE_TYPE.BM25, SCORE_TYPE.VECTOR}:
-                    score_type = SCORE_TYPE.BOTH
-                scores[id] = (score, score_type, history)
+                if id not in scores:
+                    score = 1 / (self._k + rank) * weight
+                    scores[id] = (RrfScore(score=score), item)
+                else:
+                    rrf_score, stored_item = scores[id]
+                    rrf_score.score += 1 / (self._k + rank) * weight
+                    stored_item.scores.append(item.current_score)
 
-                position = (i, rank)
-                match_positions.setdefault(item.paragraph_id, []).append(position)
+                    if (stored_item == SCORE_TYPE.BM25 and item.score_type == SCORE_TYPE.VECTOR) or (
+                        stored_item == SCORE_TYPE.VECTOR and item.score_type == SCORE_TYPE.BM25
+                    ):
+                        stored_item.score_type = SCORE_TYPE.BOTH
 
         merged = []
-        for paragraph_id, positions in match_positions.items():
-            # we are getting only one position, effectively deduplicating
-            # multiple matches for the same text block
-            i, j = match_positions[paragraph_id][0]
-            score, score_type, history = scores[paragraph_id]
-            item = rankings[i][0][j]
-            history.append(RrfScore(score=score))
-            item.scores = history
-            item.score_type = score_type
+        for paragraph_id, (rrf_score, item) in scores.items():
+            item.scores.append(rrf_score)
             merged.append(item)
 
         return merged

--- a/nucliadb/src/nucliadb/search/search/rank_fusion.py
+++ b/nucliadb/src/nucliadb/search/search/rank_fusion.py
@@ -168,8 +168,12 @@ class ReciprocalRankFusion(RankFusionAlgorithm):
                     rrf_score.score += 1 / (self._k + rank) * weight
                     stored_item.scores.append(item.current_score)
 
-                    if (stored_item == SCORE_TYPE.BM25 and item.score_type == SCORE_TYPE.VECTOR) or (
-                        stored_item == SCORE_TYPE.VECTOR and item.score_type == SCORE_TYPE.BM25
+                    if (
+                        stored_item.score_type == SCORE_TYPE.BM25
+                        and item.score_type == SCORE_TYPE.VECTOR
+                    ) or (
+                        stored_item.score_type == SCORE_TYPE.VECTOR
+                        and item.score_type == SCORE_TYPE.BM25
                     ):
                         stored_item.score_type = SCORE_TYPE.BOTH
 


### PR DESCRIPTION
### Description
We currently have some latency weird spikes on the rank fusion dashboard (some p90 >50ms and even >100ms). The metric comes from a blocking function that computes RRF, no await, just CPU bound. Here I'm trying to reduce the number of allocations and thus, GC interruptions in the middle. Copilot suggested hashing f-strings was a bad idea too, so I replaced it for tuple hashing (which is quite faster).

### How was this PR tested?
A couple of local pytest benchmarks with and without GC show how disabling GC improves the rank fusion performance quite significantly. With the improvements done, this runs as fast as the previous without GC enabled. Avg and p50 should be x2 faster. Let's see in prod
