### PR TITLE
Implement more generic operators for key-value JSON filtering

### DIFF
--- a/nucliadb/src/nucliadb/common/exceptions.py
+++ b/nucliadb/src/nucliadb/common/exceptions.py
@@ -18,6 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from nucliadb_models.kv_schemas import KVFieldType, KVSchemaField
+
 
 class InvalidQueryError(Exception):
     """Raised when parsing a query containing an invalid parameter"""
@@ -26,3 +28,12 @@ class InvalidQueryError(Exception):
         self.param = param
         self.reason = reason
         super().__init__(f"Invalid query. Error in {param}: {reason}")
+
+
+class InvalidKVType(InvalidQueryError):
+    def __init__(self, schema_id: str, schema_field: KVSchemaField, invalid_type: KVFieldType):
+        super().__init__(
+            "key_value",
+            f"Key '{schema_field.key}' in schema '{schema_id}' is of type '{schema_field.type}', "
+            f"but '{invalid_type} has been provided",
+        )

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -19,6 +19,7 @@
 #
 
 from datetime import datetime
+from typing import Type
 
 from nidx_protos import nodereader_pb2
 from nidx_protos.nodereader_pb2 import FilterExpression as PBFilterExpression
@@ -145,10 +146,10 @@ async def parse_kv_expression(
     return _parse_kv_expression(expr, all_schemas)
 
 
-KEY_VALUE_ALLOWED_TYPES = {
-    Eq._name: {KVFieldType.TEXT, KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.BOOLEAN},
-    Gte._name: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
-    Lte._name: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
+KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Gte] | Type[Lte], set[KVFieldType]] = {
+    Eq: {KVFieldType.TEXT, KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.BOOLEAN},
+    Gte: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
+    Lte: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
 }
 
 
@@ -178,13 +179,13 @@ def _parse_kv_expression(
         schema_field = field_map[expr.key]
 
         # validate operand types for the expression operation
-        allowed_types = KEY_VALUE_ALLOWED_TYPES[expr._name]
+        allowed_types = KEY_VALUE_ALLOWED_TYPES[type(expr)]
         if schema_field.type not in allowed_types:
             allowed = " or".join([f"'{type}'" for type in allowed_types])
             raise InvalidQueryError(
                 "key_value",
                 f"Key '{expr.key}' in schema '{expr.schema_id}' is of type '{schema_field.type}', "
-                f"but '{expr._name}' requires type {allowed}",
+                f"but '{type(expr).__name__.lower()}' requires type {allowed}",
             )
 
         json_filter.path.field_id = f"k/{expr.schema_id}"
@@ -200,7 +201,7 @@ def _parse_kv_expression(
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.BOOLEAN)
                 json_filter.path.boolean = expr.eq
             elif isinstance(expr.eq, float):
-                if schema_field.type != KVFieldType.FLOAT:
+                if schema_field.type not in (KVFieldType.FLOAT, KVFieldType.INTEGER):
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
                 json_filter.path.float_range.lower = expr.eq
                 json_filter.path.float_range.upper = expr.eq

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -39,13 +39,12 @@ from nucliadb_models.filters import (
     FieldFilterExpression,
     FieldMimetype,
     Generated,
-    Gte,
+    Inequalities,
     Keyword,
     Kind,
     KVFilterExpression,
     Label,
     Language,
-    Lte,
     Not,
     Or,
     OriginCollaborator,
@@ -146,10 +145,9 @@ async def parse_kv_expression(
     return _parse_kv_expression(expr, all_schemas)
 
 
-KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Gte] | Type[Lte], set[KVFieldType]] = {
+KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities], set[KVFieldType]] = {
     Eq: {KVFieldType.TEXT, KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.BOOLEAN},
-    Gte: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
-    Lte: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
+    Inequalities: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
 }
 
 
