### PR TITLE
Add metric to track number of searched shards

### DIFF
--- a/nucliadb/src/nucliadb/search/search/metrics.py
+++ b/nucliadb/src/nucliadb/search/search/metrics.py
@@ -28,6 +28,8 @@ node_features = metrics.Counter("nucliadb_node_features", labels={"type": ""})
 query_parse_dependency_observer = metrics.Observer("query_parse_dependency", labels={"type": ""})
 query_parser_observer = metrics.Observer("nucliadb_query_parser", labels={"type": ""})
 search_observer = metrics.Observer("nucliadb_search", labels={"type": ""})
+searched_shards_histogram = metrics.Histogram("nucliadb_searched_shards", labels={"type": ""})
+
 
 buckets = [
     0.005,

--- a/nucliadb/src/nucliadb/search/search/retrieval.py
+++ b/nucliadb/src/nucliadb/search/search/retrieval.py
@@ -33,7 +33,7 @@ from nucliadb.common.external_index_providers.base import TextBlockMatch
 from nucliadb.common.ids import ParagraphId, VectorId
 from nucliadb.search import logger
 from nucliadb.search.requesters.utils import Method, nidx_query
-from nucliadb.search.search.metrics import merge_observer, search_observer
+from nucliadb.search.search.metrics import merge_observer, search_observer, searched_shards_histogram
 from nucliadb.search.search.query_parser.models import UnitRetrieval
 from nucliadb.search.search.query_parser.parsers.unit_retrieval import convert_retrieval_to_proto
 from nucliadb.search.search.rank_fusion import IndexSource, get_rank_fusion
@@ -72,6 +72,7 @@ async def text_block_search(
 
     pb_query = convert_retrieval_to_proto(retrieval)
     shards_response, queried_shards = await nidx_search(kbid, pb_query)
+    searched_shards_histogram.observe(len(queried_shards), {"type": "search"})
 
     keyword_results = keyword_results_to_text_block_matches(shards_response.paragraph.results)
     semantic_results = semantic_results_to_text_block_matches(shards_response.vector.documents)


### PR DESCRIPTION
### Description
Search requests to multiple shards are not efficient at all. We perform between N and 2N requests to nidx-searcher pods (where N is the number of shards). The amount of users with multiple shards is small, but may be responsible for the majority of traffic.

This PR adds a new histogram metric to track the number of queried shards per request to show the distribution of requests and number of shards.
