### PR TITLE
Nidx: Support for S3 endpoint TLS validation option

### DIFF
--- a/charts/nidx/README.md
+++ b/charts/nidx/README.md
@@ -23,7 +23,7 @@ nidx chart
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | containerRegistry | string | `"CONTAINER_REGISTRY_TO_REPLACE"` | Container registry (e.g. docker.io/nuclia) |
 | image | string | `"IMAGE_TO_REPLACE"` | Image name (without registry eg. nidx:latest) |
-| env | string | `nil` |  |
+| env | object | `{}` | Global environment variables to add to all containers |
 | envFrom | object | `{}` | Global environment variables mount to add to all containers |
 | podAnnotations | object | `{}` | Global pod annotations to add to all pods |
 | podLabels | object | `{"nidxMetrics":"enabled"}` | Global pod labels to add to all pods |

--- a/charts/nidx/README.md
+++ b/charts/nidx/README.md
@@ -23,8 +23,8 @@ nidx chart
 | imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | containerRegistry | string | `"CONTAINER_REGISTRY_TO_REPLACE"` | Container registry (e.g. docker.io/nuclia) |
 | image | string | `"IMAGE_TO_REPLACE"` | Image name (without registry eg. nidx:latest) |
-| env | object | `{}` |  |
-| envFrom | object | `{}` |  |
+| env | string | `nil` |  |
+| envFrom | object | `{}` | Global environment variables mount to add to all containers |
 | podAnnotations | object | `{}` | Global pod annotations to add to all pods |
 | podLabels | object | `{"nidxMetrics":"enabled"}` | Global pod labels to add to all pods |
 | maintenance | bool | `false` | Enable maintenance mode, which disables writes while keeping searchers active |

--- a/charts/nidx/values.yaml
+++ b/charts/nidx/values.yaml
@@ -24,7 +24,7 @@ env: {}
   # -- Custom S3 endpoint URL for indexer.
   # INDEXER__ENDPOINT: https://<url>:9021
   # -- Enable or disable TLS certificate verification for indexer S3 connections.
-  # INDEXER__VERIFY_SSL: "False"
+  # INDEXER__ALLOW_INVALID_CERTIFICATES: "true"
   # -- S3 access key for indexer (if not using IAM or default credentials).
   # INDEXER__CLIENT_ID: "your-access-key"
   # -- S3 secret key for indexer (if not using IAM or default credentials).
@@ -52,7 +52,7 @@ env: {}
   # -- Custom S3 endpoint URL for storage.
   # STORAGE__ENDPOINT: https://<url>:9021
   # -- Enable or disable TLS certificate verification for storage S3 connections.
-  # STORAGE__VERIFY_SSL: "False"
+  # STORAGE__ALLOW_INVALID_CERTIFICATES: "true"
   # -- S3 access key for storage (if not using IAM or default credentials).
   # STORAGE__CLIENT_ID: "your-access-key"
   # -- S3 secret key for storage (if not using IAM or default credentials).

--- a/charts/nidx/values.yaml
+++ b/charts/nidx/values.yaml
@@ -13,7 +13,8 @@ containerRegistry: CONTAINER_REGISTRY_TO_REPLACE
 # -- Image name (without registry eg. nidx:latest)
 image: IMAGE_TO_REPLACE
 
-env:
+# -- Global environment variables to add to all containers
+env: {}
   # -- Object store backend type for indexer.
   # INDEXER__OBJECT_STORE: s3
   # -- S3 bucket name used by indexer.

--- a/charts/nidx/values.yaml
+++ b/charts/nidx/values.yaml
@@ -13,7 +13,57 @@ containerRegistry: CONTAINER_REGISTRY_TO_REPLACE
 # -- Image name (without registry eg. nidx:latest)
 image: IMAGE_TO_REPLACE
 