@@ -166,7 +164,7 @@ def _parse_kv_expression(
     elif isinstance(expr, Not):
         json_filter.bool_not.CopyFrom(_parse_kv_expression(expr.operand, schemas))
 
-    elif isinstance(expr, (Eq, Gte, Lte)):
+    elif isinstance(expr, (Eq, Inequalities)):
         schema = schemas.schemas.get(expr.schema_id)
         if schema is None:
             raise InvalidQueryError("key_value", f"Unknown key-value schema: '{expr.schema_id}'")
@@ -201,49 +199,52 @@ def _parse_kv_expression(
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.BOOLEAN)
                 json_filter.path.boolean = expr.eq
             elif isinstance(expr.eq, float):
-                if schema_field.type not in (KVFieldType.FLOAT, KVFieldType.INTEGER):
+                if schema_field.type not in KVFieldType.FLOAT:
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
                 json_filter.path.float_range.lower = expr.eq
                 json_filter.path.float_range.upper = expr.eq
             elif isinstance(expr.eq, int):
-                if schema_field.type != KVFieldType.INTEGER:
+                # we accepts ints for float types but not the other way around
+                if schema_field.type not in (KVFieldType.INTEGER, KVFieldType.FLOAT):
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
                 json_filter.path.int_range.lower = expr.eq
                 json_filter.path.int_range.upper = expr.eq
             else:
                 assert_never(expr.eq)
 
-        elif isinstance(expr, Gte):
-            if isinstance(expr.gte, float):
-                if schema_field.type not in (KVFieldType.FLOAT, KVFieldType.INTEGER):
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
-                json_filter.path.float_range.lower = expr.gte
-            elif isinstance(expr.gte, int):
-                if schema_field.type != KVFieldType.INTEGER:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
-                json_filter.path.int_range.lower = expr.gte
-            elif isinstance(expr.gte, datetime):
-                if schema_field.type != KVFieldType.DATE:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
-                json_filter.path.date_range.lower.FromDatetime(expr.gte)
-            else:
-                assert_never(expr.gte)
-
-        elif isinstance(expr, Lte):
-            if isinstance(expr.lte, float):
-                if schema_field.type not in (KVFieldType.FLOAT, KVFieldType.INTEGER):
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
-                json_filter.path.float_range.upper = expr.lte
-            elif isinstance(expr.lte, int):
-                if schema_field.type != KVFieldType.INTEGER:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
-                json_filter.path.int_range.upper = expr.lte
-            elif isinstance(expr.lte, datetime):
-                if schema_field.type != KVFieldType.DATE:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
-                json_filter.path.date_range.upper.FromDatetime(expr.lte)
-            else:
-                assert_never(expr.lte)
+        elif isinstance(expr, Inequalities):
+            if expr.gte is not None:
+                if isinstance(expr.gte, float):
+                    if schema_field.type not in KVFieldType.FLOAT:
+                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
+                    json_filter.path.float_range.lower = expr.gte
+                elif isinstance(expr.gte, int):
+                    # we accepts ints for float types but not the other way around
+                    if schema_field.type not in (KVFieldType.INTEGER, KVFieldType.FLOAT):
+                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
+                    json_filter.path.int_range.lower = expr.gte
+                elif isinstance(expr.gte, datetime):
+                    if schema_field.type != KVFieldType.DATE:
+                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
+                    json_filter.path.date_range.lower.FromDatetime(expr.gte)
+                else:
+                    assert_never(expr.gte)
+            if expr.lte is not None:
+                if isinstance(expr.lte, float):
+                    if schema_field.type not in KVFieldType.FLOAT:
+                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
+                    json_filter.path.float_range.upper = expr.lte
+                elif isinstance(expr.lte, int):
+                    # we accepts ints for float types but not the other way around
+                    if schema_field.type not in (KVFieldType.INTEGER, KVFieldType.FLOAT):
+                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
+                    json_filter.path.int_range.upper = expr.lte
+                elif isinstance(expr.lte, datetime):
+                    if schema_field.type != KVFieldType.DATE:
+                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
+                    json_filter.path.date_range.upper.FromDatetime(expr.lte)
+                else:
+                    assert_never(expr.lte)
         else:
             assert_never(expr)
     else:

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -142,9 +142,7 @@ async def parse_kv_expression(
     """
     async with datamanagers.with_ro_transaction() as txn:
         all_schemas = await datamanagers.kv_schemas.get_all(txn, kbid=kbid)
-    oxpr = _parse_kv_expression(expr, all_schemas)
-    print(oxpr)
-    return oxpr
+    return _parse_kv_expression(expr, all_schemas)
 
 
 KEY_VALUE_ALLOWED_TYPES = {

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -150,6 +150,69 @@ KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities], set[KVFieldType]] =
     Inequalities: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
 }
 
+KV_VALUE_FIELD_TYPES: dict[type, set[KVFieldType]] = {
+    str: {KVFieldType.TEXT},
+    bool: {KVFieldType.BOOLEAN},
+    float: {KVFieldType.FLOAT},
+    int: {KVFieldType.INTEGER, KVFieldType.FLOAT},
+    datetime: {KVFieldType.DATE},
+}
+
+
+def _validate_kv_schema(
+    schemas: KBKVSchemas,
+    expr: Eq | Inequalities,
+) -> None:
+    schema = schemas.schemas.get(expr.schema_id)
+    if schema is None:
+        raise InvalidQueryError("key_value", f"Unknown key-value schema: '{expr.schema_id}'")
+    field_map = {f.key: f for f in schema.fields}
+    if expr.key not in field_map:
+        raise InvalidQueryError(
+            "key_value",
+            f"Key '{expr.key}' not found in schema '{expr.schema_id}'",
+        )
+    schema_field = field_map[expr.key]
+
+    # validate operator is applicable for the field type
+    allowed_types = KEY_VALUE_ALLOWED_TYPES[type(expr)]
+    if schema_field.type not in allowed_types:
+        allowed = " or".join([f"'{type}'" for type in allowed_types])
+        raise InvalidQueryError(
+            "key_value",
+            f"Key '{expr.key}' in schema '{expr.schema_id}' is of type '{schema_field.type}', "
+            f"but '{type(expr).__name__.lower()}' requires type {allowed}",
+        )
+
+    # validate value type(s) match the field type
+    expected_field_types = KV_VALUE_FIELD_TYPES.get(expr._value_type())
+    if expected_field_types is None or schema_field.type not in expected_field_types:
+        raise InvalidKVType(expr.schema_id, schema_field, schema_field.type)
+
+
+def _set_range_bound(
+    path: nodereader_pb2.JsonFieldPathFilter,
+    value: int | float | datetime,
+    lower: bool = False,
+) -> None:
+    if isinstance(value, float):
+        if lower:
+            path.float_range.lower = value
+        else:
+            path.float_range.upper = value
+    elif isinstance(value, int):
+        if lower:
+            path.int_range.lower = value
+        else:
+            path.int_range.upper = value
+    elif isinstance(value, datetime):
+        if lower:
+            path.date_range.lower.FromDatetime(value)
+        else:
+            path.date_range.upper.FromDatetime(value)
+    else:
+        assert_never(value)
+
 
 def _parse_kv_expression(
     expr: KVFilterExpression,
@@ -164,89 +227,37 @@ def _parse_kv_expression(
     elif isinstance(expr, Not):
         json_filter.bool_not.CopyFrom(_parse_kv_expression(expr.operand, schemas))
 
-    elif isinstance(expr, (Eq, Inequalities)):
-        schema = schemas.schemas.get(expr.schema_id)
-        if schema is None:
-            raise InvalidQueryError("key_value", f"Unknown key-value schema: '{expr.schema_id}'")
-        field_map = {f.key: f for f in schema.fields}
-        if expr.key not in field_map:
-            raise InvalidQueryError(
-                "key_value",
-                f"Key '{expr.key}' not found in schema '{expr.schema_id}'",
-            )
-        schema_field = field_map[expr.key]
-
-        # validate operand types for the expression operation
-        allowed_types = KEY_VALUE_ALLOWED_TYPES[type(expr)]
-        if schema_field.type not in allowed_types:
-            allowed = " or".join([f"'{type}'" for type in allowed_types])
-            raise InvalidQueryError(
-                "key_value",
-                f"Key '{expr.key}' in schema '{expr.schema_id}' is of type '{schema_field.type}', "
-                f"but '{type(expr).__name__.lower()}' requires type {allowed}",
-            )
+    elif isinstance(expr, Eq):
+        _validate_kv_schema(schemas, expr)
 
         json_filter.path.field_id = f"k/{expr.schema_id}"
         json_filter.path.json_path = expr.key
 
-        if isinstance(expr, Eq):
-            if isinstance(expr.eq, str):
-                if schema_field.type != KVFieldType.TEXT:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.TEXT)
+        match expr.eq:
+            case str():
                 json_filter.path.text = expr.eq
-            elif isinstance(expr.eq, bool):
-                if schema_field.type != KVFieldType.BOOLEAN:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.BOOLEAN)
+            case bool():
                 json_filter.path.boolean = expr.eq
-            elif isinstance(expr.eq, float):
-                if schema_field.type not in KVFieldType.FLOAT:
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
+            case float():
                 json_filter.path.float_range.lower = expr.eq
                 json_filter.path.float_range.upper = expr.eq
-            elif isinstance(expr.eq, int):
-                # we accepts ints for float types but not the other way around
-                if schema_field.type not in (KVFieldType.INTEGER, KVFieldType.FLOAT):
-                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
+            case int():
                 json_filter.path.int_range.lower = expr.eq
                 json_filter.path.int_range.upper = expr.eq
-            else:
+            case _:
                 assert_never(expr.eq)
 
-        elif isinstance(expr, Inequalities):
-            if expr.gte is not None:
-                if isinstance(expr.gte, float):
-                    if schema_field.type not in KVFieldType.FLOAT:
-                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
-                    json_filter.path.float_range.lower = expr.gte
-                elif isinstance(expr.gte, int):
-                    # we accepts ints for float types but not the other way around
-                    if schema_field.type not in (KVFieldType.INTEGER, KVFieldType.FLOAT):
-                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
-                    json_filter.path.int_range.lower = expr.gte
-                elif isinstance(expr.gte, datetime):
-                    if schema_field.type != KVFieldType.DATE:
-                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
-                    json_filter.path.date_range.lower.FromDatetime(expr.gte)
-                else:
-                    assert_never(expr.gte)
-            if expr.lte is not None:
-                if isinstance(expr.lte, float):
-                    if schema_field.type not in KVFieldType.FLOAT:
-                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
-                    json_filter.path.float_range.upper = expr.lte
-                elif isinstance(expr.lte, int):
-                    # we accepts ints for float types but not the other way around
-                    if schema_field.type not in (KVFieldType.INTEGER, KVFieldType.FLOAT):
-                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
-                    json_filter.path.int_range.upper = expr.lte
-                elif isinstance(expr.lte, datetime):
-                    if schema_field.type != KVFieldType.DATE:
-                        raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
-                    json_filter.path.date_range.upper.FromDatetime(expr.lte)
-                else:
-                    assert_never(expr.lte)
-        else:
-            assert_never(expr)
+    elif isinstance(expr, Inequalities):
+        _validate_kv_schema(schemas, expr)
+
+        json_filter.path.field_id = f"k/{expr.schema_id}"
+        json_filter.path.json_path = expr.key
+
+        if expr.gte is not None:
+            _set_range_bound(json_filter.path, expr.gte, lower=True)
+        if expr.lte is not None:
+            _set_range_bound(json_filter.path, expr.lte, lower=False)
+
     else:
         assert_never(expr)
 

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -215,7 +215,7 @@ def _parse_kv_expression(
 
         elif isinstance(expr, Gte):
             if isinstance(expr.gte, float):
-                if schema_field.type != KVFieldType.FLOAT:
+                if schema_field.type not in (KVFieldType.FLOAT, KVFieldType.INTEGER):
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
                 json_filter.path.float_range.lower = expr.gte
             elif isinstance(expr.gte, int):
@@ -231,7 +231,7 @@ def _parse_kv_expression(
 
         elif isinstance(expr, Lte):
             if isinstance(expr.lte, float):
-                if schema_field.type != KVFieldType.FLOAT:
+                if schema_field.type not in (KVFieldType.FLOAT, KVFieldType.INTEGER):
                     raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
                 json_filter.path.float_range.upper = expr.lte
             elif isinstance(expr.lte, int):

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -18,13 +18,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from datetime import datetime
 
 from nidx_protos import nodereader_pb2
 from nidx_protos.nodereader_pb2 import FilterExpression as PBFilterExpression
 from typing_extensions import assert_never
 
 from nucliadb.common import datamanagers
-from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.exceptions import InvalidKVType, InvalidQueryError
 from nucliadb.common.ids import FIELD_TYPE_NAME_TO_STR
 from nucliadb_models.common import Paragraph
 from nucliadb_models.filters import (
@@ -32,19 +33,18 @@ from nucliadb_models.filters import (
     DateCreated,
     DateModified,
     Entity,
+    Eq,
     Field,
     FieldFilterExpression,
     FieldMimetype,
     Generated,
+    Gte,
     Keyword,
     Kind,
-    KVBoolMatch,
-    KVDateRange,
-    KVExactMatch,
     KVFilterExpression,
-    KVRange,
     Label,
     Language,
+    Lte,
     Not,
     Or,
     OriginCollaborator,
@@ -57,7 +57,7 @@ from nucliadb_models.filters import (
     ResourceMimetype,
     Status,
 )
-from nucliadb_models.kv_schemas import KBKVSchemas
+from nucliadb_models.kv_schemas import KBKVSchemas, KVFieldType
 from nucliadb_models.metadata import ResourceProcessingStatus
 
 # Filters that end up as a facet
@@ -131,142 +131,126 @@ async def parse_expression(
     return f
 
 
-def parse_kv_filter_expression(
+async def parse_kv_expression(
     expr: KVFilterExpression,
-) -> nodereader_pb2.JsonFilterExpression:
-    """Convert a KVFilterExpression tree into a JsonFilterExpression proto."""
-    if isinstance(expr, And):
-        result = nodereader_pb2.JsonFilterExpression()
-        result.bool_and.operands.extend([parse_kv_filter_expression(op) for op in expr.operands])
-        return result
-    elif isinstance(expr, Or):
-        result = nodereader_pb2.JsonFilterExpression()
-        result.bool_or.operands.extend([parse_kv_filter_expression(op) for op in expr.operands])
-        return result
-    elif isinstance(expr, Not):
-        result = nodereader_pb2.JsonFilterExpression()
-        result.bool_not.CopyFrom(parse_kv_filter_expression(expr.operand))
-        return result
-    elif isinstance(expr, KVExactMatch):
-        path = nodereader_pb2.JsonFieldPathFilter(
-            field_id=f"k/{expr.field_id}",
-            json_path=expr.key,
-        )
-        path.text = expr.value
-        return nodereader_pb2.JsonFilterExpression(path=path)
-    elif isinstance(expr, KVRange):
-        path = nodereader_pb2.JsonFieldPathFilter(
-            field_id=f"k/{expr.field_id}",
-            json_path=expr.key,
-        )
-        # Detect int vs float from the bound values
-        is_int = all(
-            v is None or (isinstance(v, int) and not isinstance(v, bool)) for v in [expr.gte, expr.lte]
-        )
-        if is_int:
-            if expr.gte is not None:
-                path.int_range.lower = int(expr.gte)
-            if expr.lte is not None:
-                path.int_range.upper = int(expr.lte)
-        else:
-            if expr.gte is not None:
-                path.float_range.lower = expr.gte
-            if expr.lte is not None:
-                path.float_range.upper = expr.lte
-        return nodereader_pb2.JsonFilterExpression(path=path)
-    elif isinstance(expr, KVBoolMatch):
-        path = nodereader_pb2.JsonFieldPathFilter(
-            field_id=f"k/{expr.field_id}",
-            json_path=expr.key,
-        )
-        path.boolean = expr.value
-        return nodereader_pb2.JsonFilterExpression(path=path)
-    elif isinstance(expr, KVDateRange):
-        path = nodereader_pb2.JsonFieldPathFilter(
-            field_id=f"k/{expr.field_id}",
-            json_path=expr.key,
-        )
-        if expr.gte is not None:
-            path.date_range.lower.FromDatetime(expr.gte)
-        if expr.lte is not None:
-            path.date_range.upper.FromDatetime(expr.lte)
-        return nodereader_pb2.JsonFilterExpression(path=path)
-    else:
-        assert_never(expr)
-
-
-def _parse_kv_filter_expression(
-    expr: KVFilterExpression,
-    all_schemas: KBKVSchemas,
     kbid: str,
 ) -> nodereader_pb2.JsonFilterExpression:
-    """Recursive helper that validates a KVFilterExpression tree using pre-fetched schemas."""
+    """Convert a key-value filter expression tree into it's proto
+    representation, validating types against the corresponding key-value schemas
+    used
+
+    """
+    async with datamanagers.with_ro_transaction() as txn:
+        all_schemas = await datamanagers.kv_schemas.get_all(txn, kbid=kbid)
+    oxpr = _parse_kv_expression(expr, all_schemas)
+    print(oxpr)
+    return oxpr
+
+
+KEY_VALUE_ALLOWED_TYPES = {
+    Eq._name: {KVFieldType.TEXT, KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.BOOLEAN},
+    Gte._name: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
+    Lte._name: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
+}
+
+
+def _parse_kv_expression(
+    expr: KVFilterExpression,
+    schemas: KBKVSchemas,
+) -> nodereader_pb2.JsonFilterExpression:
+    json_filter = nodereader_pb2.JsonFilterExpression()
+
     if isinstance(expr, And):
-        result = nodereader_pb2.JsonFilterExpression()
-        result.bool_and.operands.extend(
-            [_parse_kv_filter_expression(op, all_schemas, kbid) for op in expr.operands]
-        )
-        return result
+        json_filter.bool_and.operands.extend([_parse_kv_expression(op, schemas) for op in expr.operands])
     elif isinstance(expr, Or):
-        result = nodereader_pb2.JsonFilterExpression()
-        result.bool_or.operands.extend(
-            [_parse_kv_filter_expression(op, all_schemas, kbid) for op in expr.operands]
-        )
-        return result
+        json_filter.bool_or.operands.extend([_parse_kv_expression(op, schemas) for op in expr.operands])
     elif isinstance(expr, Not):
-        result = nodereader_pb2.JsonFilterExpression()
-        result.bool_not.CopyFrom(_parse_kv_filter_expression(expr.operand, all_schemas, kbid))
-        return result
-    elif isinstance(expr, (KVExactMatch, KVRange, KVBoolMatch, KVDateRange)):
-        schema = all_schemas.schemas.get(expr.field_id)
+        json_filter.bool_not.CopyFrom(_parse_kv_expression(expr.operand, schemas))
+
+    elif isinstance(expr, (Eq, Gte, Lte)):
+        schema = schemas.schemas.get(expr.schema_id)
         if schema is None:
-            raise InvalidQueryError("key_value", f"Unknown key-value schema: '{expr.field_id}'")
+            raise InvalidQueryError("key_value", f"Unknown key-value schema: '{expr.schema_id}'")
         field_map = {f.key: f for f in schema.fields}
         if expr.key not in field_map:
             raise InvalidQueryError(
                 "key_value",
-                f"Key '{expr.key}' not found in schema '{expr.field_id}'",
+                f"Key '{expr.key}' not found in schema '{expr.schema_id}'",
             )
         schema_field = field_map[expr.key]
-        if isinstance(expr, KVExactMatch) and schema_field.type != "text":
+
+        # validate operand types for the expression operation
+        allowed_types = KEY_VALUE_ALLOWED_TYPES[expr._name]
+        if schema_field.type not in allowed_types:
+            allowed = " or".join([f"'{type}'" for type in allowed_types])
             raise InvalidQueryError(
                 "key_value",
-                f"Key '{expr.key}' in schema '{expr.field_id}' is of type '{schema_field.type}', "
-                f"but 'exact_match' requires type 'text'",
+                f"Key '{expr.key}' in schema '{expr.schema_id}' is of type '{schema_field.type}', "
+                f"but '{expr._name}' requires type {allowed}",
             )
-        elif isinstance(expr, KVRange) and schema_field.type not in ("float", "integer"):
-            raise InvalidQueryError(
-                "key_value",
-                f"Key '{expr.key}' in schema '{expr.field_id}' is of type '{schema_field.type}', "
-                f"but 'range' requires type 'float' or 'integer'",
-            )
-        elif isinstance(expr, KVBoolMatch) and schema_field.type != "boolean":
-            raise InvalidQueryError(
-                "key_value",
-                f"Key '{expr.key}' in schema '{expr.field_id}' is of type '{schema_field.type}', "
-                f"but 'bool_match' requires type 'boolean'",
-            )
-        elif isinstance(expr, KVDateRange) and schema_field.type != "date":
-            raise InvalidQueryError(
-                "key_value",
-                f"Key '{expr.key}' in schema '{expr.field_id}' is of type '{schema_field.type}', "
-                f"but 'date_range' requires type 'date'",
-            )
-        return parse_kv_filter_expression(expr)
+
+        json_filter.path.field_id = f"k/{expr.schema_id}"
+        json_filter.path.json_path = expr.key
+
+        if isinstance(expr, Eq):
+            if isinstance(expr.eq, str):
+                if schema_field.type != KVFieldType.TEXT:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.TEXT)
+                json_filter.path.text = expr.eq
+            elif isinstance(expr.eq, bool):
+                if schema_field.type != KVFieldType.BOOLEAN:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.BOOLEAN)
+                json_filter.path.boolean = expr.eq
+            elif isinstance(expr.eq, float):
+                if schema_field.type != KVFieldType.FLOAT:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
+                json_filter.path.float_range.lower = expr.eq
+                json_filter.path.float_range.upper = expr.eq
+            elif isinstance(expr.eq, int):
+                if schema_field.type != KVFieldType.INTEGER:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
+                json_filter.path.int_range.lower = expr.eq
+                json_filter.path.int_range.upper = expr.eq
+            else:
+                assert_never(expr.eq)
+
+        elif isinstance(expr, Gte):
+            if isinstance(expr.gte, float):
+                if schema_field.type != KVFieldType.FLOAT:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
+                json_filter.path.float_range.lower = expr.gte
+            elif isinstance(expr.gte, int):
+                if schema_field.type != KVFieldType.INTEGER:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
+                json_filter.path.int_range.lower = expr.gte
+            elif isinstance(expr.gte, datetime):
+                if schema_field.type != KVFieldType.DATE:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
+                json_filter.path.date_range.lower.FromDatetime(expr.gte)
+            else:
+                assert_never(expr.gte)
+
+        elif isinstance(expr, Lte):
+            if isinstance(expr.lte, float):
+                if schema_field.type != KVFieldType.FLOAT:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.FLOAT)
+                json_filter.path.float_range.upper = expr.lte
+            elif isinstance(expr.lte, int):
+                if schema_field.type != KVFieldType.INTEGER:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.INTEGER)
+                json_filter.path.int_range.upper = expr.lte
+            elif isinstance(expr.lte, datetime):
+                if schema_field.type != KVFieldType.DATE:
+                    raise InvalidKVType(expr.schema_id, schema_field, KVFieldType.DATE)
+                json_filter.path.date_range.upper.FromDatetime(expr.lte)
+            else:
+                assert_never(expr.lte)
+        else:
+            assert_never(expr)
     else:
         assert_never(expr)
 
-
-async def parse_kv_filter_expression_with_validation(
-    expr: KVFilterExpression,
-    kbid: str,
-) -> nodereader_pb2.JsonFilterExpression:
-    """Convert a KVFilterExpression tree into a JsonFilterExpression proto,
-    validating field_id and key against the KV schema.
-    Fetches all schemas once and passes them through the recursive helper."""
-    async with datamanagers.with_ro_transaction() as txn:
-        all_schemas = await datamanagers.kv_schemas.get_all(txn, kbid=kbid)
-    return _parse_kv_filter_expression(expr, all_schemas, kbid)
+    return json_filter
 
 
 def facet_from_filter(expr: FacetFilter) -> str:

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.common.filter_expression import (
     parse_expression,
-    parse_kv_filter_expression_with_validation,
+    parse_kv_expression,
 )
 from nucliadb.common.models_utils.from_proto import RelationNodeTypeMap
 from nucliadb.search.search.metrics import query_parser_observer
@@ -236,9 +236,7 @@ class _FindParser:
             if self.item.filter_expression.field:
                 field_expr = await parse_expression(self.item.filter_expression.field, self.kbid)
             if self.item.filter_expression.key_value:
-                json_expr = await parse_kv_filter_expression_with_validation(
-                    self.item.filter_expression.key_value, self.kbid
-                )
+                json_expr = await parse_kv_expression(self.item.filter_expression.key_value, self.kbid)
             if self.item.filter_expression.paragraph:
                 paragraph_expr = await parse_expression(self.item.filter_expression.paragraph, self.kbid)
             if self.item.filter_expression.operator == FilterExpression.Operator.OR:

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/retrieve.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/retrieve.py
@@ -25,7 +25,7 @@ import nucliadb_models.retrieval
 from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.common.filter_expression import (
     parse_expression,
-    parse_kv_filter_expression_with_validation,
+    parse_kv_expression,
 )
 from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.exceptions import InternalParserError
@@ -325,7 +325,7 @@ class _RetrievalParser:
                     self.kbid,
                 )
             if self.item.filters.filter_expression.key_value is not None:
-                filters.json_expression = await parse_kv_filter_expression_with_validation(
+                filters.json_expression = await parse_kv_expression(
                     self.item.filters.filter_expression.key_value, self.kbid
                 )
             if self.item.filters.filter_expression.operator == FilterExpression.Operator.OR:

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -344,51 +344,6 @@ async def test_kv_field_filter(
             f"Unexpected match for `{key} {op} {value}`: matched {resources} instead of {expected}"
         )
 
-    invalid_filters = [
-        # float value on an integer field
-        ("quantity", "eq", 3.5),
-        ("quantity", "gte", 3.5),
-        ("quantity", "lte", 3.5),
-    ]
-    for key, op, value in invalid_filters:
-        resp = await nucliadb_reader.post(
-            f"/kb/{kbid}/find",
-            json={
-                "query": "product item",
-                "features": ["keyword"],
-                "filter_expression": {
-                    "key_value": {
-                        "schema_id": "product",
-                        "key": key,
-                        op: value,
-                    }
-                },
-            },
-        )
-        assert resp.status_code == 412, resp.text
-
-    # --- Float range price >= 10.0 → finds resource 1 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "price",
-            "gte": 10.0,
-        }
-    )
-    assert rid1 in rids, f"Expected rid1 in results for price>=10.0, got {rids}"
-    assert rid2 not in rids, f"Expected rid2 NOT in results for price>=10.0, got {rids}"
-
-    # --- Integer range quantity <= 5 → finds resource 1 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "quantity",
-            "lte": 5,
-        }
-    )
-    assert rid1 in rids, f"Expected rid1 in results for quantity<=5, got {rids}"
-    assert rid2 not in rids, f"Expected rid2 NOT in results for quantity<=5, got {rids}"
-
     # --- AND: color=red AND in_stock=True → finds resource 1 only ---
     rids = await find_with_filter(
         {

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -310,16 +310,62 @@ async def test_kv_field_filter(
         assert resp.status_code == 200, resp.text
         return set(resp.json()["resources"].keys())
 
-    # --- Exact match on color=red → finds resource 1 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "color",
-            "eq": "red",
-        }
-    )
-    assert rid1 in rids, f"Expected rid1 in results for color=red, got {rids}"
-    assert rid2 not in rids, f"Expected rid2 NOT in results for color=red, got {rids}"
+    filters = [
+        # exact match
+        ("color", "eq", "red", {rid1}),
+        ("color", "eq", "blue", {rid2}),
+        ("color", "eq", "black", set()),
+        ("price", "eq", 5.0, {rid2}),
+        ("price", "eq", 5, {rid2}),
+        ("quantity", "eq", 3, {rid1}),
+        ("in_stock", "eq", True, {rid1}),
+        ("quantity", "gte", 1, {rid1, rid2}),
+        ("quantity", "gte", 5, {rid2}),
+        ("price", "gte", 5.0, {rid1, rid2}),
+        ("price", "gte", 5, {rid1, rid2}),  # price (float) can be filtered by an int
+        ("price", "gte", 5.01, {rid1}),
+        ("launched_at", "gte", "2024-01-01T00:00:00Z", {rid2}),
+        ("quantity", "lte", 20, {rid1, rid2}),
+        ("quantity", "lte", 5, {rid1}),
+        ("price", "lte", 12.5, {rid1, rid2}),
+        ("price", "lte", 5, {rid2}),  # price (float) can be filtered by an int
+        ("price", "lte", 4.99, set()),
+        ("launched_at", "lte", "2023-12-31T23:59:59Z", {rid1}),
+    ]
+    for key, op, value, expected in filters:
+        resources = await find_with_filter(
+            {
+                "schema_id": "product",
+                "key": key,
+                op: value,
+            }
+        )
+        assert resources == expected, (
+            f"Unexpected match for `{key} {op} {value}`: matched {resources} instead of {expected}"
+        )
+
+    invalid_filters = [
+        # float value on an integer field
+        ("quantity", "eq", 3.5),
+        ("quantity", "gte", 3.5),
+        ("quantity", "lte", 3.5),
+    ]
+    for key, op, value in invalid_filters:
+        resp = await nucliadb_reader.post(
+            f"/kb/{kbid}/find",
+            json={
+                "query": "product item",
+                "features": ["keyword"],
+                "filter_expression": {
+                    "key_value": {
+                        "schema_id": "product",
+                        "key": key,
+                        op: value,
+                    }
+                },
+            },
+        )
+        assert resp.status_code == 412, resp.text
 
     # --- Float range price >= 10.0 → finds resource 1 only ---
     rids = await find_with_filter(
@@ -332,17 +378,6 @@ async def test_kv_field_filter(
     assert rid1 in rids, f"Expected rid1 in results for price>=10.0, got {rids}"
     assert rid2 not in rids, f"Expected rid2 NOT in results for price>=10.0, got {rids}"
 
-    # --- Bool match in_stock=True → finds resource 1 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "in_stock",
-            "eq": True,
-        }
-    )
-    assert rid1 in rids, f"Expected rid1 in results for in_stock=True, got {rids}"
-    assert rid2 not in rids, f"Expected rid2 NOT in results for in_stock=True, got {rids}"
-
     # --- Integer range quantity <= 5 → finds resource 1 only ---
     rids = await find_with_filter(
         {
@@ -353,17 +388,6 @@ async def test_kv_field_filter(
     )
     assert rid1 in rids, f"Expected rid1 in results for quantity<=5, got {rids}"
     assert rid2 not in rids, f"Expected rid2 NOT in results for quantity<=5, got {rids}"
-
-    # --- Exact match on color=blue → finds resource 2 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "color",
-            "eq": "blue",
-        }
-    )
-    assert rid2 in rids, f"Expected rid2 in results for color=blue, got {rids}"
-    assert rid1 not in rids, f"Expected rid1 NOT in results for color=blue, got {rids}"
 
     # --- AND: color=red AND in_stock=True → finds resource 1 only ---
     rids = await find_with_filter(
@@ -385,28 +409,6 @@ async def test_kv_field_filter(
     assert rid1 in rids, f"Expected rid1 in results for color=red AND in_stock=True, got {rids}"
     assert rid2 not in rids, f"Expected rid2 NOT in results for color=red AND in_stock=True, got {rids}"
 
-    # --- Date range: launched_at >= 2024-01-01 → finds resource 2 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "launched_at",
-            "gte": "2024-01-01T00:00:00Z",
-        }
-    )
-    assert rid2 in rids, f"Expected rid2 in results for launched_at>=2024, got {rids}"
-    assert rid1 not in rids, f"Expected rid1 NOT in results for launched_at>=2024, got {rids}"
-
-    # --- Date range: launched_at <= 2023-12-31 → finds resource 1 only ---
-    rids = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "launched_at",
-            "lte": "2023-12-31T23:59:59Z",
-        }
-    )
-    assert rid1 in rids, f"Expected rid1 in results for launched_at<=2023, got {rids}"
-    assert rid2 not in rids, f"Expected rid2 NOT in results for launched_at<=2023, got {rids}"
-
 
 @pytest.mark.deploy_modes("standalone")
 async def test_kv_filter_schema_validation(
@@ -414,13 +416,12 @@ async def test_kv_filter_schema_validation(
     nucliadb_writer: AsyncClient,
     standalone_knowledgebox: str,
 ):
-    """
-    Covers: schema validation for key_value filter expressions.
-    Unknown schema_id or key should return 422.
+    """Test key-value schema validations: invalid schema, field or invalid types
+    (type in schema is not compatible with query types)
+
     """
     kbid = standalone_knowledgebox
 
-    # Setup: create schema
     resp = await nucliadb_writer.post(f"/kb/{kbid}/kv-schemas", json=PRODUCT_SCHEMA)
     assert resp.status_code == 201, resp.text
 
@@ -437,7 +438,6 @@ async def test_kv_filter_schema_validation(
         )
         return resp.status_code
 
-    # --- Unknown schema_id → 422 ---
     status = await find_with_filter(
         {
             "schema_id": "nonexistent_schema",
@@ -445,9 +445,8 @@ async def test_kv_filter_schema_validation(
             "eq": "red",
         }
     )
-    assert status == 412, f"Expected 412 for unknown schema_id, got {status}"
+    assert status == 412
 
-    # --- Unknown key → 422 ---
     status = await find_with_filter(
         {
             "schema_id": "product",
@@ -455,44 +454,59 @@ async def test_kv_filter_schema_validation(
             "eq": "red",
         }
     )
-    assert status == 412, f"Expected 412 for unknown key, got {status}"
+    assert status == 412
 
-    # --- Wrong predicate type: exact_match on a float field → 422 ---
-    status = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "price",
-            "eq": "12.5",
-        }
-    )
-    assert status == 412, f"Expected 412 for exact_match on float field, got {status}"
-
-    # --- Wrong predicate type: eq on a text field → 422 ---
-    status = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "color",
-            "eq": True,
-        }
-    )
-    assert status == 412, f"Expected 412 for eq on text field, got {status}"
-
-    # --- Wrong predicate type: range on a text field → 412 ---
-    status = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "color",
-            "gte": 1.0,
-        }
-    )
-    assert status == 412, f"Expected 412 for range on text field, got {status}"
-
-    # --- Wrong predicate type: date_range on a text field → 412 ---
-    status = await find_with_filter(
-        {
-            "schema_id": "product",
-            "key": "color",
-            "gte": "2024-01-01T00:00:00Z",
-        }
-    )
-    assert status == 412, f"Expected 412 for date_range on text field, got {status}"
+    # Test schema validation for invalid combinations of schemaa field types and
+    # query values
+    for key, op, value in [
+        # invalid types for a BOOLEAN field
+        ("in_stock", "eq", "true"),
+        ("in_stock", "eq", 10),
+        ("in_stock", "gte", 10),
+        ("in_stock", "lte", 10),
+        ("in_stock", "eq", 3.5),
+        ("in_stock", "gte", 3.5),
+        ("in_stock", "lte", 3.5),
+        ("in_stock", "gte", "2024-01-01T00:00:00Z"),
+        ("in_stock", "lte", "2024-01-01T00:00:00Z"),
+        # invalid types for an INTEGER field
+        ("quantity", "eq", "10"),
+        ("quantity", "eq", True),
+        ("quantity", "eq", 3.5),
+        ("quantity", "gte", 3.5),
+        ("quantity", "lte", 3.5),
+        ("quantity", "gte", "2024-01-01T00:00:00Z"),
+        ("quantity", "lte", "2024-01-01T00:00:00Z"),
+        # invalid types for an FLOAT field
+        ("price", "eq", "3.5"),
+        ("price", "eq", True),
+        ("price", "gte", "2024-01-01T00:00:00Z"),
+        ("price", "lte", "2024-01-01T00:00:00Z"),
+        # invalid types for a TEXT field
+        ("color", "eq", True),
+        ("color", "eq", 10),
+        ("color", "gte", 10),
+        ("color", "lte", 10),
+        ("color", "eq", 3.5),
+        ("color", "gte", 3.5),
+        ("color", "lte", 3.5),
+        ("color", "gte", "2024-01-01T00:00:00Z"),
+        ("color", "lte", "2024-01-01T00:00:00Z"),
+        # invalid types for a DATE field
+        ("launched_at", "eq", "today"),
+        ("launched_at", "eq", True),
+        ("launched_at", "eq", 10),
+        ("launched_at", "gte", 10),
+        ("launched_at", "lte", 10),
+        ("launched_at", "eq", 3.5),
+        ("launched_at", "gte", 3.5),
+        ("launched_at", "lte", 3.5),
+    ]:
+        status = await find_with_filter(
+            {
+                "schema_id": "product",
+                "key": key,
+                op: value,
+            }
+        )
+        assert status == 412, f"Expected validation error for `{key} {op} {value}`, got {status}"

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -302,7 +302,9 @@ async def test_kv_field_filter(
             json={
                 "query": "product item",
                 "features": ["keyword"],
-                "filter_expression": filter_expression,
+                "filter_expression": {
+                    "key_value": filter_expression,
+                },
             },
         )
         assert resp.status_code == 200, resp.text
