### PR TITLE
Clean vector result text fetching

### DIFF
--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -35,7 +35,7 @@ from nidx_protos.nodereader_pb2 import (
     VectorSearchResponse,
 )
 
-from nucliadb.common.ids import FieldId, ParagraphId
+from nucliadb.common.ids import FieldId, ParagraphId, VectorId
 from nucliadb.common.models_utils import from_proto
 from nucliadb.common.models_utils.from_proto import (
     RelationNodeTypeMap,
@@ -79,7 +79,7 @@ from nucliadb_models.search import (
 from nucliadb_protos.utils_pb2 import RelationNode
 
 from .metrics import merge_observer
-from .paragraphs import get_paragraph_text, get_text_sentence
+from .paragraphs import get_paragraph_text
 
 Bm25Score = tuple[float, float]
 TimestampScore = datetime.datetime
@@ -258,49 +258,36 @@ async def merge_vectors_results(
 
     result_sentence_list: list[Sentence] = []
     for result in raw_vectors_list:
-        id_count = result.doc_id.id.count("/")
-        if id_count == 4:
-            rid, field_type, field, index, position = result.doc_id.id.split("/")
-            subfield = None
-        elif id_count == 5:
-            (
-                rid,
-                field_type,
-                field,
-                subfield,
-                index,
-                position,
-            ) = result.doc_id.id.split("/")
-        if result.metadata.HasField("position"):
-            start_int = result.metadata.position.start
-            end_int = result.metadata.position.end
-            index_int = result.metadata.position.index
-        else:
-            # bbb pull position from key for old results that were
-            # not properly filling metadata
-            start, end = position.split("-")
-            start_int = int(start)
-            end_int = int(end)
-            try:
-                index_int = int(index)
-            except ValueError:
-                index_int = -1
-        text = await get_text_sentence(
-            rid, field_type, field, kbid, index_int, start_int, end_int, subfield
+        vector_id = VectorId.from_string(result.doc_id.id)
+        # In case we have multiple vectors per paragraph, the vector id will
+        # have its start-end referencing a portion of the paragraph. However, we
+        # are interested in the whole paragraph, not only the portion, so we'll
+        # use the metadata.position to get the actual paragraph start-end
+        # positions
+        paragraph_id = ParagraphId(
+            field_id=vector_id.field_id,
+            paragraph_start=result.metadata.position.start,
+            paragraph_end=result.metadata.position.end,
         )
+
+        text = await get_paragraph_text(kbid=kbid, paragraph_id=paragraph_id)
         result_sentence_list.append(
             Sentence(
                 score=result.score,
-                rid=rid,
-                field_type=field_type,
-                field=field,
+                rid=vector_id.rid,
+                field_type=vector_id.field_id.type,
+                field=vector_id.field_id.key,
                 text=text,
-                index=index,
-                position=TextPosition(start=start_int, end=end_int, index=index_int),
+                index=str(vector_id.index),
+                position=TextPosition(
+                    start=paragraph_id.paragraph_start,
+                    end=paragraph_id.paragraph_end,
+                    index=vector_id.index,
+                ),
             )
         )
-        if rid not in resources:
-            resources.append(rid)
+        if vector_id.rid not in resources:
+            resources.append(vector_id.rid)
 
     return Sentences(
         results=result_sentence_list,

--- a/nucliadb/src/nucliadb/search/search/paragraphs.py
+++ b/nucliadb/src/nucliadb/search/search/paragraphs.py
@@ -96,43 +96,6 @@ async def get_paragraph_text(
     return text
 
 
-async def get_text_sentence(
-    rid: str,
-    field_type: str,
-    field: str,
-    kbid: str,
-    index: int,
-    start: int,
-    end: int,
-    split: str | None = None,
-) -> str:
-    """
-    Leave separated from get paragraph for now until we understand the differences
-    better.
-    """
-    orm_resource = await cache.get_resource(kbid, rid)
-
-    if orm_resource is None:
-        logger.warning("Resource does not exist on DB", extra={"kbid": kbid, "rid": rid})
-        return ""
-
-    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
-    field_obj = await orm_resource.get_field(field, field_type_int, load=False)
-    extracted_text = await field_obj.get_extracted_text()
-    if extracted_text is None:
-        logger.info(f"{rid} {field} {field_type_int} extracted_text does not exist on DB")
-        return ""
-    start = start - 1
-    if start < 0:
-        start = 0
-    if split not in (None, ""):
-        text = extracted_text.split_text[split]
-        splitted_text = text[start:end]
-    else:
-        splitted_text = extracted_text.text[start:end]
-    return splitted_text
-
-
 def highlight_paragraph(
     text: str, words: list[str] | None = None, ematches: list[str] | None = None
 ) -> str:

--- a/nucliadb/src/nucliadb/search/search/retrieval.py
+++ b/nucliadb/src/nucliadb/search/search/retrieval.py
@@ -227,8 +227,18 @@ def semantic_result_to_text_block_match(item: DocumentScored) -> TextBlockMatch:
     except (IndexError, ValueError):
         raise InvalidDocId(item.doc_id.id)
 
+    # In case we have multiple vectors per paragraph, the vector id will have
+    # its start-end referencing a portion of the paragraph. However, we are
+    # interested in the whole paragraph, not only the portion, so we'll use the
+    # metadata.position to get the actual paragraph start-end positions
+    paragraph_id = ParagraphId(
+        field_id=vector_id.field_id,
+        paragraph_start=item.metadata.position.start,
+        paragraph_end=item.metadata.position.end,
+    )
+
     return TextBlockMatch(
-        paragraph_id=ParagraphId.from_vector_id(vector_id),
+        paragraph_id=paragraph_id,
         scores=[SemanticScore(score=item.score)],
         score_type=SCORE_TYPE.VECTOR,
         order=0,  # NOTE: this will be filled later

--- a/nucliadb/tests/search/unit/test_find_post_index.py
+++ b/nucliadb/tests/search/unit/test_find_post_index.py
@@ -78,18 +78,14 @@ async def test_find_post_index_search(expected_find_response: dict[str, Any], pr
                     split="subfield-y",
                     start=0,
                     end=17,
-                    index=2,
+                    index=10,
                     paragraph="rid-2/f/field-b/subfield-y/0-17",
                     score=nodereader_pb2.ResultScore(
                         bm25=0.7025,
                     ),
                     metadata=noderesources_pb2.ParagraphMetadata(
                         position=noderesources_pb2.Position(
-                            index=2,
-                            start=0,
-                            end=17,
-                            page_number=10,
-                            in_page=True,
+                            index=2, start=0, end=17, page_number=10, in_page=True
                         ),
                         page_with_visual=True,
                         representation=noderesources_pb2.Representation(
@@ -110,12 +106,18 @@ async def test_find_post_index_search(expected_find_response: dict[str, Any], pr
                     ),
                     score=1.5,
                     labels=["u/link", "/k/text"],
+                    metadata=noderesources_pb2.SentenceMetadata(
+                        position=noderesources_pb2.Position(index=5, start=0, end=30)
+                    ),
                 ),
                 nodereader_pb2.DocumentScored(
                     doc_id=nodereader_pb2.DocumentVectorIdentifier(
                         id="rid-2/f/field-b/subfield-y/10/0-17",
                     ),
                     score=0.89,
+                    metadata=noderesources_pb2.SentenceMetadata(
+                        position=noderesources_pb2.Position(index=10, start=0, end=17)
+                    ),
                 ),
             ],
         ),
@@ -369,7 +371,7 @@ def expected_find_response():
                                 "position": {
                                     "end": 30,
                                     "end_seconds": [],
-                                    "index": 0,
+                                    "index": 5,
                                     "page_number": 0,
                                     "start": 0,
                                     "start_seconds": [],


### PR DESCRIPTION
### Description
The code to obtain the paragraph text from vector results in /search was rather legacy and abandoned. This PR is an attempt to fix it and hopefully not breaking anything.

There are a couple of points to keep in mind for the review:
- In an old PR (https://github.com/nuclia/nucliadb/pull/1285) we changed the metadata indexed for each vector from the start-end of the vector to the start-end of the paragraph. This, as far as I can think, can only be useful in the context of multi-vector paragraphs, where the start-end wasn't the same as the paragraph stored in the keyword index.
- As we've done many refactors since then, we can assume all indexes have this metadata properly populated (so no need for the bw/c branch) 
- In the `get_text_sentence` there was a `start - 1` that doesn't make sense with the paragraph indexes
- The comment on the `get_text_sentence` saying we don't understand the differences was just scary

So, my hypothesis is the following: we can get rid of the bw/c code and the `start - 1` is a bug as things are right now.

### How was this PR tested?
Our current test suite.

In addition, I did some local tests to find the same paragraph in a /search with keyword and semantic. The results show how the text from semantic search has 1 char more than the keyword search one.