-env: {}
+env:
+  # -- Object store backend type for indexer.
+  # INDEXER__OBJECT_STORE: s3
+  # -- S3 bucket name used by indexer.
+  # INDEXER__BUCKET: ndb-index-env-name
+  # -- S3 region used by indexer.
+  # INDEXER__REGION_NAME: env-name
+  # -- Custom S3 endpoint URL for indexer.
+  # INDEXER__ENDPOINT: https://<url>:9021
+  # -- Enable or disable TLS certificate verification for indexer S3 connections.
+  # INDEXER__VERIFY_SSL: "False"
+  # -- S3 access key for indexer (if not using IAM or default credentials).
+  # INDEXER__CLIENT_ID: "your-access-key"
+  # -- S3 secret key for indexer (if not using IAM or default credentials).
+  # INDEXER__CLIENT_SECRET: "your-secret-key"
+  # -- GCP service account credentials for indexer (base64-encoded JSON).
+  # INDEXER__BASE64_CREDS: "base64-encoded-json"
+  # -- Azure Blob container URL for indexer.
+  # INDEXER__CONTAINER_URL: "https://account.blob.core.windows.net/container"
+  # -- Maximum number of concurrent indexer object store requests.
+  # INDEXER__MAX_REQUESTS: "10"
+  # -- Request timeout in seconds for indexer object store operations.
+  # INDEXER__TIMEOUT: "120"
+  # -- Azure storage account key for indexer.
+  # INDEXER__ACCOUNT_KEY: "your-azure-account-key"
+  # -- Object store backend type for storage.
+  # STORAGE__OBJECT_STORE: s3
+  # -- S3 bucket name used by storage.
+  # STORAGE__BUCKET: ndb-nidx-env-name
+  # -- S3 region used by storage.
+  # STORAGE__REGION_NAME: env-name
+  # -- Maximum number of concurrent storage object store requests.
+  # STORAGE__MAX_REQUESTS: "10"
+  # -- Request timeout in seconds for storage object store operations.
+  # STORAGE__TIMEOUT: "120"
+  # -- Custom S3 endpoint URL for storage.
+  # STORAGE__ENDPOINT: https://<url>:9021
+  # -- Enable or disable TLS certificate verification for storage S3 connections.
+  # STORAGE__VERIFY_SSL: "False"
+  # -- S3 access key for storage (if not using IAM or default credentials).
+  # STORAGE__CLIENT_ID: "your-access-key"
+  # -- S3 secret key for storage (if not using IAM or default credentials).
+  # STORAGE__CLIENT_SECRET: "your-secret-key"
+  # -- GCP service account credentials for storage (base64-encoded JSON).
+  # STORAGE__BASE64_CREDS: "base64-encoded-json"
+  # -- Azure Blob container URL for storage.
+  # STORAGE__CONTAINER_URL: "https://account.blob.core.windows.net/container"
+  # -- Azure storage account key for storage.
+  # STORAGE__ACCOUNT_KEY: "your-azure-account-key"
+
+# -- Global environment variables mount to add to all containers
 envFrom: {}
 
 # -- Global pod annotations to add to all pods

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -56,6 +56,7 @@ pub enum ObjectStoreKind {
         client_secret: Option<String>,
         region_name: String,
         endpoint: Option<String>,
+        verify_ssl: Option<bool>,
     },
     Azure {
         container_url: String,
@@ -115,6 +116,7 @@ impl ObjectStoreConfig {
                 client_secret,
                 region_name,
                 endpoint,
+                verify_ssl,
             } => {
                 let mut builder = AmazonS3Builder::from_env()
                     .with_region(region_name.clone())
@@ -130,8 +132,15 @@ impl ObjectStoreConfig {
                     // This is needed for minio compatibility
                     builder = builder.with_endpoint(endpoint.clone().unwrap()).with_allow_http(true);
                 }
-                if let Some(t) = self.timeout {
-                    builder = builder.with_client_options(ClientOptions::new().with_timeout(Duration::from_secs(t)));
+                if self.timeout.is_some() || matches!(verify_ssl, Some(false)) {
+                    let mut options = ClientOptions::new();
+                    if let Some(t) = self.timeout {
+                        options = options.with_timeout(Duration::from_secs(t));
+                    }
+                    if let Some(verify_ssl) = verify_ssl {
+                        options = options.with_allow_invalid_certificates(!*verify_ssl);
+                    }
+                    builder = builder.with_client_options(options);
                 }
                 Box::new(builder.build().unwrap())
             }
@@ -422,6 +431,8 @@ impl Settings {
 mod tests {
     use std::collections::HashMap;
 
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -441,5 +452,57 @@ mod tests {
             settings.merge.log.min_number_of_segments,
             LogMergeSettings::default().min_number_of_segments
         );
+    }
+
+    #[test]
+    fn test_s3_verify_ssl_default_is_enabled() {
+        let raw = json!({
+            "object_store": "s3",
+            "bucket": "bucket",
+            "region_name": "us-east-1"
+        });
+        let config: ObjectStoreConfig = serde_json::from_value(raw).unwrap();
+
+        match config.kind {
+            ObjectStoreKind::S3 { verify_ssl, .. } => {
+                assert_eq!(verify_ssl, None);
+            }
+            _ => panic!("Expected s3 object store kind"),
+        }
+    }
+
+    #[test]
+    fn test_s3_verify_ssl_can_be_disabled() {
+        let raw = json!({
+            "object_store": "s3",
+            "bucket": "bucket",
+            "region_name": "us-east-1",
+            "verify_ssl": false
+        });
+        let config: ObjectStoreConfig = serde_json::from_value(raw).unwrap();
+
+        match config.kind {
+            ObjectStoreKind::S3 { verify_ssl, .. } => {
+                assert_eq!(verify_ssl, Some(false));
+            }
+            _ => panic!("Expected s3 object store kind"),
+        }
+    }
+
+    #[test]
+    fn test_indexer_verify_ssl_env_var_is_parsed() {
+        let env = [
+            ("METADATA__DATABASE_URL", "postgresql://localhost"),
+            ("INDEXER__OBJECT_STORE", "s3"),
+            ("INDEXER__BUCKET", "bucket"),
+            ("INDEXER__REGION_NAME", "us-east-1"),
+            ("INDEXER__VERIFY_SSL", "false"),
+        ];
+
+        let settings = EnvSettings::from_map(HashMap::from(env.map(|(k, v)| (k.to_string(), v.to_string()))));
+        let indexer = settings.indexer.expect("indexer settings should be present");
+
+        // The object store client is built from env; this test verifies env parsing accepts VERIFY_SSL.
+        assert!(indexer.nats_server.is_none());
     }
 }

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -71,52 +71,28 @@ fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<
     ))
 }
 
