### PR TITLE
e2e: Upgrade testing environment to Kubernetes 1.35

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9 # v0.4.3
         with:
-          channel: "1.33/stable"
+          channel: "1.35/stable"
           devMode: "true"
           addons: '["dns", "rbac", "hostpath-storage", "registry", "helm", "storage"]'
 


### PR DESCRIPTION
### Description
We don't run 1.33 anywhere anymore, it's EOL is on 2026-06-28. Switching to 1.35 as that's the version we'll be upgrading to starting this month

### How was this PR tested?
This is testing