### PR TITLE
nucliadb-shared chart: Option to specify arbitrary env values

### DIFF
--- a/charts/nucliadb_shared/templates/nucliadb.cm.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.cm.yaml
@@ -115,4 +115,8 @@ data:
   NIDX_SEARCHER_ADDRESS: "{{ .searcher_address }}"
 {{- end }}
 
+{{- range $key, $value := .Values.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+
 {{- end }}

--- a/charts/nucliadb_shared/templates/nucliadb.secret.yaml
+++ b/charts/nucliadb_shared/templates/nucliadb.secret.yaml
@@ -28,4 +28,7 @@ data:
 {{- if .Values.encryption.secret_key }}
   ENCRYPTION_SECRET_KEY: {{ .Values.encryption.secret_key | default "" | b64enc }}
 {{- end }}
+{{- range $key, $value := .Values.extraSecretEnv }}
+  {{ $key }}: {{ $value | default "" | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/nucliadb_shared/values.yaml
+++ b/charts/nucliadb_shared/values.yaml
@@ -107,6 +107,16 @@ flipt_server_url: null
 encryption:
   secret_key: XX
 
+# -- Extra environment variables to be added into the configmap --
+extraEnv: {}
+  # EXTRA_ENV_VAR_1: value1
+  # EXTRA_ENV_VAR_2: value2
+
+# -- Extra sensitive environment variables to be added into the secret --
+extraSecretEnv: {}
+  # EXTRA_SENSITIVE_VAR_1: value1
+  # EXTRA_SENSITIVE_VAR_2: value2
+
 # nidx:
 #   api_address:
 #   searcher_address:


### PR DESCRIPTION
This pull request adds support for injecting extra environment variables and sensitive environment variables into the NucliaDB Helm chart via `values.yaml`. This makes it easier to customize deployments without modifying the chart templates directly.

**Environment variable injection:**

* Added support for specifying extra environment variables through the `extraEnv` field in `values.yaml`, which are rendered into the `nucliadb.cm.yaml` configmap template. [[1]](diffhunk://#diff-4b7747b349750c5a81ecf1f420c218517d13a2f09cf39cbde9f69ad8a133f56cR110-R119) [[2]](diffhunk://#diff-9d2ad27467ea53ab08d32f836e5cc71f1894db2b6898532b483f76cf016393a6R118-R121)
* Added support for specifying extra sensitive environment variables through the `extraSecretEnv` field in `values.yaml`, which are rendered into the `nucliadb.secret.yaml` secret template with base64 encoding. [[1]](diffhunk://#diff-4b7747b349750c5a81ecf1f420c218517d13a2f09cf39cbde9f69ad8a133f56cR110-R119) [[2]](diffhunk://#diff-384182aa839a9dcc2c6b3bdc08378208cb09ba3175aad312269233121c68197eR31-R33)

### How was this PR tested?
Helm template ... 