### PR TITLE
Add integer range to key-value

### DIFF
--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -158,7 +158,7 @@ KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities] | Type[Contains], se
         KVFieldType.DATE,
     },
     Inequalities: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
-    Contains: {KVFieldType.RANGE},
+    Contains: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
 }
 
 # Map from Python types a value can have and which key-value field types can be
@@ -167,7 +167,7 @@ KV_VALUE_FIELD_TYPES: dict[type, list[KVFieldType]] = {
     str: [KVFieldType.TEXT],
     bool: [KVFieldType.BOOLEAN],
     float: [KVFieldType.FLOAT],
-    int: [KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.RANGE],
+    int: [KVFieldType.INTEGER, KVFieldType.FLOAT],
     datetime: [KVFieldType.DATE],
 }
 
@@ -195,6 +195,14 @@ def _validate_kv_schema(
             "key_value",
             f"Key '{expr.key}' in schema '{expr.schema_id}' is of type '{schema_field.type}', "
             f"but '{type(expr).__name__.lower()}' requires type {allowed}",
+        )
+
+    # validate range operations
+    if schema_field.range is False and isinstance(expr, (Contains,)):
+        raise InvalidQueryError(
+            "key_value",
+            f"Key '{expr.key}' in schema '{expr.schema_id}' is not a range type. "
+            f"Therefore '{type(expr).__name__.lower()}' can't be used",
         )
 
     # validate value type(s) match the field type

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -291,8 +291,8 @@ def _parse_kv_expression(
 
         lower_bound.path.field_id = f"k/{expr.schema_id}"
         upper_bound.path.field_id = f"k/{expr.schema_id}"
-        lower_bound.path.json_path = f"{expr.key}._range_min"
-        upper_bound.path.json_path = f"{expr.key}._range_max"
+        lower_bound.path.json_path = f"{expr.key}.min"
+        upper_bound.path.json_path = f"{expr.key}.max"
 
         # we want our value to be >= the lower bound and <= the upper bound
         _set_range_bound(lower_bound.path, expr.contains, lower=False)

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -31,6 +31,7 @@ from nucliadb.common.ids import FIELD_TYPE_NAME_TO_STR
 from nucliadb_models.common import Paragraph
 from nucliadb_models.filters import (
     And,
+    Contains,
     DateCreated,
     DateModified,
     Entity,
@@ -146,7 +147,9 @@ async def parse_kv_expression(
     return _parse_kv_expression(expr, all_schemas)
 
 
-KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities], set[KVFieldType]] = {
+# Map between an operator and the possible schema field types. This is must be
+# synchronized with the types the operators have, e.g. Eq.eq types
+KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities] | Type[Contains], set[KVFieldType]] = {
     Eq: {
         KVFieldType.TEXT,
         KVFieldType.INTEGER,
@@ -155,20 +158,23 @@ KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities], set[KVFieldType]] =
         KVFieldType.DATE,
     },
     Inequalities: {KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.DATE},
+    Contains: {KVFieldType.RANGE},
 }
 
+# Map from Python types a value can have and which key-value field types can be
+# used on. For example, an int value can be used in an int/float/range types
 KV_VALUE_FIELD_TYPES: dict[type, list[KVFieldType]] = {
     str: [KVFieldType.TEXT],
     bool: [KVFieldType.BOOLEAN],
     float: [KVFieldType.FLOAT],
-    int: [KVFieldType.INTEGER, KVFieldType.FLOAT],
+    int: [KVFieldType.INTEGER, KVFieldType.FLOAT, KVFieldType.RANGE],
     datetime: [KVFieldType.DATE],
 }
 
 
 def _validate_kv_schema(
     schemas: KBKVSchemas,
-    expr: Eq | Inequalities,
+    expr: Eq | Inequalities | Contains,
 ) -> None:
     schema = schemas.schemas.get(expr.schema_id)
     if schema is None:
