### PR TITLE
Add endpoint to delete messages in a conversation

### DIFF
--- a/nucliadb/src/migrations/0039_backfill_converation_splits_metadata.py
+++ b/nucliadb/src/migrations/0039_backfill_converation_splits_metadata.py
@@ -74,6 +74,10 @@ async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
                     to_fix.append((rid, field_id))
 
         for rid, field_id in to_fix:
+            logger.info(
+                "Backfilling splits metadata",
+                extra={"kbid": kbid, "rid": rid, "field_id": field_id},
+            )
             async with context.kv_driver.rw_transaction() as txn2:
                 splits_metadata = await build_splits_metadata(
                     txn2, context.blob_storage, kbid, rid, field_id

--- a/nucliadb/src/migrations/0043_backfill_conversation_splits_page.py
+++ b/nucliadb/src/migrations/0043_backfill_conversation_splits_page.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Migration #43
+
+Backfill the `page` field in SplitsMetadata entries for conversation fields.
+
+Previously, SplitsMetadata tracked which message idents existed but did not
+record which page each message belongs to. This migration iterates all
+conversation fields and sets the correct page number on each split metadata
+entry, enabling efficient page-targeted deletions.
+"""
+
+import logging
+from typing import cast
+
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction
+from nucliadb.ingest.fields.conversation import (
+    Conversation,
+)
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox as KnowledgeBoxORM
+from nucliadb.migrator.context import ExecutionContext
+from nucliadb_protos import resources_pb2
+
+logger = logging.getLogger(__name__)
+
+
+async def migrate(context: ExecutionContext) -> None: ...
+
+
+async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
+    BATCH_SIZE = 100
+    start = ""
+    while True:
+        to_fix: list[tuple[str, str]] = []
+        async with context.kv_driver.rw_transaction() as txn:
+            txn = cast(PGTransaction, txn)
+            async with txn.connection.cursor() as cur:
+                await cur.execute(
+                    """
+                    SELECT key FROM resources
+                    WHERE key ~ ('^/kbs/' || %s || '/r/[^/]*/f/c/[^/]*$')
+                    AND key > %s
+                    ORDER BY key
+                    LIMIT %s""",
+                    (kbid, start, BATCH_SIZE),
+                )
+                rows = await cur.fetchall()
+                if len(rows) == 0:
+                    return
+                for row in rows:
+                    key = row[0]
+                    start = key
+                    rid = key.split("/")[4]
+                    field_id = key.split("/")[7]
+                    to_fix.append((rid, field_id))
+
+        for rid, field_id in to_fix:
+            async with context.kv_driver.rw_transaction() as txn:
+                try:
+                    await backfill_splits_page(txn, context.blob_storage, kbid, rid, field_id)
+                    await txn.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to backfill splits page metadata",
+                        extra={"kbid": kbid, "rid": rid, "field_id": field_id},
+                    )
+
+
+async def backfill_splits_page(txn: Transaction, storage, kbid: str, rid: str, field_id: str) -> None:
+    kb_orm = KnowledgeBoxORM(txn, storage, kbid)
+    resource_obj = await kb_orm.get(rid)
+    if resource_obj is None:
+        return
+
+    field_obj: Conversation = await resource_obj.get_field(
+        field_id, resources_pb2.FieldType.CONVERSATION, load=False
+    )
+    splits_metadata = await field_obj.get_splits_metadata()
+    conv_metadata = await field_obj.get_metadata()
+    for page_number in range(1, conv_metadata.pages + 1):
+        page = await field_obj.get_value(page=page_number)
+        if page is None:
+            continue
+        for message in page.messages:
+            splits_metadata.metadata.get_or_create(message.ident).page = page_number
+    await field_obj.set_splits_metadata(splits_metadata)

--- a/nucliadb/src/nucliadb/export_import/utils.py
+++ b/nucliadb/src/nucliadb/export_import/utils.py
@@ -98,6 +98,7 @@ BM_FIELDS = {
         "delete_question_answers",
         "errors",
         "generated_by",
+        "delete_splits",
     ],
     # No longer used fields
     "deprecated": [

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -267,46 +267,24 @@ class Conversation(Field[PBConversation]):
         metadata = await self.get_metadata()
         splits_metadata = await self.get_splits_metadata()
         idents_to_delete = set(message_idents) - set(splits_metadata.deleted_splits)
+        idents_to_delete = idents_to_delete & set(splits_metadata.metadata.keys())
 
-        group_by_page: dict[int, set[str]] = {}
-        idents_without_page = set()
+        page_idents: dict[int, set[str]] = {}
         for ident in idents_to_delete:
             split_meta = splits_metadata.metadata.get(ident)
             if split_meta is not None:
-                group_by_page.setdefault(split_meta.page, set()).add(ident)
-            else:
-                idents_without_page.add(ident)
+                page_idents.setdefault(split_meta.page, set()).add(ident)
 
-        for page, idents in group_by_page.items():
+        for page, idents in page_idents.items():
             some_deleted_in_page = False
             page_obj = await self.db_get_value(page)
             for message in page_obj.messages:
-                if message.ident in idents or message.ident in idents_without_page:
+                if message.ident in idents:
                     message.content.text = ""
                     total_deleted += 1
                     some_deleted_in_page = True
                     splits_metadata.deleted_splits.append(message.ident)
                     idents_to_delete.remove(message.ident)
-
-            if some_deleted_in_page:
-                # If we deleted a message in this page, we need to update it in the database.
-                await self.db_set_value(page_obj, page)
-
-        # The remaining messages may not have the page metadata yet, so we need to delete by iterating all the pages.
-        for page in range(1, metadata.pages + 1):
-            if page in group_by_page:
-                # We already visited this page, so we know the message is not in it.
-                continue
-            some_deleted_in_page = False
-            page_obj = await self.db_get_value(page)
-            for message in page_obj.messages:
-                if message.ident in idents_without_page:
-                    message.content.text = ""
-                    total_deleted += 1
-                    some_deleted_in_page = True
-                    splits_metadata.deleted_splits.append(message.ident)
-                    idents_to_delete.remove(message.ident)
-
             if some_deleted_in_page:
                 # If we deleted a message in this page, we need to update it in the database.
                 await self.db_set_value(page_obj, page)

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -18,8 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import uuid
-from typing import Any
+from typing import Any, Iterable
 
+from nucliadb.ingest import logger
 from nucliadb.ingest.fields.base import Field
 from nucliadb_protos.resources_pb2 import CloudFile, FieldConversation, SplitsMetadata
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
@@ -115,7 +116,14 @@ class Conversation(Field[PBConversation]):
         while True:
             # Fit the messages in the last page
             available_space = metadata.size - len(last_page.messages)
-            last_page.messages.extend(messages[:available_space])
+            page_messages = messages[:available_space]
+
+            # Add the page to the split metadata, so we can track in which page each message is for efficient deletion later.
+            for message in page_messages:
+                split_meta = self._splits_metadata.metadata.get_or_create(message.ident)
+                split_meta.page = metadata.pages
+
+            last_page.messages.extend(page_messages)
 
             # Save the last page
             await self.db_set_value(last_page, metadata.pages)
@@ -243,3 +251,84 @@ class Conversation(Field[PBConversation]):
         await self.resource.txn.set(key, payload.SerializeToString())
         self._split_metadata = payload
         self.resource.modified = True
+
+    async def delete_messages(self, message_idents: Iterable[str]) -> int:
+        """Delete messages by their ident from conversation pages.
+
+        Messages are removed in-place from their pages without restructuring
+        pages, so that page numbering stays stable.
+
+        Returns the number of messages actually deleted.
+
+        Processed metadata for the deleted messages (e.g: text, vectors, etc) is not deleted immediately.
+        """
+        total_deleted = 0
+
+        metadata = await self.get_metadata()
+        splits_metadata = await self.get_splits_metadata()
+        idents_to_delete = set(message_idents)
+
+        group_by_page: dict[int, set[str]] = {}
+        idents_without_page = set()
+        for ident in idents_to_delete:
+            split_meta = splits_metadata.metadata.get(ident)
+            if split_meta is not None:
+                group_by_page.setdefault(split_meta.page, set()).add(ident)
+            else:
+                idents_without_page.add(ident)
+
+        for page, idents in group_by_page.items():
+            some_deleted_in_page = False
+            page_obj = await self.db_get_value(page)
+            for message in page_obj.messages:
+                if (
+                    message.ident in idents or message.ident in idents_without_page
+                ) and not message.deleted:
+                    # TODO: store references of idents to be deleted somewhere else so that purge job can use them
+                    message.deleted = True
+                    message.content.text = ""
+                    total_deleted += 1
+                    some_deleted_in_page = True
+                    idents_to_delete.remove(message.ident)
+
+            if some_deleted_in_page:
+                # If we deleted a message in this page, we need to update it in the database.
+                await self.db_set_value(page_obj, page)
+
+        # The remaining messages may not have the page metadata yet, so we need to delete by iterating all the pages.
+        for remaining_ident in idents_without_page:
+            for page in range(1, metadata.pages + 1):
+                if page in group_by_page:
+                    # We already visited this page, so we know the message is not in it.
+                    continue
+                some_deleted_in_page = False
+                page_obj = await self.db_get_value(page)
+                for message in page_obj.messages:
+                    if message.ident == remaining_ident and not message.deleted:
+                        # TODO: store references of idents to be deleted somewhere else so that purge job can use them
+                        message.deleted = True
+                        message.content.text = ""
+                        total_deleted += 1
+                        some_deleted_in_page = True
+                        idents_to_delete.remove(message.ident)
+                        break
+
+                if some_deleted_in_page:
+                    # If we deleted a message in this page, we need to update it in the database.
+                    await self.db_set_value(page_obj, page)
+
+        if len(idents_to_delete) > 0:
+            logger.warning(
+                "Some message idents were not found in the conversation and could not be deleted",
+                extra={
+                    "kbid": self.kbid,
+                    "rid": self.rid,
+                    "idents": list(idents_to_delete),
+                },
+            )
+
+        if total_deleted > 0:
+            metadata.deleted_messages += total_deleted
+            await self.db_set_metadata(metadata)
+
+        return total_deleted

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -281,9 +281,7 @@ class Conversation(Field[PBConversation]):
             some_deleted_in_page = False
             page_obj = await self.db_get_value(page)
             for message in page_obj.messages:
-                if (
-                    message.ident in idents or message.ident in idents_without_page
-                ) and not message.deleted:
+                if message.ident in idents or message.ident in idents_without_page:
                     message.content.text = ""
                     total_deleted += 1
                     some_deleted_in_page = True
@@ -295,25 +293,23 @@ class Conversation(Field[PBConversation]):
                 await self.db_set_value(page_obj, page)
 
         # The remaining messages may not have the page metadata yet, so we need to delete by iterating all the pages.
-        for remaining_ident in idents_without_page:
-            for page in range(1, metadata.pages + 1):
-                if page in group_by_page:
-                    # We already visited this page, so we know the message is not in it.
-                    continue
-                some_deleted_in_page = False
-                page_obj = await self.db_get_value(page)
-                for message in page_obj.messages:
-                    if message.ident == remaining_ident and not message.deleted:
-                        message.content.text = ""
-                        total_deleted += 1
-                        some_deleted_in_page = True
-                        splits_metadata.deleted_splits.append(message.ident)
-                        idents_to_delete.remove(message.ident)
-                        break
+        for page in range(1, metadata.pages + 1):
+            if page in group_by_page:
+                # We already visited this page, so we know the message is not in it.
+                continue
+            some_deleted_in_page = False
+            page_obj = await self.db_get_value(page)
+            for message in page_obj.messages:
+                if message.ident in idents_without_page:
+                    message.content.text = ""
+                    total_deleted += 1
+                    some_deleted_in_page = True
+                    splits_metadata.deleted_splits.append(message.ident)
+                    idents_to_delete.remove(message.ident)
 
-                if some_deleted_in_page:
-                    # If we deleted a message in this page, we need to update it in the database.
-                    await self.db_set_value(page_obj, page)
+            if some_deleted_in_page:
+                # If we deleted a message in this page, we need to update it in the database.
+                await self.db_set_value(page_obj, page)
 
         if len(idents_to_delete) > 0:
             logger.warning(

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -284,8 +284,6 @@ class Conversation(Field[PBConversation]):
                 if (
                     message.ident in idents or message.ident in idents_without_page
                 ) and not message.deleted:
-                    # TODO: store references of idents to be deleted somewhere else so that purge job can use them
-                    message.deleted = True
                     message.content.text = ""
                     total_deleted += 1
                     some_deleted_in_page = True
@@ -306,8 +304,6 @@ class Conversation(Field[PBConversation]):
                 page_obj = await self.db_get_value(page)
                 for message in page_obj.messages:
                     if message.ident == remaining_ident and not message.deleted:
-                        # TODO: store references of idents to be deleted somewhere else so that purge job can use them
-                        message.deleted = True
                         message.content.text = ""
                         total_deleted += 1
                         some_deleted_in_page = True

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -322,7 +322,6 @@ class Conversation(Field[PBConversation]):
             )
 
         if total_deleted > 0:
-            metadata.deleted_messages += total_deleted
             await self.db_set_metadata(metadata)
             await self.set_splits_metadata(splits_metadata)
 

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -266,7 +266,7 @@ class Conversation(Field[PBConversation]):
 
         metadata = await self.get_metadata()
         splits_metadata = await self.get_splits_metadata()
-        idents_to_delete = set(message_idents)
+        idents_to_delete = set(message_idents) - set(splits_metadata.deleted_splits)
 
         group_by_page: dict[int, set[str]] = {}
         idents_without_page = set()
@@ -289,6 +289,7 @@ class Conversation(Field[PBConversation]):
                     message.content.text = ""
                     total_deleted += 1
                     some_deleted_in_page = True
+                    splits_metadata.deleted_splits.append(message.ident)
                     idents_to_delete.remove(message.ident)
 
             if some_deleted_in_page:
@@ -310,6 +311,7 @@ class Conversation(Field[PBConversation]):
                         message.content.text = ""
                         total_deleted += 1
                         some_deleted_in_page = True
+                        splits_metadata.deleted_splits.append(message.ident)
                         idents_to_delete.remove(message.ident)
                         break
 
@@ -330,5 +332,6 @@ class Conversation(Field[PBConversation]):
         if total_deleted > 0:
             metadata.deleted_messages += total_deleted
             await self.db_set_metadata(metadata)
+            await self.set_splits_metadata(splits_metadata)
 
         return total_deleted

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import uuid
+from collections import defaultdict
 from typing import Any, Iterable
 
 from nucliadb.ingest import logger
@@ -268,17 +269,17 @@ class Conversation(Field[PBConversation]):
         idents_to_delete = set(message_idents) - set(splits_metadata.deleted_splits)
         idents_to_delete = idents_to_delete & set(splits_metadata.metadata.keys())
 
-        page_idents: dict[int, set[str]] = {}
+        page_idents: dict[int, set[str]] = defaultdict(set)
         for ident in idents_to_delete:
             split_meta = splits_metadata.metadata.get(ident)
             if split_meta is not None:
-                page_idents.setdefault(split_meta.page, set()).add(ident)
+                page_idents[split_meta.page].add(ident)
 
         for page, idents in page_idents.items():
             some_deleted_in_page = False
             page_obj = await self.db_get_value(page)
             for message in page_obj.messages:
-                if message.ident in idents:
+                if message.ident in idents and message.ident not in splits_metadata.deleted_splits:
                     message.content.text = ""
                     total_deleted += 1
                     some_deleted_in_page = True

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -264,7 +264,6 @@ class Conversation(Field[PBConversation]):
         """
         total_deleted = 0
 
-        metadata = await self.get_metadata()
         splits_metadata = await self.get_splits_metadata()
         idents_to_delete = set(message_idents) - set(splits_metadata.deleted_splits)
         idents_to_delete = idents_to_delete & set(splits_metadata.metadata.keys())
@@ -300,7 +299,6 @@ class Conversation(Field[PBConversation]):
             )
 
         if total_deleted > 0:
-            await self.db_set_metadata(metadata)
             await self.set_splits_metadata(splits_metadata)
 
         return total_deleted

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -260,7 +260,7 @@ class Conversation(Field[PBConversation]):
 
         Returns the number of messages actually deleted.
 
-        Processed metadata for the deleted messages (e.g: text, vectors, etc) is not deleted immediately.
+        Processed metadata for the deleted messages (e.g: text, vectors, etc) are not deleted for now.
         """
         total_deleted = 0
 

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -104,12 +104,14 @@ class ResourceBrain:
         field_author: FieldAuthor | None,
         replace_field: bool,
         skip_index: bool,
+        deleted_splits: set[str] | None = None,
     ) -> None:
         self.apply_field_text(
             field_key,
             extracted_text,
             replace_field=replace_field,
             skip_texts=skip_index,
+            deleted_splits=deleted_splits,
         )
         self.apply_field_labels(
             field_key,
@@ -125,13 +127,14 @@ class ResourceBrain:
         extracted_text: ExtractedText,
         replace_field: bool,
         skip_texts: bool | None,
-    ):
+        deleted_splits: set[str] | None = None,
+    ) -> None:
         if skip_texts is not None:
             self.brain.skip_texts = skip_texts
 
         field_text = extracted_text.text
 
-        for split_id in self.sorted_splits(extracted_text):
+        for split_id in self.sorted_splits(extracted_text, deleted_splits=deleted_splits):
             split_text = extracted_text.split_text[split_id]
             field_text += f"{split_text} "
 
@@ -222,6 +225,7 @@ class ResourceBrain:
         skip_paragraphs_index: bool | None,
         skip_texts_index: bool | None,
         append_splits: set[str] | None = None,
+        deleted_splits: set[str] | None = None,
     ) -> None:
         """
         append_splits: when provided, only the splits in this set will be indexed. This is used for conversation appends, to
@@ -234,6 +238,7 @@ class ResourceBrain:
             extracted_text,
             replace_field=False,
             skip_texts=skip_texts_index,
+            deleted_splits=deleted_splits,
         )
         self.apply_field_paragraphs(
             field_key,
@@ -244,10 +249,17 @@ class ResourceBrain:
             replace_field=replace_field,
             skip_paragraphs=skip_paragraphs_index,
             append_splits=append_splits,
+            deleted_splits=deleted_splits,
         )
 
-    def sorted_splits(self, extracted_text: ExtractedText) -> Iterator[str]:
-        yield from sorted(extracted_text.split_text.keys())
+    def sorted_splits(
+        self, extracted_text: ExtractedText, deleted_splits: set[str] | None = None
+    ) -> Iterator[str]:
+        yield from sorted(
+            split_id
+            for split_id in extracted_text.split_text.keys()
+            if deleted_splits is None or split_id not in deleted_splits
+        )
 
     @observer.wrap({"type": "apply_field_paragraphs"})
     def apply_field_paragraphs(
@@ -260,6 +272,7 @@ class ResourceBrain:
         replace_field: bool,
         skip_paragraphs: bool | None,
         append_splits: set[str] | None = None,
+        deleted_splits: set[str] | None = None,
     ) -> None:
         if skip_paragraphs is not None:
             self.brain.skip_paragraphs = skip_paragraphs
@@ -272,9 +285,9 @@ class ResourceBrain:
         # Used to adjust the paragraph start/end when indexing splits, as they are all
         # concatenated in the main text part of the brain Resource.
         split_offset = 0
-        for subfield in self.sorted_splits(extracted_text):
+        for subfield in self.sorted_splits(extracted_text, deleted_splits=deleted_splits):
             if subfield not in field_computed_metadata.split_metadata or should_skip_split_indexing(
-                subfield, replace_field, append_splits
+                subfield, replace_field, append_splits, deleted_splits
             ):
                 # We're skipping this split but we need to adjust the offset as we have added the text
                 # of this split to the main text
@@ -528,10 +541,11 @@ class ResourceBrain:
         # cut to specific dimension if specified
         vector_dimension: int | None = None,
         append_splits: set[str] | None = None,
+        deleted_splits: set[str] | None = None,
     ):
         fid = ids.FieldId.from_string(f"{self.rid}/{field_id}")
         for subfield, vectors in vo.split_vectors.items():