-fn deserialize_bool_option<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<bool>, D::Error> {
-    use serde::de::Error;
-    
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum BoolOrString {
-        Bool(bool),
-        String(String),
-    }
-    
-    match BoolOrString::deserialize(deserializer)? {
-        BoolOrString::Bool(b) => Ok(Some(b)),
-        BoolOrString::String(s) => {
-            match s.to_lowercase().as_str() {
-                "true" | "1" | "yes" => Ok(Some(true)),
-                "false" | "0" | "no" => Ok(Some(false)),
-                _ => Err(Error::custom("expected 'true' or 'false' for boolean")),
-            }
-        }
-    }
-}
-
 // Wrapper type for boolean that deserializes from both bool and string
-#[derive(Clone, Copy, Debug)]
-struct VerifySSL(pub Option<bool>);
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VerifySSL(pub Option<bool>);
 
 impl<'de> Deserialize<'de> for VerifySSL {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::de::Error;
-        
+
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum BoolOrString {
             Bool(bool),
             String(String),
         }
-        
+
         match BoolOrString::deserialize(deserializer)? {
             BoolOrString::Bool(b) => Ok(VerifySSL(Some(b))),
-            BoolOrString::String(s) => {
-                match s.to_lowercase().as_str() {
-                    "true" | "1" | "yes" => Ok(VerifySSL(Some(true))),
-                    "false" | "0" | "no" => Ok(VerifySSL(Some(false))),
-                    _ => Err(Error::custom("expected 'true' or 'false' for boolean")),
-                }
-            }
+            BoolOrString::String(s) => match s.to_lowercase().as_str() {
+                "true" | "1" | "yes" => Ok(VerifySSL(Some(true))),
+                "false" | "0" | "no" => Ok(VerifySSL(Some(false))),
+                _ => Err(Error::custom("expected 'true' or 'false' for boolean")),
+            },
         }
     }
 }