@@ -311,12 +313,9 @@ async def test_kv_field_filter(
     # --- Exact match on color=red → finds resource 1 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "exact_match",
-                "field_id": "product",
-                "key": "color",
-                "value": "red",
-            }
+            "schema_id": "product",
+            "key": "color",
+            "eq": "red",
         }
     )
     assert rid1 in rids, f"Expected rid1 in results for color=red, got {rids}"
@@ -325,12 +324,9 @@ async def test_kv_field_filter(
     # --- Float range price >= 10.0 → finds resource 1 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "range",
-                "field_id": "product",
-                "key": "price",
-                "gte": 10.0,
-            }
+            "schema_id": "product",
+            "key": "price",
+            "gte": 10.0,
         }
     )
     assert rid1 in rids, f"Expected rid1 in results for price>=10.0, got {rids}"
@@ -339,12 +335,9 @@ async def test_kv_field_filter(
     # --- Bool match in_stock=True → finds resource 1 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "bool_match",
-                "field_id": "product",
-                "key": "in_stock",
-                "value": True,
-            }
+            "schema_id": "product",
+            "key": "in_stock",
+            "eq": True,
         }
     )
     assert rid1 in rids, f"Expected rid1 in results for in_stock=True, got {rids}"
@@ -353,12 +346,9 @@ async def test_kv_field_filter(
     # --- Integer range quantity <= 5 → finds resource 1 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "range",
-                "field_id": "product",
-                "key": "quantity",
-                "lte": 5,
-            }
+            "schema_id": "product",
+            "key": "quantity",
+            "lte": 5,
         }
     )
     assert rid1 in rids, f"Expected rid1 in results for quantity<=5, got {rids}"
