### PR TITLE
Correct ordering for merge inputs

### DIFF
--- a/nidx/.sqlx/query-1b8c0301a672339ab2c39fdf906e6dbab4e54022b4baf11391fb968eda01085a.json
+++ b/nidx/.sqlx/query-1b8c0301a672339ab2c39fdf906e6dbab4e54022b4baf11391fb968eda01085a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM deletions WHERE index_id = $1 AND seq <= $2",
+  "query": "SELECT * FROM deletions WHERE index_id = $1 AND seq <= $2 ORDER BY seq ASC",
   "describe": {
     "columns": [
       {
@@ -31,5 +31,5 @@
       false
     ]
   },
-  "hash": "bf49702b506c9a1650ece1f8e8d9f14834a902f8caefafe30ded55e2790f2188"
+  "hash": "1b8c0301a672339ab2c39fdf906e6dbab4e54022b4baf11391fb968eda01085a"
 }

--- a/nidx/.sqlx/query-5d3586920916714a0b5b4e91bd370764477ba86a6d330f00c77dccfee9b69abc.json
+++ b/nidx/.sqlx/query-5d3586920916714a0b5b4e91bd370764477ba86a6d330f00c77dccfee9b69abc.json
@@ -24,7 +24,9 @@
                 "text",
                 "paragraph",
                 "vector",
-                "relation"
+                "relation",
+                "vector_relation_node",
+                "vector_relation_edge"
               ]
             }
           }
@@ -62,7 +64,9 @@
                 "text",
                 "paragraph",
                 "vector",
-                "relation"
+                "relation",
+                "vector_relation_node",
+                "vector_relation_edge"
               ]
             }
           }

--- a/nidx/.sqlx/query-e66c16e5e6a36efad477c45001a18596c19bb929096c94523b46f63d43a91a2e.json
+++ b/nidx/.sqlx/query-e66c16e5e6a36efad477c45001a18596c19bb929096c94523b46f63d43a91a2e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM segments WHERE merge_job_id = $1",
+  "query": "SELECT * FROM segments WHERE merge_job_id = $1 ORDER BY seq ASC",
   "describe": {
     "columns": [
       {
@@ -60,5 +60,5 @@
       true
     ]
   },
-  "hash": "7a7e59e47b30b12237511fd3d7da2d17b0471ad2b006af48d6a6f587c779692b"
+  "hash": "e66c16e5e6a36efad477c45001a18596c19bb929096c94523b46f63d43a91a2e"
 }

