### PR TITLE
PostgreSQL idle connections handinling improvements

### DIFF
--- a/charts/nidx/values.yaml
+++ b/charts/nidx/values.yaml
@@ -39,6 +39,12 @@ env: {}
   # INDEXER__TIMEOUT: "120"
   # -- Azure storage account key for indexer.
   # INDEXER__ACCOUNT_KEY: "your-azure-account-key"
+  # -- Database URL for indexer metadata storage (e.g. PostgreSQL).
+  # METADATA__DATABASE_URL: postgres://user:password@host:port/dbname
+  # -- PostgreSQL Pool idle timeout in seconds for indexer metadata storage.
+  # METADATA__IDLE_TIMEOUT_SECONDS: "300"
+  # -- PostgreSQL Pool max lifetime in seconds for indexer metadata storage.
+  # METADATA__MAX_LIFETIME_SECONDS: "1800"
   # -- Object store backend type for storage.
   # STORAGE__OBJECT_STORE: s3
   # -- S3 bucket name used by storage.

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -22,14 +22,6 @@ env: {}
   # DRIVER_PG_CONNECTION_POOL_MAX_IDLE_SECONDS: "300"
   # -- PostgreSQL connection pool max lifetime in seconds
   # DRIVER_PG_CONNECTION_POOL_MAX_LIFETIME_SECONDS: "1800"
-  # -- PostgreSQL TCP keepalive settings
-  # DRIVER_PG_KEEPALIVES: "true"
-  # -- PostgreSQL Idle time before first keepalive probe
-  # DRIVER_PG_KEEPALIVES_IDLE_SECONDS: "30"
-  # -- PostgreSQL interval between keepalive probes
-  # DRIVER_PG_KEEPALIVES_INTERVAL_SECONDS: "10"
-  # -- PostgreSQL count of keepalive probes before declaring the connection dead
-  # DRIVER_PG_KEEPALIVES_COUNT: "3"
 
 # Configmap and/or secrets to mount into the environment
 envFrom:

--- a/charts/nucliadb_ingest/values.yaml
+++ b/charts/nucliadb_ingest/values.yaml
@@ -18,6 +18,18 @@ image: IMAGE_TO_REPLACE
 # settings not mapped directly through env
 env: {}
   # EXAMPLE: "VALUE"
+  # -- PostgreSQL connection pool max idle time in seconds
+  # DRIVER_PG_CONNECTION_POOL_MAX_IDLE_SECONDS: "300"
+  # -- PostgreSQL connection pool max lifetime in seconds
+  # DRIVER_PG_CONNECTION_POOL_MAX_LIFETIME_SECONDS: "1800"
+  # -- PostgreSQL TCP keepalive settings
+  # DRIVER_PG_KEEPALIVES: "true"
+  # -- PostgreSQL Idle time before first keepalive probe
+  # DRIVER_PG_KEEPALIVES_IDLE_SECONDS: "30"
+  # -- PostgreSQL interval between keepalive probes
+  # DRIVER_PG_KEEPALIVES_INTERVAL_SECONDS: "10"
+  # -- PostgreSQL count of keepalive probes before declaring the connection dead
+  # DRIVER_PG_KEEPALIVES_COUNT: "3"
 
 # Configmap and/or secrets to mount into the environment
 envFrom:

--- a/nidx/src/metadata.rs
+++ b/nidx/src/metadata.rs
@@ -51,13 +51,17 @@ impl NidxMetadata {
             .parse()
             .map_err(|e| sqlx::Error::Configuration(format!("Invalid database URL: {e}").into()))?;
 
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .acquire_timeout(Duration::from_secs(2))
-            .idle_timeout(Duration::from_secs(settings.idle_timeout_seconds))
-            .max_lifetime(Duration::from_secs(settings.max_lifetime_seconds))
-            .test_before_acquire(true)
-            .connect_with(connect_options)
-            .await?;
+        let mut pool_options = sqlx::postgres::PgPoolOptions::new().acquire_timeout(Duration::from_secs(2));
+
+        if let Some(idle_timeout_seconds) = settings.idle_timeout_seconds {
+            pool_options = pool_options.idle_timeout(Duration::from_secs(idle_timeout_seconds));
+        }
+
+        if let Some(max_lifetime_seconds) = settings.max_lifetime_seconds {
+            pool_options = pool_options.max_lifetime(Duration::from_secs(max_lifetime_seconds));
+        }
+
+        let pool = pool_options.connect_with(connect_options).await?;
 
         if !settings.disable_migrations {
             Self::run_migrations(&pool).await?;

--- a/nidx/src/metadata.rs
+++ b/nidx/src/metadata.rs
@@ -46,9 +46,17 @@ pub struct NidxMetadata {
 
 impl NidxMetadata {
     pub async fn new(settings: &MetadataSettings) -> sqlx::Result<Self> {
+        let connect_options: sqlx::postgres::PgConnectOptions = settings
+            .database_url
+            .parse()
+            .map_err(|e| sqlx::Error::Configuration(format!("Invalid database URL: {e}").into()))?;
+
         let pool = sqlx::postgres::PgPoolOptions::new()
             .acquire_timeout(Duration::from_secs(2))
-            .connect(&settings.database_url)
+            .idle_timeout(Duration::from_secs(settings.idle_timeout_seconds))
+            .max_lifetime(Duration::from_secs(settings.max_lifetime_seconds))
+            .test_before_acquire(true)
+            .connect_with(connect_options)
             .await?;
 
         if !settings.disable_migrations {

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -191,21 +191,10 @@ pub struct MetadataSettings {
     pub database_url: String,
     #[serde(default)]
     pub disable_migrations: bool,
-    /// Max idle time for pooled connections in seconds (default: 300s).
-    #[serde(default = "MetadataSettings::default_idle_timeout")]
-    pub idle_timeout_seconds: u64,
-    /// Max lifetime for pooled connections in seconds (default: 1800s).
-    #[serde(default = "MetadataSettings::default_max_lifetime")]
-    pub max_lifetime_seconds: u64,
-}
-
-impl MetadataSettings {
-    pub fn default_idle_timeout() -> u64 {
-        300
-    }
-    pub fn default_max_lifetime() -> u64 {
-        1800
-    }
+    /// Max idle time for pooled connections in seconds (empty for default).
+    pub idle_timeout_seconds: Option<u64>,
+    /// Max lifetime for pooled connections in seconds (empty for default).
+    pub max_lifetime_seconds: Option<u64>,
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -191,6 +191,21 @@ pub struct MetadataSettings {
     pub database_url: String,
     #[serde(default)]
     pub disable_migrations: bool,
+    /// Max idle time for pooled connections in seconds (default: 300s).
+    #[serde(default = "MetadataSettings::default_idle_timeout")]
+    pub idle_timeout_seconds: u64,
+    /// Max lifetime for pooled connections in seconds (default: 1800s).
+    #[serde(default = "MetadataSettings::default_max_lifetime")]
+    pub max_lifetime_seconds: u64,
+}
+
+impl MetadataSettings {
+    fn default_idle_timeout() -> u64 {
+        300
+    }
+    fn default_max_lifetime() -> u64 {
+        1800
+    }
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/nidx/src/settings.rs
+++ b/nidx/src/settings.rs
@@ -200,10 +200,10 @@ pub struct MetadataSettings {
 }
 
 impl MetadataSettings {
-    fn default_idle_timeout() -> u64 {
+    pub fn default_idle_timeout() -> u64 {
         300
     }
-    fn default_max_lifetime() -> u64 {
+    pub fn default_max_lifetime() -> u64 {
         1800
     }
 }

--- a/nidx/tests/common/services.rs
+++ b/nidx/tests/common/services.rs
@@ -62,8 +62,8 @@ impl NidxFixture {
                 metadata: Some(MetadataSettings {
                     database_url: "ignored".to_string(),
                     disable_migrations: false,
-                    idle_timeout_seconds: MetadataSettings::default_idle_timeout(),
-                    max_lifetime_seconds: MetadataSettings::default_max_lifetime(),
+                    idle_timeout_seconds: None,
+                    max_lifetime_seconds: None,
                 }),
                 telemetry: Default::default(),
                 work_path: None,

--- a/nidx/tests/common/services.rs
+++ b/nidx/tests/common/services.rs
@@ -62,6 +62,8 @@ impl NidxFixture {
                 metadata: Some(MetadataSettings {
                     database_url: "ignored".to_string(),
                     disable_migrations: false,
+                    idle_timeout_seconds: MetadataSettings::default_idle_timeout(),
+                    max_lifetime_seconds: MetadataSettings::default_max_lifetime(),
                 }),
                 telemetry: Default::default(),
                 work_path: None,

--- a/nucliadb/src/nucliadb/common/maindb/pg.py
+++ b/nucliadb/src/nucliadb/common/maindb/pg.py
@@ -279,15 +279,11 @@ class PGDriver(Driver):
     def __init__(
         self,
         url: str,
-        connection_pool_min_size: int = 10,
+        connection_pool_min_size: int = 2,
         connection_pool_max_size: int = 10,
         acquire_timeout_ms: int = 200,
-        max_idle_seconds: float = 300.0,
-        max_lifetime_seconds: float = 1800.0,
-        keepalives: bool = True,
-        keepalives_idle_seconds: int = 30,
-        keepalives_interval_seconds: int = 10,
-        keepalives_count: int = 3,
+        max_idle_seconds: float | None = None,
+        max_lifetime_seconds: float | None = None,
     ):
         self.url = url
         self.connection_pool_min_size = connection_pool_min_size
@@ -295,29 +291,23 @@ class PGDriver(Driver):
         self.acquire_timeout_ms = acquire_timeout_ms
         self.max_idle_seconds = max_idle_seconds
         self.max_lifetime_seconds = max_lifetime_seconds
-        self.keepalives = keepalives
-        self.keepalives_idle_seconds = keepalives_idle_seconds
-        self.keepalives_interval_seconds = keepalives_interval_seconds
-        self.keepalives_count = keepalives_count
         self._lock = asyncio.Lock()
 
     async def initialize(self):
         async with self._lock:
             if self.initialized is False:
+                optional_args: dict[str, Any] = {}
+                if self.max_idle_seconds is not None:
+                    optional_args["max_idle"] = self.max_idle_seconds
+                if self.max_lifetime_seconds is not None:
+                    optional_args["max_lifetime"] = self.max_lifetime_seconds
                 self.pool = psycopg_pool.AsyncConnectionPool(
                     self.url,
                     min_size=self.connection_pool_min_size,
                     max_size=self.connection_pool_max_size,
-                    max_idle=self.max_idle_seconds,
-                    max_lifetime=self.max_lifetime_seconds,
                     check=psycopg_pool.AsyncConnectionPool.check_connection,
-                    kwargs={
-                        "keepalives": 1 if self.keepalives else 0,
-                        "keepalives_idle": self.keepalives_idle_seconds,
-                        "keepalives_interval": self.keepalives_interval_seconds,
-                        "keepalives_count": self.keepalives_count,
-                    },
                     open=False,
+                    **optional_args,
                 )
                 await self.pool.open()
 

--- a/nucliadb/src/nucliadb/common/maindb/pg.py
+++ b/nucliadb/src/nucliadb/common/maindb/pg.py
@@ -36,6 +36,7 @@ from nucliadb_telemetry import metrics
 
 RETRIABLE_EXCEPTIONS = (
     psycopg_pool.PoolTimeout,
+    psycopg.OperationalError,
     OSError,
     ConnectionResetError,
 )
@@ -281,11 +282,23 @@ class PGDriver(Driver):
         connection_pool_min_size: int = 10,
         connection_pool_max_size: int = 10,
         acquire_timeout_ms: int = 200,
+        max_idle_seconds: float = 300.0,
+        max_lifetime_seconds: float = 1800.0,
+        keepalives: bool = True,
+        keepalives_idle_seconds: int = 30,
+        keepalives_interval_seconds: int = 10,
+        keepalives_count: int = 3,
     ):
         self.url = url
         self.connection_pool_min_size = connection_pool_min_size
         self.connection_pool_max_size = connection_pool_max_size
         self.acquire_timeout_ms = acquire_timeout_ms
+        self.max_idle_seconds = max_idle_seconds
+        self.max_lifetime_seconds = max_lifetime_seconds
+        self.keepalives = keepalives
+        self.keepalives_idle_seconds = keepalives_idle_seconds
+        self.keepalives_interval_seconds = keepalives_interval_seconds
+        self.keepalives_count = keepalives_count
         self._lock = asyncio.Lock()
 
     async def initialize(self):
@@ -295,7 +308,15 @@ class PGDriver(Driver):
                     self.url,
                     min_size=self.connection_pool_min_size,
                     max_size=self.connection_pool_max_size,
+                    max_idle=self.max_idle_seconds,
+                    max_lifetime=self.max_lifetime_seconds,
                     check=psycopg_pool.AsyncConnectionPool.check_connection,
+                    kwargs={
+                        "keepalives": 1 if self.keepalives else 0,
+                        "keepalives_idle": self.keepalives_idle_seconds,
+                        "keepalives_interval": self.keepalives_interval_seconds,
+                        "keepalives_count": self.keepalives_count,
+                    },
                     open=False,
                 )
                 await self.pool.open()

--- a/nucliadb/src/nucliadb/common/maindb/utils.py
+++ b/nucliadb/src/nucliadb/common/maindb/utils.py
@@ -53,6 +53,12 @@ async def setup_driver() -> Driver:
             connection_pool_min_size=settings.driver_pg_connection_pool_min_size,
             connection_pool_max_size=settings.driver_pg_connection_pool_max_size,
             acquire_timeout_ms=settings.driver_pg_connection_pool_acquire_timeout_ms,
+            max_idle_seconds=settings.driver_pg_connection_pool_max_idle_seconds,
+            max_lifetime_seconds=settings.driver_pg_connection_pool_max_lifetime_seconds,
+            keepalives=settings.driver_pg_keepalives,
+            keepalives_idle_seconds=settings.driver_pg_keepalives_idle_seconds,
+            keepalives_interval_seconds=settings.driver_pg_keepalives_interval_seconds,
+            keepalives_count=settings.driver_pg_keepalives_count,
         )
         set_utility(Utility.MAINDB_DRIVER, pg_driver)
     else:

--- a/nucliadb/src/nucliadb/common/maindb/utils.py
+++ b/nucliadb/src/nucliadb/common/maindb/utils.py
@@ -55,10 +55,6 @@ async def setup_driver() -> Driver:
             acquire_timeout_ms=settings.driver_pg_connection_pool_acquire_timeout_ms,
             max_idle_seconds=settings.driver_pg_connection_pool_max_idle_seconds,
             max_lifetime_seconds=settings.driver_pg_connection_pool_max_lifetime_seconds,
-            keepalives=settings.driver_pg_keepalives,
-            keepalives_idle_seconds=settings.driver_pg_keepalives_idle_seconds,
-            keepalives_interval_seconds=settings.driver_pg_keepalives_interval_seconds,
-            keepalives_count=settings.driver_pg_keepalives_count,
         )
         set_utility(Utility.MAINDB_DRIVER, pg_driver)
     else:

--- a/nucliadb/src/nucliadb/ingest/settings.py
+++ b/nucliadb/src/nucliadb/ingest/settings.py
@@ -44,7 +44,7 @@ class DriverSettings(BaseSettings):
         description="PostgreSQL DSN. The connection string to the PG server. Example: postgres://username:password@postgres:5432/nucliadb.",
     )
     driver_pg_connection_pool_min_size: int = Field(
-        default=10,
+        default=2,
         description="PostgreSQL min pool size. The minimum number of connections to the PostgreSQL server.",
     )
     driver_pg_connection_pool_max_size: int = Field(
@@ -55,29 +55,13 @@ class DriverSettings(BaseSettings):
         default=1000,
         description="PostgreSQL pool acquire timeout in ms. The maximum time to wait until a connection becomes available.",
     )
-    driver_pg_connection_pool_max_idle_seconds: float = Field(
-        default=300.0,
+    driver_pg_connection_pool_max_idle_seconds: float | None = Field(
+        default=None,
         description="PostgreSQL pool max idle time in seconds. Connections idle longer than this are closed.",
     )
-    driver_pg_connection_pool_max_lifetime_seconds: float = Field(
-        default=1800.0,
+    driver_pg_connection_pool_max_lifetime_seconds: float | None = Field(
+        default=None,
         description="PostgreSQL pool max connection lifetime in seconds. Connections older than this are recycled.",
-    )
-    driver_pg_keepalives: bool = Field(
-        default=True,
-        description="Enable TCP keepalives on PostgreSQL connections.",
-    )
-    driver_pg_keepalives_idle_seconds: int = Field(
-        default=30,
-        description="Seconds of idle time before sending a TCP keepalive probe.",
-    )
-    driver_pg_keepalives_interval_seconds: int = Field(
-        default=10,
-        description="Seconds between TCP keepalive probes.",
-    )
-    driver_pg_keepalives_count: int = Field(
-        default=3,
-        description="Number of missed TCP keepalive probes before the connection is considered dead.",
     )
     driver_pg_log_on_select_for_update: bool = Field(
         default=False,

--- a/nucliadb/src/nucliadb/ingest/settings.py
+++ b/nucliadb/src/nucliadb/ingest/settings.py
@@ -55,6 +55,30 @@ class DriverSettings(BaseSettings):
         default=1000,
         description="PostgreSQL pool acquire timeout in ms. The maximum time to wait until a connection becomes available.",
     )
+    driver_pg_connection_pool_max_idle_seconds: float = Field(
+        default=300.0,
+        description="PostgreSQL pool max idle time in seconds. Connections idle longer than this are closed.",
+    )
+    driver_pg_connection_pool_max_lifetime_seconds: float = Field(
+        default=1800.0,
+        description="PostgreSQL pool max connection lifetime in seconds. Connections older than this are recycled.",
+    )
+    driver_pg_keepalives: bool = Field(
+        default=True,
+        description="Enable TCP keepalives on PostgreSQL connections.",
+    )
+    driver_pg_keepalives_idle_seconds: int = Field(
+        default=30,
+        description="Seconds of idle time before sending a TCP keepalive probe.",
+    )
+    driver_pg_keepalives_interval_seconds: int = Field(
+        default=10,
+        description="Seconds between TCP keepalive probes.",
+    )
+    driver_pg_keepalives_count: int = Field(
+        default=3,
+        description="Number of missed TCP keepalive probes before the connection is considered dead.",
+    )
     driver_pg_log_on_select_for_update: bool = Field(
         default=False,
         description="If true, log a warning when a SELECT FOR UPDATE is executed. This is useful to detect potential deadlocks.",

--- a/nucliadb/tests/ndbfixtures/maindb.py
+++ b/nucliadb/tests/ndbfixtures/maindb.py
@@ -126,7 +126,7 @@ async def pg_maindb_settings(request) -> AsyncIterator[DriverSettings]:
     yield DriverSettings(
         driver=DriverConfig.PG,
         driver_pg_url=url,
-        driver_pg_connection_pool_min_size=10,
+        driver_pg_connection_pool_min_size=2,
         driver_pg_connection_pool_max_size=10,
         driver_pg_connection_pool_acquire_timeout_ms=200,
     )


### PR DESCRIPTION
### Description
This pull request introduces new configuration options and improvements for PostgreSQL connection pooling and TCP keepalive settings in both the indexer metadata and ingest components. These changes allow for better control over database connection lifetimes and resilience, helping to avoid stale or dropped connections in long-running services. The most important changes are grouped below:

**PostgreSQL Connection Pooling Enhancements:**

* Added support for configuring maximum idle time and maximum lifetime for PostgreSQL connection pool connections in both the indexer metadata (`METADATA__IDLE_TIMEOUT_SECONDS`, `METADATA__MAX_LIFETIME_SECONDS`) and ingest (`DRIVER_PG_CONNECTION_POOL_MAX_IDLE_SECONDS`, `DRIVER_PG_CONNECTION_POOL_MAX_LIFETIME_SECONDS`) components, with sensible defaults. [[1]](diffhunk://#diff-27e9cc266923d087b3a45d52d4bfd0e283837dcb6eb6e6b0c06eb17e724d29edR42-R47) [[2]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5R21-R32) [[3]](diffhunk://#diff-43e4afeb367e7e4e2d79686e9dd133a1f06b2facd8e9d214899818ef5d935c66R194-R208) [[4]](diffhunk://#diff-a21d9a7000098000fa0fc52d94c6f06b61c52faf73a3e8660fced5700e383d7eR58-R81)
* Updated the Rust (`nidx`) and Python (`nucliadb`) code to use these new settings when creating connection pools, ensuring that idle or stale connections are closed and recycled appropriately. [[1]](diffhunk://#diff-c515ed8b7da3794321be932c24b7317974e087345c36eb40960595379c099ca2R49-R59) [[2]](diffhunk://#diff-eb08c2e8a5060b9c677ee5a8bd2fb3f5ada2dccfbc8b431a499931c4084706baR285-R301) [[3]](diffhunk://#diff-772636d9822605cdda6aa819987fb1fb9590ea33fb894503f19acd676c11b2e1R56-R61)

**TCP Keepalive Configuration:**

* Introduced new settings for enabling and customizing TCP keepalive behavior on PostgreSQL connections in the ingest component, including idle time, interval, and probe count. These help maintain long-lived connections through firewalls and network devices. [[1]](diffhunk://#diff-eaf1be2de1fe2ebf6401e80e4e6e1ea121dd17692340646308796192bb0ef7b5R21-R32) [[2]](diffhunk://#diff-a21d9a7000098000fa0fc52d94c6f06b61c52faf73a3e8660fced5700e383d7eR58-R81) [[3]](diffhunk://#diff-eb08c2e8a5060b9c677ee5a8bd2fb3f5ada2dccfbc8b431a499931c4084706baR285-R301) [[4]](diffhunk://#diff-eb08c2e8a5060b9c677ee5a8bd2fb3f5ada2dccfbc8b431a499931c4084706baR311-R319) [[5]](diffhunk://#diff-772636d9822605cdda6aa819987fb1fb9590ea33fb894503f19acd676c11b2e1R56-R61)

**Resilience Improvements:**

* Added `psycopg.OperationalError` to the list of retriable exceptions in the PostgreSQL driver, improving error handling and automatic recovery from dropped connections.

These changes make the database connectivity more robust and customizable, reducing the risk of connection-related issues in production deployments.

### How was this PR tested?
Describe how you tested this PR.
