### PR TITLE
Fix naive datetime subtraction in JetStream telemetry

### DIFF
--- a/nucliadb_telemetry/src/nucliadb_telemetry/jetstream.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/jetstream.py
@@ -104,8 +104,11 @@ async def _traced_callback(origin_cb: Callable[[Msg], Awaitable[None]], tracer: 
             set_span_exception(span, error)
             raise error
         finally:
+            timestamp = msg.metadata.timestamp
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
             msg_consume_time_histo.observe(
-                (datetime.now(timezone.utc) - msg.metadata.timestamp).total_seconds(),
+                (datetime.now(timezone.utc) - timestamp).total_seconds(),
                 {
                     "stream": msg.metadata.stream,
                     "consumer": msg.metadata.consumer or "",
@@ -205,8 +208,11 @@ class JetStreamContextTelemetry:
                 set_span_exception(span, error)
                 raise error
             finally:
+                timestamp = message.metadata.timestamp
+                if timestamp.tzinfo is None:
+                    timestamp = timestamp.replace(tzinfo=timezone.utc)
                 msg_consume_time_histo.observe(
-                    (datetime.now(timezone.utc) - message.metadata.timestamp).total_seconds(),
+                    (datetime.now(timezone.utc) - timestamp).total_seconds(),
                     {
                         "stream": message.metadata.stream,
                         "consumer": message.metadata.consumer or "",


### PR DESCRIPTION
**Description**

The JetStream telemetry wrapper crashes with `TypeError: can't subtract offset-naive and offset-aware datetimes` when computing message consume latency, because NATS message metadata timestamps can be naive.

**Root Cause**

Bisected via PyPI versions: the bug was introduced in commit `23f4def9f` ("Trace pull subscribers" #3097), first shipped as `6.14.0.post6433`.

That PR refactored the subscribe wrapper into a standalone `_traced_callback` function and added `pull_one` tracing. The timestamp subtraction:

```python
(datetime.now() - msg.metadata.timestamp).total_seconds()
```

was present before, but an earlier guard (`if msg.headers is None: return`) inadvertently skipped tracing for messages without headers. Pull subscribers receive timezone-aware timestamps from NATS, which caused the crash once the guard was removed and pull_one was exposed.

**Solution**

Normalize the message metadata timestamp to UTC-aware before subtracting from `datetime.now(timezone.utc)` in both `_traced_callback` and `JetStreamContextTelemetry.pull_one`.