### PR TITLE
Skip useless object storage trips

### DIFF
--- a/nucliadb/src/nucliadb/search/api/v1/catalog.py
+++ b/nucliadb/src/nucliadb/search/api/v1/catalog.py
@@ -31,8 +31,9 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import logger
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
+from nucliadb.search.augmentor.resources import augment_resources_deep
 from nucliadb.search.search import cache
-from nucliadb.search.search.merge import fetch_resources
+from nucliadb.search.search.hydrator import ResourceHydrationOptions
 from nucliadb.search.search.query_parser.parsers import parse_catalog
 from nucliadb.search.search.utils import (
     maybe_log_request_payload,
@@ -161,12 +162,14 @@ async def catalog(
 
             catalog_results = CatalogResponse()
             catalog_results.fulltext = await catalog_search(query_parser)
-            catalog_results.resources = await fetch_resources(
-                resources=[r.rid for r in catalog_results.fulltext.results],
-                kbid=kbid,
-                show=item.show,
-                field_type_filter=list(FieldTypeName),
-                extracted=[],
+            catalog_results.resources = await augment_resources_deep(
+                kbid,
+                given=[r.rid for r in catalog_results.fulltext.results],
+                opts=ResourceHydrationOptions(
+                    show=item.show,
+                    extracted=[],
+                    field_type_filter=list(FieldTypeName),
+                ),
             )
             return catalog_results
     except InvalidQueryError as exc:

--- a/nucliadb/src/nucliadb/search/augmentor/resources.py
+++ b/nucliadb/src/nucliadb/search/augmentor/resources.py
@@ -50,33 +50,6 @@ from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
 
-async def augment_resources(
-    kbid: str,
-    given: list[str],
-    select: list[ResourceProp],
-    *,
-    concurrency_control: asyncio.Semaphore | None = None,
-) -> dict[str, AugmentedResource | None]:
-    """Augment a list of resources following an augmentation"""
-
-    ops = []
-    for rid in given:
-        task = asyncio.create_task(
-            limited_concurrency(
-                augment_resource(kbid, rid, select),
-                max_ops=concurrency_control,
-            )
-        )
-        ops.append(task)
-    results: list[AugmentedResource | None] = await asyncio.gather(*ops)
-
-    augmented = {}
-    for rid, augmentation in zip(given, results):
-        augmented[rid] = augmentation
-
-    return augmented
-
-
 @augmentor_observer.wrap({"type": "resource"})
 async def augment_resource(
     kbid: str,

--- a/nucliadb/src/nucliadb/search/augmentor/resources.py
+++ b/nucliadb/src/nucliadb/search/augmentor/resources.py
@@ -179,7 +179,7 @@ async def augment_resources_deep(
     opts: ResourceHydrationOptions,
     *,
     concurrency_control: asyncio.Semaphore | None = None,
-) -> dict[str, nucliadb_models.resource.Resource | None]:
+) -> dict[str, nucliadb_models.resource.Resource]:
     """Augment resources using the Resource model. Depending on the options,
     this can serialize resource fields, extracted data like text, vectors...
 
@@ -206,9 +206,10 @@ async def augment_resources_deep(
         ops.append(task)
     results: list[nucliadb_models.resource.Resource | None] = await asyncio.gather(*ops)
 
-    augmented: dict[str, nucliadb_models.resource.Resource | None] = {}
+    augmented: dict[str, nucliadb_models.resource.Resource] = {}
     for rid, augmentation in zip(given, results):
-        augmented[rid] = augmentation
+        if augmentation is not None:
+            augmented[rid] = augmentation
 
     return augmented
 

--- a/nucliadb/src/nucliadb/search/search/fetch.py
+++ b/nucliadb/src/nucliadb/search/search/fetch.py
@@ -17,61 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import asyncio
-from contextvars import ContextVar
 
 from nidx_protos.nodereader_pb2 import DocumentResult
 
-from nucliadb.common.maindb.utils import get_driver
-from nucliadb.ingest.orm.resource import Resource as ResourceORM
-from nucliadb.ingest.serialize import managed_serialize
-from nucliadb.search import SERVICE_NAME, logger
+from nucliadb.search import logger
 from nucliadb.search.search import cache
-from nucliadb_models.common import FieldTypeName
-from nucliadb_models.resource import ExtractedDataTypeName, Resource
-from nucliadb_models.search import ResourceProperties
-from nucliadb_utils import const
-from nucliadb_utils.utilities import has_feature
-
-rcache: ContextVar[dict[str, ResourceORM] | None] = ContextVar("rcache", default=None)
-
-
-async def fetch_resources(
-    resources: list[str],
-    kbid: str,
-    show: list[ResourceProperties],
-    field_type_filter: list[FieldTypeName],
-    extracted: list[ExtractedDataTypeName],
-) -> dict[str, Resource]:
-    if ResourceProperties.EXTRACTED in show and has_feature(
-        const.Features.IGNORE_EXTRACTED_IN_SEARCH, context={"kbid": kbid}, default=False
-    ):
-        # Returning extracted metadata in search results is deprecated and this flag
-        # will be set to True for all KBs in the future.
-        show.remove(ResourceProperties.EXTRACTED)
-        extracted = []
-
-    result = {}
-    async with get_driver().ro_transaction() as txn:
-        tasks = []
-        for resource in resources:
-            tasks.append(
-                asyncio.create_task(
-                    managed_serialize(
-                        txn,
-                        kbid,
-                        resource,
-                        show,
-                        field_type_filter=field_type_filter,
-                        extracted=extracted,
-                        service_name=SERVICE_NAME,
-                    )
-                )
-            )
-        for resource, serialization in zip(resources, await asyncio.gather(*tasks)):
-            if serialization is not None:
-                result[resource] = serialization
-    return result
 
 
 async def get_labels_resource(result: DocumentResult, kbid: str) -> list[str]:

--- a/nucliadb/src/nucliadb/search/search/fetch.py
+++ b/nucliadb/src/nucliadb/search/search/fetch.py
@@ -139,20 +139,3 @@ async def get_labels_paragraph(result: ParagraphResult, kbid: str) -> list[str]:
                 labels.append(f"{classification.labelset}/{classification.label}")
 
     return labels
-
-
-async def get_seconds_paragraph(
-    result: ParagraphResult, kbid: str
-) -> tuple[list[int], list[int]] | None:
-    orm_resource = await cache.get_resource(kbid, result.uuid)
-
-    if orm_resource is None:
-        logger.warning("Resource does not exist on DB", extra={"kbid": kbid, "rid": result.uuid})
-        return None
-
-    paragraph = await get_paragraph_from_resource(orm_resource=orm_resource, result=result)
-
-    if paragraph is not None and len(paragraph.end_seconds) > 0 and paragraph.end_seconds[0] > 0:
-        return (list(paragraph.start_seconds), list(paragraph.end_seconds))
-
-    return None

--- a/nucliadb/src/nucliadb/search/search/fetch.py
+++ b/nucliadb/src/nucliadb/search/search/fetch.py
@@ -107,35 +107,3 @@ async def get_labels_resource(result: DocumentResult, kbid: str) -> list[str]:
             labels.append(f"{classification.labelset}/{classification.label}")
 
     return labels
-
-
-async def get_labels_paragraph(result: ParagraphResult, kbid: str) -> list[str]:
-    orm_resource = await cache.get_resource(kbid, result.uuid)
-
-    if orm_resource is None:
-        logger.warning("Resource does not exist on DB", extra={"kbid": kbid, "rid": result.uuid})
-        return []
-
-    labels: list[str] = []
-    basic = await orm_resource.get_basic()
-    if basic is not None:
-        for classification in basic.usermetadata.classifications:
-            labels.append(f"{classification.labelset}/{classification.label}")
-
-    _, field_type, field = result.field.split("/")
-    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
-    field_obj = await orm_resource.get_field(field, field_type_int, load=False)
-    field_metadata = await field_obj.get_field_metadata()
-    if field_metadata:
-        paragraph = None
-        if result.split not in (None, ""):
-            metadata = field_metadata.split_metadata[result.split]
-            paragraph = metadata.paragraphs[result.index]
-        elif len(field_metadata.metadata.paragraphs) > result.index:
-            paragraph = field_metadata.metadata.paragraphs[result.index]
-
-        if paragraph is not None:
-            for classification in paragraph.classifications:
-                labels.append(f"{classification.labelset}/{classification.label}")
-
-    return labels

--- a/nucliadb/src/nucliadb/search/search/fetch.py
+++ b/nucliadb/src/nucliadb/search/search/fetch.py
@@ -20,9 +20,8 @@
 import asyncio
 from contextvars import ContextVar
 
-from nidx_protos.nodereader_pb2 import DocumentResult, ParagraphResult
+from nidx_protos.nodereader_pb2 import DocumentResult
 
-from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.orm.resource import Resource as ResourceORM
 from nucliadb.ingest.serialize import managed_serialize
@@ -31,7 +30,6 @@ from nucliadb.search.search import cache
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName, Resource
 from nucliadb_models.search import ResourceProperties
-from nucliadb_protos.resources_pb2 import Paragraph
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
@@ -74,23 +72,6 @@ async def fetch_resources(
             if serialization is not None:
                 result[resource] = serialization
     return result
-
-
-async def get_paragraph_from_resource(
-    orm_resource: ResourceORM, result: ParagraphResult
-) -> Paragraph | None:
-    _, field_type, field = result.field.split("/")
-    field_type_int = FIELD_TYPE_STR_TO_PB[field_type]
-    field_obj = await orm_resource.get_field(field, field_type_int, load=False)
-    field_metadata = await field_obj.get_field_metadata()
-    paragraph = None
-    if field_metadata:
-        if result.split not in (None, ""):
-            metadata = field_metadata.split_metadata[result.split]
-            paragraph = metadata.paragraphs[result.index]
-        elif len(field_metadata.metadata.paragraphs) > result.index:
-            paragraph = field_metadata.metadata.paragraphs[result.index]
-    return paragraph
 
 
 async def get_labels_resource(result: DocumentResult, kbid: str) -> list[str]:

--- a/nucliadb/src/nucliadb/search/search/find_merge.py
+++ b/nucliadb/src/nucliadb/search/search/find_merge.py
@@ -220,7 +220,7 @@ async def hydrate_and_rerank(
     results = await asyncio.gather(*ops)
 
     augmented_paragraphs: dict[ParagraphId, AugmentedParagraph] = results[0]  # type: ignore
-    augmented_resources: dict[str, Resource | None] = results[1]  # type: ignore
+    augmented_resources: dict[str, Resource] = results[1]  # type: ignore
 
     # add hydrated text to our text blocks
     for text_block in text_blocks:

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -46,8 +46,10 @@ from nucliadb.models.internal.augment import AugmentedParagraph, Metadata, Parag
 from nucliadb.models.internal.augment import Paragraph as AugmentorParagraph
 from nucliadb.search import logger
 from nucliadb.search.augmentor.augmentor import augment_paragraphs
+from nucliadb.search.augmentor.resources import augment_resources_deep
 from nucliadb.search.search.cut import cut_page
-from nucliadb.search.search.fetch import fetch_resources, get_labels_resource
+from nucliadb.search.search.fetch import get_labels_resource
+from nucliadb.search.search.hydrator import ResourceHydrationOptions
 from nucliadb.search.search.paragraphs import highlight_paragraph
 from nucliadb.search.search.query_parser.models import FulltextQuery, UnitRetrieval
 from nucliadb_models.common import FieldTypeName
@@ -575,7 +577,15 @@ async def merge_results(
             graphs, retrieval.query.relation.entry_points
         )
 
-    api_results.resources = await fetch_resources(resources, kbid, show, field_type_filter, extracted)
+    api_results.resources = await augment_resources_deep(
+        kbid,
+        given=resources,
+        opts=ResourceHydrationOptions(
+            show=show,
+            field_type_filter=field_type_filter,
+            extracted=extracted,
+        ),
+    )
     return api_results
 
 

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -435,8 +435,12 @@ async def load_paragraph(
         except Exception as exc:
             logger.warning("Error highlighting paragraph", extra={"kbid": kbid}, exc_info=exc)
 
+    # bw/c: historically, we returned labels from maindb, which didn't have the
+    # /l prefix. As we now return the labels from the index (which do have the
+    # /l), we trim the prefix
+    labels = list(set((label.removeprefix("/l/") for label in result.labels)))
+
     _, field_type, field = result.field.split("/")
-    labels = await get_labels_paragraph(result, kbid)
     fuzzy_result = len(result.matches) > 0
     new_paragraph = Paragraph(
         score=result.score.bm25,

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -104,7 +104,7 @@ async def merge_documents_results(
     query: FulltextQuery,
     top_k: int,
     offset: int,
-) -> tuple[Resources, list[str]]:
+) -> tuple[Resources, set[str]]:
     raw_resource_list: list[tuple[DocumentResult, SortValue]] = []
     facets: dict[str, Any] = {}
     total = 0
@@ -139,7 +139,7 @@ async def merge_documents_results(
     # ordering of results with same scores accross multiple shards doesn't change
     raw_resource_list.sort(key=lambda x: x[1], reverse=(query.sort == SortOrder.DESC))
 
-    result_resource_ids = []
+    result_resource_ids = set()
     result_resource_list: list[ResourceResult] = []
     for result, _ in raw_resource_list:
         labels = await get_labels_resource(result, kbid)
@@ -154,8 +154,7 @@ async def merge_documents_results(
                 labels=labels,
             )
         )
-        if result.uuid not in result_resource_ids:
-            result_resource_ids.append(result.uuid)
+        result_resource_ids.add(result.uuid)
 
     return Resources(
         facets=facets,
@@ -237,7 +236,7 @@ async def merge_vectors_results(
     top_k: int,
     concurrency_control: asyncio.Semaphore | None = None,
     min_score: float | None = None,
-) -> tuple[Sentences, list[str]]:
+) -> tuple[Sentences, set[str]]:
     facets: dict[str, Any] = {}
     raw_vectors_list: list[DocumentScored] = []
 
@@ -254,7 +253,7 @@ async def merge_vectors_results(
 
     raw_vectors_list, _ = cut_page(raw_vectors_list, top_k)
 
-    resources = []
+    result_resource_ids = set()
 
     augments = []
     result_index_by_id = {}
@@ -292,8 +291,7 @@ async def merge_vectors_results(
         )
         result_index_by_id[paragraph_id] = len(result_sentence_list) - 1
 
-        if vector_id.rid not in resources:
-            resources.append(vector_id.rid)
+        result_resource_ids.add(vector_id.rid)
 
     augmented_paragraphs: dict[ParagraphId, AugmentedParagraph] = await augment_paragraphs(
         kbid, given=augments, select=[ParagraphText()], concurrency_control=concurrency_control
@@ -312,7 +310,7 @@ async def merge_vectors_results(
         page_number=0,  # Bw/c with pagination
         page_size=top_k,
         min_score=round(min_score or 0, ndigits=3),
-    ), resources
+    ), result_resource_ids
 
 
 async def merge_paragraph_results(
@@ -324,7 +322,7 @@ async def merge_paragraph_results(
     min_score: float,
     offset: int,
     concurrency_control: asyncio.Semaphore | None = None,
-) -> tuple[Paragraphs, list[str]]:
+) -> tuple[Paragraphs, set[str]]:
     raw_paragraph_list: list[tuple[ParagraphId, ParagraphResult, SortValue]] = []
     facets: dict[str, Any] = {}
     query = None
@@ -437,7 +435,7 @@ async def merge_paragraph_results(
         page_size=top_k,
         next_page=next_page,
         min_score=min_score,
-    ), list(result_resource_ids)
+    ), result_resource_ids
 
 
 @merge_observer.wrap({"type": "merge_relations"})

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -47,12 +47,7 @@ from nucliadb.models.internal.augment import Paragraph as AugmentorParagraph
 from nucliadb.search import logger
 from nucliadb.search.augmentor.augmentor import augment_paragraphs
 from nucliadb.search.search.cut import cut_page
-from nucliadb.search.search.fetch import (
-    fetch_resources,
-    get_labels_paragraph,
-    get_labels_resource,
-    get_seconds_paragraph,
-)
+from nucliadb.search.search.fetch import fetch_resources, get_labels_paragraph, get_labels_resource
 from nucliadb.search.search.paragraphs import highlight_paragraph
 from nucliadb.search.search.query_parser.models import FulltextQuery, UnitRetrieval
 from nucliadb_models.common import FieldTypeName
@@ -224,16 +219,9 @@ async def merge_suggest_paragraph_results(
                 end=result.metadata.position.end,
                 page_number=result.metadata.position.page_number,
             ),
+            start_seconds=list(result.metadata.position.start_seconds) or None,
+            end_seconds=list(result.metadata.position.end_seconds) or None,
         )
-        if len(result.metadata.position.start_seconds) or len(result.metadata.position.end_seconds):
-            new_paragraph.start_seconds = list(result.metadata.position.start_seconds)
-            new_paragraph.end_seconds = list(result.metadata.position.end_seconds)
-        else:
-            # TODO: Remove once we are sure all data has been migrated!
-            seconds_positions = await get_seconds_paragraph(result, kbid)
-            if seconds_positions is not None:
-                new_paragraph.start_seconds = seconds_positions[0]
-                new_paragraph.end_seconds = seconds_positions[1]
         result_paragraph_list.append(new_paragraph)
     return Paragraphs(results=result_paragraph_list, query=query, min_score=0)
 

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -47,7 +47,7 @@ from nucliadb.models.internal.augment import Paragraph as AugmentorParagraph
 from nucliadb.search import logger
 from nucliadb.search.augmentor.augmentor import augment_paragraphs
 from nucliadb.search.search.cut import cut_page
-from nucliadb.search.search.fetch import fetch_resources, get_labels_paragraph, get_labels_resource
+from nucliadb.search.search.fetch import fetch_resources, get_labels_resource
 from nucliadb.search.search.paragraphs import highlight_paragraph
 from nucliadb.search.search.query_parser.models import FulltextQuery, UnitRetrieval
 from nucliadb_models.common import FieldTypeName
@@ -205,7 +205,10 @@ async def merge_suggest_paragraph_results(
             ematches=ematches,  # type: ignore
             matches=result.matches,  # type: ignore
         )
-        labels = await get_labels_paragraph(result, kbid)
+        # bw/c: historically, we returned labels from maindb, which didn't have the
+        # /l prefix. As we now return the labels from the index (which do have the
+        # /l), we trim the prefix
+        labels = list(set((label.removeprefix("/l/") for label in result.labels)))
         new_paragraph = Paragraph(
             score=result.score.bm25,
             rid=result.uuid,

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -452,17 +452,9 @@ async def load_paragraph(
             page_number=result.metadata.position.page_number,
         ),
         fuzzy_result=fuzzy_result,
+        start_seconds=list(result.metadata.position.start_seconds) or None,
+        end_seconds=list(result.metadata.position.end_seconds) or None,
     )
-    if len(result.metadata.position.start_seconds) or len(result.metadata.position.end_seconds):
-        new_paragraph.start_seconds = list(result.metadata.position.start_seconds)
-        new_paragraph.end_seconds = list(result.metadata.position.end_seconds)
-    else:
-        # TODO: Remove once we are sure all data has been migrated!
-        seconds_positions = await get_seconds_paragraph(result, kbid)
-        if seconds_positions is not None:
-            new_paragraph.start_seconds = seconds_positions[0]
-            new_paragraph.end_seconds = seconds_positions[1]
-
     return new_paragraph
 
 

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -533,7 +533,7 @@ async def merge_results(
 
     api_results = KnowledgeboxSearchResults()
 
-    resources: list[str] = list()
+    resources = set()
 
     if retrieval.query.fulltext is not None:
         api_results.fulltext, matched_resources = await merge_documents_results(
@@ -543,7 +543,7 @@ async def merge_results(
             top_k=retrieval.top_k,
             offset=offset,
         )
-        resources.extend(matched_resources)
+        resources.update(matched_resources)
 
     if retrieval.query.keyword is not None:
         sort = SortOptions(
@@ -560,7 +560,7 @@ async def merge_results(
             offset=offset,
             concurrency_control=concurrency_control,
         )
-        resources.extend(matched_resources)
+        resources.update(matched_resources)
 
     if retrieval.query.semantic is not None:
         api_results.sentences, matched_resources = await merge_vectors_results(
@@ -570,7 +570,7 @@ async def merge_results(
             min_score=retrieval.query.semantic.min_score,
             concurrency_control=concurrency_control,
         )
-        resources.extend(matched_resources)
+        resources.update(matched_resources)
 
     if retrieval.query.relation is not None:
         api_results.relations = await merge_relations_results(
@@ -579,7 +579,7 @@ async def merge_results(
 
     api_results.resources = await augment_resources_deep(
         kbid,
-        given=resources,
+        given=list(resources),
         opts=ResourceHydrationOptions(
             show=show,
             field_type_filter=field_type_filter,

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -381,17 +381,47 @@ async def merge_paragraph_results(
         concurrency_control=concurrency_control,
     )
 
-    result_paragraph_list: list[Paragraph] = await asyncio.gather(
-        *(
-            load_paragraph(result, kbid, augmented_paragraphs.get(paragraph_id), highlight, ematches)
-            for paragraph_id, result, _ in raw_paragraph_list
-        )
-    )
+    result_paragraph_list: list[Paragraph] = []
+    result_resource_ids = set()
+    for paragraph_id, result, _ in raw_paragraph_list:
+        augmented = augmented_paragraphs.get(paragraph_id)
+        text = augmented.text or "" if augmented else ""
+        if text and highlight:
+            try:
+                text = highlight_paragraph(
+                    text,
+                    words=result.matches,  # type: ignore[arg-type,ty:invalid-argument-type]
+                    ematches=ematches,
+                )
+            except Exception as exc:
+                logger.warning("Error highlighting paragraph", extra={"kbid": kbid}, exc_info=exc)
 
-    result_resource_ids = []
-    for paragraph in result_paragraph_list:
-        if paragraph.rid not in result_resource_ids:
-            result_resource_ids.append(paragraph.rid)
+        fuzzy_result = len(result.matches) > 0
+        # bw/c: historically, we returned labels from maindb, which didn't have the
+        # /l prefix. As we now return the labels from the index (which do have the
+        # /l), we trim the prefix
+        labels = list(set((label.removeprefix("/l/") for label in result.labels)))
+
+        result_resource_ids.add(paragraph_id.rid)
+        result_paragraph_list.append(
+            Paragraph(
+                score=result.score.bm25,
+                rid=paragraph_id.rid,
+                field_type=paragraph_id.field_id.type,
+                field=paragraph_id.field_id.key,
+                text=text,
+                labels=labels,
+                position=TextPosition(
+                    index=result.metadata.position.index,
+                    start=result.metadata.position.start,
+                    end=result.metadata.position.end,
+                    page_number=result.metadata.position.page_number,
+                ),
+                fuzzy_result=fuzzy_result,
+                start_seconds=list(result.metadata.position.start_seconds) or None,
+                end_seconds=list(result.metadata.position.end_seconds) or None,
+            )
+        )
 
     return Paragraphs(
         results=result_paragraph_list,
@@ -402,52 +432,7 @@ async def merge_paragraph_results(
         page_size=top_k,
         next_page=next_page,
         min_score=min_score,
-    ), result_resource_ids
-
-
-async def load_paragraph(
-    result: ParagraphResult,
-    kbid: str,
-    augmented: AugmentedParagraph | None,
-    highlight: bool,
-    ematches: list[str] | None,
-) -> Paragraph:
-    text = augmented.text or "" if augmented else ""
-    if text and highlight:
-        try:
-            text = highlight_paragraph(
-                text,
-                words=result.matches,  # type: ignore[arg-type,ty:invalid-argument-type]
-                ematches=ematches,
-            )
-        except Exception as exc:
-            logger.warning("Error highlighting paragraph", extra={"kbid": kbid}, exc_info=exc)
-
-    # bw/c: historically, we returned labels from maindb, which didn't have the
-    # /l prefix. As we now return the labels from the index (which do have the
-    # /l), we trim the prefix
-    labels = list(set((label.removeprefix("/l/") for label in result.labels)))
-
-    _, field_type, field = result.field.split("/")
-    fuzzy_result = len(result.matches) > 0
-    new_paragraph = Paragraph(
-        score=result.score.bm25,
-        rid=result.uuid,
-        field_type=field_type,
-        field=field,
-        text=text,
-        labels=labels,
-        position=TextPosition(
-            index=result.metadata.position.index,
-            start=result.metadata.position.start,
-            end=result.metadata.position.end,
-            page_number=result.metadata.position.page_number,
-        ),
-        fuzzy_result=fuzzy_result,
-        start_seconds=list(result.metadata.position.start_seconds) or None,
-        end_seconds=list(result.metadata.position.end_seconds) or None,
-    )
-    return new_paragraph
+    ), list(result_resource_ids)
 
 
 @merge_observer.wrap({"type": "merge_relations"})


### PR DESCRIPTION
### Description
In /search and /suggest merge, we are doing a bunch of lookups to maindb/storage that are actually not needed as the information is already returned by the index. In addition, we were not properly utilizing request cache in fetch.py, concurrency in key points and some other improvements around.

### How was this PR tested?
Describe how you tested this PR.
