### PR TITLE
Remove /ask from search VirtualService

### DIFF
--- a/charts/nucliadb_search/templates/search.vs.yaml
+++ b/charts/nucliadb_search/templates/search.vs.yaml
@@ -79,22 +79,3 @@ spec:
               number: {{.Values.serving.port}}
             host: "search.{{ .Release.Namespace }}.svc.cluster.local"
 
-    # Generic canary release (traffic shifting) for /ask endpoints
-    - name: ask_endpoint
-      match:
-        - uri:
-            regex: '^/api/v\d+/kb/[^/]+/ask$'
-          method:
-            regex: "POST|OPTIONS"
-        - uri:
-            regex: '^/api/v\d+/kb/[^/]+/(resource|slug)/[^/]+/ask$'
-          method:
-            regex: "POST|OPTIONS"
-      route:
-        - destination:
-            host: "arag-api.arag.svc.cluster.local"
-            port:
-              number: {{ .Values.ask_canary.rao_serving_port }}
-      retries:
-        attempts: 3
-        retryOn: connect-failure,5xx


### PR DESCRIPTION
### Description
/ask endpoint definition has already been moved to RAO, we can remove it from here

### How was this PR tested?
Describe how you tested this PR.
