### PR TITLE
Add int/float eq operation in JSON filtering

### DIFF
--- a/nidx/nidx_json/src/search.rs
+++ b/nidx/nidx_json/src/search.rs
@@ -34,6 +34,7 @@ pub struct JsonPathFilter {
 #[derive(Clone)]
 pub enum JsonPredicate {
     Text(String),
+    Boolean(bool),
     Int(i64),
     IntRange {
         lower: Option<i64>,
@@ -44,11 +45,11 @@ pub enum JsonPredicate {
         lower: Option<f64>,
         upper: Option<f64>,
     },
+    Date(tantivy::DateTime),
     DateRange {
         lower: Option<tantivy::DateTime>,
         upper: Option<tantivy::DateTime>,
     },
-    Boolean(bool),
 }
 
 #[derive(Clone)]
@@ -82,16 +83,14 @@ fn build_leaf_query(filter: &JsonPathFilter, json_field: Field) -> Box<dyn Query
                 Bound::Included(term),
             ))
         }
-        JsonPredicate::Int(val) => {
-            // Use the fast field to do exact match
+
+        JsonPredicate::Boolean(val) => {
             let mut term = Term::from_field_json_path(json_field, &path, false);
             term.append_type_and_fast_value(*val);
-            Box::new(FastFieldRangeQuery::new(
-                Bound::Included(term.clone()),
-                Bound::Included(term),
-            ))
+            Box::new(TermQuery::new(term, IndexRecordOption::Basic))
         }
-        JsonPredicate::Float(val) => {
+
+        JsonPredicate::Int(val) => {
             // Use the fast field to do exact match
             let mut term = Term::from_field_json_path(json_field, &path, false);
             term.append_type_and_fast_value(*val);
@@ -115,6 +114,16 @@ fn build_leaf_query(filter: &JsonPathFilter, json_field: Field) -> Box<dyn Query
             Box::new(FastFieldRangeQuery::new(build_bound(lower), build_bound(upper)))
         }
 
+        JsonPredicate::Float(val) => {
+            // Use the fast field to do exact match
+            let mut term = Term::from_field_json_path(json_field, &path, false);
+            term.append_type_and_fast_value(*val);
+            Box::new(FastFieldRangeQuery::new(
+                Bound::Included(term.clone()),
+                Bound::Included(term),
+            ))
+        }
+
         JsonPredicate::FloatRange { lower, upper } => {
             let build_bound = |opt: &Option<f64>| -> Bound<Term> {
                 match opt {
@@ -129,10 +138,14 @@ fn build_leaf_query(filter: &JsonPathFilter, json_field: Field) -> Box<dyn Query
             Box::new(FastFieldRangeQuery::new(build_bound(lower), build_bound(upper)))
         }
 
-        JsonPredicate::Boolean(val) => {
+        JsonPredicate::Date(val) => {
+            // Use the fast field to do exact match
             let mut term = Term::from_field_json_path(json_field, &path, false);
             term.append_type_and_fast_value(*val);
-            Box::new(TermQuery::new(term, IndexRecordOption::Basic))
+            Box::new(FastFieldRangeQuery::new(
+                Bound::Included(term.clone()),
+                Bound::Included(term),
+            ))
         }
 
         JsonPredicate::DateRange { lower, upper } => {
@@ -541,6 +554,21 @@ mod tests {
             path("k/product", "color", JsonPredicate::Text("red apple".to_string())),
         );
         assert!(!results.contains(&id), "wrong case should not match");
+    }
+
+    #[test]
+    fn test_date_exact() {
+        let (svc, _old, mid, _new) = build_date_index();
+        // [2021-01-01 .. 2023-01-01]
+        let results = search(
+            &svc,
+            path(
+                "t/event",
+                "ts",
+                JsonPredicate::Date(tantivy::DateTime::from_timestamp_secs(1655251200)),
+            ),
+        );
+        assert_eq!(results, HashSet::from([mid]));
     }
 
     #[test]

--- a/nidx/nidx_json/src/search.rs
+++ b/nidx/nidx_json/src/search.rs
@@ -34,11 +34,12 @@ pub struct JsonPathFilter {
 #[derive(Clone)]
 pub enum JsonPredicate {
     Text(String),
-
+    Int(i64),
     IntRange {
         lower: Option<i64>,
         upper: Option<i64>,
     },
+    Float(f64),
     FloatRange {
         lower: Option<f64>,
         upper: Option<f64>,
@@ -76,6 +77,24 @@ fn build_leaf_query(filter: &JsonPathFilter, json_field: Field) -> Box<dyn Query
             // Use the fast field to do exact match
             let mut term = Term::from_field_json_path(json_field, &path, true);
             term.append_type_and_str(val);
+            Box::new(FastFieldRangeQuery::new(
+                Bound::Included(term.clone()),
+                Bound::Included(term),
+            ))
+        }
+        JsonPredicate::Int(val) => {
+            // Use the fast field to do exact match
+            let mut term = Term::from_field_json_path(json_field, &path, false);
+            term.append_type_and_fast_value(*val);
+            Box::new(FastFieldRangeQuery::new(
+                Bound::Included(term.clone()),
+                Bound::Included(term),
+            ))
+        }
+        JsonPredicate::Float(val) => {
+            // Use the fast field to do exact match
+            let mut term = Term::from_field_json_path(json_field, &path, false);
+            term.append_type_and_fast_value(*val);
             Box::new(FastFieldRangeQuery::new(
                 Bound::Included(term.clone()),
                 Bound::Included(term),
@@ -290,6 +309,15 @@ mod tests {
     }
 
     #[test]
+    fn test_int_exact() {
+        let (svc, apple, banana, cherry) = build_test_index();
+        let results = search(&svc, path("t/product", "price", JsonPredicate::Int(150)));
+        assert!(results.contains(&apple));
+        assert!(!results.contains(&banana));
+        assert!(!results.contains(&cherry));
+    }
+
+    #[test]
     fn test_int_range() {
         let (svc, apple, banana, cherry) = build_test_index();
         let results = search(
@@ -324,6 +352,15 @@ mod tests {
         );
         assert!(results.contains(&apple));
         assert!(results.contains(&cherry));
+    }
+
+    #[test]
+    fn test_float_exact() {
+        let (svc, apple, banana, cherry) = build_test_index();
+        let results = search(&svc, path("t/product", "score", JsonPredicate::Float(3.2)));
+        assert!(!results.contains(&apple));
+        assert!(results.contains(&banana));
+        assert!(!results.contains(&cherry));
     }
 
     #[test]

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -349,6 +349,7 @@ message JsonFieldPathFilter {
         bool boolean = 6;
         int64 int = 8;
         double float = 9;
+        google.protobuf.Timestamp date = 10;
         IntegerRangePredicate int_range   = 4;
         FloatRangePredicate float_range = 5;
         DateRangePredicate date_range = 7;

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -346,9 +346,11 @@ message JsonFieldPathFilter {
 
     oneof predicate {
         string text = 3;
+        bool boolean = 6;
+        int64 int = 8;
+        double float = 9;
         IntegerRangePredicate int_range   = 4;
         FloatRangePredicate float_range = 5;
-        bool boolean = 6;
         DateRangePredicate date_range = 7;
     }
 }

--- a/nidx/src/searcher/query_planner.rs
+++ b/nidx/src/searcher/query_planner.rs
@@ -251,6 +251,7 @@ fn proto_to_json_filter(expr: &nidx_protos::JsonFilterExpression) -> anyhow::Res
                     upper: r.upper,
                 },
                 Predicate::Boolean(b) => JsonPredicate::Boolean(*b),
+                Predicate::Date(ts) => JsonPredicate::Date(nidx_json::DateTime::from_timestamp_secs(ts.seconds)),
                 Predicate::DateRange(r) => {
                     let ts_to_dt =
                         |ts: &nidx_protos::prost_types::Timestamp| nidx_json::DateTime::from_timestamp_secs(ts.seconds);

--- a/nidx/src/searcher/query_planner.rs
+++ b/nidx/src/searcher/query_planner.rs
@@ -240,10 +240,12 @@ fn proto_to_json_filter(expr: &nidx_protos::JsonFilterExpression) -> anyhow::Res
                 .ok_or_else(|| anyhow::anyhow!("Missing predicate"))?
             {
                 Predicate::Text(s) => JsonPredicate::Text(s.clone()),
+                Predicate::Int(i) => JsonPredicate::Int(*i),
                 Predicate::IntRange(r) => JsonPredicate::IntRange {
                     lower: r.lower,
                     upper: r.upper,
                 },
+                Predicate::Float(f) => JsonPredicate::Float(*f),
                 Predicate::FloatRange(r) => JsonPredicate::FloatRange {
                     lower: r.lower,
                     upper: r.upper,

--- a/nucliadb/src/nucliadb/common/exceptions.py
+++ b/nucliadb/src/nucliadb/common/exceptions.py
@@ -18,8 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from nucliadb_models.kv_schemas import KVFieldType, KVSchemaField
-
 
 class InvalidQueryError(Exception):
     """Raised when parsing a query containing an invalid parameter"""
@@ -28,12 +26,3 @@ class InvalidQueryError(Exception):
         self.param = param
         self.reason = reason
         super().__init__(f"Invalid query. Error in {param}: {reason}")
-
-
-class InvalidKVType(InvalidQueryError):
-    def __init__(self, schema_id: str, schema_field: KVSchemaField, invalid_type: KVFieldType):
-        super().__init__(
-            "key_value",
-            f"Key '{schema_field.key}' in schema '{schema_id}' is of type '{schema_field.type}', "
-            f"but '{invalid_type} has been provided",
-        )

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -26,7 +26,7 @@ from nidx_protos.nodereader_pb2 import FilterExpression as PBFilterExpression
 from typing_extensions import assert_never
 
 from nucliadb.common import datamanagers
-from nucliadb.common.exceptions import InvalidKVType, InvalidQueryError
+from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.common.ids import FIELD_TYPE_NAME_TO_STR
 from nucliadb_models.common import Paragraph
 from nucliadb_models.filters import (
@@ -146,16 +146,22 @@ async def parse_kv_expression(
 
 
 KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities], set[KVFieldType]] = {
-    Eq: {KVFieldType.TEXT, KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.BOOLEAN},
+    Eq: {
+        KVFieldType.TEXT,
+        KVFieldType.INTEGER,
+        KVFieldType.FLOAT,
+        KVFieldType.BOOLEAN,
+        KVFieldType.DATE,
+    },
     Inequalities: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
 }
 
-KV_VALUE_FIELD_TYPES: dict[type, set[KVFieldType]] = {
-    str: {KVFieldType.TEXT},
-    bool: {KVFieldType.BOOLEAN},
-    float: {KVFieldType.FLOAT},
-    int: {KVFieldType.INTEGER, KVFieldType.FLOAT},
-    datetime: {KVFieldType.DATE},
+KV_VALUE_FIELD_TYPES: dict[type, list[KVFieldType]] = {
+    str: [KVFieldType.TEXT],
+    bool: [KVFieldType.BOOLEAN],
+    float: [KVFieldType.FLOAT],
+    int: [KVFieldType.INTEGER, KVFieldType.FLOAT],
+    datetime: [KVFieldType.DATE],
 }
 
 
@@ -186,8 +192,14 @@ def _validate_kv_schema(
 
     # validate value type(s) match the field type
     expected_field_types = KV_VALUE_FIELD_TYPES.get(expr._value_type())
-    if expected_field_types is None or schema_field.type not in expected_field_types:
-        raise InvalidKVType(expr.schema_id, schema_field, schema_field.type)
+    assert expected_field_types is not None, "missing a type in the key-value field types dict!"
+    if schema_field.type not in expected_field_types:
+        invalid_type = expected_field_types[0]
+        raise InvalidQueryError(
+            "key_value",
+            f"Key '{schema_field.key}' in schema '{expr.schema_id}' is of type '{schema_field.type}', "
+            f"but '{invalid_type} has been provided",
+        )
 
 
 def _set_range_bound(
@@ -242,6 +254,8 @@ def _parse_kv_expression(
                 json_filter.path.float = expr.eq
             case int():
                 json_filter.path.int = expr.eq
+            case datetime():
+                json_filter.path.date.FromDatetime(expr.eq)
             case _:
                 assert_never(expr.eq)
 

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -239,11 +239,9 @@ def _parse_kv_expression(
             case bool():
                 json_filter.path.boolean = expr.eq
             case float():
-                json_filter.path.float_range.lower = expr.eq
-                json_filter.path.float_range.upper = expr.eq
+                json_filter.path.float = expr.eq
             case int():
-                json_filter.path.int_range.lower = expr.eq
-                json_filter.path.int_range.upper = expr.eq
+                json_filter.path.int = expr.eq
             case _:
                 assert_never(expr.eq)
 

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -311,25 +311,33 @@ async def test_kv_field_filter(
         return set(resp.json()["resources"].keys())
 
     filters = [
-        # exact match
-        ("color", "eq", "red", {rid1}),
-        ("color", "eq", "blue", {rid2}),
-        ("color", "eq", "black", set()),
-        ("price", "eq", 5.0, {rid2}),
-        ("price", "eq", 5, {rid2}),
-        ("quantity", "eq", 3, {rid1}),
+        # BOOLEAN fields
         ("in_stock", "eq", True, {rid1}),
+        ("in_stock", "eq", False, {rid2}),
+        # INTEGER fields
+        ("quantity", "eq", 3, {rid1}),
         ("quantity", "gte", 1, {rid1, rid2}),
         ("quantity", "gte", 5, {rid2}),
-        ("price", "gte", 5.0, {rid1, rid2}),
-        ("price", "gte", 5, {rid1, rid2}),  # price (float) can be filtered by an int
-        ("price", "gte", 5.01, {rid1}),
-        ("launched_at", "gte", "2024-01-01T00:00:00Z", {rid2}),
         ("quantity", "lte", 20, {rid1, rid2}),
         ("quantity", "lte", 5, {rid1}),
+        # FLOAT fields
+        ("price", "eq", 5, {rid2}),
+        ("price", "eq", 5.0, {rid2}),
+        ("price", "gte", 5.0, {rid1, rid2}),
+        ("price", "gte", 5.01, {rid1}),
         ("price", "lte", 12.5, {rid1, rid2}),
-        ("price", "lte", 5, {rid2}),  # price (float) can be filtered by an int
         ("price", "lte", 4.99, set()),
+        #  price (float) can be filtered by an int
+        ("price", "eq", 5, {rid2}),
+        ("price", "gte", 5, {rid1, rid2}),
+        ("price", "lte", 5, {rid2}),
+        # TEXT fields
+        ("color", "eq", "black", set()),
+        ("color", "eq", "blue", {rid2}),
+        ("color", "eq", "red", {rid1}),
+        # DATE fields
+        ("launched_at", "eq", "2024-06-01T00:00:00Z", {rid2}),
+        ("launched_at", "gte", "2024-01-01T00:00:00Z", {rid2}),
         ("launched_at", "lte", "2023-12-31T23:59:59Z", {rid1}),
     ]
     for key, op, value, expected in filters:

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -321,7 +321,7 @@ class KVFilter(BaseModel, ABC, extra="forbid"):
 class Eq(KVFilter):
     """Equal (==) operator"""
 
-    eq: str | int | float | bool
+    eq: bool | int | float | DateTime | str
 
     def _value_type(self) -> type:
         return type(self.eq)


### PR DESCRIPTION
### Description
Add a specific eq operation for int/float instead of using an inclusive range with the same value

### How was this PR tested?
Existing tests