@@ -367,12 +357,9 @@ async def test_kv_field_filter(
     # --- Exact match on color=blue → finds resource 2 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "exact_match",
-                "field_id": "product",
-                "key": "color",
-                "value": "blue",
-            }
+            "schema_id": "product",
+            "key": "color",
+            "eq": "blue",
         }
     )
     assert rid2 in rids, f"Expected rid2 in results for color=blue, got {rids}"
@@ -381,22 +368,18 @@ async def test_kv_field_filter(
     # --- AND: color=red AND in_stock=True → finds resource 1 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "and": [
-                    {
-                        "op": "exact_match",
-                        "field_id": "product",
-                        "key": "color",
-                        "value": "red",
-                    },
-                    {
-                        "op": "bool_match",
-                        "field_id": "product",
-                        "key": "in_stock",
-                        "value": True,
-                    },
-                ]
-            }
+            "and": [
+                {
+                    "schema_id": "product",
+                    "key": "color",
+                    "eq": "red",
+                },
+                {
+                    "schema_id": "product",
+                    "key": "in_stock",
+                    "eq": True,
+                },
+            ]
         }
     )
     assert rid1 in rids, f"Expected rid1 in results for color=red AND in_stock=True, got {rids}"
@@ -405,12 +388,9 @@ async def test_kv_field_filter(
     # --- Date range: launched_at >= 2024-01-01 → finds resource 2 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "date_range",
-                "field_id": "product",
-                "key": "launched_at",
-                "gte": "2024-01-01T00:00:00Z",
-            }
+            "schema_id": "product",
+            "key": "launched_at",
+            "gte": "2024-01-01T00:00:00Z",
         }
     )
     assert rid2 in rids, f"Expected rid2 in results for launched_at>=2024, got {rids}"
