### PR TITLE
Fix breaking change on SDK argument ordering

### DIFF
--- a/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
+++ b/nucliadb_sdk/src/nucliadb_sdk/v2/sdk.py
@@ -725,9 +725,10 @@ def _request_sync_builder(
 
     def _func(
         self: NucliaDB,
-        query_params: QUERY_PARAMS_TYPE | None = None,
         content: INPUT_TYPE | None = None,
         headers: dict[str, str] | None = None,
+        *,
+        query_params: QUERY_PARAMS_TYPE | None = None,
         **kwargs,
     ) -> OUTPUT_TYPE:
         path, data = prepare_request(
@@ -873,9 +874,10 @@ def _request_async_builder(
 
     async def _func(
         self: NucliaDBAsync,
-        query_params: QUERY_PARAMS_TYPE = None,
         content: INPUT_TYPE | None = None,
         headers: dict[str, str] | None = None,
+        *,
+        query_params: QUERY_PARAMS_TYPE = None,
         **kwargs,
     ):
         path, data = prepare_request(


### PR DESCRIPTION
### Description
Changes on https://github.com/nuclia/nucliadb/pull/3687 were breaking, as some users may pass content and headers as arguments (not keyword). Reverse order and keep enforcing keyword for `query_params`. We should enforce keyword for content and headers but as it may be another breaking change, we leave it like this for now

### How was this PR tested?
Describe how you tested this PR.
