### PR TITLE
Filtering by resource field prefix

### DIFF
--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -309,7 +309,7 @@ message FilterExpression {
     message ResourceFieldPrefixFilter {
         string resource_id = 1;
         string field_type = 2;
-        optional string field_id_prefix = 3;
+        string field_id_prefix = 3;
     }
 
     oneof expr {

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -306,6 +306,11 @@ message FilterExpression {
     message FacetFilter {
         string facet = 1;
     }
+    message ResourceFieldPrefixFilter {
+        string resource_id = 1;
+        string field_type = 2;
+        optional string field_id_prefix = 3;
+    }
 
     oneof expr {
         FilterExpressionList bool_and = 1;
@@ -317,6 +322,7 @@ message FilterExpression {
         KeywordFilter keyword = 6;
         DateRangeFilter date = 7;
         FacetFilter facet = 8;
+        ResourceFieldPrefixFilter resource_field_prefix = 9;
     }
 }
 

--- a/nidx/nidx_text/src/search_query.rs
+++ b/nidx/nidx_text/src/search_query.rs
@@ -182,6 +182,23 @@ pub fn filter_to_query(schema: &TextSchema, expr: &FilterExpression) -> Box<dyn 
             Term::from_facet(schema.field, &Facet::from(&field_key(field_filter))),
             IndexRecordOption::Basic,
         )),
+        nidx_protos::filter_expression::Expr::ResourceFieldPrefix(resource_field_prefix_filter) => {
+            let resource_id = &resource_field_prefix_filter.resource_id;
+            let field_id_prefix = &resource_field_prefix_filter.field_id_prefix;
+
+            // encoded_field_id_bytes stores uuid_bytes (16) + "field_type/field_name"
+            let uuid = uuid::Uuid::parse_str(resource_id).expect("Invalid resource_id UUID");
+            let field_id_partial = format!("{}/{}", resource_field_prefix_filter.field_type, field_id_prefix);
+            let prefix_bytes = schema::encode_field_id_bytes(uuid, &field_id_partial);
+
+            let lower = Term::from_field_bytes(schema.encoded_field_id_bytes, &prefix_bytes);
+            // Upper bound: increment last byte to create exclusive upper bound for prefix match
+            let mut upper_bytes = prefix_bytes.clone();
+            *upper_bytes.last_mut().unwrap() += 1;
+            let upper = Term::from_field_bytes(schema.encoded_field_id_bytes, &upper_bytes);
+
+            Box::new(RangeQuery::new(Bound::Included(lower), Bound::Excluded(upper)))
+        }
         nidx_protos::filter_expression::Expr::Keyword(keyword_filter) => {
             translate_keyword_to_text_query(&keyword_filter.keyword, schema)
         }

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -114,8 +114,7 @@ async def parse_expression(
     elif isinstance(expr, _ResourceFieldPrefix):
         f.resource_field_prefix.resource_id = expr.resource_id
         f.resource_field_prefix.field_type = FIELD_TYPE_NAME_TO_STR[expr.field_type]
-        if expr.field_name_prefix:
-            f.resource_field_prefix.field_id_prefix = expr.field_name_prefix
+        f.resource_field_prefix.field_id_prefix = expr.field_name_prefix
     elif isinstance(expr, Keyword):
         f.keyword.keyword = expr.word
     elif isinstance(expr, DateCreated):

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -55,9 +55,9 @@ from nucliadb_models.filters import (
     OriginTag,
     ParagraphFilterExpressionType,
     Resource,
+    ResourceFieldPrefix,
     ResourceMimetype,
     Status,
-    _ResourceFieldPrefix,
 )
 from nucliadb_models.kv_schemas import KBKVSchemas, KVFieldType
 from nucliadb_models.metadata import ResourceProcessingStatus
@@ -112,7 +112,7 @@ async def parse_expression(
         f.field.field_type = FIELD_TYPE_NAME_TO_STR[expr.type]
         if expr.name:
             f.field.field_id = expr.name
-    elif isinstance(expr, _ResourceFieldPrefix):
+    elif isinstance(expr, ResourceFieldPrefix):
         f.resource_field_prefix.resource_id = expr.resource_id
         f.resource_field_prefix.field_type = FIELD_TYPE_NAME_TO_STR[expr.field_type]
         f.resource_field_prefix.field_id_prefix = expr.field_name_prefix

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -56,6 +56,7 @@ from nucliadb_models.filters import (
     Resource,
     ResourceMimetype,
     Status,
+    _ResourceFieldPrefix,
 )
 from nucliadb_models.kv_schemas import KBKVSchemas, KVFieldType
 from nucliadb_models.metadata import ResourceProcessingStatus
@@ -110,6 +111,11 @@ async def parse_expression(
         f.field.field_type = FIELD_TYPE_NAME_TO_STR[expr.type]
         if expr.name:
             f.field.field_id = expr.name
+    elif isinstance(expr, _ResourceFieldPrefix):
+        f.resource_field_prefix.resource_id = expr.resource_id
+        f.resource_field_prefix.field_type = FIELD_TYPE_NAME_TO_STR[expr.field_type]
+        if expr.field_name_prefix:
+            f.resource_field_prefix.field_id_prefix = expr.field_name_prefix
     elif isinstance(expr, Keyword):
         f.keyword.keyword = expr.word
     elif isinstance(expr, DateCreated):

--- a/nucliadb/tests/nucliadb/integration/search/test_filters_expression.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters_expression.py
@@ -306,3 +306,121 @@ async def test_filtering_expression(
             expected_uuids = {slug_to_uuid[slug] for slug in expected_slugs}
             found_uuids = set(body["resources"].keys())
             assert found_uuids == expected_uuids
+
+
+@pytest.mark.deploy_modes("standalone")
+async def test_filtering_expression_resource_field_prefix(
+    nucliadb_reader: AsyncClient, nucliadb_writer: AsyncClient, standalone_knowledgebox: str
+):
+    kbid = standalone_knowledgebox
+
+    slug_to_uuid = {}
+    # Create resources with different text fields
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/resources",
+        json={
+            "title": "Resource1",
+            "slug": "resource1",
+            "texts": {
+                "conversation_intro": {"body": "Hello world", "format": "PLAIN"},
+                "conversation_body": {"body": "Main content here", "format": "PLAIN"},
+                "summary": {"body": "A short summary", "format": "PLAIN"},
+            },
+        },
+    )
+    assert resp.status_code == 201
+    resource1_uuid = resp.json()["uuid"]
+    slug_to_uuid["resource1"] = resource1_uuid
+
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/resources",
+        json={
+            "title": "Resource2",
+            "slug": "resource2",
+            "texts": {
+                "conversation_thread": {"body": "Thread discussion", "format": "PLAIN"},
+                "notes": {"body": "Some notes", "format": "PLAIN"},
+            },
+        },
+    )
+    assert resp.status_code == 201
+    resource2_uuid = resp.json()["uuid"]
+    slug_to_uuid["resource2"] = resource2_uuid
+
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/resources",
+        json={
+            "title": "Resource3",
+            "slug": "resource3",
+            "texts": {
+                "other_field": {"body": "Other content", "format": "PLAIN"},
+            },
+        },
+    )
+    assert resp.status_code == 201
+    resource3_uuid = resp.json()["uuid"]
+    slug_to_uuid["resource3"] = resource3_uuid
+
+    for filters, expected_slugs in [
+        # Match all text fields with prefix "conversation" in resource1
+        (
+            {
+                "prop": "resource_field_prefix",
+                "resource_id": resource1_uuid,
+                "field_type": "text",
+                "field_name_prefix": "conversation",
+            },
+            ["resource1"],
+        ),
+        # Match all text fields with prefix "conversation" in resource2
+        (
+            {
+                "prop": "resource_field_prefix",
+                "resource_id": resource2_uuid,
+                "field_type": "text",
+                "field_name_prefix": "conversation",
+            },
+            ["resource2"],
+        ),
+        # Match all text fields with prefix "conversation" in resource3 (no match)
+        (
+            {
+                "prop": "resource_field_prefix",
+                "resource_id": resource3_uuid,
+                "field_type": "text",
+                "field_name_prefix": "conversation",
+            },
+            [],
+        ),
+        # Match all text fields (empty prefix) in resource1
+        (
+            {
+                "prop": "resource_field_prefix",
+                "resource_id": resource1_uuid,
+                "field_type": "text",
+                "field_name_prefix": "",
+            },
+            ["resource1"],
+        ),
+        # Match with a prefix that doesn't exist
+        (
+            {
+                "prop": "resource_field_prefix",
+                "resource_id": resource1_uuid,
+                "field_type": "text",
+                "field_name_prefix": "nonexistent",
+            },
+            [],
+        ),
+    ]:
+        resp = await nucliadb_reader.post(
+            f"/kb/{kbid}/find",
+            json={"query": "", "filter_expression": {"field": filters}},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        expected_uuids = {slug_to_uuid[slug] for slug in expected_slugs}
+        found_uuids = set(body["resources"].keys())
+        assert found_uuids == expected_uuids, (
+            f"Failed for filter {filters}: expected {expected_slugs}, got {found_uuids}"
+        )

--- a/nucliadb/tests/nucliadb/integration/search/test_filters_expression.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_filters_expression.py
@@ -332,36 +332,7 @@ async def test_filtering_expression_resource_field_prefix(
     resource1_uuid = resp.json()["uuid"]
     slug_to_uuid["resource1"] = resource1_uuid
 
-    resp = await nucliadb_writer.post(
-        f"/kb/{kbid}/resources",
-        json={
-            "title": "Resource2",
-            "slug": "resource2",
-            "texts": {
-                "conversation_thread": {"body": "Thread discussion", "format": "PLAIN"},
-                "notes": {"body": "Some notes", "format": "PLAIN"},
-            },
-        },
-    )
-    assert resp.status_code == 201
-    resource2_uuid = resp.json()["uuid"]
-    slug_to_uuid["resource2"] = resource2_uuid
-
-    resp = await nucliadb_writer.post(
-        f"/kb/{kbid}/resources",
-        json={
-            "title": "Resource3",
-            "slug": "resource3",
-            "texts": {
-                "other_field": {"body": "Other content", "format": "PLAIN"},
-            },
-        },
-    )
-    assert resp.status_code == 201
-    resource3_uuid = resp.json()["uuid"]
-    slug_to_uuid["resource3"] = resource3_uuid
-
-    for filters, expected_slugs in [
+    for filters, expected_fields in [
         # Match all text fields with prefix "conversation" in resource1
         (
             {
@@ -370,25 +341,15 @@ async def test_filtering_expression_resource_field_prefix(
                 "field_type": "text",
                 "field_name_prefix": "conversation",
             },
-            ["resource1"],
+            ["conversation_intro", "conversation_body"],
         ),
-        # Match all text fields with prefix "conversation" in resource2
+        # Match all text fields with prefix "foobar" in resource1 (no match)
         (
             {
                 "prop": "resource_field_prefix",
-                "resource_id": resource2_uuid,
+                "resource_id": resource1_uuid,
                 "field_type": "text",
-                "field_name_prefix": "conversation",
-            },
-            ["resource2"],
-        ),
-        # Match all text fields with prefix "conversation" in resource3 (no match)
-        (
-            {
-                "prop": "resource_field_prefix",
-                "resource_id": resource3_uuid,
-                "field_type": "text",
-                "field_name_prefix": "conversation",
+                "field_name_prefix": "foobar",
             },
             [],
         ),
@@ -400,7 +361,7 @@ async def test_filtering_expression_resource_field_prefix(
                 "field_type": "text",
                 "field_name_prefix": "",
             },
-            ["resource1"],
+            ["conversation_intro", "conversation_body", "summary"],
         ),
         # Match with a prefix that doesn't exist
         (
@@ -414,13 +375,12 @@ async def test_filtering_expression_resource_field_prefix(
         ),
     ]:
         resp = await nucliadb_reader.post(
-            f"/kb/{kbid}/find",
-            json={"query": "", "filter_expression": {"field": filters}},
+            f"/kb/{kbid}/search",
+            json={"query": "", "filter_expression": {"field": filters}, "features": ["fulltext"]},
         )
         assert resp.status_code == 200, resp.text
         body = resp.json()
-        expected_uuids = {slug_to_uuid[slug] for slug in expected_slugs}
-        found_uuids = set(body["resources"].keys())
-        assert found_uuids == expected_uuids, (
-            f"Failed for filter {filters}: expected {expected_slugs}, got {found_uuids}"
+        found_fields = {result["field"] for result in body["fulltext"]["results"]}
+        assert found_fields == set(expected_fields), (
+            f"Failed for filter {filters}: expected {expected_fields}, got {found_fields}"
         )

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -121,7 +121,7 @@ class Field(FilterProp, extra="forbid"):
     )
 
 
-class _ResourceFieldPrefix(FilterProp, extra="forbid"):
+class ResourceFieldPrefix(FilterProp, extra="forbid"):
     """Matches a field or set of fields"""
 
     prop: Literal["resource_field_prefix"] = "resource_field_prefix"
@@ -419,7 +419,7 @@ FieldFilterExpressionType = (
     | Annotated[Not["FieldFilterExpressionType"], Tag("not")]
     | Annotated[Resource, Tag("resource")]
     | Annotated[Field, Tag("field")]
-    | Annotated[pydantic.json_schema.SkipJsonSchema[_ResourceFieldPrefix], Tag("resource_field_prefix")]
+    | Annotated[pydantic.json_schema.SkipJsonSchema[ResourceFieldPrefix], Tag("resource_field_prefix")]
     | Annotated[Keyword, Tag("keyword")]
     | Annotated[DateCreated, Tag("created")]
     | Annotated[DateModified, Tag("modified")]

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -121,6 +121,19 @@ class Field(FilterProp, extra="forbid"):
     )
 
 
+class _ResourceFieldPrefix(FilterProp, extra="forbid"):
+    """Matches a field or set of fields"""
+
+    prop: Literal["field"] = "resource_field_prefix"
+    resource_id: str = pydantic.Field(description="ID of the resource containing the field(s) to match")
+    field_type: FieldTypeName = pydantic.Field(description="Type of the fields to match")
+    field_name_prefix: str | None = pydantic.Field(
+        default=None,
+        title="Field Filter",
+        description="Prefix of the name of the field to match. If blank, matches all fields of the given type in the given resource",
+    )
+
+
 class Keyword(FilterProp, extra="forbid"):
     """Matches all fields that contain a keyword"""
 
@@ -390,6 +403,7 @@ FieldFilterExpressionType = (
     | Annotated[Not["FieldFilterExpressionType"], Tag("not")]
     | Annotated[Resource, Tag("resource")]
     | Annotated[Field, Tag("field")]
+    | Annotated[_ResourceFieldPrefix, Tag("resource_field_prefix")]
     | Annotated[Keyword, Tag("keyword")]
     | Annotated[DateCreated, Tag("created")]
     | Annotated[DateModified, Tag("modified")]

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -419,7 +419,7 @@ FieldFilterExpressionType = (
     | Annotated[Not["FieldFilterExpressionType"], Tag("not")]
     | Annotated[Resource, Tag("resource")]
     | Annotated[Field, Tag("field")]
-    | Annotated[_ResourceFieldPrefix, Tag("resource_field_prefix")]
+    | Annotated[pydantic.json_schema.SkipJsonSchema[_ResourceFieldPrefix], Tag("resource_field_prefix")]
     | Annotated[Keyword, Tag("keyword")]
     | Annotated[DateCreated, Tag("created")]
     | Annotated[DateModified, Tag("modified")]

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -124,7 +124,7 @@ class Field(FilterProp, extra="forbid"):
 class _ResourceFieldPrefix(FilterProp, extra="forbid"):
     """Matches a field or set of fields"""
 
-    prop: Literal["field"] = "resource_field_prefix"
+    prop: Literal["resource_field_prefix"] = "resource_field_prefix"
     resource_id: str = pydantic.Field(description="ID of the resource containing the field(s) to match")
     field_type: FieldTypeName = pydantic.Field(description="Type of the fields to match")
     field_name_prefix: str | None = pydantic.Field(

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -122,7 +122,10 @@ class Field(FilterProp, extra="forbid"):
 
 
 class ResourceFieldPrefix(FilterProp, extra="forbid"):
-    """Matches a field or set of fields"""
+    """Matches a field or set of fields.
+
+    This filter is for internal use only and is not exposed in the public API schema.
+    """
 
     prop: Literal["resource_field_prefix"] = "resource_field_prefix"
     resource_id: str = pydantic.Field(description="ID of the resource containing the field(s) to match")
@@ -419,7 +422,7 @@ FieldFilterExpressionType = (
     | Annotated[Not["FieldFilterExpressionType"], Tag("not")]
     | Annotated[Resource, Tag("resource")]
     | Annotated[Field, Tag("field")]
-    | Annotated[pydantic.json_schema.SkipJsonSchema[ResourceFieldPrefix], Tag("resource_field_prefix")]
+    | pydantic.json_schema.SkipJsonSchema[Annotated[ResourceFieldPrefix, Tag("resource_field_prefix")]]
     | Annotated[Keyword, Tag("keyword")]
     | Annotated[DateCreated, Tag("created")]
     | Annotated[DateModified, Tag("modified")]

--- a/nucliadb_models/src/nucliadb_models/filters.py
+++ b/nucliadb_models/src/nucliadb_models/filters.py
@@ -127,11 +127,18 @@ class _ResourceFieldPrefix(FilterProp, extra="forbid"):
     prop: Literal["resource_field_prefix"] = "resource_field_prefix"
     resource_id: str = pydantic.Field(description="ID of the resource containing the field(s) to match")
     field_type: FieldTypeName = pydantic.Field(description="Type of the fields to match")
-    field_name_prefix: str | None = pydantic.Field(
-        default=None,
-        title="Field Filter",
+    field_name_prefix: str = pydantic.Field(
         description="Prefix of the name of the field to match. If blank, matches all fields of the given type in the given resource",
     )
+
+    @field_validator("resource_id", mode="after")
+    def validate_id(cls, v: str) -> str:
+        if v is not None:
+            try:
+                UUID(v)
+            except ValueError:
+                raise ValueError(f"resource_id filter '{v}' should be a valid UUID")
+        return v
 
 
 class Keyword(FilterProp, extra="forbid"):


### PR DESCRIPTION
### Description
Add a new type of filter expression filter to be able to filter by resource field prefix.
This makes filtering for the memory use case much easier, as we need to do queries like:

```python
@pytest.mark.deploy_modes("standalone")
async def test_filtering_expression_memory_use_case(
    nucliadb_reader: AsyncClient, nucliadb_writer: AsyncClient, standalone_knowledgebox: str
):
    kbid = standalone_knowledgebox
    resp = await nucliadb_writer.post(
        f"/kb/{kbid}/resources",
        json={
            "title": "Resource1",
            "slug": "resource1",
            "texts": {
                "content1": {"body": "Hello world 1", "format": "PLAIN"},
                "content2": {"body": "Hello world 2", "format": "PLAIN"},
                "memory--user1_at_company_dot_com": {"body": "Annotations of user 1", "format": "PLAIN"},
                "memory--user2_at_company_dot_com": {"body": "Annotations of user 2", "format": "PLAIN"},
            },
        },
    )
    assert resp.status_code == 201
    rid = resp.json()["uuid"]
    resp = await nucliadb_reader.post(
        f"/kb/{kbid}/search",
        json={
            "query": "",
            "filter_expression": {
                "field": {
                    "and": [
                        {"prop": "resource", "id": rid},
                        {
                            "or": [
                                {
                                    "not": {
                                        "prop": "resource_field_prefix",
                                        "resource_id": rid,
                                        "field_type": "text",
                                        "field_name_prefix": "memory--",
                                    }
                                },
                                {
                                    "prop": "field",
                                    "type": "text",
                                    "name": "memory--user1_at_company_dot_com",
                                },
                            ]
                        },
                    ]
                }
            },
            "features": ["fulltext"],
        },
    )
    assert resp.status_code == 200, resp.text
    body = resp.json()
    found_fields = {
        result["field_type"] + "/" + result["field"] for result in body["fulltext"]["results"]
    }
    assert found_fields == {"a/title", "t/content1", "t/content2", "t/memory--user1_at_company_dot_com"}

```

### How was this PR tested?
Integration tests