@@ -419,12 +399,9 @@ async def test_kv_field_filter(
     # --- Date range: launched_at <= 2023-12-31 → finds resource 1 only ---
     rids = await find_with_filter(
         {
-            "key_value": {
-                "op": "date_range",
-                "field_id": "product",
-                "key": "launched_at",
-                "lte": "2023-12-31T23:59:59Z",
-            }
+            "schema_id": "product",
+            "key": "launched_at",
+            "lte": "2023-12-31T23:59:59Z",
         }
     )
     assert rid1 in rids, f"Expected rid1 in results for launched_at<=2023, got {rids}"
@@ -439,7 +416,7 @@ async def test_kv_filter_schema_validation(
 ):
     """
     Covers: schema validation for key_value filter expressions.
-    Unknown field_id or key should return 422.
+    Unknown schema_id or key should return 422.
     """
     kbid = standalone_knowledgebox
 
@@ -453,33 +430,29 @@ async def test_kv_filter_schema_validation(
             json={
                 "query": "product item",
                 "features": ["keyword"],
-                "filter_expression": filter_expression,
+                "filter_expression": {
+                    "key_value": filter_expression,
+                },
             },
         )
         return resp.status_code
 
-    # --- Unknown field_id → 422 ---
+    # --- Unknown schema_id → 422 ---
     status = await find_with_filter(
         {
-            "key_value": {
-                "op": "exact_match",
-                "field_id": "nonexistent_schema",
-                "key": "color",
-                "value": "red",
-            }
+            "schema_id": "nonexistent_schema",
+            "key": "color",
+            "eq": "red",
         }
     )
-    assert status == 412, f"Expected 412 for unknown field_id, got {status}"
+    assert status == 412, f"Expected 412 for unknown schema_id, got {status}"
 
     # --- Unknown key → 422 ---
     status = await find_with_filter(
         {
-            "key_value": {
-                "op": "exact_match",
-                "field_id": "product",
-                "key": "nonexistent_key",
-                "value": "red",
-            }
+            "schema_id": "product",
+            "key": "nonexistent_key",
+            "eq": "red",
         }
     )
     assert status == 412, f"Expected 412 for unknown key, got {status}"
@@ -487,38 +460,29 @@ async def test_kv_filter_schema_validation(
     # --- Wrong predicate type: exact_match on a float field → 422 ---
     status = await find_with_filter(
         {
-            "key_value": {
-                "op": "exact_match",
-                "field_id": "product",
-                "key": "price",
-                "value": "12.5",
-            }
+            "schema_id": "product",
+            "key": "price",
+            "eq": "12.5",
         }
     )
     assert status == 412, f"Expected 412 for exact_match on float field, got {status}"
 
-    # --- Wrong predicate type: bool_match on a text field → 422 ---
+    # --- Wrong predicate type: eq on a text field → 422 ---
     status = await find_with_filter(
         {
-            "key_value": {
-                "op": "bool_match",
-                "field_id": "product",
-                "key": "color",
-                "value": True,
-            }
+            "schema_id": "product",
+            "key": "color",
+            "eq": True,
         }
     )
-    assert status == 412, f"Expected 412 for bool_match on text field, got {status}"
+    assert status == 412, f"Expected 412 for eq on text field, got {status}"
 
     # --- Wrong predicate type: range on a text field → 412 ---
     status = await find_with_filter(
         {
-            "key_value": {
-                "op": "range",
-                "field_id": "product",
-                "key": "color",
-                "gte": 1.0,
-            }
+            "schema_id": "product",
+            "key": "color",
+            "gte": 1.0,
         }
     )
     assert status == 412, f"Expected 412 for range on text field, got {status}"
@@ -526,12 +490,9 @@ async def test_kv_filter_schema_validation(
     # --- Wrong predicate type: date_range on a text field → 412 ---
     status = await find_with_filter(
         {
-            "key_value": {
-                "op": "date_range",
-                "field_id": "product",
-                "key": "color",
-                "gte": "2024-01-01T00:00:00Z",
-            }
+            "schema_id": "product",
+            "key": "color",
+            "gte": "2024-01-01T00:00:00Z",
         }
     )
     assert status == 412, f"Expected 412 for date_range on text field, got {status}"

--- a/nucliadb/tests/search/integration/api/v1/test_retrieve.py
+++ b/nucliadb/tests/search/integration/api/v1/test_retrieve.py
@@ -483,20 +483,27 @@ async def test_retrieve_with_kv_field_filter(
 
     products = await retrieve_with_kv_filter(
         {
-            "field_id": "product",
+            "schema_id": "product",
             "key": "color",
-            "op": "exact_match",
-            "value": "white",
+            "eq": "white",
         }
     )
     assert products == {"floral-skirt", "white-t-shirt"}
 
     products = await retrieve_with_kv_filter(
-        {"field_id": "product", "key": "price", "op": "range", "gte": 20.0}
+        {
+            "schema_id": "product",
+            "key": "price",
+            "gte": 20.0,
+        }
     )
     assert products == {"floral-skirt"}
 
     products = await retrieve_with_kv_filter(
-        {"field_id": "product", "key": "price", "op": "range", "lte": 20.0}
+        {
+            "schema_id": "product",
+            "key": "price",
+            "lte": 20.0,
+        }
     )
     assert products == {"white-t-shirt"}

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
@@ -315,11 +315,17 @@ class KVFilter(BaseModel, ABC, extra="forbid"):
     schema_id: str
     key: str
 
+    @abstractmethod
+    def _value_type(self) -> type: ...
+
 
 class Eq(KVFilter):
     """Equal (==) operator"""
 
     eq: str | int | float | bool
+
+    def _value_type(self) -> type:
+        return type(self.eq)
 
 
 class Inequalities(KVFilter):
@@ -327,6 +333,13 @@ class Inequalities(KVFilter):
 
     gte: int | float | DateTime | None = pydantic.Field(default=None)
     lte: int | float | DateTime | None = pydantic.Field(default=None)
+
+    def _value_type(self) -> type:
+        # At least one is always set (validated by check_bounds)
+        # and when both are set, they're guaranteed to be compatible types
+        value = self.gte if self.gte is not None else self.lte
+        assert value is not None
+        return type(value)
 
     @model_validator(mode="after")
     def check_bounds(self) -> Self:

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Sequence
 from enum import Enum
-from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar
 from uuid import UUID
 
 import pydantic
@@ -314,29 +314,22 @@ class KVFilter(BaseModel, ABC, extra="forbid"):
     schema_id: str
     key: str
 
-    @property
-    @abstractmethod
-    def _name(self) -> str: ...
-
 
 class Eq(KVFilter):
     """Equal (==) operator"""
 
-    _name: ClassVar[Literal["eq"]] = "eq"
     eq: str | int | float | bool
 
 
 class Gte(KVFilter):
     """Greater-than or equal (>=) operator"""
 
-    _name: ClassVar[Literal["gte"]] = "gte"
     gte: int | float | DateTime
 
 
 class Lte(KVFilter):
     """Less-than or equal (<=) operator"""
 
-    _name: ClassVar[Literal["lte"]] = "lte"
     lte: int | float | DateTime
 
 

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -14,6 +14,7 @@
 #
 from abc import ABC
 from collections.abc import Sequence
+from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Generic, Literal, TypeVar
 from uuid import UUID
@@ -321,16 +322,35 @@ class Eq(KVFilter):
     eq: str | int | float | bool
 
 
-class Gte(KVFilter):
-    """Greater-than or equal (>=) operator"""
+class Inequalities(KVFilter):
+    """Inequality operators that can be grouped to perform range queries."""
 
-    gte: int | float | DateTime
+    gte: int | float | DateTime | None = pydantic.Field(default=None)
+    lte: int | float | DateTime | None = pydantic.Field(default=None)
 
+    @model_validator(mode="after")
+    def check_bounds(self) -> Self:
+        if self.gte is None and self.lte is None:
+            raise ValueError("must provide at least one operator (gte or lte)")
 
-class Lte(KVFilter):
-    """Less-than or equal (<=) operator"""
+        # only one operator is used, we can't have conflicting types
+        if self.gte is None or self.lte is None:
+            return self
 
-    lte: int | float | DateTime
+        # when more than one operator is used, we can already validate some
+        # obvious invalid combinations
+        if isinstance(self.lte, datetime) and isinstance(self.gte, datetime):
+            if self.lte < self.gte:
+                raise ValueError(f"lte ({self.lte}) must be >= than gte ({self.gte})")
+        if isinstance(self.lte, (int, float)) and isinstance(self.gte, (int, float)):
+            if self.lte < self.gte:
+                raise ValueError(f"lte ({self.lte}) must be >= than gte ({self.gte})")
+        if isinstance(self.lte, datetime) and isinstance(self.gte, (int, float)):
+            raise ValueError("can't mix numeric and datetimes comparisons in the same operator")
+        if isinstance(self.lte, (int, float)) and isinstance(self.gte, datetime):
+            raise ValueError("can't mix numeric and datetimes comparisons in the same operator")
+
+        return self
 
 
 # The discriminator function is optional, everything works without it.
@@ -419,9 +439,9 @@ def kv_discriminator(v: Any) -> str | None:
         elif "eq" in v:
             return "eq"
         elif "gte" in v:
-            return "gte"
+            return "inequalities"
         elif "lte" in v:
-            return "lte"
+            return "inequalities"
         else:
             return ""
 
@@ -433,10 +453,8 @@ def kv_discriminator(v: Any) -> str | None:
         return "not"
     elif isinstance(v, Eq):
         return "eq"
-    elif isinstance(v, Gte):
-        return "gte"
-    elif isinstance(v, Lte):
-        return "lte"
+    elif isinstance(v, Inequalities):
+        return "inequalities"
     else:
         return ""
 
@@ -446,8 +464,7 @@ KVFilterExpression = Annotated[
     | Annotated[Or["KVFilterExpression"], Tag("or")]
     | Annotated[Not["KVFilterExpression"], Tag("not")]
     | Annotated[Eq, Tag("eq")]
-    | Annotated[Gte, Tag("gte")]
-    | Annotated[Lte, Tag("lte")],
+    | Annotated[Inequalities, Tag("inequalities")],
     Discriminator(kv_discriminator),
 ]
 

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, ClassVar, Generic, Literal, TypeVar
 from uuid import UUID
 
 import pydantic
@@ -303,98 +303,41 @@ class Status(FilterProp, extra="forbid"):
     status: ResourceProcessingStatus = pydantic.Field(description="The status of the resource")
 
 
-# --- New KV filter classes (top-level key_value in FilterExpression) ---
+#
+# Key-value filter classes (top-level key_value in FilterExpression)
+#
 
 
-class KVExactMatch(BaseModel, extra="forbid"):
-    """Matches a key-value field where the given key exactly matches the given string value"""
+class KVFilter(BaseModel, ABC, extra="forbid"):
+    """Abstract class for all key-value filters"""
 
-    op: Literal["exact_match"] = "exact_match"
-    field_id: str = pydantic.Field(description="The KV field/schema name, e.g. 'product'")
-    key: str = pydantic.Field(description="The key within the KV data, e.g. 'color'")
-    value: str = pydantic.Field(description="The string value to match exactly")
+    schema_id: str
+    key: str
 
-
-class KVRange(BaseModel, extra="forbid"):
-    """Matches a key-value field where the given key falls within a numeric range"""
-
-    op: Literal["range"] = "range"
-    field_id: str = pydantic.Field(description="The KV field/schema name, e.g. 'product'")
-    key: str = pydantic.Field(description="The key within the KV data, e.g. 'price'")
-    gte: float | int | None = pydantic.Field(default=None, description="Greater than or equal to")
-    lte: float | int | None = pydantic.Field(default=None, description="Less than or equal to")
-
-    @model_validator(mode="after")
-    def check_bounds(self) -> "KVRange":
-        if self.gte is None and self.lte is None:
-            raise ValueError("KVRange requires at least one bound (gte or lte)")
-        if self.gte is not None and self.lte is not None and self.lte < self.gte:
-            raise ValueError(f"KVRange lte ({self.lte}) must be >= gte ({self.gte})")
-        return self
+    @property
+    @abstractmethod
+    def _name(self) -> str: ...
 
 
-class KVBoolMatch(BaseModel, extra="forbid"):
-    """Matches a key-value field where the given key matches the given boolean value"""
+class Eq(KVFilter):
+    """Equal (==) operator"""
 
-    op: Literal["bool_match"] = "bool_match"
-    field_id: str = pydantic.Field(description="The KV field/schema name, e.g. 'product'")
-    key: str = pydantic.Field(description="The key within the KV data, e.g. 'in_stock'")
-    value: bool = pydantic.Field(description="The boolean value to match")
+    _name: ClassVar[Literal["eq"]] = "eq"
+    eq: str | int | float | bool
 
 
-class KVDateRange(BaseModel, extra="forbid"):
-    """Matches a key-value field where the given date key falls within a date/time range"""
+class Gte(KVFilter):
+    """Greater-than or equal (>=) operator"""
 
-    op: Literal["date_range"] = "date_range"
-    field_id: str = pydantic.Field(description="The KV field/schema name, e.g. 'event'")
-    key: str = pydantic.Field(description="The key within the KV data, e.g. 'ts'")
-    gte: DateTime | None = pydantic.Field(
-        default=None, description="Greater than or equal to (inclusive lower bound)"
-    )
-    lte: DateTime | None = pydantic.Field(
-        default=None, description="Less than or equal to (inclusive upper bound)"
-    )
-
-    @model_validator(mode="after")
-    def check_bounds(self) -> "KVDateRange":
-        if self.gte is None and self.lte is None:
-            raise ValueError("KVDateRange requires at least one bound (gte or lte)")
-        if self.gte is not None and self.lte is not None and self.lte < self.gte:
-            raise ValueError(f"KVDateRange lte ({self.lte}) must be >= gte ({self.gte})")
-        return self
+    _name: ClassVar[Literal["gte"]] = "gte"
+    gte: int | float | DateTime
 
 
-def kv_discriminator(v: Any) -> str | None:
-    if isinstance(v, dict):
-        if "and" in v:
-            return "and"
-        elif "or" in v:
-            return "or"
-        elif "not" in v:
-            return "not"
-        else:
-            return v.get("op")
+class Lte(KVFilter):
+    """Less-than or equal (<=) operator"""
 
-    if isinstance(v, And):
-        return "and"
-    elif isinstance(v, Or):
-        return "or"
-    elif isinstance(v, Not):
-        return "not"
-    else:
-        return getattr(v, "op", None)
-
-
-KVFilterExpression = Annotated[
-    Annotated[And["KVFilterExpression"], Tag("and")]
-    | Annotated[Or["KVFilterExpression"], Tag("or")]
-    | Annotated[Not["KVFilterExpression"], Tag("not")]
-    | Annotated[KVExactMatch, Tag("exact_match")]
-    | Annotated[KVRange, Tag("range")]
-    | Annotated[KVBoolMatch, Tag("bool_match")]
-    | Annotated[KVDateRange, Tag("date_range")],
-    Discriminator(kv_discriminator),
-]
+    _name: ClassVar[Literal["lte"]] = "lte"
+    lte: int | float | DateTime
 
 
 # The discriminator function is optional, everything works without it.
@@ -469,6 +412,50 @@ ResourceFilterExpression = Annotated[
     | Annotated[OriginCollaborator, Tag("origin_collaborator")]
     | Annotated[Status, Tag("status")],
     Discriminator(filter_discriminator),
+]
+
+
+def kv_discriminator(v: Any) -> str | None:
+    if isinstance(v, dict):
+        if "and" in v:
+            return "and"
+        elif "or" in v:
+            return "or"
+        elif "not" in v:
+            return "not"
+        elif "eq" in v:
+            return "eq"
+        elif "gte" in v:
+            return "gte"
+        elif "lte" in v:
+            return "lte"
+        else:
+            return ""
+
+    if isinstance(v, And):
+        return "and"
+    elif isinstance(v, Or):
+        return "or"
+    elif isinstance(v, Not):
+        return "not"
+    elif isinstance(v, Eq):
+        return "eq"
+    elif isinstance(v, Gte):
+        return "gte"
+    elif isinstance(v, Lte):
+        return "lte"
+    else:
+        return ""
+
+
+KVFilterExpression = Annotated[
+    Annotated[And["KVFilterExpression"], Tag("and")]
+    | Annotated[Or["KVFilterExpression"], Tag("or")]
+    | Annotated[Not["KVFilterExpression"], Tag("not")]
+    | Annotated[Eq, Tag("eq")]
+    | Annotated[Gte, Tag("gte")]
+    | Annotated[Lte, Tag("lte")],
+    Discriminator(kv_discriminator),
 ]
 
 

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -14,7 +14,6 @@
 #
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Generic, Literal, TypeVar
 from uuid import UUID
@@ -350,18 +349,13 @@ class Inequalities(KVFilter):
         if self.gte is None or self.lte is None:
             return self
 
-        # when more than one operator is used, we can already validate some
-        # obvious invalid combinations
-        if isinstance(self.lte, datetime) and isinstance(self.gte, datetime):
-            if self.lte < self.gte:
+        # we don't want differing types in a expression with mutliple inequality
+        # operators
+        if type(self.gte) is type(self.lte):
+            if self.lte < self.gte:  # type: ignore # ty doesn't understand we already checked this
                 raise ValueError(f"lte ({self.lte}) must be >= than gte ({self.gte})")
-        if isinstance(self.lte, (int, float)) and isinstance(self.gte, (int, float)):
-            if self.lte < self.gte:
-                raise ValueError(f"lte ({self.lte}) must be >= than gte ({self.gte})")
-        if isinstance(self.lte, datetime) and isinstance(self.gte, (int, float)):
-            raise ValueError("can't mix numeric and datetimes comparisons in the same operator")
-        if isinstance(self.lte, (int, float)) and isinstance(self.gte, datetime):
-            raise ValueError("can't mix numeric and datetimes comparisons in the same operator")
+        else:
+            raise ValueError("`gte` and `lte` types must be the same")
 
         return self
 

--- a/nucliadb_models/tests/test_filters.py
+++ b/nucliadb_models/tests/test_filters.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Bosutech XXI S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from datetime import datetime, timedelta
+
+import pytest
+from pydantic_core import ValidationError
+
+from nucliadb_models import filters
+
+
+@pytest.mark.parametrize(
+    "gte,lte",
+    [
+        # must select a filter
+        (None, None),
+        # combine int/float with dates
+        (10, datetime.now()),
+        (3.5, datetime.now()),
+        (datetime.now(), 10),
+        (datetime.now(), 3.5),
+        # lte < gte
+        (20, 10),
+        (20.0, 10),
+        (20, 10.0),
+        (20.0, 10.0),
+        (datetime.now(), datetime.now() - timedelta(days=1)),
+    ],
+)
+def test_key_value_inequality_filter_bounds_check(
+    gte: int | float | datetime | None,
+    lte: int | float | datetime | None,
+):
+    with pytest.raises(ValidationError):
+        filters.Inequalities(schema_id="schema", key="k", gte=gte, lte=lte)


### PR DESCRIPTION
### Description
Replace type-specific operators (bool_match, exact_match) for more generic operators (eq, gte, lte) in key-value JSON filtering. 

### How was this PR tested?
Integration tests