@@ -276,6 +282,23 @@ def _parse_kv_expression(
             _set_range_bound(json_filter.path, expr.gte, lower=True)
         if expr.lte is not None:
             _set_range_bound(json_filter.path, expr.lte, lower=False)
+
+    elif isinstance(expr, Contains):
+        _validate_kv_schema(schemas, expr)
+
+        lower_bound = nodereader_pb2.JsonFilterExpression()
+        upper_bound = nodereader_pb2.JsonFilterExpression()
+
+        lower_bound.path.field_id = f"k/{expr.schema_id}"
+        upper_bound.path.field_id = f"k/{expr.schema_id}"
+        lower_bound.path.json_path = f"{expr.key}._range_min"
+        upper_bound.path.json_path = f"{expr.key}._range_max"
+
+        # we want our value to be >= the lower bound and <= the upper bound
+        _set_range_bound(lower_bound.path, expr.contains, lower=False)
+        _set_range_bound(upper_bound.path, expr.contains, lower=True)
+
+        json_filter.bool_and.operands.extend([lower_bound, upper_bound])
 
     else:
         assert_never(expr)

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -148,7 +148,7 @@ async def parse_kv_expression(
 
 
 # Map between an operator and the possible schema field types. This is must be
-# synchronized with the types the operators have, e.g. Eq.eq types
+# synchronized with the types the operators have, e.g. `Eq.eq` types
 KEY_VALUE_ALLOWED_TYPES: dict[Type[Eq] | Type[Inequalities] | Type[Contains], set[KVFieldType]] = {
     Eq: {
         KVFieldType.TEXT,
@@ -197,13 +197,26 @@ def _validate_kv_schema(
             f"but '{type(expr).__name__.lower()}' requires type {allowed}",
         )
 
-    # validate range operations
-    if schema_field.range is False and isinstance(expr, (Contains,)):
-        raise InvalidQueryError(
-            "key_value",
-            f"Key '{expr.key}' in schema '{expr.schema_id}' is not a range type. "
-            f"Therefore '{type(expr).__name__.lower()}' can't be used",
-        )
+    if schema_field.range is True:
+        # validate range fields use valid range operators
+        if type(expr) not in {
+            Contains,
+        }:
+            raise InvalidQueryError(
+                "key_value",
+                f"Key '{expr.key}' in schema '{expr.schema_id}' is not a range type. "
+                f"Therefore '{type(expr).__name__.lower()}' can't be used",
+            )
+    else:
+        # validate non-range fields don't use range operators
+        if type(expr) in {
+            Contains,
+        }:
+            raise InvalidQueryError(
+                "key_value",
+                f"Key '{expr.key}' in schema '{expr.schema_id}' is not a range type. "
+                f"Therefore '{type(expr).__name__.lower()}' can't be used",
+            )
 
     # validate value type(s) match the field type
     expected_field_types = KV_VALUE_FIELD_TYPES.get(expr._value_type())

--- a/nucliadb/src/nucliadb/common/models_utils/from_proto.py
+++ b/nucliadb/src/nucliadb/common/models_utils/from_proto.py
@@ -17,8 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
-
 from typing import Any
 
 from google.protobuf.json_format import MessageToDict
@@ -40,6 +38,7 @@ from nucliadb_models.extracted import (
 )
 from nucliadb_models.file import FieldFile
 from nucliadb_models.internal.shards import KnowledgeboxShards
+from nucliadb_models.key_value import KeyValueField
 from nucliadb_models.link import FieldLink
 from nucliadb_models.metadata import (
     ComputedMetadata,
@@ -462,6 +461,14 @@ def field_text(message: resources_pb2.FieldText) -> FieldText:
             preserving_proto_field_name=True,
             always_print_fields_with_no_presence=True,
         )
+    )
+
+
+def field_key_value(message: resources_pb2.FieldKeyValue) -> KeyValueField | None:
+    if not message.data:
+        return None
+    return KeyValueField(
+        schema_id=message.schema_id, data=KeyValueField.parse_from_proto_json(message.data)
     )
 
 

--- a/nucliadb/src/nucliadb/ingest/fields/key_value.py
+++ b/nucliadb/src/nucliadb/ingest/fields/key_value.py
@@ -24,7 +24,8 @@ from datetime import datetime
 from typing_extensions import assert_never
 
 from nucliadb.ingest.fields.base import Field
-from nucliadb_models.kv_schemas import KVFieldType, KVSchema, Range
+from nucliadb_models.key_value import Range
+from nucliadb_models.kv_schemas import KVFieldType, KVSchema
 from nucliadb_protos.resources_pb2 import FieldKeyValue
 
 

--- a/nucliadb/src/nucliadb/ingest/fields/key_value.py
+++ b/nucliadb/src/nucliadb/ingest/fields/key_value.py
@@ -20,12 +20,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from typing_extensions import assert_never
 
 from nucliadb.ingest.fields.base import Field
 from nucliadb_models.key_value import Range
-from nucliadb_models.kv_schemas import KVFieldType, KVSchema
+from nucliadb_models.kv_schemas import KVFieldType, KVSchema, KVSchemaField
 from nucliadb_protos.resources_pb2 import FieldKeyValue
 
 
@@ -44,7 +45,7 @@ def validate_kv_data(data: dict, schema: KVSchema) -> None:
     _validate_keys(data, schema)
     schema_fields = {f.key: f for f in schema.fields}
     for key, value in data.items():
-        check_kv_type(schema.name, key, value, schema_fields[key].type)
+        check_kv_type(schema.name, schema_fields[key], key, value)
 
 
 def _validate_keys(data: dict, schema: KVSchema) -> None:
@@ -57,7 +58,9 @@ def _validate_keys(data: dict, schema: KVSchema) -> None:
         raise ValueError(f"Missing required keys for schema {schema.name!r}: {missing}")
 
 
-def check_kv_type(schema_name: str, key: str, value: object, expected: KVFieldType) -> None:
+def check_kv_type(schema_name: str, schema_field: KVSchemaField, key: str, value: object) -> None:
+    expected = schema_field.type
+
     ok = False
     if expected is KVFieldType.TEXT:
         if isinstance(value, str):
@@ -72,23 +75,29 @@ def check_kv_type(schema_name: str, key: str, value: object, expected: KVFieldTy
         else:
             ok = False
     elif expected is KVFieldType.INTEGER:
-        ok = isinstance(value, int) and not isinstance(value, bool)
+        if schema_field.range and isinstance(value, Range):
+            ok = (isinstance(value.lower, int) and not isinstance(value.lower, bool)) and (
+                isinstance(value.upper, int) and not isinstance(value.upper, bool)
+            )
+        else:
+            ok = isinstance(value, int) and not isinstance(value, bool)
     elif expected is KVFieldType.FLOAT:
-        ok = isinstance(value, (int, float)) and not isinstance(value, bool)
+        if schema_field.range and isinstance(value, Range):
+            ok = (isinstance(value.lower, (int, float)) and not isinstance(value.lower, bool)) and (
+                isinstance(value.upper, (int, float)) and not isinstance(value.upper, bool)
+            )
+        else:
+            ok = isinstance(value, (int, float)) and not isinstance(value, bool)
     elif expected is KVFieldType.BOOLEAN:
         ok = isinstance(value, bool)
     elif expected is KVFieldType.DATE:
-        # Dates must be stored as ISO-8601 strings (e.g. "2024-01-15T00:00:00Z")
-        if isinstance(value, str):
-            try:
-                datetime.fromisoformat(value)
-                ok = True
-            except ValueError:
+        if schema_field.range:
+            if isinstance(value, Range):
+                ok = is_datetime(value.lower) and is_datetime(value.upper)
+            else:
                 ok = False
         else:
-            ok = False
-    elif expected is KVFieldType.RANGE:
-        ok = isinstance(value, Range)
+            ok = is_datetime(value)
     else:
         assert_never(expected)
     if not ok:
@@ -100,3 +109,19 @@ def check_kv_type(schema_name: str, key: str, value: object, expected: KVFieldTy
         raise ValueError(
             f"Key {key!r} in schema {schema_name!r} expects type {expected.value!r}, got {type(value).__name__}"
         )
+
+
+def is_datetime(value: Any) -> bool:
+    # Dates must be stored as ISO-8601 strings (e.g. "2024-01-15T00:00:00Z"), so
+    # we validate against this
+    if isinstance(value, datetime):
+        ok = True
+    elif isinstance(value, str):
+        try:
+            datetime.fromisoformat(value)
+            ok = True
+        except ValueError:
+            ok = False
+    else:
+        ok = False
+    return ok

--- a/nucliadb/src/nucliadb/ingest/fields/key_value.py
+++ b/nucliadb/src/nucliadb/ingest/fields/key_value.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from typing_extensions import assert_never
 
 from nucliadb.ingest.fields.base import Field
-from nucliadb_models.kv_schemas import KVFieldType, KVSchema
+from nucliadb_models.kv_schemas import KVFieldType, KVSchema, Range
 from nucliadb_protos.resources_pb2 import FieldKeyValue
 
 
@@ -86,6 +86,8 @@ def check_kv_type(schema_name: str, key: str, value: object, expected: KVFieldTy
                 ok = False
         else:
             ok = False
+    elif expected is KVFieldType.RANGE:
+        ok = isinstance(value, Range)
     else:
         assert_never(expected)
     if not ok:

--- a/nucliadb/src/nucliadb/ingest/fields/key_value.py
+++ b/nucliadb/src/nucliadb/ingest/fields/key_value.py
@@ -63,17 +63,10 @@ def check_kv_type(schema_name: str, schema_field: KVSchemaField, key: str, value
 
     ok = False
     if expected is KVFieldType.TEXT:
-        if isinstance(value, str):
-            try:
-                dt = datetime.fromisoformat(value)
-                # Tantivy's JSON indexer auto-parses strings as DateTime only when
-                # they parse as RFC 3339, which requires both a time component and a
-                # timezone offset (Z or ±HH:MM).
-                ok = dt.tzinfo is None
-            except ValueError:
-                ok = True  # not parseable as a date at all, safe
-        else:
-            ok = False
+        # Tantivy's JSON indexer auto-parses strings as DateTime only when
+        # they parse as RFC 3339, which requires both a time component and a
+        # timezone offset (Z or ±HH:MM)
+        ok = isinstance(value, str) and not is_datetime(value)
     elif expected is KVFieldType.INTEGER:
         if schema_field.range and isinstance(value, Range):
             ok = (isinstance(value.lower, int) and not isinstance(value.lower, bool)) and (
@@ -112,16 +105,16 @@ def check_kv_type(schema_name: str, schema_field: KVSchemaField, key: str, value
 
 
 def is_datetime(value: Any) -> bool:
-    # Dates must be stored as ISO-8601 strings (e.g. "2024-01-15T00:00:00Z"), so
-    # we validate against this
+    # Dates must be stored as RFC 3339, which requires both a time component and
+    # a timezone offset (Z or ±HH:MM).
     if isinstance(value, datetime):
-        ok = True
+        ok = value.tzinfo is not None
     elif isinstance(value, str):
         try:
-            datetime.fromisoformat(value)
-            ok = True
+            dt = datetime.fromisoformat(value)
+            ok = dt.tzinfo is not None
         except ValueError:
-            ok = False
+            ok = False  # not parseable as a date
     else:
         ok = False
     return ok

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -306,10 +306,7 @@ async def serialize_resource(
                 if field.id not in resource.data.key_values:
                     resource.data.key_values[field.id] = KeyValueFieldData()
                 if include_value and value is not None:
-                    # data is a single JSON string containing the entire KV payload
-                    kv = from_proto.field_key_value(value)
-                    if kv is not None:
-                        resource.data.key_values[field.id].value = kv.data
+                    resource.data.key_values[field.id].value = from_proto.field_key_value(value)
                 if include_errors:
                     await serialize_field_errors(field, resource.data.key_values[field.id])
     return resource

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -19,8 +19,6 @@
 #
 
 
-import json
-
 import nucliadb_models as models
 from nucliadb.common import datamanagers
 from nucliadb.common.maindb.driver import Transaction
@@ -309,9 +307,9 @@ async def serialize_resource(
                     resource.data.key_values[field.id] = KeyValueFieldData()
                 if include_value and value is not None:
                     # data is a single JSON string containing the entire KV payload
-                    resource.data.key_values[field.id].value = (
-                        json.loads(value.data) if value.data else {}
-                    )
+                    kv = from_proto.field_key_value(value)
+                    if kv is not None:
+                        resource.data.key_values[field.id].value = kv.data
                 if include_errors:
                     await serialize_field_errors(field, resource.data.key_values[field.id])
     return resource

--- a/nucliadb/src/nucliadb/reader/api/models.py
+++ b/nucliadb/src/nucliadb/reader/api/models.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 import nucliadb_models as models
 from nucliadb_models.common import FieldTypeName
+from nucliadb_models.key_value import KeyValueField
 from nucliadb_models.resource import (
     ConversationFieldExtractedData,
     Error,
@@ -33,7 +34,14 @@ from nucliadb_models.resource import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    ValueType = models.FieldText | models.FieldFile | models.FieldLink | models.Conversation | None
+    ValueType = (
+        models.FieldText
+        | models.FieldFile
+        | models.FieldLink
+        | models.Conversation
+        | KeyValueField
+        | None
+    )
 else:
     # without Any, pydantic fails to anything as validate() fails using the Union
     ValueType = Any

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import json
 from typing import cast
 
 from fastapi import Header, HTTPException, Query, Request, Response
@@ -421,7 +420,7 @@ async def _get_resource_field(
                 resource_field.value = from_proto.field_link(value)
 
             if isinstance(value, resources_pb2.FieldKeyValue):
-                resource_field.value = json.loads(value.data) if value.data else None
+                resource_field.value = from_proto.field_key_value(value)
 
             if field_type is FieldTypeName.KEY_VALUE and value is None:
                 raise HTTPException(status_code=404, detail="Key-value field does not exist")

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import dataclasses
-import json
 from datetime import datetime
 
 from fastapi import HTTPException
@@ -284,7 +283,7 @@ async def parse_key_value_field(
 
     pb = writer.key_value_fields[key]
     pb.schema_id = kv_field.schema_id
-    pb.data = json.dumps(kv_field.data)
+    pb.data = kv_field.serialize_json_for_proto()
 
     writer.field_statuses.append(
         FieldIDStatus(

--- a/nucliadb/tests/nucliadb/integration/test_backups.py
+++ b/nucliadb/tests/nucliadb/integration/test_backups.py
@@ -271,8 +271,8 @@ async def check_kv_schema(nucliadb_reader: AsyncClient, kbid: str):
         if resp.status_code == 200:
             kv_values.append(resp.json()["value"])
     assert len(kv_values) == 1, "Expected exactly one resource with a KV field"
-    assert kv_values[0]["color"] == "red"
-    assert kv_values[0]["price"] == 9.99
+    assert kv_values[0]["data"]["color"] == "red"
+    assert kv_values[0]["data"]["price"] == 9.99
 
 
 async def check_resources(nucliadb_reader: AsyncClient, kbid: str):

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -29,6 +29,7 @@ PRODUCT_SCHEMA = {
         {"key": "in_stock", "type": "boolean", "required": False},
         {"key": "quantity", "type": "integer", "required": False},
         {"key": "launched_at", "type": "date", "required": False},
+        {"key": "delivery_days", "type": "range", "required": False},
     ],
 }
 
@@ -40,6 +41,7 @@ VALID_PRODUCT_DATA = {
         "in_stock": True,
         "quantity": 3,
         "launched_at": "2024-01-15T00:00:00Z",
+        "delivery_days": {"lower": 1, "upper": 5},
     },
 }
 
@@ -87,6 +89,7 @@ async def test_kv_field_crud(
     assert value["in_stock"] is True
     assert value["quantity"] == 3
     assert value["launched_at"] == "2024-01-15T00:00:00Z"
+    assert value["delivery_days"] == {"lower": 1, "upper": 5}
 
     # --- Update resource via PATCH ---
     resp = await nucliadb_writer.patch(
@@ -101,7 +104,7 @@ async def test_kv_field_crud(
 
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid}/key_value/product")
     assert resp.status_code == 200, resp.text
-    assert resp.json()["value"]["color"] == "blue"
+    assert resp.json()["value"]["data"]["color"] == "blue"
 
     # --- Set/get via PUT on a fresh resource ---
     resp = await nucliadb_writer.post(f"/kb/{kbid}/resources", json={"title": "Second resource"})
@@ -117,11 +120,12 @@ async def test_kv_field_crud(
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid2}/key_value/product")
     assert resp.status_code == 200, resp.text
     value = resp.json()["value"]
-    assert value["color"] == "red"
-    assert value["price"] == 12.5
-    assert value["in_stock"] is True
-    assert value["quantity"] == 3
-    assert value["launched_at"] == "2024-01-15T00:00:00Z"
+    assert value["schema_id"] == "product"
+    assert value["data"]["color"] == "red"
+    assert value["data"]["price"] == 12.5
+    assert value["data"]["in_stock"] is True
+    assert value["data"]["quantity"] == 3
+    assert value["data"]["launched_at"] == "2024-01-15T00:00:00Z"
 
     # --- Update field: only required keys; optional keys disappear ---
     resp = await nucliadb_writer.put(
@@ -133,8 +137,8 @@ async def test_kv_field_crud(
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid2}/key_value/product")
     assert resp.status_code == 200, resp.text
     value = resp.json()["value"]
-    assert value["color"] == "green"
-    assert value["price"] == 5.0
+    assert value["data"]["color"] == "green"
+    assert value["data"]["price"] == 5.0
     assert "in_stock" not in value
     assert "quantity" not in value
 
@@ -265,6 +269,7 @@ async def test_kv_field_filter(
                         "in_stock": True,
                         "quantity": 3,
                         "launched_at": "2023-06-01T00:00:00Z",
+                        "delivery_days": {"lower": 1, "upper": 5},
                     },
                 }
             },
@@ -288,6 +293,7 @@ async def test_kv_field_filter(
                         "in_stock": False,
                         "quantity": 10,
                         "launched_at": "2024-06-01T00:00:00Z",
+                        "delivery_days": {"lower": 2, "upper": 3},
                     },
                 }
             },
@@ -339,6 +345,9 @@ async def test_kv_field_filter(
         ("launched_at", "eq", "2024-06-01T00:00:00Z", {rid2}),
         ("launched_at", "gte", "2024-01-01T00:00:00Z", {rid2}),
         ("launched_at", "lte", "2023-12-31T23:59:59Z", {rid1}),
+        # RANGE fields
+        ("delivery_days", "contains", 2, {rid1, rid2}),
+        ("delivery_days", "contains", 4, {rid1}),
     ]
     for key, op, value, expected in filters:
         resources = await find_with_filter(
@@ -348,6 +357,10 @@ async def test_kv_field_filter(
                 op: value,
             }
         )
+        {
+            "key": "price_range",
+            "contains": 10,
+        }
         assert resources == expected, (
             f"Unexpected match for `{key} {op} {value}`: matched {resources} instead of {expected}"
         )
@@ -430,6 +443,7 @@ async def test_kv_filter_schema_validation(
         ("in_stock", "eq", 3.5),
         ("in_stock", "gte", 3.5),
         ("in_stock", "lte", 3.5),
+        ("in_stock", "eq", "2024-01-01T00:00:00Z"),
         ("in_stock", "gte", "2024-01-01T00:00:00Z"),
         ("in_stock", "lte", "2024-01-01T00:00:00Z"),
         # invalid types for an INTEGER field
@@ -438,11 +452,13 @@ async def test_kv_filter_schema_validation(
         ("quantity", "eq", 3.5),
         ("quantity", "gte", 3.5),
         ("quantity", "lte", 3.5),
+        ("quantity", "eq", "2024-01-01T00:00:00Z"),
         ("quantity", "gte", "2024-01-01T00:00:00Z"),
         ("quantity", "lte", "2024-01-01T00:00:00Z"),
         # invalid types for an FLOAT field
         ("price", "eq", "3.5"),
         ("price", "eq", True),
+        ("price", "eq", "2024-01-01T00:00:00Z"),
         ("price", "gte", "2024-01-01T00:00:00Z"),
         ("price", "lte", "2024-01-01T00:00:00Z"),
         # invalid types for a TEXT field
@@ -453,6 +469,7 @@ async def test_kv_filter_schema_validation(
         ("color", "eq", 3.5),
         ("color", "gte", 3.5),
         ("color", "lte", 3.5),
+        ("color", "eq", "2024-01-01T00:00:00Z"),
         ("color", "gte", "2024-01-01T00:00:00Z"),
         ("color", "lte", "2024-01-01T00:00:00Z"),
         # invalid types for a DATE field
@@ -464,6 +481,13 @@ async def test_kv_filter_schema_validation(
         ("launched_at", "eq", 3.5),
         ("launched_at", "gte", 3.5),
         ("launched_at", "lte", 3.5),
+        # invalid types for a RANGE field
+        ("delivery_days", "eq", "today"),
+        ("delivery_days", "eq", True),
+        ("delivery_days", "eq", 10.0),
+        ("delivery_days", "eq", "2024-01-01T00:00:00Z"),
+        ("delivery_days", "gte", "2024-01-01T00:00:00Z"),
+        ("delivery_days", "lte", "2024-01-01T00:00:00Z"),
     ]:
         status = await find_with_filter(
             {

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -29,7 +29,7 @@ PRODUCT_SCHEMA = {
         {"key": "in_stock", "type": "boolean", "required": False},
         {"key": "quantity", "type": "integer", "required": False},
         {"key": "launched_at", "type": "date", "required": False},
-        {"key": "delivery_days", "type": "range", "required": False},
+        {"key": "delivery_days", "type": "integer", "range": True, "required": False},
     ],
 }
 
@@ -84,12 +84,12 @@ async def test_kv_field_crud(
     assert "key_values" in data["data"]
     assert "product" in data["data"]["key_values"]
     value = data["data"]["key_values"]["product"]["value"]
-    assert value["color"] == "red"
-    assert value["price"] == 12.5
-    assert value["in_stock"] is True
-    assert value["quantity"] == 3
-    assert value["launched_at"] == "2024-01-15T00:00:00Z"
-    assert value["delivery_days"] == {"lower": 1, "upper": 5}
+    assert value["data"]["color"] == "red"
+    assert value["data"]["price"] == 12.5
+    assert value["data"]["in_stock"] is True
+    assert value["data"]["quantity"] == 3
+    assert value["data"]["launched_at"] == "2024-01-15T00:00:00Z"
+    assert value["data"]["delivery_days"] == {"lower": 1, "upper": 5}
 
     # --- Update resource via PATCH ---
     resp = await nucliadb_writer.patch(

--- a/nucliadb/tests/nucliadb/unit/test_kv_schemas.py
+++ b/nucliadb/tests/nucliadb/unit/test_kv_schemas.py
@@ -114,9 +114,10 @@ class TestValidateKvData:
     def test_valid_date_iso_datetime_string(self):
         validate_kv_data({"name": "launch", "ts": "2024-01-15T00:00:00Z"}, DATE_SCHEMA)
 
-    def test_valid_date_iso_date_only_string(self):
-        # Date-only ISO strings are valid (no time component)
-        validate_kv_data({"name": "launch", "ts": "2024-01-15"}, DATE_SCHEMA)
+    def test_invalid_date_iso_date_only_string(self):
+        # Date-only ISO strings are invalid (no time component)
+        with pytest.raises(ValueError, match="expects type 'date'"):
+            validate_kv_data({"name": "launch", "ts": "2024-01-15"}, DATE_SCHEMA)
 
     def test_valid_date_with_optional_end(self):
         validate_kv_data(

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -360,6 +360,15 @@ class Inequalities(KVFilter):
         return self
 
 
+class Contains(KVFilter):
+    """Computes whether a value exists inside a range"""
+
+    contains: int | float
+
+    def _value_type(self) -> type:
+        return type(self.contains)
+
+
 # The discriminator function is optional, everything works without it.
 # We implement it because it makes pydantic produce more user-friendly errors
 def filter_discriminator(v: Any) -> str | None:
@@ -453,6 +462,8 @@ def kv_discriminator(v: Any) -> str | None:
             return "inequalities"
         elif "lte" in v:
             return "inequalities"
+        elif "contains" in v:
+            return "contains"
         else:
             return ""
 
@@ -466,6 +477,8 @@ def kv_discriminator(v: Any) -> str | None:
         return "eq"
     elif isinstance(v, Inequalities):
         return "inequalities"
+    elif isinstance(v, Contains):
+        return "contains"
     else:
         return ""
 
@@ -476,6 +489,7 @@ KVFilterExpressionType = (
     | Annotated[Not["KVFilterExpression"], Tag("not")]
     | Annotated[Eq, Tag("eq")]
     | Annotated[Inequalities, Tag("inequalities")]
+    | Annotated[Contains, Tag("contains")]
 )
 KVFilterExpression = Annotated[KVFilterExpressionType, Discriminator(kv_discriminator)]
 

--- a/nucliadb_models/src/nucliadb_models/key_value.py
+++ b/nucliadb_models/src/nucliadb_models/key_value.py
@@ -13,10 +13,74 @@
 # limitations under the License.
 #
 import json
+from datetime import datetime
+from typing import Any
 
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    SerializerFunctionWrapHandler,
+    TypeAdapter,
+    model_serializer,
+    model_validator,
+)
+from typing_extensions import Self
 
-from nucliadb_models.kv_schemas import KVValue
+from nucliadb_models.utils import DateTime
+
+
+class Range(BaseModel):
+    """A closed-bound integer range [lower, upper]."""
+
+    lower: int | float | DateTime = Field(..., description="Lower closed bound (inclusive)")
+    upper: int | float | DateTime = Field(..., description="Upper closed bound (inclusive)")
+
+    @model_validator(mode="after")
+    def check_bounds(self) -> Self:
+        # we don't want differing types in a expression with mutliple inequality
+        # operators
+        if type(self.lower) is type(self.upper):
+            if not (self.lower < self.upper):  # type: ignore # ty doesn't understand we already checked this
+                raise ValueError(
+                    f"lower endpoint ({self.lower}) must be < than its upper endpoint ({self.upper})"
+                )
+        else:
+            raise ValueError("`lower` and `upper` types must be the same")
+
+        return self
+
+    @model_serializer(mode="wrap")
+    def serialize_model(
+        self,
+        handler: SerializerFunctionWrapHandler,
+        info: SerializationInfo,
+    ) -> dict[str, object]:
+        if info.context == "proto":
+            # special serialization for proto
+            return {
+                "min": self.lower,
+                "max": self.upper,
+            }
+        else:
+            # fallback to default serialization
+            return handler(self)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_from_proto(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            range_min = data.pop("min", None)
+            if range_min is not None:
+                data["lower"] = range_min
+            range_max = data.pop("max", None)
+            if range_max is not None:
+                data["upper"] = range_max
+        return data
+
+
+# Type alias for valid KV field values
+KVValue = str | int | float | bool | datetime | Range
 
 
 class KeyValueField(BaseModel):

--- a/nucliadb_models/src/nucliadb_models/key_value.py
+++ b/nucliadb_models/src/nucliadb_models/key_value.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Bosutech XXI S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+from nucliadb_models.kv_schemas import KVValue
+
+
+class KeyValueField(BaseModel):
+    """A key-value field value. The field id (key in the resource's key_values dict)
+    must equal the schema name — enforcing one KV field per schema per resource."""
+
+    schema_id: str = Field(
+        ...,
+        title="Schema ID",
+        description="The name of the KV schema this field conforms to.",
+    )
+    data: dict[str, KVValue] = Field(
+        default_factory=dict,
+        title="Data",
+        description="Key-value pairs conforming to the schema.",
+    )
+
+    def serialize_json_for_proto(self) -> str:
+        """Serialize to JSON for storage purposes
+
+        This includes special handling for specific fields like Range, that
+        serialize differently in the REST API than internally
+
+        """
+        return json.dumps(self.model_dump(include={"data"}, context="proto").get("data", {}))
+
+    @classmethod
+    def parse_from_proto_json(cls, serialized: str) -> dict[str, KVValue]:
+        """Parses the `data` portion of the field from the stored JSON
+        representation, that differs from the representation in the REST API
+
+        """
+        return TypeAdapter(dict[str, KVValue]).validate_json(serialized)

--- a/nucliadb_models/src/nucliadb_models/kv_schemas.py
+++ b/nucliadb_models/src/nucliadb_models/kv_schemas.py
@@ -31,66 +31,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from datetime import datetime
 from enum import Enum
-from typing import Any
 
 from pydantic import (
     BaseModel,
     Field,
-    SerializationInfo,
-    SerializerFunctionWrapHandler,
-    model_serializer,
     model_validator,
 )
-from typing_extensions import Self
-
-
-class Range(BaseModel):
-    """A closed-bound integer range [lower, upper]."""
-
-    lower: int = Field(..., description="Lower closed bound (inclusive)")
-    upper: int = Field(..., description="Upper closed bound (inclusive)")
-
-    @model_validator(mode="after")
-    def check_bounds(self) -> Self:
-        if not (self.lower < self.upper):
-            raise ValueError(
-                f"IntegerInterval lower endpoint ({self.lower}) must be < than its upper endpoint ({self.upper})"
-            )
-        return self
-
-    @model_serializer(mode="wrap")
-    def serialize_model(
-        self,
-        handler: SerializerFunctionWrapHandler,
-        info: SerializationInfo,
-    ) -> dict[str, object]:
-        if info.context == "proto":
-            # special serialization for proto
-            return {
-                "min": self.lower,
-                "max": self.upper,
-            }
-        else:
-            # fallback to default serialization
-            return handler(self)
-
-    @model_validator(mode="before")
-    @classmethod
-    def parse_from_proto(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            range_min = data.pop("min", None)
-            if range_min is not None:
-                data["lower"] = range_min
-            range_max = data.pop("max", None)
-            if range_max is not None:
-                data["upper"] = range_max
-        return data
-
-
-# Type alias for valid KV field values
-KVValue = str | int | float | bool | datetime | Range
 
 MAX_KV_SCHEMAS = 20
 MAX_KV_SCHEMA_FIELDS = 50

--- a/nucliadb_models/src/nucliadb_models/kv_schemas.py
+++ b/nucliadb_models/src/nucliadb_models/kv_schemas.py
@@ -33,11 +33,64 @@
 #
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+    model_validator,
+)
+from typing_extensions import Self
+
+
+class Range(BaseModel):
+    """A closed-bound integer range [lower, upper]."""
+
+    lower: int = Field(..., description="Lower closed bound (inclusive)")
+    upper: int = Field(..., description="Upper closed bound (inclusive)")
+
+    @model_validator(mode="after")
+    def check_bounds(self) -> Self:
+        if not (self.lower < self.upper):
+            raise ValueError(
+                f"IntegerInterval lower endpoint ({self.lower}) must be < than its upper endpoint ({self.upper})"
+            )
+        return self
+
+    @model_serializer(mode="wrap")
+    def serialize_model(
+        self,
+        handler: SerializerFunctionWrapHandler,
+        info: SerializationInfo,
+    ) -> dict[str, object]:
+        if info.context == "proto":
+            # special serialization for proto
+            return {
+                "_range_min": self.lower,
+                "_range_max": self.upper,
+            }
+        else:
+            # fallback to default serialization
+            return handler(self)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_from_proto(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            range_min = data.pop("_range_min", None)
+            if range_min is not None:
+                data["lower"] = range_min
+            range_max = data.pop("_range_max", None)
+            if range_max is not None:
+                data["upper"] = range_max
+        return data
+
 
 # Type alias for valid KV field values
-KVValue = str | int | float | bool | datetime
+KVValue = str | int | float | bool | datetime | Range
 
 MAX_KV_SCHEMAS = 20
 MAX_KV_SCHEMA_FIELDS = 50
@@ -49,6 +102,7 @@ class KVFieldType(str, Enum):
     FLOAT = "float"
     BOOLEAN = "boolean"
     DATE = "date"
+    RANGE = "range"
 
 
 class KVSchemaField(BaseModel):

--- a/nucliadb_models/src/nucliadb_models/kv_schemas.py
+++ b/nucliadb_models/src/nucliadb_models/kv_schemas.py
@@ -69,8 +69,8 @@ class Range(BaseModel):
         if info.context == "proto":
             # special serialization for proto
             return {
-                "_range_min": self.lower,
-                "_range_max": self.upper,
+                "min": self.lower,
+                "max": self.upper,
             }
         else:
             # fallback to default serialization
@@ -80,10 +80,10 @@ class Range(BaseModel):
     @classmethod
     def parse_from_proto(cls, data: Any) -> Any:
         if isinstance(data, dict):
-            range_min = data.pop("_range_min", None)
+            range_min = data.pop("min", None)
             if range_min is not None:
                 data["lower"] = range_min
-            range_max = data.pop("_range_max", None)
+            range_max = data.pop("max", None)
             if range_max is not None:
                 data["upper"] = range_max
         return data

--- a/nucliadb_models/src/nucliadb_models/kv_schemas.py
+++ b/nucliadb_models/src/nucliadb_models/kv_schemas.py
@@ -33,11 +33,8 @@
 #
 from enum import Enum
 
-from pydantic import (
-    BaseModel,
-    Field,
-    model_validator,
-)
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
 
 MAX_KV_SCHEMAS = 20
 MAX_KV_SCHEMA_FIELDS = 50
@@ -60,6 +57,17 @@ class KVSchemaField(BaseModel):
         default=False,
         description="When enabled, this field stores a range instead of a single value and operations like `contains` are possible",
     )
+
+    @model_validator(mode="after")
+    def validate_allowed_range_types(self) -> Self:
+        allowed_range_types = {
+            KVFieldType.INTEGER,
+            KVFieldType.FLOAT,
+            KVFieldType.DATE,
+        }
+        if self.range is True and self.type not in allowed_range_types:
+            raise ValueError(f"{self.type} is not an allowed range type")
+        return self
 
 
 class KVSchema(BaseModel):

--- a/nucliadb_models/src/nucliadb_models/kv_schemas.py
+++ b/nucliadb_models/src/nucliadb_models/kv_schemas.py
@@ -49,7 +49,6 @@ class KVFieldType(str, Enum):
     FLOAT = "float"
     BOOLEAN = "boolean"
     DATE = "date"
-    RANGE = "range"
 
 
 class KVSchemaField(BaseModel):
@@ -57,6 +56,10 @@ class KVSchemaField(BaseModel):
     type: KVFieldType
     description: str = ""
     required: bool = True
+    range: bool = Field(
+        default=False,
+        description="When enabled, this field stores a range instead of a single value and operations like `contains` are possible",
+    )
 
 
 class KVSchema(BaseModel):

--- a/nucliadb_models/src/nucliadb_models/resource.py
+++ b/nucliadb_models/src/nucliadb_models/resource.py
@@ -36,7 +36,7 @@ from nucliadb_models.extracted import (
     VectorObject,
 )
 from nucliadb_models.file import FieldFile
-from nucliadb_models.kv_schemas import KVValue
+from nucliadb_models.key_value import KeyValueField
 from nucliadb_models.link import FieldLink
 from nucliadb_models.metadata import (
     ComputedMetadata,
@@ -265,7 +265,7 @@ class GenericFieldData(BaseModel):
 
 
 class KeyValueFieldData(BaseModel):
-    value: dict[str, KVValue] | None = None
+    value: KeyValueField | None = None
     error: Error | None = None
     status: str | None = None
     errors: list[Error] | None = None

--- a/nucliadb_models/src/nucliadb_models/writer.py
+++ b/nucliadb_models/src/nucliadb_models/writer.py
@@ -20,7 +20,7 @@ from pydantic.json_schema import SkipJsonSchema
 from nucliadb_models import content_types
 from nucliadb_models.conversation import InputConversationField
 from nucliadb_models.file import FileField
-from nucliadb_models.kv_schemas import KVValue
+from nucliadb_models.key_value import KVValue
 from nucliadb_models.link import LinkField
 from nucliadb_models.metadata import (
     Extra,

--- a/nucliadb_models/src/nucliadb_models/writer.py
+++ b/nucliadb_models/src/nucliadb_models/writer.py
@@ -50,6 +50,15 @@ class KeyValueField(BaseModel):
         description="Key-value pairs conforming to the schema.",
     )
 
+    def serialize_json_for_proto(self) -> str:
+        """Serialize to JSON for proto purposes
+
+        This includes special handling for specific fields like Range, that
+        serialize differently in the REST API than internally to nidx
+
+        """
+        return json.dumps(self.model_dump(include={"data"}, context="proto").get("data", {}))
+
 
 class FieldDefaults:
     title = Field(None, title="Title", max_length=2048)


### PR DESCRIPTION
### Description
- Adding a new range type for integer ranges. The type has custom serialization in order to store a different representation in the database and decouple it from the models (it'd be too bad if a pydantic model change can break bw/c with stored data)
- Changed the field value serialization to include schema_id, otherwise, we can't know the schema from a GET
- Adding the `contains` operator to check if an integer is in a range

### How was this PR tested?
New tests
