### PR TITLE
Chart shared: Fix default key for S3 certificate validation

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -30,11 +30,11 @@ data:
 {{- with .Values.storage.s3_endpoint }}
   S3_ENDPOINT: {{ . }}
 {{- end }}
-{{- if .Values.storage.s3_ssl }}
-  S3_SSL: "True"
-{{- end }}
+  S3_SSL: {{ .Values.storage.s3_ssl | quote }}
   S3_VERIFY_SSL: {{ .Values.storage.s3_verify_ssl | quote }}
-  S3_VERIFY_SSL_CERTIFICATE: {{ .Values.storage.s3_verify_ssl_certificate | quote }}
+{{- with .Values.storage.s3_verify_ssl_certificate }}
+  S3_VERIFY_SSL_CERTIFICATE: {{ . | quote }}
+{{- end }}
   S3_MAX_POOL_CONNECTIONS: {{ .Values.storage.s3_max_pool_connections | quote }}
   S3_REGION_NAME: {{ .Values.storage.s3_region_name }}
   S3_BUCKET: {{ .Values.storage.s3_bucket }}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -37,7 +37,8 @@ storage:
   s3_client_id: XX
   s3_client_secret: XX
   s3_ssl: True
-  s3_verify_ssl_certificate: True
+  s3_verify_ssl: True
+  s3_verify_ssl_certificate: null
   s3_max_pool_connections: 30
   s3_region_name: XX
   s3_bucket: nucliadb-{kbid}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -37,7 +37,7 @@ storage:
   s3_client_id: XX
   s3_client_secret: XX
   s3_ssl: True
-  s3_verify_ssl: True
+  s3_verify_ssl_certificate: True
   s3_max_pool_connections: 30
   s3_region_name: XX
   s3_bucket: nucliadb-{kbid}


### PR DESCRIPTION
This pull request makes a minor configuration update to the S3 storage settings in the `charts/nucliadb_shared/values.yaml` file. The change renames the `s3_verify_ssl` parameter to `s3_verify_ssl_certificate` for improved clarity and accuracy.