@@ -187,10 +163,8 @@ impl ObjectStoreConfig {
                     if let Some(t) = self.timeout {
                         options = options.with_timeout(Duration::from_secs(t));
                     }
-                    if let Some(VerifySSL(ssl_opt)) = verify_ssl {
-                        if let Some(verify) = ssl_opt {
-                            options = options.with_allow_invalid_certificates(!verify);
-                        }
+                    if let Some(VerifySSL(Some(verify))) = verify_ssl {
+                        options = options.with_allow_invalid_certificates(!verify);
                     }
                     builder = builder.with_client_options(options);
                 }

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -56,7 +56,8 @@ pub enum ObjectStoreKind {
         client_secret: Option<String>,
         region_name: String,
         endpoint: Option<String>,
-        verify_ssl: Option<VerifySSL>,
+        #[serde(default, deserialize_with = "deserialize_bool")]
+        allow_invalid_certificates: Option<bool>,
     },
     Azure {
         container_url: String,
@@ -71,30 +72,10 @@ fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<
     ))
 }
 
-// Wrapper type for boolean that deserializes from both bool and string
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct VerifySSL(pub Option<bool>);
-
-impl<'de> Deserialize<'de> for VerifySSL {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use serde::de::Error;
-
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum BoolOrString {
-            Bool(bool),
-            String(String),
-        }
-
-        match BoolOrString::deserialize(deserializer)? {
-            BoolOrString::Bool(b) => Ok(VerifySSL(Some(b))),
-            BoolOrString::String(s) => match s.to_lowercase().as_str() {
-                "true" | "1" | "yes" => Ok(VerifySSL(Some(true))),
-                "false" | "0" | "no" => Ok(VerifySSL(Some(false))),
-                _ => Err(Error::custom("expected 'true' or 'false' for boolean")),
-            },
-        }
-    }
+fn deserialize_bool<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<bool>, D::Error> {
+    Ok(Some(
+        String::deserialize(deserializer)?.parse().expect("Expected a bool"),
+    ))
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -142,7 +123,7 @@ impl ObjectStoreConfig {
                 client_secret,
                 region_name,
                 endpoint,
-                verify_ssl,
+                allow_invalid_certificates,
             } => {
                 let mut builder = AmazonS3Builder::from_env()
                     .with_region(region_name.clone())
@@ -158,13 +139,13 @@ impl ObjectStoreConfig {
                     // This is needed for minio compatibility
                     builder = builder.with_endpoint(endpoint.clone().unwrap()).with_allow_http(true);
                 }
-                if self.timeout.is_some() || matches!(verify_ssl, Some(VerifySSL(Some(false)))) {
+                if self.timeout.is_some() || allow_invalid_certificates.is_some() {
                     let mut options = ClientOptions::new();
                     if let Some(t) = self.timeout {
                         options = options.with_timeout(Duration::from_secs(t));
                     }
-                    if let Some(VerifySSL(Some(verify))) = verify_ssl {
-                        options = options.with_allow_invalid_certificates(!verify);
+                    if let Some(allow_invalid_certificates) = allow_invalid_certificates {
+                        options = options.with_allow_invalid_certificates(*allow_invalid_certificates);
                     }
                     builder = builder.with_client_options(options);
                 }
@@ -481,7 +462,7 @@ mod tests {
     }
 
     #[test]
-    fn test_s3_verify_ssl_default_is_enabled() {
+    fn test_s3_allow_invalid_certificates_default_is_none() {
         let raw = json!({
             "object_store": "s3",
             "bucket": "bucket",
@@ -490,45 +471,34 @@ mod tests {
         let config: ObjectStoreConfig = serde_json::from_value(raw).unwrap();
 
         match config.kind {
-            ObjectStoreKind::S3 { verify_ssl, .. } => {
-                assert_eq!(verify_ssl, None);
+            ObjectStoreKind::S3 {
+                allow_invalid_certificates,
+                ..
+            } => {
+                assert_eq!(allow_invalid_certificates, None);
             }
             _ => panic!("Expected s3 object store kind"),
         }
     }
 
     #[test]
-    fn test_s3_verify_ssl_can_be_disabled() {
+    fn test_s3_allow_invalid_certificates_enabled() {
         let raw = json!({
             "object_store": "s3",
             "bucket": "bucket",
             "region_name": "us-east-1",
-            "verify_ssl": false
+            "allow_invalid_certificates": "true"
         });
         let config: ObjectStoreConfig = serde_json::from_value(raw).unwrap();
 
         match config.kind {
-            ObjectStoreKind::S3 { verify_ssl, .. } => {
-                assert_eq!(verify_ssl, Some(VerifySSL(Some(false))));
+            ObjectStoreKind::S3 {
+                allow_invalid_certificates,
+                ..
+            } => {
+                assert_eq!(allow_invalid_certificates, Some(true));
             }
             _ => panic!("Expected s3 object store kind"),
         }
-    }
-
-    #[test]
-    fn test_indexer_verify_ssl_env_var_is_parsed() {
-        let env = [
-            ("METADATA__DATABASE_URL", "postgresql://localhost"),
-            ("INDEXER__OBJECT_STORE", "s3"),
-            ("INDEXER__BUCKET", "bucket"),
-            ("INDEXER__REGION_NAME", "us-east-1"),
-            ("INDEXER__VERIFY_SSL", "false"),
-        ];
-
-        let settings = EnvSettings::from_map(HashMap::from(env.map(|(k, v)| (k.to_string(), v.to_string()))));
-        let indexer = settings.indexer.expect("indexer settings should be present");
-
-        // The object store client is built from env; this test verifies env parsing accepts VERIFY_SSL.
-        assert!(indexer.nats_server.is_none());
     }
 }

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -56,7 +56,7 @@ pub enum ObjectStoreKind {
         client_secret: Option<String>,
         region_name: String,
         endpoint: Option<String>,
-        verify_ssl: Option<bool>,
+        verify_ssl: Option<VerifySSL>,
     },
     Azure {
         container_url: String,
@@ -69,6 +69,56 @@ fn deserialize_u64<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<
     Ok(Some(
         String::deserialize(deserializer)?.parse().expect("Expected a number"),
     ))
+}
+
+fn deserialize_bool_option<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<bool>, D::Error> {
+    use serde::de::Error;
+    
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BoolOrString {
+        Bool(bool),
+        String(String),
+    }
+    
+    match BoolOrString::deserialize(deserializer)? {
+        BoolOrString::Bool(b) => Ok(Some(b)),
+        BoolOrString::String(s) => {
+            match s.to_lowercase().as_str() {
+                "true" | "1" | "yes" => Ok(Some(true)),
+                "false" | "0" | "no" => Ok(Some(false)),
+                _ => Err(Error::custom("expected 'true' or 'false' for boolean")),
+            }
+        }
+    }
+}
+
+// Wrapper type for boolean that deserializes from both bool and string
+#[derive(Clone, Copy, Debug)]
+struct VerifySSL(pub Option<bool>);
+
+impl<'de> Deserialize<'de> for VerifySSL {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+        
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum BoolOrString {
+            Bool(bool),
+            String(String),
+        }
+        
+        match BoolOrString::deserialize(deserializer)? {
+            BoolOrString::Bool(b) => Ok(VerifySSL(Some(b))),
+            BoolOrString::String(s) => {
+                match s.to_lowercase().as_str() {
+                    "true" | "1" | "yes" => Ok(VerifySSL(Some(true))),
+                    "false" | "0" | "no" => Ok(VerifySSL(Some(false))),
+                    _ => Err(Error::custom("expected 'true' or 'false' for boolean")),
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -132,13 +182,15 @@ impl ObjectStoreConfig {
                     // This is needed for minio compatibility
                     builder = builder.with_endpoint(endpoint.clone().unwrap()).with_allow_http(true);
                 }
-                if self.timeout.is_some() || matches!(verify_ssl, Some(false)) {
+                if self.timeout.is_some() || matches!(verify_ssl, Some(VerifySSL(Some(false)))) {
                     let mut options = ClientOptions::new();
                     if let Some(t) = self.timeout {
                         options = options.with_timeout(Duration::from_secs(t));
                     }
-                    if let Some(verify_ssl) = verify_ssl {
-                        options = options.with_allow_invalid_certificates(!*verify_ssl);
+                    if let Some(VerifySSL(ssl_opt)) = verify_ssl {
+                        if let Some(verify) = ssl_opt {
+                            options = options.with_allow_invalid_certificates(!verify);
+                        }
                     }
                     builder = builder.with_client_options(options);
                 }
@@ -483,7 +535,7 @@ mod tests {
 
         match config.kind {
             ObjectStoreKind::S3 { verify_ssl, .. } => {
-                assert_eq!(verify_ssl, Some(false));
+                assert_eq!(verify_ssl, Some(VerifySSL(Some(false))));
             }
             _ => panic!("Expected s3 object store kind"),
         }


### PR DESCRIPTION
This pull request introduces support for configuring SSL certificate verification for S3-compatible object storage backends in the nidx chart and backend. It updates Helm chart values and documentation to expose the `verify_ssl` option, modifies the Rust backend to pass this setting to the S3 client, and adds tests to ensure correct parsing and behavior.

**Helm chart and configuration improvements:**

* Updated `charts/nidx/README.md` and `charts/nidx/values.yaml` to document and expose the `verify_ssl` option for both indexer and storage S3 object store configurations, allowing users to enable or disable TLS certificate verification via environment variables. [[1]](diffhunk://#diff-61bfba9309f0d7f8c3a1a9f32ba5c57cd1437aafcd8bbc2c33c1f5a5445a5413L26-R27) [[2]](diffhunk://#diff-27e9cc266923d087b3a45d52d4bfd0e283837dcb6eb6e6b0c06eb17e724d29edL16-R66)

**Backend (Rust) enhancements:**

* Added an optional `verify_ssl` field to the `ObjectStoreKind::S3` variant in `nidx/src/settings.rs`, and updated the S3 client builder to respect this setting, disabling certificate verification when requested. [[1]](diffhunk://#diff-43e4afeb367e7e4e2d79686e9dd133a1f06b2facd8e9d214899818ef5d935c66R59) [[2]](diffhunk://#diff-43e4afeb367e7e4e2d79686e9dd133a1f06b2facd8e9d214899818ef5d935c66R119) [[3]](diffhunk://#diff-43e4afeb367e7e4e2d79686e9dd133a1f06b2facd8e9d214899818ef5d935c66R135-R143)

**Testing and reliability:**

* Added unit tests to `nidx/src/settings.rs` to verify correct parsing of the `verify_ssl` setting from both JSON and environment variables, and to ensure the default behavior is to enable certificate verification. [[1]](diffhunk://#diff-43e4afeb367e7e4e2d79686e9dd133a1f06b2facd8e9d214899818ef5d935c66R434-R435) [[2]](diffhunk://#diff-43e4afeb367e7e4e2d79686e9dd133a1f06b2facd8e9d214899818ef5d935c66R456-R507)### Description
Describe the proposed changes made in this PR.

### How was this PR tested?
Describe how you tested this PR.