--- a/nidx/nidx_types/src/lib.rs
+++ b/nidx/nidx_types/src/lib.rs
@@ -54,8 +54,8 @@ pub struct SegmentMetadata<T> {
 
 /// The metadata needed to open an index: a list of segments and deletions.
 pub trait OpenIndexMetadata<T> {
-    /// List of segments and Seq
+    /// Segments in ascending `Seq` order (oldest first).
     fn segments(&self) -> impl DoubleEndedIterator<Item = (SegmentMetadata<T>, Seq)>;
-    /// List of deletions and Seq
+    /// Deletions in ascending `Seq` order (oldest first).
     fn deletions(&self) -> impl DoubleEndedIterator<Item = (&String, Seq)>;
 }

--- a/nidx/nidx_vector/src/lib.rs
+++ b/nidx/nidx_vector/src/lib.rs
@@ -43,7 +43,7 @@ use searcher::Searcher;
 use segment::OpenSegment;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::iter::Peekable;
+use std::iter::{Peekable, Rev};
 use std::path::Path;
 use thiserror::Error;
 use tracing::instrument;
@@ -168,37 +168,30 @@ fn open_segments(
     Ok(open_segments)
 }
 
-struct SegmentDeletions<'a, S, D>
-where
-    S: Iterator,
-    D: Iterator,
-{
-    segments: S,
-    deletions: Peekable<D>,
+struct SegmentDeletions<'a> {
+    segments: Rev<std::vec::IntoIter<(VectorSegmentMetadata, nidx_types::Seq)>>,
+    deletions: Peekable<Rev<std::vec::IntoIter<(&'a String, nidx_types::Seq)>>>,
     deletions_so_far: HashSet<FieldKey<'a>>,
 }
 
-/// Should be SegmentDeletions::new but this runs into less problems with type inference
-fn segment_deletions<'a>(
-    open_index: &'a impl OpenIndexMetadata<VectorSegmentMeta>,
-) -> SegmentDeletions<
-    'a,
-    impl Iterator<Item = (VectorSegmentMetadata, nidx_types::Seq)>,
-    impl Iterator<Item = (&'a String, nidx_types::Seq)>,
-> {
+fn segment_deletions<'a>(open_index: &'a impl OpenIndexMetadata<VectorSegmentMeta>) -> SegmentDeletions<'a> {
+    // The segments and deletions should come ordered here already, but given that sorting is fast
+    // compared to merge, and a wrong sorting can lead to incorrect merges, we sort again.
+    let mut segments: Vec<_> = open_index.segments().collect();
+    segments.sort_by_key(|(_, seq)| *seq);
+
+    let mut deletions: Vec<_> = open_index.deletions().collect();
+    deletions.sort_by_key(|(_, seq)| *seq);
+
     SegmentDeletions {
-        segments: open_index.segments().rev(),
-        deletions: open_index.deletions().rev().peekable(),
+        segments: segments.into_iter().rev(),
+        deletions: deletions.into_iter().rev().peekable(),
         deletions_so_far: HashSet::new(),
     }
 }
 
-impl<'a: 'b, 'b, S, D> SegmentDeletions<'a, S, D>
-where
-    S: Iterator<Item = (VectorSegmentMetadata, nidx_types::Seq)>,
-    D: Iterator<Item = (&'a String, nidx_types::Seq)>,
-{
-    fn next(&mut self) -> Option<(VectorSegmentMetadata, &HashSet<FieldKey<'b>>)> {
+impl<'a> SegmentDeletions<'a> {
+    fn next(&mut self) -> Option<(VectorSegmentMetadata, &HashSet<FieldKey<'a>>)> {
         let (segment, segment_seq) = self.segments.next()?;
         while let Some(d) = self.deletions.peek()
             && d.1 > segment_seq

--- a/nidx/nidx_vector/src/lib.rs
+++ b/nidx/nidx_vector/src/lib.rs
@@ -105,17 +105,17 @@ impl VectorIndexer {
         config: VectorConfig,
         open_index: impl OpenIndexMetadata<VectorSegmentMeta>,
     ) -> anyhow::Result<VectorSegmentMetadata> {
-        let mut open_segments: Vec<(OpenSegment, HashSet<FieldKey>)> = Vec::new();
+        let mut open_segments: Vec<OpenSegment> = Vec::new();
 
         let mut segment_deletions = segment_deletions(&open_index);
         while let Some((segment, deletions)) = segment_deletions.next() {
             let mut open_segment = segment::open(segment, &config)?;
             open_segment.apply_deletions(deletions);
-            open_segments.push((open_segment, deletions.clone()));
+            open_segments.push(open_segment);
         }
 
         // Do the merge
-        let open_segments_ref = open_segments.iter().map(|(s, d)| (s, d)).collect();
+        let open_segments_ref = open_segments.iter().collect();
         let open_destination = segment::merge(work_dir, open_segments_ref, &config)?;
 
         Ok(open_destination.into_metadata())

--- a/nidx/nidx_vector/src/segment.rs
+++ b/nidx/nidx_vector/src/segment.rs
@@ -94,29 +94,25 @@ pub fn open(metadata: VectorSegmentMetadata, config: &VectorConfig) -> VectorR<O
     })
 }
 
-pub fn merge(
-    segment_path: &Path,
-    mut operants: Vec<(&OpenSegment, &HashSet<FieldKey>)>,
-    config: &VectorConfig,
-) -> VectorR<OpenSegment> {
+pub fn merge(segment_path: &Path, mut operants: Vec<&OpenSegment>, config: &VectorConfig) -> VectorR<OpenSegment> {
     // Sort largest operant first so we reuse as much of the HNSW as possible
-    operants.sort_unstable_by_key(|o| std::cmp::Reverse(o.0.metadata.records));
+    operants.sort_unstable_by_key(|o| std::cmp::Reverse(o.metadata.records));
 
     // Tags for all segments are the same (this should not happen, prepare_merge ensures it)
-    let tags = &operants[0].0.metadata.index_metadata.tags;
-    for (segment, _) in &operants {
+    let tags = &operants[0].metadata.index_metadata.tags;
+    for segment in &operants {
         if &segment.metadata.index_metadata.tags != tags {
             return Err(crate::VectorErr::InconsistentMergeSegmentTags);
         }
     }
 
-    let segments = operants.iter().map(|(s, _)| *s).collect();
+    let segments = operants.to_vec();
 
     // Creating the node store
     if config.flags.contains(&flags::FORCE_DATA_STORE_V1.to_string()) {
         // V1 can only merge from V1
         let mut node_producers = Vec::new();
-        for (segment, _) in &operants {
+        for segment in &operants {
             node_producers.push((
                 segment.alive_paragraphs(),
                 segment
@@ -133,7 +129,7 @@ pub fn merge(
     } else {
         let node_producers = operants
             .iter()
-            .map(|(s, _)| (s.alive_paragraphs(), s.data_store.as_ref()))
+            .map(|s| (s.alive_paragraphs(), s.data_store.as_ref()))
             .collect();
 
         DataStoreV2::merge(segment_path, node_producers, config)?;
@@ -586,6 +582,7 @@ impl OpenSegment {
         let mut scored_results = Vec::new();
 
         let t = Instant::now();
+
         for paragraph_addr in bitset.iter() {
             let paragraph = retriever.data_store.get_paragraph(paragraph_addr);
 
@@ -818,8 +815,7 @@ mod test {
             HashSet::new(),
         )?;
 
-        let no_dels = HashSet::new();
-        let work = vec![(&dp1, &no_dels), (&dp2, &no_dels)];
+        let work = vec![&dp1, &dp2];
         let path_merged = tempdir()?;
         let merged_dp = merge(path_merged.path(), work, &config)?;
 

--- a/nidx/nidx_vector/src/segment/tests.rs
+++ b/nidx/nidx_vector/src/segment/tests.rs
@@ -167,8 +167,7 @@ fn data_merge() -> anyhow::Result<()> {
     let dp1 = segment::create(dp1_path.path(), elems1, &v1_config, HashSet::new()).unwrap();
     assert!(dp1.data_store.as_any().downcast_ref::<DataStoreV1>().is_some());
 
-    let no_dels = HashSet::new();
-    let work = vec![(&dp1, &no_dels), (&dp0, &no_dels)];
+    let work = vec![&dp1, &dp0];
 
     let dp_path = tempdir()?;
     let dp = segment::merge(dp_path.path(), work, &v1_config).unwrap();
@@ -189,8 +188,7 @@ fn data_merge() -> anyhow::Result<()> {
     dp0.apply_deletions(&[FieldKey::from_field_id(&key1).unwrap()].into());
     dp1.apply_deletions(&[FieldKey::from_field_id(&key0).unwrap()].into());
     dp1.apply_deletions(&[FieldKey::from_field_id(&key1).unwrap()].into());
-    let no_dels = HashSet::new();
-    let work = vec![(&dp1, &no_dels), (&dp0, &no_dels)];
+    let work = vec![&dp1, &dp0];
 
     let dp_path = tempdir()?;
     let dp = segment::merge(dp_path.path(), work, &v1_config).unwrap();
@@ -217,8 +215,7 @@ fn data_merge_v2() -> anyhow::Result<()> {
     let dp1 = segment::create(dp1_path.path(), elems1, &CONFIG, HashSet::new()).unwrap();
     assert!(dp1.data_store.as_any().downcast_ref::<DataStoreV2>().is_some());
 
-    let no_dels = HashSet::new();
-    let work = vec![(&dp1, &no_dels), (&dp0, &no_dels)];
+    let work = vec![&dp1, &dp0];
 
     let dp_path = tempdir()?;
     let dp = segment::merge(dp_path.path(), work, &CONFIG).unwrap();
@@ -239,8 +236,7 @@ fn data_merge_v2() -> anyhow::Result<()> {
     dp0.apply_deletions(&[FieldKey::from_field_id(&key1).unwrap()].into());
     dp1.apply_deletions(&[FieldKey::from_field_id(&key0).unwrap()].into());
     dp1.apply_deletions(&[FieldKey::from_field_id(&key1).unwrap()].into());
-    let no_dels = HashSet::new();
-    let work = vec![(&dp1, &no_dels), (&dp0, &no_dels)];
+    let work = vec![&dp1, &dp0];
 
     let dp_path = tempdir()?;
     let dp = segment::merge(dp_path.path(), work, &CONFIG).unwrap();
@@ -270,8 +266,7 @@ fn data_merge_mixed() -> anyhow::Result<()> {
     let dp1 = segment::create(dp1_path.path(), elems1, &CONFIG, HashSet::new()).unwrap();
     assert!(dp1.data_store.as_any().downcast_ref::<DataStoreV2>().is_some());
 
-    let no_dels = HashSet::new();
-    let work = vec![(&dp1, &no_dels), (&dp0, &no_dels)];
+    let work = vec![&dp1, &dp0];
 
     let dp_path = tempdir()?;
     let dp = segment::merge(dp_path.path(), work, &CONFIG).unwrap();
@@ -292,8 +287,7 @@ fn data_merge_mixed() -> anyhow::Result<()> {
     dp0.apply_deletions(&[FieldKey::from_field_id(&key1).unwrap()].into());
     dp1.apply_deletions(&[FieldKey::from_field_id(&key0).unwrap()].into());
     dp1.apply_deletions(&[FieldKey::from_field_id(&key1).unwrap()].into());
-    let no_dels = HashSet::new();
-    let work = vec![(&dp1, &no_dels), (&dp0, &no_dels)];
+    let work = vec![&dp1, &dp0];
 
     let dp_path = tempdir()?;
     let dp = segment::merge(dp_path.path(), work, &CONFIG).unwrap();
@@ -438,8 +432,7 @@ fn fast_data_merge() -> VectorR<()> {
     )?;
 
     // Merge without deletions
-    let no_dels = HashSet::new();
-    let work = vec![(&big_segment, &no_dels), (&small_segment, &no_dels)];
+    let work = vec![(&big_segment), (&small_segment)];
     let output_dir = tempfile::tempdir()?;
     let t = Instant::now();
     let dp = segment::merge(output_dir.path(), work, &CONFIG)?;
@@ -460,7 +453,7 @@ fn fast_data_merge() -> VectorR<()> {
         .apply_deletions(&[FieldKey::from_field_id("00000000000000000000000000000000/f/file/0-100").unwrap()].into());
     small_segment
         .apply_deletions(&[FieldKey::from_field_id("00000000000000000000000000000002/f/file/0-100").unwrap()].into());
-    let work = vec![(&big_segment, &no_dels), (&small_segment, &no_dels)];
+    let work = vec![(&big_segment), (&small_segment)];
     let output_dir = tempfile::tempdir()?;
     let t = Instant::now();
     let dp = segment::merge(output_dir.path(), work, &CONFIG)?;

--- a/nidx/src/metadata/deletion.rs
+++ b/nidx/src/metadata/deletion.rs
@@ -54,7 +54,7 @@ impl Deletion {
     ) -> Result<Vec<Deletion>, sqlx::Error> {
         sqlx::query_as!(
             Deletion,
-            "SELECT * FROM deletions WHERE index_id = $1 AND seq <= $2",
+            "SELECT * FROM deletions WHERE index_id = $1 AND seq <= $2 ORDER BY seq ASC",
             index_id as IndexId,
             i64::from(&seq)
         )

--- a/nidx/src/metadata/segment.rs
+++ b/nidx/src/metadata/segment.rs
@@ -204,9 +204,13 @@ impl Segment {
         meta: impl Executor<'_, Database = Postgres>,
         merge_job_id: i64,
     ) -> sqlx::Result<Vec<Segment>> {
-        sqlx::query_as!(Segment, "SELECT * FROM segments WHERE merge_job_id = $1", merge_job_id)
-            .fetch_all(meta)
-            .await
+        sqlx::query_as!(
+            Segment,
+            "SELECT * FROM segments WHERE merge_job_id = $1 ORDER BY seq ASC",
+            merge_job_id
+        )
+        .fetch_all(meta)
+        .await
     }
 
     pub fn metadata<T: for<'de> Deserialize<'de>>(&self, path: PathBuf) -> SegmentMetadata<T> {

--- a/nidx/src/worker.rs
+++ b/nidx/src/worker.rs
@@ -231,7 +231,9 @@ mod tests {
         indexer::{delete_resource, index_resource},
         metadata::{IndexConfig, NidxMetadata, Shard},
     };
+    use nidx_protos::StringList;
     use nidx_tests::*;
+    use nidx_vector::config::{VectorConfig, VectorType};
 
     #[sqlx::test]
     async fn test_merge_deleted_resource(pool: sqlx::PgPool) -> anyhow::Result<()> {
@@ -268,6 +270,78 @@ mod tests {
         // Results in no segments
         let segments = index.segments(&meta.pool).await.unwrap();
         assert_eq!(segments.len(), 0);
+
+        Ok(())
+    }
+
+    /// Regression test for a bug where merging two segments — when the database returns them in
+    /// descending ID order (newest ID first) — caused the newest resource's vectors to be
+    /// incorrectly deleted. This is because the nidx_vector opener was order sensitive.
+    #[sqlx::test]
+    async fn test_merge_keeps_new_resource_when_segment_order_is_reversed(pool: sqlx::PgPool) -> anyhow::Result<()> {
+        const VECTOR_CONFIG: VectorConfig = VectorConfig::for_paragraphs(VectorType::DenseF32 { dimension: 3 });
+
+        let meta = NidxMetadata::new_with_pool(pool).await?;
+        let storage = Arc::new(object_store::memory::InMemory::new());
+        let work_dir = tempdir()?;
+
+        let kbid = Uuid::new_v4();
+        let shard = Shard::create(&meta.pool, kbid).await?;
+        let index = Index::create(&meta.pool, shard.id, "multilingual", VECTOR_CONFIG.into()).await?;
+
+        // Index resource2 FIRST so its segment gets a lower database ID. Postgres tends to return
+        // in insertion-order when there is no ORDER BY (might be affected by fragmentation in table)
+        let mut resource2 = little_prince(shard.id.to_string(), None);
+        let rid2 = resource2.resource.as_ref().unwrap().uuid.clone();
+        // Add same-seq deletion for resource2's own field — the atomic update pattern.
+        resource2.vector_prefixes_to_delete.insert(
+            "multilingual".to_string(),
+            StringList {
+                items: vec![format!("{rid2}/a/summary")],
+            },
+        );
+        index_resource(
+            &meta,
+            storage.clone(),
+            work_dir.path(),
+            &shard.id.to_string(),
+            resource2,
+            3i64.into(),
+        )
+        .await?;
+
+        let segments_after_r2 = index.segments(&meta.pool).await?;
+        assert_eq!(segments_after_r2.len(), 1);
+
+        // Index resource1 at seq=1
+        let resource1 = little_prince(shard.id.to_string(), None);
+        index_resource(
+            &meta,
+            storage.clone(),
+            work_dir.path(),
+            &shard.id.to_string(),
+            resource1,
+            1i64.into(),
+        )
+        .await?;
+
+        let segments_after_r1 = index.segments(&meta.pool).await?;
+        assert_eq!(segments_after_r1.len(), 2);
+
+        // Merge both segments together with job.seq = 3
+        let live_segments = index.segments(&meta.pool).await?;
+        let all_ids: Vec<_> = live_segments.iter().map(|s| s.id).collect();
+        let merge_job2 = MergeJob::create(&meta, index.id, &all_ids, 3i64.into(), 0).await?;
+        run_job(&meta, &merge_job2, storage.clone(), work_dir.path()).await?;
+
+        let final_segments = index.segments(&meta.pool).await?;
+        assert_eq!(final_segments.len(), 1, "merge should produce exactly one segment");
+
+        // Both resources must survive. The bug causes this to be 1 instead of 2.
+        assert_eq!(
+            final_segments[0].records, 2,
+            "merged segment must contain vectors from both resources"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
### Description

- Always order merge inputs correctly (missing ORDER BY clause)
- Clean up unneeded deletions parameters from merge operants

### How was this PR tested?
Describe how you tested this PR.