-            if should_skip_split_indexing(subfield, replace_field, append_splits):
+            if should_skip_split_indexing(subfield, replace_field, append_splits, deleted_splits):
                 continue
             _field_id = ids.FieldId(
                 rid=fid.rid,
@@ -858,6 +872,11 @@ class ParagraphPages:
             return 0
 
 
-def should_skip_split_indexing(split: str, replace_field: bool, append_splits: set[str] | None) -> bool:
+def should_skip_split_indexing(
+    split: str, replace_field: bool, append_splits: set[str] | None, deleted_splits: set[str] | None
+) -> bool:
+    if deleted_splits is not None and split in deleted_splits:
+        # This split is deleted, we should skip indexing it
+        return True
     # When replacing the whole field, reindex all splits. Otherwise, we're only indexing the splits that are appended
     return not replace_field and append_splits is not None and split not in append_splits

--- a/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
+++ b/nucliadb/src/nucliadb/ingest/orm/brain_v2.py
@@ -19,6 +19,7 @@
 #
 import json
 import logging
+from collections import defaultdict
 from collections.abc import Iterator
 from copy import deepcopy
 from dataclasses import dataclass
@@ -407,7 +408,7 @@ class ResourceBrain:
     def _get_paragraph_user_classifications(
         self, basic_user_field_metadata: UserFieldMetadata | None
     ) -> ParagraphClassifications:
-        pc = ParagraphClassifications(valid={}, denied={})
+        pc = ParagraphClassifications(valid=defaultdict(list), denied=defaultdict(list))
         if basic_user_field_metadata is None:
             return pc
         for annotated_paragraph in basic_user_field_metadata.paragraphs:
@@ -415,9 +416,9 @@ class ResourceBrain:
                 paragraph_key = compute_paragraph_key(self.rid, annotated_paragraph.key)
                 classif_label = f"/l/{classification.labelset}/{classification.label}"
                 if classification.cancelled_by_user:
-                    pc.denied.setdefault(paragraph_key, []).append(classif_label)
+                    pc.denied[paragraph_key].append(classif_label)
                 else:
-                    pc.valid.setdefault(paragraph_key, []).append(classif_label)
+                    pc.valid[paragraph_key].append(classif_label)
         return pc
 
     @observer.wrap({"type": "generate_relations"})

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -76,6 +76,7 @@ class IndexMessageBuilder:
         replace: bool = True,
         vectorset_configs: list[VectorSetConfig] | None = None,
         append_splits: set[str] | None = None,
+        deleted_splits: set[str] | None = None,
     ):
         field = await self.resource.get_field(fieldid.field, fieldid.field_type)
         extracted_text = await field.get_extracted_text()
@@ -104,6 +105,7 @@ class IndexMessageBuilder:
                     field_author,
                     replace_field=replace_texts,
                     skip_index=skip_texts_index,
+                    deleted_splits=deleted_splits,
                 )
         if paragraphs or vectors:
             # The paragraphs are needed to generate the vectors. However, we don't need to index them
@@ -128,6 +130,7 @@ class IndexMessageBuilder:
                     skip_paragraphs_index=skip_paragraphs_index,
                     skip_texts_index=skip_texts_index,
                     append_splits=append_splits,
+                    deleted_splits=deleted_splits,
                 )
         if vectors:
             assert vectorset_configs is not None
@@ -146,6 +149,7 @@ class IndexMessageBuilder:
                         replace_field=replace,
                         vector_dimension=dimension,
                         append_splits=append_splits,
+                        deleted_splits=deleted_splits,
                     )
 
         if relations:
@@ -207,6 +211,8 @@ class IndexMessageBuilder:
         Builds the index message for the broker message coming from the writer.
         The writer messages are not adding new vectors to the index.
         """
+        vectorsets_configs = None
+
         assert message.source == BrokerMessage.MessageSource.WRITER
 
         self._apply_field_deletions(self.brain, message.delete_fields)
@@ -226,6 +232,14 @@ class IndexMessageBuilder:
         for fieldid in fields_to_index:
             if fieldid in message.delete_fields:
                 continue
+            deleted_splits = None
+            if fieldid.field_type == FieldType.CONVERSATION:
+                _, deleted_splits = await get_stored_split_ids(fieldid, self.resource)
+
+            vectors_update = needs_vectors_update(fieldid, message)
+            if vectors_update and vectorsets_configs is None:
+                vectorsets_configs = await self.get_vectorsets_configs()
+
             await self._apply_field_index_data(
                 self.brain,
                 fieldid,
@@ -233,8 +247,10 @@ class IndexMessageBuilder:
                 texts=prefilter_update or needs_texts_update(fieldid, message),
                 paragraphs=needs_paragraphs_update(fieldid, message),
                 relations=False,  # Relations at the field level are not modified by the writer
-                vectors=False,  # Vectors are never added by the writer
+                vectors=vectors_update,
+                vectorset_configs=vectorsets_configs,
                 replace=not resource_created,
+                deleted_splits=deleted_splits,
             )
         return self.brain.brain
 
@@ -264,9 +280,10 @@ class IndexMessageBuilder:
             # All other fields are always replaced upon modification.
             replace_field = True
             modified_splits = None
+            deleted_splits = None
             if fieldid.field_type == FieldType.CONVERSATION:
                 modified_splits = await get_bm_modified_split_ids(fieldid, message, self.resource)
-                stored_splits = await get_stored_split_ids(fieldid, self.resource)
+                stored_splits, deleted_splits = await get_stored_split_ids(fieldid, self.resource)
                 is_append_messages_op = modified_splits.issubset(stored_splits) and 0 < len(
                     modified_splits
                 ) < len(stored_splits)
@@ -289,6 +306,7 @@ class IndexMessageBuilder:
                 replace=replace_field,
                 vectorset_configs=vectorsets_configs,
                 append_splits=modified_splits,
+                deleted_splits=deleted_splits,
             )
         return self.brain.brain
 
@@ -302,6 +320,9 @@ class IndexMessageBuilder:
         ]
         vectorsets_configs = await self.get_vectorsets_configs()
         for fieldid in fields_to_index:
+            deleted_splits = None
+            if fieldid.field_type == FieldType.CONVERSATION:
+                _, deleted_splits = await get_stored_split_ids(fieldid, self.resource)
             await self._apply_field_index_data(
                 self.brain,
                 fieldid,
@@ -312,6 +333,7 @@ class IndexMessageBuilder:
                 vectors=True,
                 replace=reindex,
                 vectorset_configs=vectorsets_configs,
+                deleted_splits=deleted_splits,
             )
         return self.brain.brain
 
@@ -353,6 +375,10 @@ def get_bm_modified_fields(message: BrokerMessage) -> list[FieldID]:
         if message.basic.summary != "":
             modified.add(("summary", FieldType.GENERIC))
 
+    # Deleted splits also need reindexing of the field
+    for ds in message.delete_splits:
+        modified.add((ds.field.field, ds.field.field_type))
+
     if message.source == BrokerMessage.MessageSource.PROCESSOR:
         # Messages with field metadata, extracted text or field vectors need indexing
         for fm in message.field_metadata:
@@ -380,6 +406,7 @@ def needs_paragraphs_update(field_id: FieldID, message: BrokerMessage) -> bool:
         has_paragraph_annotations(field_id, message)
         or has_new_extracted_text(field_id, message)
         or has_new_field_metadata(field_id, message)
+        or has_deleted_splits(field_id, message)
     )
 
 
@@ -407,18 +434,34 @@ def has_new_extracted_text(
     return any(extracted_text.field == field_id for extracted_text in message.extracted_text)
 
 
+def has_deleted_splits(
+    field_id: FieldID,
+    message: BrokerMessage,
+) -> bool:
+    return any(
+        delete_split.field == field_id and len(delete_split.splits) > 0
+        for delete_split in message.delete_splits
+    )
+
+
 def needs_texts_update(
     field_id: FieldID,
     message: BrokerMessage,
 ) -> bool:
-    return has_new_extracted_text(field_id, message) or has_new_field_metadata(field_id, message)
+    return (
+        has_new_extracted_text(field_id, message)
+        or has_new_field_metadata(field_id, message)
+        or has_deleted_splits(field_id, message)
+    )
 
 
 def needs_vectors_update(
     field_id: FieldID,
     message: BrokerMessage,
 ) -> bool:
-    return any(field_vectors.field == field_id for field_vectors in message.field_vectors)
+    return has_deleted_splits(field_id, message) or any(
+        field_vectors.field == field_id for field_vectors in message.field_vectors
+    )
 
 
 async def get_bm_modified_split_ids(
@@ -445,11 +488,13 @@ async def get_bm_modified_split_ids(
 async def get_stored_split_ids(
     conversation_field_id: FieldID,
     resource: Resource,
-) -> set[str]:
+) -> tuple[set[str], set[str]]:
     fid = conversation_field_id
     conv: Conversation = await resource.get_field(fid.field, fid.field_type, load=False)
     splits_metadata = await conv.get_splits_metadata()
-    return set(splits_metadata.metadata)
+    deleted_splits = set(splits_metadata.deleted_splits)
+    non_deleted_splits = set(splits_metadata.metadata.keys()) - deleted_splits
+    return non_deleted_splits, deleted_splits
 
 
 def needs_relations_update(

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -493,8 +493,8 @@ async def get_stored_split_ids(
     conv: Conversation = await resource.get_field(fid.field, fid.field_type, load=False)
     splits_metadata = await conv.get_splits_metadata()
     deleted_splits = set(splits_metadata.deleted_splits)
-    non_deleted_splits = set(splits_metadata.metadata.keys()) - deleted_splits
-    return non_deleted_splits, deleted_splits
+    existing_splits = set(splits_metadata.metadata.keys()) - deleted_splits
+    return existing_splits, deleted_splits
 
 
 def needs_relations_update(

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -344,9 +344,8 @@ class Processor:
                 else:  # pragma: no cover
                     raise InvalidBrokerMessage(f"Unknown broker message source: {message.source}")
 
-                # apply changes from the broker message to the resource
+                # apply changes from the broker message to the
                 await self.apply_resource(message, resource, update=(not created))
-
                 # index message
                 if resource.modified:
                     index_message = await self.generate_index_message(resource, message, created)

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -344,8 +344,9 @@ class Processor:
                 else:  # pragma: no cover
                     raise InvalidBrokerMessage(f"Unknown broker message source: {message.source}")
 
-                # apply changes from the broker message to the
+                # apply changes from the broker message to the resource
                 await self.apply_resource(message, resource, update=(not created))
+
                 # index message
                 if resource.modified:
                     index_message = await self.generate_index_message(resource, message, created)

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -368,6 +368,7 @@ class Resource:
         field = await self.get_field(payload.field.field, FieldType.CONVERSATION)
         conv = cast(Conversation, field)
         await conv.delete_messages(payload.splits)
+        self.modified = True
 
     async def field_exists(self, type: FieldType.ValueType, field: str) -> bool:
         """Return whether this resource has this field or not."""

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -23,7 +23,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 
 from nucliadb.common import datamanagers, file_md5
 from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG
@@ -362,6 +362,13 @@ class Resource:
                 self.all_fields_keys.remove(field)
         await field_obj.delete()
 
+    async def delete_splits(self, payload: writer_pb2.DeleteSplits) -> None:
+        if payload.field.field_type != FieldType.CONVERSATION:
+            raise ValueError("delete_splits can only be applied to conversation fields")
+        field = await self.get_field(payload.field.field, FieldType.CONVERSATION)
+        conv = cast(Conversation, field)
+        await conv.delete_messages(payload.splits)
+
     async def field_exists(self, type: FieldType.ValueType, field: str) -> bool:
         """Return whether this resource has this field or not."""
         all_fields_ids = await self.get_fields_ids()
@@ -449,6 +456,9 @@ class Resource:
             await self.delete_field(fieldid.field_type, fieldid.field)
             if fieldid.field_type == FieldType.FILE:
                 await self.delete_file_field_md5(fieldid.field)
+
+        for delete_splits in message.delete_splits:
+            await self.delete_splits(delete_splits)
 
         if len(message_updated_fields) or len(message.delete_fields) or len(message.errors):
             await self.update_all_field_ids(

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -362,9 +362,9 @@ class Resource:
                 self.all_fields_keys.remove(field)
         await field_obj.delete()
 
-    async def delete_splits(self, payload: writer_pb2.DeleteSplits) -> None:
+    async def _apply_delete_splits(self, payload: writer_pb2.DeleteSplits) -> None:
         if payload.field.field_type != FieldType.CONVERSATION:
-            raise ValueError("delete_splits can only be applied to conversation fields")
+            raise ValueError("_apply_delete_splits can only be applied to conversation fields")
         field = await self.get_field(payload.field.field, FieldType.CONVERSATION)
         conv = cast(Conversation, field)
         await conv.delete_messages(payload.splits)
@@ -459,7 +459,7 @@ class Resource:
                 await self.delete_file_field_md5(fieldid.field)
 
         for delete_splits in message.delete_splits:
-            await self.delete_splits(delete_splits)
+            await self._apply_delete_splits(delete_splits)
 
         if len(message_updated_fields) or len(message.delete_fields) or len(message.errors):
             await self.update_all_field_ids(

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -437,7 +437,15 @@ async def _get_resource_field(
 
                 value = await field.get_value(page=page_to_fetch)
                 if value is not None:
+                    splits_metadata = await field.get_splits_metadata()
+                    deleted_messages = set(splits_metadata.deleted_splits)
                     resource_field.value = from_proto.conversation(value)
+                    # Skip deleted messages
+                    resource_field.value.messages = [
+                        msg
+                        for msg in (resource_field.value.messages or [])
+                        if msg.ident not in deleted_messages
+                    ]
 
         if (
             ResourceFieldProperties.EXTRACTED in show

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -482,11 +482,24 @@ async def find_conversation_message(
 ) -> tuple[int, int, resources_pb2.Message] | None:
     """Find a message in the conversation identified by `ident`."""
     conversation_metadata = await field.get_metadata()
-    for page in range(1, conversation_metadata.pages + 1):
-        conversation = await field.db_get_value(page)
+    splits_metadata = await field.get_splits_metadata()
+    deleted_splits = set(splits_metadata.deleted_splits)
+    if ident in deleted_splits:
+        return None
+    split_meta = splits_metadata.metadata.get(ident)
+    if split_meta is not None:
+        # Go directly to the page specified in the split metadata.
+        conversation = await field.db_get_value(split_meta.page)
         for idx, message in enumerate(conversation.messages):
             if message.ident == ident:
-                return page, idx, message
+                return split_meta.page, idx, message
+    else:
+        # Fallback to scroll all the conversation pages until we find it.
+        for page in range(1, conversation_metadata.pages + 1):
+            conversation = await field.db_get_value(page)
+            for idx, message in enumerate(conversation.messages):
+                if message.ident == ident:
+                    return page, idx, message
     return None
 
 
@@ -501,9 +514,14 @@ async def iter_conversation_messages(
     """
     start_page, start_index = start_from
     conversation_metadata = await field.get_metadata()
