### PR TITLE
Remove redundant key-value schema_id

### DIFF
--- a/nucliadb/src/nucliadb/common/models_utils/from_proto.py
+++ b/nucliadb/src/nucliadb/common/models_utils/from_proto.py
@@ -469,9 +469,7 @@ def field_text(message: resources_pb2.FieldText) -> FieldText:
 def field_key_value(message: resources_pb2.FieldKeyValue) -> KeyValueField | None:
     if not message.data:
         return None
-    return KeyValueField(
-        schema_id=message.schema_id, data=KeyValueField.parse_from_proto_json(message.data)
-    )
+    return KeyValueField(data=KeyValueField.parse_from_proto_json(message.data))
 
 
 def knowledgebox_config(message: knowledgebox_pb2.KnowledgeBoxConfig) -> KnowledgeBoxConfig:

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -257,23 +257,18 @@ async def parse_key_value_field(
     The entire data dict is JSON-encoded into the proto's single string data field.
     No NLP processing is needed for KV fields.
     """
-    if key != kv_field.schema_id:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Key-value field name '{key}' must match schema_id '{kv_field.schema_id}'",
-        )
 
     # Fetch schema and validate before touching the BrokerMessage
     if txn is not None:
-        schema = await datamanagers.kv_schemas.get(txn, kbid=kbid, name=kv_field.schema_id)
+        schema = await datamanagers.kv_schemas.get(txn, kbid=kbid, name=key)
     else:
         async with datamanagers.with_ro_transaction() as ro_txn:
-            schema = await datamanagers.kv_schemas.get(ro_txn, kbid=kbid, name=kv_field.schema_id)
+            schema = await datamanagers.kv_schemas.get(ro_txn, kbid=kbid, name=key)
 
     if schema is None:
         raise HTTPException(
             status_code=422,
-            detail=f"KV schema '{kv_field.schema_id}' does not exist in this knowledge box",
+            detail=f"KV schema '{key}' does not exist in this knowledge box",
         )
 
     try:
@@ -282,7 +277,7 @@ async def parse_key_value_field(
         raise HTTPException(status_code=422, detail=str(e)) from e
 
     pb = writer.key_value_fields[key]
-    pb.schema_id = kv_field.schema_id
+    pb.schema_id = key
     pb.data = kv_field.serialize_json_for_proto()
 
     writer.field_statuses.append(

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -229,13 +229,6 @@ async def test_kv_field_validation(
     )
     assert resp.status_code == 422, resp.text
 
-    # Field name in URL must match schema_id in body
-    resp = await nucliadb_writer.put(
-        f"{base_url}/product",
-        json={"data": {"color": "red", "price": 1.0}},
-    )
-    assert resp.status_code == 422, resp.text
-
 
 @pytest.mark.deploy_modes("standalone")
 async def test_kv_field_filter(

--- a/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
+++ b/nucliadb/tests/nucliadb/integration/test_key_value_fields.py
@@ -120,7 +120,6 @@ async def test_kv_field_crud(
     resp = await nucliadb_reader.get(f"/kb/{kbid}/resource/{rid2}/key_value/product")
     assert resp.status_code == 200, resp.text
     value = resp.json()["value"]
-    assert value["schema_id"] == "product"
     assert value["data"]["color"] == "red"
     assert value["data"]["price"] == 12.5
     assert value["data"]["in_stock"] is True
@@ -233,7 +232,7 @@ async def test_kv_field_validation(
     # Field name in URL must match schema_id in body
     resp = await nucliadb_writer.put(
         f"{base_url}/product",
-        json={"schema_id": "other", "data": {"color": "red", "price": 1.0}},
+        json={"data": {"color": "red", "price": 1.0}},
     )
     assert resp.status_code == 422, resp.text
 

--- a/nucliadb_models/src/nucliadb_models/key_value.py
+++ b/nucliadb_models/src/nucliadb_models/key_value.py
@@ -87,11 +87,6 @@ class KeyValueField(BaseModel):
     """A key-value field value. The field id (key in the resource's key_values dict)
     must equal the schema name — enforcing one KV field per schema per resource."""
 
-    schema_id: str = Field(
-        ...,
-        title="Schema ID",
-        description="The name of the KV schema this field conforms to.",
-    )
     data: dict[str, KVValue] = Field(
         default_factory=dict,
         title="Data",

--- a/nucliadb_models/src/nucliadb_models/writer.py
+++ b/nucliadb_models/src/nucliadb_models/writer.py
@@ -20,7 +20,7 @@ from pydantic.json_schema import SkipJsonSchema
 from nucliadb_models import content_types
 from nucliadb_models.conversation import InputConversationField
 from nucliadb_models.file import FileField
-from nucliadb_models.key_value import KVValue
+from nucliadb_models.key_value import KeyValueField
 from nucliadb_models.link import LinkField
 from nucliadb_models.metadata import (
     Extra,
@@ -33,31 +33,6 @@ from nucliadb_models.processing import PushProcessingOptions
 from nucliadb_models.security import ResourceSecurity
 from nucliadb_models.text import TextField
 from nucliadb_models.utils import FieldIdPattern, FieldIdString, SlugString
-
-
-class KeyValueField(BaseModel):
-    """A key-value field value. The field id (key in the resource's key_values dict)
-    must equal the schema name — enforcing one KV field per schema per resource."""
-
-    schema_id: str = Field(
-        ...,
-        title="Schema ID",
-        description="The name of the KV schema this field conforms to.",
-    )
-    data: dict[str, KVValue] = Field(
-        default_factory=dict,
-        title="Data",
-        description="Key-value pairs conforming to the schema.",
-    )
-
-    def serialize_json_for_proto(self) -> str:
-        """Serialize to JSON for proto purposes
-
-        This includes special handling for specific fields like Range, that
-        serialize differently in the REST API than internally to nidx
-
-        """
-        return json.dumps(self.model_dump(include={"data"}, context="proto").get("data", {}))
 
 
 class FieldDefaults:


### PR DESCRIPTION
### Description
Key-value field id must be the schema name, so we don't need to repeat ourselves with the schema_id inside the model

### How was this PR tested?
Existing tests
