### PR TITLE
Return conversation metadata when getting pages

### DIFF
--- a/nucliadb/src/nucliadb/common/models_utils/from_proto.py
+++ b/nucliadb/src/nucliadb/common/models_utils/from_proto.py
@@ -372,7 +372,9 @@ def field_metadata(
     return FieldMetadata(**value)
 
 
-def conversation(message: resources_pb2.Conversation) -> Conversation:
+def conversation_page(
+    message: resources_pb2.Conversation, total: int, pages: int, page: int
+) -> Conversation:
     as_dict = MessageToDict(
         message,
         preserving_proto_field_name=True,
@@ -381,7 +383,7 @@ def conversation(message: resources_pb2.Conversation) -> Conversation:
     for conv_message in as_dict.get("messages", []):
         for attachment_field in conv_message.get("content", {}).get("attachments_fields", []):
             attachment_field["field_type"] = attachment_field["field_type"].lower()
-    return Conversation(**as_dict)
+    return Conversation(total=total, pages=pages, page=page, **as_dict)
 
 
 def field_conversation(message: resources_pb2.FieldConversation) -> FieldConversation:

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -427,19 +427,24 @@ async def _get_resource_field(
                 raise HTTPException(status_code=404, detail="Key-value field does not exist")
 
             if isinstance(field, Conversation):
+                conversation_metadata = await field.get_metadata()
                 if page == "first":
                     page_to_fetch = 1
                 elif page == "last":
-                    conversation_metadata = await field.get_metadata()
                     page_to_fetch = conversation_metadata.pages
                 else:
                     page_to_fetch = int(page)
 
-                value = await field.get_value(page=page_to_fetch)
-                if value is not None:
+                page_value = await field.get_value(page=page_to_fetch)
+                if page_value is not None:
                     splits_metadata = await field.get_splits_metadata()
                     deleted_messages = set(splits_metadata.deleted_splits)
-                    resource_field.value = from_proto.conversation(value)
+                    resource_field.value = from_proto.conversation_page(
+                        page_value,
+                        total=conversation_metadata.total,
+                        pages=conversation_metadata.pages,
+                        page=page_to_fetch,
+                    )
                     # Skip deleted messages
                     resource_field.value.messages = [
                         msg

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -32,7 +32,7 @@ from nucliadb_models.conversation import (
     InputMessageContent,
     MessageType,
 )
-from nucliadb_models.resource import ConversationFieldData, FieldConversation, Resource
+from nucliadb_models.resource import Conversation, ConversationFieldData, FieldConversation, Resource
 from nucliadb_models.resource import Resource as ResponseResponse
 from nucliadb_models.search import (
     KnowledgeboxCounters,
@@ -164,10 +164,16 @@ async def test_conversations(
     )
     assert resp.status_code == 200
     field_resp = ResourceField.model_validate(resp.json())
-    msgs = field_resp.value["messages"]  # type: ignore
+    assert field_resp.value is not None
+    assert isinstance(field_resp.value, Conversation)
+    assert field_resp.value.total == 301
+    assert field_resp.value.pages == 2
+    assert field_resp.value.page == 1
+    assert field_resp.value.messages is not None
+    msgs = field_resp.value.messages
     assert len(msgs) == 200
-    assert [m["ident"] for m in msgs] == [str(i) for i in range(1, 201)]
-    assert msgs[0]["type"] == MessageType.QUESTION.value
+    assert [m.ident for m in msgs] == [str(i) for i in range(1, 201)]
+    assert msgs[0].type_ == MessageType.QUESTION.value
 
     # get second page
     resp = await nucliadb_reader.get(

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -32,7 +32,7 @@ from nucliadb_models.conversation import (
     InputMessageContent,
     MessageType,
 )
-from nucliadb_models.resource import Conversation, ConversationFieldData, FieldConversation, Resource
+from nucliadb_models.resource import ConversationFieldData, FieldConversation, Resource
 from nucliadb_models.resource import Resource as ResponseResponse
 from nucliadb_models.search import (
     KnowledgeboxCounters,
@@ -164,16 +164,13 @@ async def test_conversations(
     )
     assert resp.status_code == 200
     field_resp = ResourceField.model_validate(resp.json())
-    assert field_resp.value is not None
-    assert isinstance(field_resp.value, Conversation)
-    assert field_resp.value.total == 301
-    assert field_resp.value.pages == 2
-    assert field_resp.value.page == 1
-    assert field_resp.value.messages is not None
-    msgs = field_resp.value.messages
+    assert field_resp.value["total"] == 301  # type: ignore
+    assert field_resp.value["pages"] == 2  # type: ignore
+    assert field_resp.value["page"] == 1  # type: ignore
+    msgs = field_resp.value["messages"]  # type: ignore
     assert len(msgs) == 200
-    assert [m.ident for m in msgs] == [str(i) for i in range(1, 201)]
-    assert msgs[0].type_ == MessageType.QUESTION.value
+    assert [m["ident"] for m in msgs] == [str(i) for i in range(1, 201)]
+    assert msgs[0]["type"] == MessageType.QUESTION.value
 
     # get second page
     resp = await nucliadb_reader.get(

--- a/nucliadb/tests/reader/unit/reader/api/v1/test_resource.py
+++ b/nucliadb/tests/reader/unit/reader/api/v1/test_resource.py
@@ -35,7 +35,7 @@ def test_serialize_conversation_field():
     m1.content.attachments_fields.append(FieldRef(field_type=FieldType.LINK, field_id="mylink"))
     pb.messages.append(m1)
     resource_field = ResourceField(field_id="conv", field_type=FieldTypeName.CONVERSATION)
-    resource_field.value = from_proto.conversation(pb)
+    resource_field.value = from_proto.conversation_page(pb, total=1, pages=1, page=1)
     assert resource_field.value.messages
     assert resource_field.value.messages[0].content.attachments_fields[0].field_id == "mylink"
     assert (

--- a/nucliadb/tests/writer/unit/api/v1/test_resource.py
+++ b/nucliadb/tests/writer/unit/api/v1/test_resource.py
@@ -73,7 +73,10 @@ def push_payload(**kwargs):
             ),
             True,
         ),
-        (push_payload(conversationfield={"foo": Conversation(messages=[])}), True),
+        (
+            push_payload(conversationfield={"foo": Conversation(total=0, pages=0, page=0, messages=[])}),
+            True,
+        ),
         (push_payload(textfield={"foo": TextField(body="foo")}), True),
         (
             push_payload(linkfield={"foo": LinkField(uri="foo")}),

--- a/nucliadb_models/src/nucliadb_models/conversation.py
+++ b/nucliadb_models/src/nucliadb_models/conversation.py
@@ -63,6 +63,9 @@ class Conversation(BaseModel):
     a conversation in the field level.
     """
 
+    total: int = Field(description="Total number of messages in the conversation")
+    pages: int = Field(description="Total number of pages in the conversation")
+    page: int = Field(description="Current page number")
     messages: list[Message] | None = []
 
 


### PR DESCRIPTION
### Description
This makes it easier to scroll through the conversation without having to do a resource GET on all fields to know how many pages and messages there are in the conversation

[sc-14709]

### How was this PR tested?
Existing tests extended