+    splits_metadata = await field.get_splits_metadata()
+    deleted_splits = set(splits_metadata.deleted_splits)
     for page in range(start_page, conversation_metadata.pages + 1):
         conversation = await field.db_get_value(page)
         for idx, message in enumerate(conversation.messages[start_index:]):
+            if message.ident in deleted_splits:
+                # Message has been deleted, skip it
+                continue
             yield (page, start_index + idx, message)
         # next iteration we want all messages
         start_index = 0

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -485,6 +485,7 @@ async def find_conversation_message(
     splits_metadata = await field.get_splits_metadata()
     deleted_splits = set(splits_metadata.deleted_splits)
     if ident in deleted_splits:
+        # The message has been deleted, we consider it not found.
         return None
     split_meta = splits_metadata.metadata.get(ident)
     if split_meta is not None:

--- a/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/augmentor/paragraphs.py
@@ -325,6 +325,11 @@ async def get_paragraph_text_from_storage(field: Field, paragraph_id: ParagraphI
     end = paragraph_id.paragraph_end
 
     if split:
+        if isinstance(field, Conversation):
+            splits_metadata = await field.get_splits_metadata()
+            if split in set(splits_metadata.deleted_splits):
+                # Deleted splits should not be augmented.
+                return None
         return extracted_text.split_text[split][start:end]
     else:
         return extracted_text.text[start:end]

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -19,17 +19,20 @@
 #
 from collections.abc import Callable
 from inspect import iscoroutinefunction
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, cast
 
 import pydantic
-from fastapi import HTTPException, Query, Response
+from fastapi import HTTPException, Path, Query, Response
 from fastapi_versioning import version
 from starlette.requests import Request
 
 import nucliadb_models as models
+from nucliadb.common import datamanagers
 from nucliadb.common.back_pressure import maybe_back_pressure
 from nucliadb.common.maindb.utils import get_driver
+from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.knowledgebox import Resource as ORMResource
 from nucliadb.models.internal.processing import PushPayload, Source
 from nucliadb.writer import SERVICE_NAME
 from nucliadb.writer.api.constants import (
@@ -61,7 +64,7 @@ from nucliadb_models.utils import FieldIdString
 from nucliadb_models.writer import KeyValueField, ResourceFieldAdded, ResourceUpdated
 from nucliadb_protos import resources_pb2
 from nucliadb_protos.resources_pb2 import FieldID, Metadata
-from nucliadb_protos.writer_pb2 import BrokerMessage, FieldIDStatus, FieldStatus
+from nucliadb_protos.writer_pb2 import BrokerMessage, DeleteSplits, FieldIDStatus, FieldStatus
 from nucliadb_utils.authentication import requires
 from nucliadb_utils.exceptions import LimitsExceededError, SendToProcessError
 from nucliadb_utils.utilities import (
@@ -686,3 +689,110 @@ async def reprocess_file_field(
         )
 
     return ResourceUpdated(seqid=processing_info.seqid)
+
+
+DELETE_CONVERSATION_MESSAGES_DESCRIPTION = (
+    "Delete a message from a conversation field by its ident. "
+    "Note: deleting too many messages in a single conversation can degrade the performance "
+    "of the conversation field. This endpoint is not meant to be a mutability primitive, "
+    "but is rather a convenience endpoint for occasional deletions."
+)
+
+
+MessageIdent = Annotated[str, Path(max_length=128, description="The ident of the message to delete")]
+
+
+@api.delete(
+    f"/{KB_PREFIX}/{{kbid}}/{RSLUG_PREFIX}/{{rslug}}/conversation/{{field_id}}/messages/{{message_ident}}",
+    status_code=200,
+    summary="Delete conversation message (by slug)",
+    description=DELETE_CONVERSATION_MESSAGES_DESCRIPTION,
+    tags=["Resource fields"],
+)
+@requires(NucliaDBRoles.WRITER)
+@version(1)
+async def delete_conversation_messages_rslug_prefix(
+    request: Request,
+    kbid: str,
+    rslug: str,
+    field_id: FieldIdString,
+    message_ident: MessageIdent,
+) -> Response:
+    rid = await get_rid_from_slug_or_raise_error(kbid, rslug)
+    return await _delete_conversation_messages(kbid, rid, field_id, [message_ident])
+
+
+@api.delete(
+    f"/{KB_PREFIX}/{{kbid}}/{RESOURCE_PREFIX}/{{rid}}/conversation/{{field_id}}/messages/{{message_ident}}",
+    status_code=200,
+    summary="Delete conversation message (by id)",
+    description=DELETE_CONVERSATION_MESSAGES_DESCRIPTION,
+    tags=["Resource fields"],
+)
+@requires(NucliaDBRoles.WRITER)
+@version(1)
+async def delete_conversation_messages_rid_prefix(
+    request: Request,
+    kbid: str,
+    rid: str,
+    field_id: FieldIdString,
+    message_ident: MessageIdent,
+) -> Response:
+    return await _delete_conversation_messages(kbid, rid, field_id, [message_ident])
+
+
+async def validate_field_exists_or_raise_error(
+    kbid: str, rid: str, field_id: str, field_type: resources_pb2.FieldType.ValueType
+):
+    all_field_ids = await datamanagers.atomic.resources.get_all_field_ids(kbid=kbid, rid=rid)
+    if all_field_ids is not None and any(
+        fid.field == field_id and fid.field_type == field_type for fid in all_field_ids.fields
+    ):
+        # Field was found, return early
+        return
+    raise HTTPException(status_code=404, detail="Conversation field does not exist")
+
+
+async def validate_message_idents(kbid: str, rid: str, field_id: str, idents: list[str]) -> list[str]:
+    """
+    Takes the user provided idents to delete and checks agains the conversation metadata to return
+    only the valid idents that can be deleted (i.e. that exist and haven't been previously deleted).
+    This is to avoid sending to process invalid delete messages that would cause unnecessary load.
+    """
+    async with datamanagers.with_ro_transaction() as txn:
+        resource_obj = await ORMResource.get(txn, kbid=kbid, rid=rid)
+        if resource_obj is None:
+            # Resource not found, nothing to delete
+            return []
+        field = await resource_obj.get_field(field_id, resources_pb2.FieldType.CONVERSATION, load=False)
+        conv = cast(Conversation, field)
+        splits_metadata = await conv.get_splits_metadata()
+        previously_deleted_idents = set(splits_metadata.deleted_splits)
+        valid_idents = set(splits_metadata.metadata.keys()) - previously_deleted_idents
+        return list(set(idents) & valid_idents)
+
+
+async def _delete_conversation_messages(
+    kbid: str,
+    rid: str,
+    field_id: str,
+    message_idents: list[str],
+) -> Response:
+    await validate_rid_exists_or_raise_error(kbid, rid)
+    await validate_field_exists_or_raise_error(kbid, rid, field_id, resources_pb2.FieldType.CONVERSATION)
+    to_delete = await validate_message_idents(kbid, rid, field_id, message_idents)
+    if len(to_delete) == 0:
+        # No valid message idents to delete, return early to avoid unnecessary load
+        return Response(status_code=200)
+
+    writer = BrokerMessage(kbid=kbid, uuid=rid, source=BrokerMessage.MessageSource.WRITER)
+    delete_splits = DeleteSplits(
+        field=FieldID(field=field_id, field_type=resources_pb2.FieldType.CONVERSATION),
+        splits=to_delete,
+    )
+    writer.delete_splits.append(delete_splits)
+
+    partitioning = get_partitioning()
+    partition = partitioning.generate_partition(kbid, rid)
+    await transaction.commit(writer, partition)
+    return Response(status_code=200)

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -693,9 +693,9 @@ async def reprocess_file_field(
 
 DELETE_CONVERSATION_MESSAGES_DESCRIPTION = (
     "Delete a message from a conversation field by its ident. "
-    "Note: deleting too many messages in a single conversation can degrade the performance "
-    "of the conversation field. This endpoint is not meant to be a mutability primitive, "
-    "but is rather a convenience endpoint for occasional deletions."
+    "This is a convenience endpoint intended for occasional deletions — "
+    "frequent use on the same conversation may degrade read performance over time. "
+    "Deleted message identifiers are permanently reserved and cannot be reused."
 )
 
 
@@ -704,7 +704,7 @@ MessageIdent = Annotated[str, Path(max_length=128, description="The ident of the
 
 @api.delete(
     f"/{KB_PREFIX}/{{kbid}}/{RSLUG_PREFIX}/{{rslug}}/conversation/{{field_id}}/messages/{{message_ident}}",
-    status_code=200,
+    status_code=204,
     summary="Delete conversation message (by slug)",
     description=DELETE_CONVERSATION_MESSAGES_DESCRIPTION,
     tags=["Resource fields"],
@@ -724,7 +724,7 @@ async def delete_conversation_messages_rslug_prefix(
 
 @api.delete(
     f"/{KB_PREFIX}/{{kbid}}/{RESOURCE_PREFIX}/{{rid}}/conversation/{{field_id}}/messages/{{message_ident}}",
-    status_code=200,
+    status_code=204,
     summary="Delete conversation message (by id)",
     description=DELETE_CONVERSATION_MESSAGES_DESCRIPTION,
     tags=["Resource fields"],
@@ -783,7 +783,7 @@ async def _delete_conversation_messages(
     to_delete = await validate_message_idents(kbid, rid, field_id, message_idents)
     if len(to_delete) == 0:
         # No valid message idents to delete, return early to avoid unnecessary load
-        return Response(status_code=200)
+        return Response(status_code=204)
 
     writer = BrokerMessage(kbid=kbid, uuid=rid, source=BrokerMessage.MessageSource.WRITER)
     delete_splits = DeleteSplits(
@@ -795,4 +795,4 @@ async def _delete_conversation_messages(
     partitioning = get_partitioning()
     partition = partitioning.generate_partition(kbid, rid)
     await transaction.commit(writer, partition)
-    return Response(status_code=200)
+    return Response(status_code=204)

--- a/nucliadb/tests/ndbfixtures/resources/lambs.py
+++ b/nucliadb/tests/ndbfixtures/resources/lambs.py
@@ -51,6 +51,19 @@ from tests.utils import inject_message
 from tests.utils.broker_messages import BrokerMessageBuilder
 from tests.utils.dirty_index import wait_for_sync
 
+lambs_split_1_text = "Starling."
+lambs_split_2_text = "Well, Clarice, have the lambs stopped screaming...?"
+lambs_split_3_text = "Don't bother with a trace, I won't be on long enough."
+lambs_split_4_text = "Where are you, Dr. Lecter?"
+lambs_split_5_text = "Where I have a view, Clarice..."
+lambs_split_6_text = "Orion is looking splendid tonight, and Arcturus, the Herdsman, with his flock..."
+lambs_split_7_text = "Your lambs are still for now, Clarice, but not forever... You'll have to earn it again and again, this blessed silence. Because it's the plight that drives you, and the plight will never end."
+lambs_split_8_text = "Dr. Lecter -"
+lambs_split_9_text = "I have no plans to call on you, Clarice, the world being more interesting with you in it. Be sure you extend me the same courtesy."
+lambs_split_10_text = "You know I can't make that promise."
+lambs_split_11_text = "Goodbye, Clarice... You looked - so very lovely today in your blue suit."
+lambs_split_12_text = "Dr. Lecter... Dr. Lecter...!"
+
 
 async def lambs_resource(
     kbid: str,
@@ -110,7 +123,7 @@ async def lambs_resource(
                             "who": clarice,
                             "to": [lecter],
                             "content": {
-                                "text": "Starling.",
+                                "text": lambs_split_1_text,
                             },
                         },
                         {
@@ -118,7 +131,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "Well, Clarice, have the lambs stopped screaming...?",
+                                "text": lambs_split_2_text,
                                 "attachments_fields": [
                                     {
                                         "field_type": "file",
@@ -133,7 +146,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "Don't bother with a trace, I won't be on long enough.",
+                                "text": lambs_split_3_text,
                             },
                         },
                         {
@@ -141,7 +154,7 @@ async def lambs_resource(
                             "who": clarice,
                             "to": [lecter],
                             "content": {
-                                "text": "Where are you, Dr. Lecter?",
+                                "text": lambs_split_4_text,
                             },
                             "type": MessageType.QUESTION.value,
                         },
@@ -150,7 +163,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "Where I have a view, Clarice...",
+                                "text": lambs_split_5_text,
                             },
                             "type": MessageType.ANSWER.value,
                         },
@@ -159,7 +172,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "Orion is looking splendid tonight, and Arcturus, the Herdsman, with his flock...",
+                                "text": lambs_split_6_text,
                             },
                         },
                         {
@@ -167,7 +180,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "Your lambs are still for now, Clarice, but not forever... You'll have to earn it again and again, this blessed silence. Because it's the plight that drives you, and the plight will never end.",
+                                "text": lambs_split_7_text,
                             },
                         },
                         {
@@ -175,7 +188,7 @@ async def lambs_resource(
                             "who": clarice,
                             "to": [lecter],
                             "content": {
-                                "text": "Dr. Lecter -",
+                                "text": lambs_split_8_text,
                             },
                         },
                         {
@@ -183,7 +196,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "I have no plans to call on you, Clarice, the world being more interesting with you in it. Be sure you extend me the same courtesy.",
+                                "text": lambs_split_9_text,
                             },
                         },
                         {
@@ -191,7 +204,7 @@ async def lambs_resource(
                             "who": clarice,
                             "to": [lecter],
                             "content": {
-                                "text": "You know I can't make that promise.",
+                                "text": lambs_split_10_text,
                             },
                         },
                         {
@@ -199,7 +212,7 @@ async def lambs_resource(
                             "who": lecter,
                             "to": [clarice],
                             "content": {
-                                "text": "Goodbye, Clarice... You looked - so very lovely today in your blue suit.",
+                                "text": lambs_split_11_text,
                                 "attachments_fields": [
                                     {
                                         "field_type": "file",
@@ -213,7 +226,7 @@ async def lambs_resource(
                             "who": clarice,
                             "to": [lecter],
                             "content": {
-                                "text": "Dr. Lecter... Dr. Lecter...!",
+                                "text": lambs_split_12_text,
                             },
                         },
                     ]
@@ -234,18 +247,18 @@ async def lambs_resource(
                 {
                     "body": {
                         "splitText": {
-                            "5": "Where I have a view, Clarice...",
-                            "11": "Goodbye, Clarice... You looked - so very lovely today in your blue suit.",
-                            "8": "Dr. Lecter -",
-                            "2": "Well, Clarice, have the lambs stopped screaming...?",
-                            "3": "Don't bother with a trace, I won't be on long enough.",
-                            "1": "Starling.",
-                            "9": "I have no plans to call on you, Clarice, the world being more interesting with you in it. Be sure you extend me the same courtesy.",
-                            "7": "Your lambs are still for now, Clarice, but not forever... You'll have to earn it again and again, this blessed silence. Because it's the plight that drives you, and the plight will never end.",
-                            "4": "Where are you, Dr. Lecter?",
-                            "6": "Orion is looking splendid tonight, and Arcturus, the Herdsman, with his flock...",
-                            "12": "Dr. Lecter... Dr. Lecter...!",
-                            "10": "You know I can't make that promise.",
+                            "5": lambs_split_5_text,
+                            "11": lambs_split_11_text,
+                            "8": lambs_split_8_text,
+                            "2": lambs_split_2_text,
+                            "3": lambs_split_3_text,
+                            "1": lambs_split_1_text,
+                            "9": lambs_split_9_text,
+                            "7": lambs_split_7_text,
+                            "4": lambs_split_4_text,
+                            "6": lambs_split_6_text,
+                            "12": lambs_split_12_text,
+                            "10": lambs_split_10_text,
                         }
                     },
                     "field": {"fieldType": "CONVERSATION", "field": "lambs"},

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -1209,3 +1209,20 @@ async def test_delete_conversation_message(
         f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/{long_ident}",
     )
     assert resp.status_code == 422
+
+    # Verify that a deleted message ident cannot be reused
+    resp = await nucliadb_writer.put(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages",
+        json=[
+            {
+                "to": ["assistant"],
+                "who": "user",
+                "timestamp": datetime.now().isoformat(),
+                "content": {"text": "Trying to reuse deleted ident"},
+                "ident": "msg2",  # This was deleted earlier
+                "type": MessageType.QUESTION.value,
+            },
+        ],
+    )
+    assert resp.status_code == 422
+    assert "must be unique" in resp.json()["detail"]

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -784,6 +784,67 @@ async def test_replace_conversation_with_put_endpoint_deletes_previous_pages(
     assert body["value"]["messages"][0]["ident"] == "x"
 
 
+async def _test_keyword_search(
+    nucliadb_reader: AsyncClient,
+    kbid: str,
+    message_text: str,
+    message_id: str,
+    top_k: int = 1,
+    min_score: float | dict | None = None,
+):
+    payload = {
+        "query": message_text,
+        "features": ["keyword"],
+        "top_k": top_k,
+        "reranker": "noop",
+    }
+    if min_score is not None:
+        payload["min_score"] = min_score
+
+    # Test keyword search retrieves the right message
+    resp = await nucliadb_reader.post(
+        f"/kb/{kbid}/find",
+        json=payload,
+    )
+    assert resp.status_code == 200
+    results = KnowledgeboxFindResults.model_validate(resp.json())
+    assert message_id in results.best_matches
+    assert (
+        results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text == message_text
+    )
+
+
+async def _test_semantic_search(
+    nucliadb_reader: AsyncClient,
+    kbid: str,
+    message_text: str,
+    message_id: str,
+    message_vector: list[float],
+    top_k: int = 1,
+    min_score: float | dict | None = None,
+):
+    payload = {
+        "vector": message_vector,
+        "features": ["semantic"],
+        "top_k": top_k,
+        "reranker": "noop",
+        "vectorset": "multilingual",
+    }
+    if min_score is not None:
+        payload["min_score"] = min_score
+    # Test semantic search retrieves the right message
+    resp = await nucliadb_reader.post(
+        f"/kb/{kbid}/find",
+        json=payload,
+    )
+    assert resp.status_code == 200
+    results = KnowledgeboxFindResults.model_validate(resp.json())
+    assert message_id in results.best_matches
+    assert (
+        results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text == message_text
+    )
+
+
 @pytest.mark.deploy_modes("standalone")
 async def test_conversation_search(
     nucliadb_writer: AsyncClient,
@@ -798,46 +859,8 @@ async def test_conversation_search(
     message_id = f"{rid}/c/lambs/6/0-80"
     message_vector = lambs_split_6_vector[:512]
 
-    async def _test_keyword_search(message_text: str, message_id: str):
-        # Test keyword search retrieves the right message
-        resp = await nucliadb_reader.post(
-            f"/kb/{kbid}/find",
-            json={
-                "query": message_text,
-                "features": ["keyword"],
-                "top_k": 1,
-            },
-        )
-        assert resp.status_code == 200
-        results = KnowledgeboxFindResults.model_validate(resp.json())
-        assert message_id in results.best_matches
-        assert (
-            results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text
-            == message_text
-        )
-
-    async def _test_semantic_search(message_text: str, message_id: str, message_vector: list[float]):
-        # Test semantic search retrieves the right message
-        resp = await nucliadb_reader.post(
-            f"/kb/{kbid}/find",
-            json={
-                "vector": message_vector,
-                "features": ["semantic"],
-                "top_k": 1,
-                "reranker": "noop",
-                "vectorset": "multilingual",
-            },
-        )
-        assert resp.status_code == 200
-        results = KnowledgeboxFindResults.model_validate(resp.json())
-        assert message_id in results.best_matches
-        assert (
-            results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text
-            == message_text
-        )
-
-    await _test_keyword_search(message_text, message_id)
-    await _test_semantic_search(message_text, message_id, message_vector)
+    await _test_keyword_search(nucliadb_reader, kbid, message_text, message_id)
+    await _test_semantic_search(nucliadb_reader, kbid, message_text, message_id, message_vector)
 
     # Add another message to the conversation, to test that indexing works on partial updates too
     new_message_text = "Foo barba foo barba foo."
@@ -878,12 +901,14 @@ async def test_conversation_search(
     await wait_for_sync()
 
     # Previous searches still work
-    await _test_keyword_search(message_text, message_id)
-    await _test_semantic_search(message_text, message_id, message_vector)
+    await _test_keyword_search(nucliadb_reader, kbid, message_text, message_id)
+    await _test_semantic_search(nucliadb_reader, kbid, message_text, message_id, message_vector)
 
     # New message is searchable too
-    await _test_keyword_search(new_message_text, new_message_id)
-    await _test_semantic_search(new_message_text, new_message_id, new_message_vector)
+    await _test_keyword_search(nucliadb_reader, kbid, new_message_text, new_message_id)
+    await _test_semantic_search(
+        nucliadb_reader, kbid, new_message_text, new_message_id, new_message_vector
+    )
 
 
 @pytest.mark.deploy_modes("standalone")
@@ -972,10 +997,19 @@ async def test_append_messages_to_non_existent_conversation_field_creates_it(
 async def test_delete_conversation_message(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,
+    nucliadb_ingest_grpc: WriterStub,
     standalone_knowledgebox: str,
 ):
-    """Test that deleting a message from a conversation field works correctly."""
+    """Test that deleting a message from a conversation field works correctly,
+    including keyword and semantic search verification."""
     kbid = standalone_knowledgebox
+
+    msg1_text = "Hello from the user -- common text"
+    msg2_text = "Hi there from the assistant -- common text"
+    msg3_text = "How are you doing today -- common text"
+    msg1_vector = [-1.0] * 512
+    msg2_vector = [0.0] * 512
+    msg3_vector = [1.0] * 512
 
     # Create a resource with a conversation field containing 3 messages
     resp = await nucliadb_writer.post(
@@ -990,7 +1024,7 @@ async def test_delete_conversation_message(
                             "to": ["assistant"],
                             "who": "user",
                             "timestamp": datetime.now().isoformat(),
-                            "content": {"text": "Hello"},
+                            "content": {"text": msg1_text},
                             "ident": "msg1",
                             "type": MessageType.QUESTION.value,
                         },
@@ -998,7 +1032,7 @@ async def test_delete_conversation_message(
                             "to": ["user"],
                             "who": "assistant",
                             "timestamp": datetime.now().isoformat(),
-                            "content": {"text": "Hi there!"},
+                            "content": {"text": msg2_text},
                             "ident": "msg2",
                             "type": MessageType.ANSWER.value,
                         },
@@ -1006,7 +1040,7 @@ async def test_delete_conversation_message(
                             "to": ["assistant"],
                             "who": "user",
                             "timestamp": datetime.now().isoformat(),
-                            "content": {"text": "How are you?"},
+                            "content": {"text": msg3_text},
                             "ident": "msg3",
                             "type": MessageType.QUESTION.value,
                         },
@@ -1017,6 +1051,33 @@ async def test_delete_conversation_message(
     )
     assert resp.status_code == 201
     rid = resp.json()["uuid"]
+
+    msg1_pid = f"{rid}/c/chat/msg1/0-{len(msg1_text)}"
+    msg2_pid = f"{rid}/c/chat/msg2/0-{len(msg2_text)}"
+    msg3_pid = f"{rid}/c/chat/msg3/0-{len(msg3_text)}"
+
+    # Inject synthetic extracted data for the conversation messages
+    bmb = BrokerMessageBuilder(
+        kbid=kbid,
+        rid=rid,
+        source=BrokerMessage.MessageSource.PROCESSOR,
+    )
+    conv = bmb.field_builder("chat", FieldType.CONVERSATION)
+    for split, text, vector in [
+        ("msg1", msg1_text, msg1_vector),
+        ("msg2", msg2_text, msg2_vector),
+        ("msg3", msg3_text, msg3_vector),
+    ]:
+        conv.add_paragraph(
+            text=text,
+            split=split,
+            vectors={"multilingual": vector},
+        )
+    bm = bmb.build()
+    await inject_message(nucliadb_ingest_grpc, bm)
+
+    await mark_dirty()
+    await wait_for_sync()
 
     # Verify all 3 messages are present
     resp = await nucliadb_reader.get(
@@ -1029,11 +1090,23 @@ async def test_delete_conversation_message(
     assert len(msgs) == 3
     assert [m["ident"] for m in msgs] == ["msg1", "msg2", "msg3"]
 
-    # Delete the second message by rid
+    # Verify all messages are searchable before deletion
+    for text, vector, pid in [
+        (msg1_text, msg1_vector, msg1_pid),
+        (msg2_text, msg2_vector, msg2_pid),
+        (msg3_text, msg3_vector, msg3_pid),
+    ]:
+        await _test_keyword_search(nucliadb_reader, kbid, text, pid)
+        await _test_semantic_search(nucliadb_reader, kbid, text, pid, vector)
+
+    # Delete the second message by resource id
     resp = await nucliadb_writer.delete(
         f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/msg2",
     )
     assert resp.status_code == 200
+
+    await mark_dirty()
+    await wait_for_sync()
 
     # Verify msg2 is gone but msg1 and msg3 remain
     resp = await nucliadb_reader.get(
@@ -1044,6 +1117,42 @@ async def test_delete_conversation_message(
     field_resp = ResourceField.model_validate(resp.json())
     msgs = field_resp.value["messages"]  # type: ignore
     assert [m["ident"] for m in msgs] == ["msg1", "msg3"]
+
+    # Verify msg2 is no longer found by keyword search
+    resp = await nucliadb_reader.post(
+        f"/kb/{kbid}/find",
+        json={
+            "query": "common text",
+            "features": ["keyword"],
+            "top_k": 5,
+            "min_score": {"bm25": 0},  # to include all results regardless of score
+        },
+    )
+    assert resp.status_code == 200
+    results = KnowledgeboxFindResults.model_validate(resp.json())
+    assert msg2_pid not in results.best_matches
+    # Verify msg1 and msg3 are still searchable
+    assert msg1_pid in results.best_matches
+    assert msg3_pid in results.best_matches
+
+    # Verify msg2 is no longer found by semantic search
+    resp = await nucliadb_reader.post(
+        f"/kb/{kbid}/find",
+        json={
+            "vector": msg2_vector,
+            "features": ["semantic"],
+            "top_k": 5,
+            "reranker": "noop",
+            "vectorset": "multilingual",
+            "min_score": -1,  # to include all results regardless of score
+        },
+    )
+    assert resp.status_code == 200
+    results = KnowledgeboxFindResults.model_validate(resp.json())
+    assert msg2_pid not in results.best_matches
+    # Verify msg1 and msg3 are still searchable
+    assert msg1_pid in results.best_matches
+    assert msg3_pid in results.best_matches
 
     # Delete the second message again -- should be a no-op (already deleted)
     resp = await nucliadb_writer.delete(
@@ -1063,6 +1172,9 @@ async def test_delete_conversation_message(
     )
     assert resp.status_code == 200
 
+    await mark_dirty()
+    await wait_for_sync()
+
     # Verify only msg1 remains
     resp = await nucliadb_reader.get(
         f"/kb/{kbid}/resource/{rid}/conversation/chat",
@@ -1072,6 +1184,10 @@ async def test_delete_conversation_message(
     field_resp = ResourceField.model_validate(resp.json())
     msgs = field_resp.value["messages"]  # type: ignore
     assert [m["ident"] for m in msgs] == ["msg1"]
+
+    # Verify msg1 is still searchable
+    await _test_keyword_search(nucliadb_reader, kbid, msg1_text, msg1_pid)
+    await _test_semantic_search(nucliadb_reader, kbid, msg1_text, msg1_pid, msg1_vector)
 
     # Verify error cases
 

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -966,3 +966,130 @@ async def test_append_messages_to_non_existent_conversation_field_creates_it(
     assert conv_field.value is not None
     assert conv_field.value.total == 2
     assert conv_field.value.pages == 1
+
+
+@pytest.mark.deploy_modes("standalone")
+async def test_delete_conversation_message(
+    nucliadb_writer: AsyncClient,
+    nucliadb_reader: AsyncClient,
+    standalone_knowledgebox: str,
+):
+    """Test that deleting a message from a conversation field works correctly."""
+    kbid = standalone_knowledgebox
+
+    # Create a resource with a conversation field containing 3 messages
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/resources",
+        json={
+            "slug": "test_delete_msg",
+            "title": "Test Delete Message",
+            "conversations": {
+                "chat": {
+                    "messages": [
+                        {
+                            "to": ["assistant"],
+                            "who": "user",
+                            "timestamp": datetime.now().isoformat(),
+                            "content": {"text": "Hello"},
+                            "ident": "msg1",
+                            "type": MessageType.QUESTION.value,
+                        },
+                        {
+                            "to": ["user"],
+                            "who": "assistant",
+                            "timestamp": datetime.now().isoformat(),
+                            "content": {"text": "Hi there!"},
+                            "ident": "msg2",
+                            "type": MessageType.ANSWER.value,
+                        },
+                        {
+                            "to": ["assistant"],
+                            "who": "user",
+                            "timestamp": datetime.now().isoformat(),
+                            "content": {"text": "How are you?"},
+                            "ident": "msg3",
+                            "type": MessageType.QUESTION.value,
+                        },
+                    ]
+                },
+            },
+        },
+    )
+    assert resp.status_code == 201
+    rid = resp.json()["uuid"]
+
+    # Verify all 3 messages are present
+    resp = await nucliadb_reader.get(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat",
+        params={"page": 1, "show": ["value"]},
+    )
+    assert resp.status_code == 200
+    field_resp = ResourceField.model_validate(resp.json())
+    msgs = field_resp.value["messages"]  # type: ignore
+    assert len(msgs) == 3
+    assert [m["ident"] for m in msgs] == ["msg1", "msg2", "msg3"]
+
+    # Delete the second message by rid
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/msg2",
+    )
+    assert resp.status_code == 200
+
+    # Verify msg2 is gone but msg1 and msg3 remain
+    resp = await nucliadb_reader.get(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat",
+        params={"page": 1, "show": ["value"]},
+    )
+    assert resp.status_code == 200
+    field_resp = ResourceField.model_validate(resp.json())
+    msgs = field_resp.value["messages"]  # type: ignore
+    assert [m["ident"] for m in msgs] == ["msg1", "msg3"]
+
+    # Delete the second message again -- should be a no-op (already deleted)
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/msg2",
+    )
+    assert resp.status_code == 200
+
+    # Delete a non-existent message -- should be a no-op
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/nonexistent",
+    )
+    assert resp.status_code == 200
+
+    # Delete using slug endpoint
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/slug/test_delete_msg/conversation/chat/messages/msg3",
+    )
+    assert resp.status_code == 200
+
+    # Verify only msg1 remains
+    resp = await nucliadb_reader.get(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat",
+        params={"page": 1, "show": ["value"]},
+    )
+    assert resp.status_code == 200
+    field_resp = ResourceField.model_validate(resp.json())
+    msgs = field_resp.value["messages"]  # type: ignore
+    assert [m["ident"] for m in msgs] == ["msg1"]
+
+    # Verify error cases
+
+    # Non-existent resource
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/nonexistent-rid/conversation/chat/messages/msg1",
+    )
+    assert resp.status_code == 404
+
+    # Non-existent field
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/{rid}/conversation/nonexistent_field/messages/msg1",
+    )
+    assert resp.status_code == 404
+
+    # Message ident too long (> 128 chars)
+    long_ident = "a" * 129
+    resp = await nucliadb_writer.delete(
+        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/{long_ident}",
+    )
+    assert resp.status_code == 422

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -50,8 +50,17 @@ from nucliadb_protos.resources_pb2 import (
 )
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_protos.writer_pb2_grpc import WriterStub
-from tests.ndbfixtures.resources._vectors import lambs_split_6_vector
-from tests.ndbfixtures.resources.lambs import lambs_resource
+from tests.ndbfixtures.resources._vectors import (
+    lambs_split_6_vector,
+    lambs_split_7_vector,
+    lambs_split_9_vector,
+)
+from tests.ndbfixtures.resources.lambs import (
+    lambs_resource,
+    lambs_split_6_text,
+    lambs_split_7_text,
+    lambs_split_9_text,
+)
 from tests.utils import inject_message
 from tests.utils.broker_messages import BrokerMessageBuilder
 from tests.utils.dirty_index import mark_dirty, wait_for_sync
@@ -791,6 +800,7 @@ async def _test_keyword_search(
     message_id: str,
     top_k: int = 1,
     min_score: float | dict | None = None,
+    found: bool = True,
 ):
     payload = {
         "query": message_text,
@@ -808,10 +818,15 @@ async def _test_keyword_search(
     )
     assert resp.status_code == 200
     results = KnowledgeboxFindResults.model_validate(resp.json())
-    assert message_id in results.best_matches
-    assert (
-        results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text == message_text
-    )
+
+    if found:
+        assert message_id in results.best_matches
+        assert (
+            results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text
+            == message_text
+        )
+    else:
+        assert message_id not in results.best_matches
 
 
 async def _test_semantic_search(
@@ -822,6 +837,7 @@ async def _test_semantic_search(
     message_vector: list[float],
     top_k: int = 1,
     min_score: float | dict | None = None,
+    found: bool = True,
 ):
     payload = {
         "vector": message_vector,
@@ -839,10 +855,14 @@ async def _test_semantic_search(
     )
     assert resp.status_code == 200
     results = KnowledgeboxFindResults.model_validate(resp.json())
-    assert message_id in results.best_matches
-    assert (
-        results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text == message_text
-    )
+    if found:
+        assert message_id in results.best_matches
+        assert (
+            results.resources.popitem()[1].fields.popitem()[1].paragraphs.popitem()[1].text
+            == message_text
+        )
+    else:
+        assert message_id not in results.best_matches
 
 
 @pytest.mark.deploy_modes("standalone")
@@ -994,232 +1014,164 @@ async def test_append_messages_to_non_existent_conversation_field_creates_it(
 
 
 @pytest.mark.deploy_modes("standalone")
-async def test_delete_conversation_message(
+async def test_delete_conversation_message_lambs_resource(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,
     nucliadb_ingest_grpc: WriterStub,
     standalone_knowledgebox: str,
 ):
-    """Test that deleting a message from a conversation field works correctly,
-    including keyword and semantic search verification."""
     kbid = standalone_knowledgebox
 
-    msg1_text = "Hello from the user -- common text"
-    msg2_text = "Hi there from the assistant -- common text"
-    msg3_text = "How are you doing today -- common text"
-    msg1_vector = [-1.0] * 512
-    msg2_vector = [0.0] * 512
-    msg3_vector = [1.0] * 512
+    # Create a resource with the lambs conversation
+    rid = await lambs_resource(kbid, nucliadb_writer, nucliadb_ingest_grpc)
 
-    # Create a resource with a conversation field containing 3 messages
-    resp = await nucliadb_writer.post(
-        f"/kb/{kbid}/resources",
-        json={
-            "slug": "test_delete_msg",
-            "title": "Test Delete Message",
-            "conversations": {
-                "chat": {
-                    "messages": [
-                        {
-                            "to": ["assistant"],
-                            "who": "user",
-                            "timestamp": datetime.now().isoformat(),
-                            "content": {"text": msg1_text},
-                            "ident": "msg1",
-                            "type": MessageType.QUESTION.value,
-                        },
-                        {
-                            "to": ["user"],
-                            "who": "assistant",
-                            "timestamp": datetime.now().isoformat(),
-                            "content": {"text": msg2_text},
-                            "ident": "msg2",
-                            "type": MessageType.ANSWER.value,
-                        },
-                        {
-                            "to": ["assistant"],
-                            "who": "user",
-                            "timestamp": datetime.now().isoformat(),
-                            "content": {"text": msg3_text},
-                            "ident": "msg3",
-                            "type": MessageType.QUESTION.value,
-                        },
-                    ]
-                },
-            },
-        },
-    )
-    assert resp.status_code == 201
-    rid = resp.json()["uuid"]
+    lambs_split_6_vector_m = lambs_split_6_vector[:512]
+    lambs_split_7_vector_m = lambs_split_7_vector[:512]
+    lambs_split_9_vector_m = lambs_split_9_vector[:512]
 
-    msg1_pid = f"{rid}/c/chat/msg1/0-{len(msg1_text)}"
-    msg2_pid = f"{rid}/c/chat/msg2/0-{len(msg2_text)}"
-    msg3_pid = f"{rid}/c/chat/msg3/0-{len(msg3_text)}"
-
-    # Inject synthetic extracted data for the conversation messages
-    bmb = BrokerMessageBuilder(
-        kbid=kbid,
-        rid=rid,
-        source=BrokerMessage.MessageSource.PROCESSOR,
-    )
-    conv = bmb.field_builder("chat", FieldType.CONVERSATION)
-    for split, text, vector in [
-        ("msg1", msg1_text, msg1_vector),
-        ("msg2", msg2_text, msg2_vector),
-        ("msg3", msg3_text, msg3_vector),
-    ]:
-        conv.add_paragraph(
-            text=text,
-            split=split,
-            vectors={"multilingual": vector},
-        )
-    bm = bmb.build()
-    await inject_message(nucliadb_ingest_grpc, bm)
-
-    await mark_dirty()
-    await wait_for_sync()
+    lambs_split_6_pid = f"{rid}/c/lambs/6/0-{len(lambs_split_6_text)}"
+    lambs_split_7_pid = f"{rid}/c/lambs/7/0-{len(lambs_split_7_text)}"
+    lambs_split_9_pid = f"{rid}/c/lambs/9/0-{len(lambs_split_9_text)}"
 
     # Verify all 3 messages are present
     resp = await nucliadb_reader.get(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs",
         params={"page": 1, "show": ["value"]},
     )
     assert resp.status_code == 200
     field_resp = ResourceField.model_validate(resp.json())
     msgs = field_resp.value["messages"]  # type: ignore
-    assert len(msgs) == 3
-    assert [m["ident"] for m in msgs] == ["msg1", "msg2", "msg3"]
+    assert len(msgs) > 0
+    assert {"6", "7", "9"}.issubset({m["ident"] for m in msgs})
 
     # Verify all messages are searchable before deletion
-    for text, vector, pid in [
-        (msg1_text, msg1_vector, msg1_pid),
-        (msg2_text, msg2_vector, msg2_pid),
-        (msg3_text, msg3_vector, msg3_pid),
-    ]:
-        await _test_keyword_search(nucliadb_reader, kbid, text, pid)
-        await _test_semantic_search(nucliadb_reader, kbid, text, pid, vector)
+    search_cases = {
+        "split_6": {
+            "text": lambs_split_6_text,
+            "vector": lambs_split_6_vector_m,
+            "pid": lambs_split_6_pid,
+            "should_find": True,
+        },
+        "split_7": {
+            "text": lambs_split_7_text,
+            "vector": lambs_split_7_vector_m,
+            "pid": lambs_split_7_pid,
+            "should_find": True,
+        },
+        "split_9": {
+            "text": lambs_split_9_text,
+            "vector": lambs_split_9_vector_m,
+            "pid": lambs_split_9_pid,
+            "should_find": True,
+        },
+    }
+
+    async def _check_search():
+        for case in search_cases.values():
+            await _test_keyword_search(
+                nucliadb_reader, kbid, case["text"], case["pid"], found=case["should_find"]
+            )
+            await _test_semantic_search(
+                nucliadb_reader,
+                kbid,
+                case["text"],
+                case["pid"],
+                case["vector"],
+                found=case["should_find"],
+            )
+
+    await _check_search()
 
     # Delete the second message by resource id
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/msg2",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/7",
     )
     assert resp.status_code == 200
 
     await mark_dirty()
     await wait_for_sync()
 
-    # Verify msg2 is gone but msg1 and msg3 remain
+    # Verify 7 is gone but 6 and 9 remain
     resp = await nucliadb_reader.get(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs",
         params={"page": 1, "show": ["value"]},
     )
     assert resp.status_code == 200
     field_resp = ResourceField.model_validate(resp.json())
-    msgs = field_resp.value["messages"]  # type: ignore
-    assert [m["ident"] for m in msgs] == ["msg1", "msg3"]
+    msgs = {m["ident"]: m for m in field_resp.value["messages"]}  # type: ignore
+    assert {"6", "9"}.issubset(msgs.keys())
+    assert "7" not in msgs
 
-    # Verify msg2 is no longer found by keyword search
-    resp = await nucliadb_reader.post(
-        f"/kb/{kbid}/find",
-        json={
-            "query": "common text",
-            "features": ["keyword"],
-            "top_k": 5,
-            "min_score": {"bm25": 0},  # to include all results regardless of score
-        },
-    )
-    assert resp.status_code == 200
-    results = KnowledgeboxFindResults.model_validate(resp.json())
-    assert msg2_pid not in results.best_matches
-    # Verify msg1 and msg3 are still searchable
-    assert msg1_pid in results.best_matches
-    assert msg3_pid in results.best_matches
-
-    # Verify msg2 is no longer found by semantic search
-    resp = await nucliadb_reader.post(
-        f"/kb/{kbid}/find",
-        json={
-            "vector": msg2_vector,
-            "features": ["semantic"],
-            "top_k": 5,
-            "reranker": "noop",
-            "vectorset": "multilingual",
-            "min_score": -1,  # to include all results regardless of score
-        },
-    )
-    assert resp.status_code == 200
-    results = KnowledgeboxFindResults.model_validate(resp.json())
-    assert msg2_pid not in results.best_matches
-    # Verify msg1 and msg3 are still searchable
-    assert msg1_pid in results.best_matches
-    assert msg3_pid in results.best_matches
+    # Verify split 7 is no longer found by keyword search, but splits 6 and 9 are still searchable
+    search_cases["split_7"]["should_find"] = False
+    await _check_search()
 
     # Delete the second message again -- should be a no-op (already deleted)
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/msg2",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/7",
     )
     assert resp.status_code == 200
 
     # Delete a non-existent message -- should be a no-op
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/nonexistent",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/nonexistent",
     )
     assert resp.status_code == 200
 
     # Delete using slug endpoint
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/slug/test_delete_msg/conversation/chat/messages/msg3",
+        f"/kb/{kbid}/slug/lambs/conversation/lambs/messages/9",
     )
     assert resp.status_code == 200
 
     await mark_dirty()
     await wait_for_sync()
 
-    # Verify only msg1 remains
+    # Verify only split 6 remains
     resp = await nucliadb_reader.get(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs",
         params={"page": 1, "show": ["value"]},
     )
     assert resp.status_code == 200
     field_resp = ResourceField.model_validate(resp.json())
     msgs = field_resp.value["messages"]  # type: ignore
-    assert [m["ident"] for m in msgs] == ["msg1"]
+    assert {"6"}.issubset({m["ident"] for m in msgs})
 
-    # Verify msg1 is still searchable
-    await _test_keyword_search(nucliadb_reader, kbid, msg1_text, msg1_pid)
-    await _test_semantic_search(nucliadb_reader, kbid, msg1_text, msg1_pid, msg1_vector)
+    # Verify split 6 is still searchable
+    search_cases["split_9"]["should_find"] = False
+    await _check_search()
 
     # Verify error cases
 
     # Non-existent resource
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/nonexistent-rid/conversation/chat/messages/msg1",
+        f"/kb/{kbid}/resource/nonexistent-rid/conversation/lambs/messages/6",
     )
     assert resp.status_code == 404
 
     # Non-existent field
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/{rid}/conversation/nonexistent_field/messages/msg1",
+        f"/kb/{kbid}/resource/{rid}/conversation/nonexistent_field/messages/6",
     )
     assert resp.status_code == 404
 
     # Message ident too long (> 128 chars)
     long_ident = "a" * 129
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages/{long_ident}",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/{long_ident}",
     )
     assert resp.status_code == 422
 
     # Verify that a deleted message ident cannot be reused
     resp = await nucliadb_writer.put(
-        f"/kb/{kbid}/resource/{rid}/conversation/chat/messages",
+        f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages",
         json=[
             {
                 "to": ["assistant"],
                 "who": "user",
                 "timestamp": datetime.now().isoformat(),
                 "content": {"text": "Trying to reuse deleted ident"},
-                "ident": "msg2",  # This was deleted earlier
+                "ident": "7",  # This was deleted earlier
                 "type": MessageType.QUESTION.value,
             },
         ],

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -1086,7 +1086,7 @@ async def test_delete_conversation_message_lambs_resource(
     resp = await nucliadb_writer.delete(
         f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/7",
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 204
 
     await mark_dirty()
     await wait_for_sync()
@@ -1110,19 +1110,19 @@ async def test_delete_conversation_message_lambs_resource(
     resp = await nucliadb_writer.delete(
         f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/7",
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 204
 
     # Delete a non-existent message -- should be a no-op
     resp = await nucliadb_writer.delete(
         f"/kb/{kbid}/resource/{rid}/conversation/lambs/messages/nonexistent",
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 204
 
     # Delete using slug endpoint
     resp = await nucliadb_writer.delete(
         f"/kb/{kbid}/slug/lambs/conversation/lambs/messages/9",
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 204
 
     await mark_dirty()
     await wait_for_sync()

--- a/nucliadb_protos/resources.proto
+++ b/nucliadb_protos/resources.proto
@@ -165,7 +165,6 @@ message Message {
         ANSWER = 2;
     }
     MessageType type = 6;
-    bool deleted = 7;
 }
 
 message Conversation {

--- a/nucliadb_protos/resources.proto
+++ b/nucliadb_protos/resources.proto
@@ -165,6 +165,7 @@ message Message {
         ANSWER = 2;
     }
     MessageType type = 6;
+    bool deleted = 7;
 }
 
 message Conversation {
@@ -187,12 +188,18 @@ message FieldConversation {
     int32 total = 3;
     string extract_strategy = 4;
     string split_strategy = 5;
+
+    // Total number of deleted messages
+    int64 deleted_messages = 6;
 }
 
-message SplitMetadata {}
+message SplitMetadata {
+    int32 page = 1;
+}
 
 message SplitsMetadata {
     map<string, SplitMetadata> metadata = 1;
+    repeated string deleted_splits = 2;
 }
 
 message NestedPosition {

--- a/nucliadb_protos/resources.proto
+++ b/nucliadb_protos/resources.proto
@@ -187,9 +187,6 @@ message FieldConversation {
     int32 total = 3;
     string extract_strategy = 4;
     string split_strategy = 5;
-
-    // Total number of deleted messages
-    int64 deleted_messages = 6;
 }
 
 message SplitMetadata {

--- a/nucliadb_protos/writer.proto
+++ b/nucliadb_protos/writer.proto
@@ -60,6 +60,11 @@ message Error {
 }
 
 
+message DeleteSplits {
+    resources.FieldID field = 1;
+    repeated string splits = 2;
+}
+
 
 message BrokerMessage {
     reserved 2, 10, 12, 14, 15, 27, 46;
@@ -158,6 +163,9 @@ message BrokerMessage {
 
     // Field KeyValue
     map<string, resources.FieldKeyValue> key_value_fields = 47;
+
+    // To be able to delete conversation messages
+    repeated DeleteSplits delete_splits = 48;
 }
 
 message BrokerMessageBlobReference {

--- a/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
@@ -262,6 +262,16 @@ SDK_DEFINITION = {
         method="PUT",
         path_params=("kbid", "slug", "field_id"),
     ),
+    "delete_conversation_message": SdkEndpointDefinition(
+        path_template="/v1/kb/{kbid}/resource/{rid}/conversation/{field_id}/messages/{message_id}",
+        method="DELETE",
+        path_params=("kbid", "rid", "field_id", "message_id"),
+    ),
+    "delete_conversation_message_by_slug": SdkEndpointDefinition(
+        path_template="/v1/kb/{kbid}/slug/{slug}/conversation/{field_id}/messages/{message_id}",
+        method="DELETE",
+        path_params=("kbid", "slug", "field_id", "message_id"),
+    ),
     "get_resource_field": SdkEndpointDefinition(
         path_template="/v1/kb/{kbid}/resource/{rid}/{field_type}/{field_id}",
         method="GET",
@@ -1155,6 +1165,12 @@ class NucliaDB(_NucliaDBBase):
     add_conversation_message_by_slug = _request_sync_builder(
         "add_conversation_message_by_slug", list[InputMessage], ResourceFieldAdded
     )
+    delete_conversation_message = _request_sync_builder(
+        "delete_conversation_message", type(None), type(None)
+    )
+    delete_conversation_message_by_slug = _request_sync_builder(
+        "delete_conversation_message_by_slug", type(None), type(None)
+    )
     get_resource_field = _request_sync_builder("get_resource_field", type(None), ResourceField)
     get_resource_field_by_slug = _request_sync_builder(
         "get_resource_field_by_slug", type(None), ResourceField
@@ -1363,6 +1379,12 @@ class NucliaDBAsync(_NucliaDBBase):
     )
     add_conversation_message_by_slug = _request_async_builder(
         "add_conversation_message_by_slug", list[InputMessage], ResourceFieldAdded
+    )
+    delete_conversation_message = _request_async_builder(
+        "delete_conversation_message", type(None), type(None)
+    )
+    delete_conversation_message_by_slug = _request_async_builder(
+        "delete_conversation_message_by_slug", type(None), type(None)
     )
     get_resource_field = _request_async_builder("get_resource_field", type(None), ResourceField)
     get_resource_field_by_slug = _request_async_builder(


### PR DESCRIPTION
### Description

[sc-14709]

Important considerations:
- Processed data (vectors, metadata, etc) of deleted splits is not really deleted for now.
- Conversation pages are not consolidated, we just remove their text.
- For simplicify, when there are message deletions on a conversation field, the whole field is reindexed.
- Added a migration to populate the index to store page for every split, for easier deletion.

### How was this PR tested?
Integration tests.
