### PR TITLE
Multi-shard search in nidx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ license-fix:
 protos: proto-py
 
 proto-py:
-	uv sync --reinstall-package nucliadb_protos --reinstall-package nidx_protos
+	uv sync --reinstall-package nucliadb_protos --reinstall-package nidx_protos --inexact
 
 python-code-lint:
 	make -C nucliadb_dataset/ format

--- a/nidx/.sqlx/query-ed70f4bd15614ddaa8cf8eb7f528ad745fab22258ebec7a6a652ccc75e2bfcd6.json
+++ b/nidx/.sqlx/query-ed70f4bd15614ddaa8cf8eb7f528ad745fab22258ebec7a6a652ccc75e2bfcd6.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM shards WHERE id = ANY($1) AND deleted_at IS NULL",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ed70f4bd15614ddaa8cf8eb7f528ad745fab22258ebec7a6a652ccc75e2bfcd6"
+}

--- a/nidx/Cargo.toml
+++ b/nidx/Cargo.toml
@@ -55,6 +55,7 @@ lazy_static = "1.5.0"
 tower = "0.5.1"
 kube = { version = "3.0.0", features = ["runtime"] }
 k8s-openapi = { version = "0.27.0", features = ["latest"] }
+itertools = "0.14.0"
 
 # Telemetry dependencies (can be disabled, e.g: in nidx_binding)
 sentry = { version = "0.48.0", optional = true }
@@ -86,7 +87,6 @@ telemetry = [
 ]
 
 [dev-dependencies]
-itertools = "0.14.0"
 nidx_tests = { path = "nidx_tests" }
 rand = "0.10.1"
 

--- a/nidx/nidx_binding/src/lib.rs
+++ b/nidx/nidx_binding/src/lib.rs
@@ -145,7 +145,11 @@ impl NidxBinding {
         let searcher_work_dir = tempdir()?;
         let (sync_reporter, sync_watcher) = watch::channel(SyncStatus::Syncing);
         let searcher = SyncedSearcher::new(settings.metadata.clone(), searcher_work_dir.path());
-        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new_single());
+        let searcher_api = SearchServer::new(
+            settings.metadata.clone(),
+            searcher.index_cache(),
+            ShardSelector::new_single(),
+        );
         let searcher_server = GrpcServer::new("localhost:0").await?;
         let searcher_port = searcher_server.port()?;
         tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));

--- a/nidx/nidx_binding/src/lib.rs
+++ b/nidx/nidx_binding/src/lib.rs
@@ -145,11 +145,7 @@ impl NidxBinding {
         let searcher_work_dir = tempdir()?;
         let (sync_reporter, sync_watcher) = watch::channel(SyncStatus::Syncing);
         let searcher = SyncedSearcher::new(settings.metadata.clone(), searcher_work_dir.path());
-        let searcher_api = SearchServer::new(
-            settings.metadata.clone(),
-            searcher.index_cache(),
-            ShardSelector::new_single(),
-        );
+        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new_single());
         let searcher_server = GrpcServer::new("localhost:0").await?;
         let searcher_port = searcher_server.port()?;
         tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -419,10 +419,6 @@ message SearchRequest {
     GraphSearch graph_search = 29;
 
     optional JsonFilterExpression json_filter = 32;
-
-    // FF to decide whether to run the former single-shard query or a
-    // multi-shard query
-    bool multi_shard_search = 35;
 }
 
 enum SuggestFeatures {

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -456,6 +456,12 @@ message SuggestResponse {
 
 message SearchResponse {
     reserved 4;
+
+    // List of successfully queried shard ids. This is used in the multi-shard
+    // querying, where the caller must know which shards have been successfully
+    // searched to know about failures.
+    repeated string shard_ids = 6;
+
     DocumentSearchResponse document = 1;
     ParagraphSearchResponse paragraph = 2;
     VectorSearchResponse vector = 3;

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -419,6 +419,8 @@ message SearchRequest {
     GraphSearch graph_search = 29;
 
     optional JsonFilterExpression json_filter = 32;
+
+    bool multi_shard_search = 35;
 }
 
 enum SuggestFeatures {

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -420,6 +420,8 @@ message SearchRequest {
 
     optional JsonFilterExpression json_filter = 32;
 
+    // FF to decide whether to run the former single-shard query or a
+    // multi-shard query
     bool multi_shard_search = 35;
 }
 

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -374,7 +374,7 @@ message JsonFilterExpression {
 message SearchRequest {
     reserved 7, 20, 21;
 
-    string shard = 1;
+    repeated string shard_ids = 1;
 
     // query this text in all the paragraphs
     string body = 3;

--- a/nidx/src/errors.rs
+++ b/nidx/src/errors.rs
@@ -32,7 +32,9 @@ pub enum NidxError {
     #[error(transparent)]
     TokioTaskError(#[from] tokio::task::JoinError),
     #[error(transparent)]
-    GrpcError(#[from] tonic::transport::Error),
+    TransportError(#[from] tonic::transport::Error),
+    #[error(transparent)]
+    GrpcError(tonic::Status),
     #[error("Query error: {0}")]
     QueryError(String),
     #[error(transparent)]
@@ -60,6 +62,7 @@ impl From<NidxError> for tonic::Status {
             NidxError::NotFound => tonic::Status::not_found("Not found"),
             NidxError::InvalidRequest(_) => tonic::Status::invalid_argument(value.to_string()),
             NidxError::InvalidUuid(_) => tonic::Status::invalid_argument(value.to_string()),
+            NidxError::GrpcError(status) => status,
             _ => tonic::Status::internal(value.to_string()),
         }
     }

--- a/nidx/src/errors.rs
+++ b/nidx/src/errors.rs
@@ -33,6 +33,8 @@ pub enum NidxError {
     TokioTaskError(#[from] tokio::task::JoinError),
     #[error(transparent)]
     GrpcError(#[from] tonic::transport::Error),
+    #[error("Query error: {0}")]
+    QueryError(String),
     #[error(transparent)]
     Unknown(#[from] anyhow::Error),
 }

--- a/nidx/src/metadata/shard.rs
+++ b/nidx/src/metadata/shard.rs
@@ -43,6 +43,12 @@ impl Shard {
             .await
     }
 
+    pub async fn exist_many(meta: impl Executor<'_, Database = Postgres>, ids: &[Uuid]) -> sqlx::Result<Vec<Uuid>> {
+        sqlx::query_scalar!("SELECT id FROM shards WHERE id = ANY($1) AND deleted_at IS NULL", ids)
+            .fetch_all(meta)
+            .await
+    }
+
     pub async fn mark_delete(&self, meta: impl Executor<'_, Database = Postgres>) -> sqlx::Result<()> {
         sqlx::query!("UPDATE shards SET deleted_at = NOW() WHERE id = $1", self.id)
             .execute(meta)

--- a/nidx/src/metadata/shard.rs
+++ b/nidx/src/metadata/shard.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 // Copyright 2021 Bosutech XXI S.L.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +12,14 @@ use std::collections::HashMap;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-use super::index::*;
+
+use std::collections::HashMap;
+
 use futures::StreamExt;
 use sqlx::{Executor, Postgres, types::time::PrimitiveDateTime};
 use uuid::Uuid;
+
+use super::index::*;
 
 pub struct Shard {
     pub id: Uuid,

--- a/nidx/src/searcher.rs
+++ b/nidx/src/searcher.rs
@@ -203,7 +203,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
     let searcher = SyncedSearcher::new(meta.clone(), work_path);
 
     let shard_selector = ShardSelector::new(list_nodes.clone(), searcher_settings.shard_partitioning.replicas);
-    let api = grpc::SearchServer::new(searcher.index_cache(), shard_selector);
+    let api = grpc::SearchServer::new(meta, searcher.index_cache(), shard_selector);
     let server = GrpcServer::new("0.0.0.0:10001").await?;
 
     let api_task = tasks.spawn(server.serve(api.into_router(), shutdown.clone())).id();

--- a/nidx/src/searcher.rs
+++ b/nidx/src/searcher.rs
@@ -203,7 +203,7 @@ pub async fn run(settings: Settings, shutdown: CancellationToken) -> anyhow::Res
     let searcher = SyncedSearcher::new(meta.clone(), work_path);
 
     let shard_selector = ShardSelector::new(list_nodes.clone(), searcher_settings.shard_partitioning.replicas);
-    let api = grpc::SearchServer::new(meta, searcher.index_cache(), shard_selector);
+    let api = grpc::SearchServer::new(searcher.index_cache(), shard_selector);
     let server = GrpcServer::new("0.0.0.0:10001").await?;
 
     let api_task = tasks.spawn(server.serve(api.into_router(), shutdown.clone())).id();

--- a/nidx/src/searcher.rs
+++ b/nidx/src/searcher.rs
@@ -17,6 +17,7 @@ pub mod grpc;
 mod index_cache;
 mod query_language;
 mod query_planner;
+mod shard_merge;
 mod shard_search;
 pub mod shard_selector;
 mod shard_suggest;

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::{pin::Pin, sync::Arc};
 
 use futures::Stream;
@@ -22,6 +22,7 @@ use nidx_protos::nidx::nidx_searcher_server::{NidxSearcher, NidxSearcherServer};
 use nidx_protos::*;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
+use tonic::Code;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
@@ -163,7 +164,7 @@ impl NidxSearcher for SearchServer {
 
         let mut shards = vec![];
         for shard_id in &request.shard_ids {
-            let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
+            let shard_id = Uuid::parse_str(shard_id).map_err(NidxError::from)?;
             shards.push(shard_id);
         }
 
@@ -185,7 +186,7 @@ impl NidxSearcher for SearchServer {
 
     async fn suggest(&self, request: Request<SuggestRequest>) -> Result<Response<SuggestResponse>> {
         let message = request.get_ref();
-        let shard_id = uuid::Uuid::parse_str(&message.shard).map_err(NidxError::from)?;
+        let shard_id = Uuid::parse_str(&message.shard).map_err(NidxError::from)?;
         shard_request! {
             "suggest",
             self,
@@ -198,7 +199,7 @@ impl NidxSearcher for SearchServer {
 
     async fn graph_search(&self, request: Request<GraphSearchRequest>) -> Result<Response<GraphSearchResponse>> {
         let message = request.get_ref();
-        let shard_id = uuid::Uuid::parse_str(&message.shard).map_err(NidxError::from)?;
+        let shard_id = Uuid::parse_str(&message.shard).map_err(NidxError::from)?;
         shard_request! {
             "graph_search",
             self,
@@ -214,7 +215,7 @@ impl NidxSearcher for SearchServer {
         request: Request<ExtractedTextsRequest>,
     ) -> Result<Response<ExtractedTextsResponse>> {
         let message = request.get_ref();
-        let shard_id = uuid::Uuid::parse_str(&message.shard_id).map_err(NidxError::from)?;
+        let shard_id = Uuid::parse_str(&message.shard_id).map_err(NidxError::from)?;
         shard_request! {
             "extracted_texts",
             self,
@@ -231,7 +232,7 @@ impl NidxSearcher for SearchServer {
         let Some(shard) = &message.shard_id else {
             return Err(NidxError::invalid("Uuid is required").into());
         };
-        let shard_id = uuid::Uuid::parse_str(&shard.id).map_err(NidxError::from)?;
+        let shard_id = Uuid::parse_str(&shard.id).map_err(NidxError::from)?;
         shard_request! {
             "paragraphs",
             self,
@@ -249,7 +250,7 @@ impl NidxSearcher for SearchServer {
         let Some(shard) = &message.shard_id else {
             return Err(NidxError::invalid("Uuid is required").into());
         };
-        let shard_id = uuid::Uuid::parse_str(&shard.id).map_err(NidxError::from)?;
+        let shard_id = Uuid::parse_str(&shard.id).map_err(NidxError::from)?;
         shard_request! {
             "documents",
             self,
@@ -273,8 +274,8 @@ impl SearchServer {
     /// requested to query several partitions and one or more can fail, it will then return a
     /// partial result and is our responsibility to retry on other nodes.
     ///
-    async fn distributed_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> NidxResult<SearchResponse> {
-        let mut partitioner = QueryPartitioner::new(&self.shard_selector, shards)?;
+    async fn distributed_query(&self, request: SearchRequest, shards: Vec<Uuid>) -> NidxResult<SearchResponse> {
+        let mut partitioner = QueryPartitioner::new(&self.shard_selector, &shards)?;
 
         // Use the query partitioner to group requests by the most preferred
         // node per shard. We'll then do scatter-gather cycles until we complete
@@ -283,12 +284,32 @@ impl SearchServer {
         // NOTE that grouping cycles is less time-efficient, as tail latency can
         // increase due to slow/faulty nodes
         let mut responses = vec![];
-        while let Some(groups) = partitioner.next_groups_by_node()? {
+
+        let mut pending: HashSet<Uuid> = HashSet::from_iter(shards.clone());
+
+        while !pending.is_empty() {
+            let mut groups = HashMap::new();
+            for shard_id in pending.iter() {
+                let Some(node) = partitioner.next_node_for_shard(shard_id) else {
+                    // A shard doesn't have more nodes to query but we haven't finished yet. We
+                    // won't be able to complete the request in all partitions, so we abort
+                    return Err(NidxError::QueryError(format!(
+                        "Error in search, exhausted all available nodes for shard {shard_id}"
+                    )));
+                };
+                groups
+                    .entry(node)
+                    .and_modify(|shards: &mut Vec<Uuid>| shards.push(*shard_id))
+                    .or_insert(vec![*shard_id]);
+            }
+
+            // Distribute requests across nodes
             let mut tasks = JoinSet::new();
             for (node, shard_ids) in groups {
                 tasks.spawn(self.node_query(node, shard_ids, request.clone()).await?);
             }
 
+            // Aggregate results
             while let Some(join) = tasks.join_next().await {
                 match join {
                     Ok(Ok(response)) => {
@@ -298,12 +319,15 @@ impl SearchServer {
                         // The response includes a list of successful shards, that may be a subset of the
                         // requested ones. This is the way we communicate partial failures.
                         for shard_id in shards {
-                            partitioner.succeeded(&shard_id);
+                            pending.remove(&shard_id);
                         }
                         responses.push(response);
                     }
                     Ok(Err(NidxError::NotFound)) => {}
+                    Ok(Err(NidxError::GrpcError(status))) if status.code() == Code::NotFound => {}
+                    Ok(Err(NidxError::GrpcError(status))) if status.code() == Code::Unavailable => {}
                     Ok(Err(search_error)) => return Err(search_error),
+                    // Ok(Err(search_error)) => return Err(search_error),
                     Err(join_error) => {
                         // Either a panic or a cancellation happened while searching
                         return Err(NidxError::from(join_error));
@@ -327,7 +351,7 @@ impl SearchServer {
     async fn node_query(
         &self,
         node: SearcherNode,
-        shard_ids: Vec<uuid::Uuid>,
+        shard_ids: Vec<Uuid>,
         request: SearchRequest,
     ) -> NidxResult<Pin<Box<dyn Future<Output = NidxResult<PartialResponse<SearchResponse>>> + Send + 'static>>> {
         match node {
@@ -339,9 +363,11 @@ impl SearchServer {
             }
             SearcherNode::Remote(ref hostname) => {
                 match self.get_client(hostname).await {
-                    Ok(client) => Ok(Box::pin(
-                        async move { Self::remote_query(client, request, shard_ids).await },
-                    )),
+                    Ok(client) => Ok(Box::pin(async move {
+                        Self::remote_query(client, request, shard_ids)
+                            .await
+                            .map_err(NidxError::GrpcError)
+                    })),
                     Err(e) => {
                         // A client for this node is not available, although we've seen it
                         // in the k8s cluster. We skip it and will retry those shards on
@@ -362,8 +388,8 @@ impl SearchServer {
     async fn remote_query(
         mut client: SearcherClient,
         request: SearchRequest,
-        shards: Vec<uuid::Uuid>,
-    ) -> NidxResult<PartialResponse<SearchResponse>> {
+        shards: Vec<Uuid>,
+    ) -> tonic::Result<PartialResponse<SearchResponse>> {
         // Send the query to a different node specifying only a subset of shards
         let mut search_request = request.clone();
         search_request.shard_ids = shards.iter().map(|x| x.to_string()).collect();
@@ -373,45 +399,33 @@ impl SearchServer {
         let mut request = Request::new(search_request);
         request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
 
-        let response = client.search(request).await;
+        let response = client.search(request).await?.into_inner();
 
-        match response {
-            Ok(response) => {
-                let response = response.into_inner();
-                let result = if response.shard_ids.len() == shards.len() {
-                    PartialResponse { data: response, shards }
-                } else {
-                    let successful_shards = response
-                        .shard_ids
-                        .iter()
-                        .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
-                        .collect();
-                    PartialResponse {
-                        data: response,
-                        shards: successful_shards,
-                    }
-                };
-                Ok(result)
+        let result = if response.shard_ids.len() == shards.len() {
+            PartialResponse { data: response, shards }
+        } else {
+            let successful_shards = response
+                .shard_ids
+                .iter()
+                .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
+                .collect();
+            PartialResponse {
+                data: response,
+                shards: successful_shards,
             }
-            Err(status) => {
-                let error = match status.code() {
-                    tonic::Code::NotFound => NidxError::NotFound,
-                    _ => NidxError::Unknown(anyhow::Error::from(status)),
-                };
-                Err(error)
-            }
-        }
+        };
+        Ok(result)
     }
 }
 
 struct QueryPartitioner {
-    shard_nodes: HashMap<uuid::Uuid, Vec<SearcherNode>>,
+    shard_nodes: HashMap<Uuid, Vec<SearcherNode>>,
 }
 
 impl QueryPartitioner {
-    fn new(shard_selector: &ShardSelector, shards: Vec<uuid::Uuid>) -> NidxResult<Self> {
+    fn new(shard_selector: &ShardSelector, shards: &[Uuid]) -> NidxResult<Self> {
         let mut shard_nodes = HashMap::new();
-        for shard_id in &shards {
+        for shard_id in shards {
             let nodes = shard_selector.nodes_for_shard(shard_id);
             if nodes.is_empty() {
                 // We haven't found any node with this shard. As we'll never be able to return a
@@ -423,32 +437,12 @@ impl QueryPartitioner {
         Ok(Self { shard_nodes })
     }
 
-    fn next_groups_by_node(&mut self) -> Result<Option<HashMap<SearcherNode, Vec<uuid::Uuid>>>, NidxError> {
-        if self.shard_nodes.is_empty() {
-            return Ok(None);
-        }
-
-        let mut shard_groups = HashMap::new();
-        for (shard_id, nodes) in self.shard_nodes.iter_mut() {
-            if nodes.is_empty() {
-                // A shard doesn't have more nodes to query but we haven't finished yet. We
-                // won't be able to complete the request in all partitions, so we abort
-                return Err(NidxError::QueryError(format!(
-                    "Error in search, exhausted all available nodes for shard {shard_id}"
-                )));
-            }
-
-            let node = nodes.remove(0);
-            shard_groups
-                .entry(node)
-                .and_modify(|shards: &mut Vec<uuid::Uuid>| shards.push(*shard_id))
-                .or_insert(vec![*shard_id]);
-        }
-        Ok(Some(shard_groups))
-    }
-
-    fn succeeded(&mut self, shard_id: &uuid::Uuid) {
-        self.shard_nodes.remove(shard_id);
+    /// Return the next preferred node to query for a shard.
+    ///
+    /// *Panics* if a called with a shard that wasn't in the original set
+    fn next_node_for_shard(&mut self, shard: &Uuid) -> Option<SearcherNode> {
+        let nodes = self.shard_nodes.get_mut(shard).unwrap();
+        if !nodes.is_empty() { Some(nodes.remove(0)) } else { None }
     }
 }
 

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::{pin::Pin, sync::Arc};
 
+use axum::http::request;
 use futures::Stream;
 use nidx_protos::nidx::nidx_searcher_client::NidxSearcherClient;
 use nidx_protos::nidx::nidx_searcher_server::{NidxSearcher, NidxSearcherServer};
@@ -269,6 +270,55 @@ impl NidxSearcher for SearchServer {
     }
 }
 
+struct DistributedQuery {
+    shard_nodes: HashMap<uuid::Uuid, Vec<SearcherNode>>,
+}
+
+impl DistributedQuery {
+    fn new(shard_selector: &ShardSelector, shards: Vec<uuid::Uuid>) -> NidxResult<Self> {
+        let mut shard_nodes = HashMap::new();
+        for shard_id in &shards {
+            let nodes = shard_selector.nodes_for_shard(shard_id);
+            if nodes.is_empty() {
+                // We haven't found any node with this shard. As we'll never be able to return a
+                // full result, we fail fast
+                return Err(NidxError::NotFound);
+            }
+
+            shard_nodes.insert(*shard_id, nodes);
+        }
+
+        Ok(Self { shard_nodes })
+    }
+
+    fn next_queries(&mut self) -> Result<Option<HashMap<SearcherNode, Vec<uuid::Uuid>>>, NidxError> {
+        if self.shard_nodes.is_empty() {
+            return Ok(None);
+        }
+        let mut shard_groups = HashMap::new();
+        for (shard_id, nodes) in self.shard_nodes.iter_mut() {
+            if nodes.is_empty() {
+                // A shard doesn't have more nodes to query but we haven't finished yet. We
+                // won't be able to complete the request in all partitions, so we abort
+                return Err(NidxError::QueryError(format!(
+                    "Error in search, exhausted all available nodes for shard {shard_id}"
+                )));
+            }
+
+            let node = nodes.remove(0);
+            shard_groups
+                .entry(node)
+                .and_modify(|shards: &mut Vec<uuid::Uuid>| shards.push(*shard_id))
+                .or_insert(vec![*shard_id]);
+        }
+        Ok(Some(shard_groups))
+    }
+
+    fn ok(&mut self, shard_id: &uuid::Uuid) {
+        self.shard_nodes.remove(shard_id);
+    }
+}
+
 impl SearchServer {
     /// Perform a distributed query over a partitioned dataset across a cluster of nodes.
     ///
@@ -282,74 +332,17 @@ impl SearchServer {
     ///
     async fn distributed_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> NidxResult<SearchResponse> {
         // Locate which nodes contain each shard and get a list by preference
-        let mut shard_nodes = HashMap::new();
-        for shard_id in &shards {
-            let nodes = self.shard_selector.nodes_for_shard(shard_id);
-            if nodes.is_empty() {
-                // We haven't found any node with this shard. As we'll never be able to return a
-                // full result, we fail fast
-                return Err(NidxError::NotFound);
-            }
-
-            shard_nodes.insert(*shard_id, nodes);
-        }
+        let mut queryer = DistributedQuery::new(&self.shard_selector, shards)?;
 
         // Now, we'll do scatter-gather cycles using the most preferred node per shard. Grouping
         // cycles is less time-efficient, as we wait for the slowest request, but we minimize the
         // amount of requests through the cluster.
         let mut responses = vec![];
-        while !shard_nodes.is_empty() {
-            let mut shard_groups = HashMap::new();
-            for (shard_id, nodes) in shard_nodes.iter_mut() {
-                if nodes.is_empty() {
-                    // A shard doesn't have more nodes to query but we haven't finished yet. We
-                    // won't be able to complete the request in all partitions, so we abort
-                    return Err(NidxError::QueryError(format!(
-                        "Error in search, exhausted all available nodes for shard {shard_id}"
-                    )));
-                }
-
-                let node = nodes.remove(0);
-                shard_groups
-                    .entry(node)
-                    .and_modify(|shards: &mut Vec<uuid::Uuid>| shards.push(*shard_id))
-                    .or_insert(vec![*shard_id]);
-            }
-
+        while let Some(shard_groups) = queryer.next_queries()? {
             let mut tasks = JoinSet::new();
             for (node, shard_ids) in shard_groups {
-                match node {
-                    SearcherNode::This => {
-                        tasks.spawn(shard_search::search(
-                            shard_ids,
-                            Arc::clone(&self.index_cache),
-                            request.clone(),
-                        ));
-                    }
-                    SearcherNode::Remote(ref hostname) => {
-                        match self.get_client(hostname).await {
-                            Ok(client) => {
-                                tasks.spawn(Self::remote_query(client, request.clone(), shard_ids));
-                            }
-                            Err(e) => {
-                                // A client for this node is not available, although we've seen it
-                                // in the k8s cluster. We skip it and will retry those shards on
-                                // another node to complete the request
-                                warn!(
-                                    ?node,
-                                    ?shard_ids,
-                                    "{}",
-                                    format!("Error getting a client for node '{hostname}': {e}")
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-
-            if tasks.is_empty() {
-                // All requests failed, keep iterating and wish more luck on the next round of
-                continue;
+                self.spawn_node_search(&mut tasks, node, shard_ids, request.clone())
+                    .await;
             }
 
             while let Some(join) = tasks.join_next().await {
@@ -362,7 +355,7 @@ impl SearchServer {
                             let shard_id = uuid::Uuid::parse_str(shard_id)
                                 .expect("we always populates queried shards with valid UUIDs");
                             // We now remove successful shards from the set of shards we want to query
-                            shard_nodes.remove(&shard_id);
+                            queryer.ok(&shard_id);
                         }
                         responses.push(response);
                     }
@@ -371,7 +364,8 @@ impl SearchServer {
                     }
                     Err(join_error) => {
                         // Either a panic or a cancellation happened while searching
-                        warn!("A shard query failed in tokio: {:?}", join_error.to_string());
+                        error!("A shard query failed in tokio: {:?}", join_error.to_string());
+                        return Err(join_error.into());
                     }
                 }
             }
@@ -387,6 +381,38 @@ impl SearchServer {
             )
         };
         Ok(merged)
+    }
+
+    async fn spawn_node_search(
+        &self,
+        tasks: &mut JoinSet<NidxResult<SearchResult<SearchResponse>>>,
+        node: SearcherNode,
+        shard_ids: Vec<uuid::Uuid>,
+        request: SearchRequest,
+    ) {
+        match node {
+            SearcherNode::This => {
+                tasks.spawn(shard_search::search(shard_ids, Arc::clone(&self.index_cache), request));
+            }
+            SearcherNode::Remote(ref hostname) => {
+                match self.get_client(hostname).await {
+                    Ok(client) => {
+                        tasks.spawn(Self::remote_query(client, request, shard_ids));
+                    }
+                    Err(e) => {
+                        // A client for this node is not available, although we've seen it
+                        // in the k8s cluster. We skip it and will retry those shards on
+                        // another node to complete the request
+                        warn!(
+                            ?node,
+                            ?shard_ids,
+                            "{}",
+                            format!("Error getting a client for node '{hostname}': {e}")
+                        );
+                    }
+                }
+            }
+        }
     }
 
     async fn remote_query(

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -155,82 +155,27 @@ impl NidxSearcher for SearchServer {
         let message = request.get_ref();
 
         if !message.multi_shard_search {
+            // Former single-shard request
+
             if message.shard_ids.is_empty() {
                 return Err(NidxError::invalid("requests must contain at least a shard id").into());
             }
             let shard_id = uuid::Uuid::parse_str(&message.shard_ids[0]).map_err(NidxError::from)?;
-            shard_request! {
-                "search",
-                self,
-                request,
-                shard_id,
-                LOCAL => shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone()).await,
-                REMOTE => search
-            }
+            self.shard_search(shard_id, &request).await
         } else {
-            let mut errors = Vec::new();
+            // New multi-shard request. gRPC call contains the list of all
+            // shards we have to search. We now can decide the most efficient
+            // way to perform the distributed query
+
             let mut responses = Vec::with_capacity(message.shard_ids.len());
 
-            let local_only = request.metadata().contains_key(HEADER_LOCAL_ONLY);
             for shard_id in &message.shard_ids {
                 let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
 
-                let nodes = if local_only {
-                    vec![SearcherNode::This]
-                } else {
-                    self.shard_selector.nodes_for_shard(&shard_id)
-                };
-
-                for node in &nodes {
-                    debug!(?node, ?shard_id, "Attempting search");
-                    let result = match node {
-                        SearcherNode::This => {
-                            shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone())
-                                .await
-                                .map(Response::new)
-                        }
-                        SearcherNode::Remote(hostname) => match self.get_client(hostname).await {
-                            Ok(mut client) => {
-                                let mut request = Request::new(message.clone());
-                                request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
-                                client.search(request).await.map_err(|e| match e.code() {
-                                    tonic::Code::NotFound => NidxError::NotFound,
-                                    _ => NidxError::Unknown(anyhow::Error::from(e)),
-                                })
-                            }
-                            Err(e) => Err(e),
-                        },
-                    };
-                    match result {
-                        Ok(response) => {
-                            responses.push(response);
-                            break;
-                        }
-                        Err(e) => {
-                            warn!(
-                                ?node,
-                                ?shard_id,
-                                concat!("Error in search, trying with next node: {:?}"),
-                                e
-                            );
-                            errors.push(e);
-                        }
-                    }
-                }
-
-                if !errors.is_empty() {
-                    error!(
-                        ?errors,
-                        ?nodes,
-                        ?shard_id,
-                        "Error in search, exhausted all availabled nodes"
-                    );
-                    if let Some(reported_error) = errors.pop() {
-                        return Err(reported_error.into());
-                    } else {
-                        return Err(Status::internal("Unknown search error"));
-                    }
-                }
+                // When searching a shard fails, we can't provide results. We
+                // return the error and fail the whole request
+                let response = self.shard_search(shard_id, &request).await?;
+                responses.push(response);
             }
 
             let merged = shard_merge::merge(
@@ -317,6 +262,24 @@ impl NidxSearcher for SearchServer {
             LOCAL => streams::document_iterator(Arc::clone(&self.index_cache), message.clone()).await,
             REMOTE => documents,
             STREAM => Self::DocumentsStream
+        }
+    }
+}
+
+impl SearchServer {
+    async fn shard_search(
+        &self,
+        shard_id: uuid::Uuid,
+        request: &Request<SearchRequest>,
+    ) -> Result<Response<SearchResponse>> {
+        let message = request.get_ref();
+        shard_request! {
+            "search",
+            self,
+            request,
+            shard_id,
+            LOCAL => shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone()).await,
+            REMOTE => search
         }
     }
 }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -21,6 +21,7 @@ use nidx_protos::nidx::nidx_searcher_client::NidxSearcherClient;
 use nidx_protos::nidx::nidx_searcher_server::{NidxSearcher, NidxSearcherServer};
 use nidx_protos::*;
 use tokio::sync::RwLock;
+use tokio::task::JoinSet;
 use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
@@ -152,31 +153,25 @@ macro_rules! shard_request {
 #[tonic::async_trait]
 impl NidxSearcher for SearchServer {
     async fn search(&self, request: Request<SearchRequest>) -> Result<Response<SearchResponse>> {
-        let message = request.get_ref();
+        let local_only = request.metadata().contains_key(HEADER_LOCAL_ONLY);
+        let request = request.into_inner();
 
-        if message.shard_ids.len() == 1 {
-            let shard_id = uuid::Uuid::parse_str(&message.shard_ids[0]).map_err(NidxError::from)?;
-            self.shard_search(shard_id, &request).await
-        } else {
-            // Distributed query across multiple shards
-            let mut responses = Vec::with_capacity(message.shard_ids.len());
-
-            for shard_id in &message.shard_ids {
-                let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
-
-                // When searching a shard fails, we can't provide results. We
-                // return the error and fail the whole request
-                let response = self.shard_search(shard_id, &request).await?;
-                responses.push(response);
-            }
-
-            let merged = shard_merge::merge(
-                responses.into_iter().map(|r| r.into_inner()).collect(),
-                OrderBy::from(message),
-                Limit(message.result_per_page as usize),
-            );
-            Ok(Response::new(merged))
+        let mut shards = vec![];
+        for shard_id in &request.shard_ids {
+            let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
+            shards.push(shard_id);
         }
+
+        let response = if local_only {
+            // This is a hopped node, i.e., another searcher has delegated this part of the query to
+            // us. We must query our shards and return either a full or partial response or an error.
+            // We won't hop to any other node
+            self.local_query(request, shards).await?
+        } else {
+            // A query may need to be distributed across nodes in order to search in all partitions.
+            self.distributed_query(request, shards).await?
+        };
+        Ok(Response::new(response))
     }
 
     async fn suggest(&self, request: Request<SuggestRequest>) -> Result<Response<SuggestResponse>> {
@@ -259,19 +254,188 @@ impl NidxSearcher for SearchServer {
 }
 
 impl SearchServer {
-    async fn shard_search(
-        &self,
-        shard_id: uuid::Uuid,
-        request: &Request<SearchRequest>,
-    ) -> Result<Response<SearchResponse>> {
-        let message = request.get_ref();
-        shard_request! {
-            "search",
-            self,
-            request,
-            shard_id,
-            LOCAL => shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone()).await,
-            REMOTE => search
+    /// Perform a distributed query over a partitioned dataset across a cluster of nodes.
+    ///
+    /// The whole dataset is partitioned and distributed (with replication) across nidx-searcher
+    /// nodes. To answer a query, we must query all partitions (shards) and merge the results into a
+    /// single respose.
+    ///
+    /// This function is responsible for partial failure handling and retry. As a node can be
+    /// requested to query several partitions and one or more can fail, it will then return a
+    /// partial result and is our responsibility to retry on other nodes.
+    ///
+    async fn distributed_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> NidxResult<SearchResponse> {
+        // Locate which nodes contain each shard and get a list by preference
+        let mut shard_nodes = HashMap::new();
+        for shard_id in &shards {
+            let nodes = self.shard_selector.nodes_for_shard(shard_id);
+            if nodes.is_empty() {
+                // We haven't found any node with this shard. As we'll never be able to return a
+                // full result, we fail fast
+                return Err(NidxError::NotFound);
+            }
+
+            shard_nodes.insert(*shard_id, nodes);
         }
+
+        // Now, we'll do scatter-gather cycles using the most preferred node per shard. Grouping
+        // cycles is less time-efficient, as we wait for the slowest request, but we minimize the
+        // amount of requests through the cluster.
+        let mut responses = vec![];
+        while !shard_nodes.is_empty() {
+            let mut shard_groups = HashMap::new();
+            for (shard_id, nodes) in shard_nodes.iter_mut() {
+                if nodes.is_empty() {
+                    // A shard doesn't have more nodes to query but we haven't finished yet. We
+                    // won't be able to complete the request in all partitions, so we abort
+                    return Err(NidxError::QueryError(format!(
+                        "Error in search, exhausted all available nodes for shard {shard_id}"
+                    )));
+                }
+
+                let node = nodes.remove(0);
+                shard_groups
+                    .entry(node)
+                    .and_modify(|shards: &mut Vec<uuid::Uuid>| shards.push(*shard_id))
+                    .or_insert(vec![*shard_id]);
+            }
+
+            let mut tasks = JoinSet::new();
+            for (node, shard_ids) in shard_groups {
+                match node {
+                    SearcherNode::This => {
+                        // TODO: if we pass down the list of shard ids, we'll be able to reuse the
+                        // query plan for all of them
+                        for shard_id in shard_ids.into_iter() {
+                            tasks.spawn(shard_search::search(
+                                shard_id,
+                                Arc::clone(&self.index_cache),
+                                request.clone(),
+                            ));
+                        }
+                    }
+                    SearcherNode::Remote(ref hostname) => {
+                        match self.get_client(hostname).await {
+                            Ok(mut client) => {
+                                // Send the query to a different node specifying only a subset of shards
+                                let mut search_request = request.clone();
+                                search_request.shard_ids = shard_ids.into_iter().map(|x| x.to_string()).collect();
+
+                                // We do include a marker header to indicate we already hopped in
+                                // the cluster. This avoids an infinite loop across nodes
+                                let mut request = Request::new(search_request);
+                                request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
+                                tasks.spawn(async move {
+                                    client.search(request).await.map(|resp| resp.into_inner()).map_err(|e| {
+                                        match e.code() {
+                                            tonic::Code::NotFound => NidxError::NotFound,
+                                            _ => NidxError::Unknown(anyhow::Error::from(e)),
+                                        }
+                                    })
+                                });
+                            }
+                            Err(e) => {
+                                // A client for this shard is not available. This is probably a bad
+                                // sign, as we haven't connected to it yet, so it's a problem on our
+                                // side. However, if we manage to get a client for another node for
+                                // this shards, we can still complete the request
+                                warn!(
+                                    ?node,
+                                    ?shard_ids,
+                                    concat!("Error in search, trying with next node: {:?}"),
+                                    e
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            if tasks.is_empty() {
+                // All requests failed, keep iterating and wish more luck on the next round of
+                continue;
+            }
+
+            while let Some(join) = tasks.join_next().await {
+                match join {
+                    Ok(Ok(response)) => {
+                        responses.push(response);
+                    }
+                    Ok(Err(search_error)) => {
+                        warn!("An error occurred while searching: {search_error:?}");
+                    }
+                    Err(join_error) => {
+                        // Either a panic or a cancellation happened while searching
+                        warn!("A shard query failed in tokio: {:?}", join_error.to_string());
+                    }
+                }
+            }
+
+            for response in &responses {
+                // The response includes a list of successful shards, that may be a subset of the
+                // requested ones. This is the way we communicate partial failures.
+                for shard_id in &response.shard_ids {
+                    let shard_id =
+                        uuid::Uuid::parse_str(shard_id).expect("we always populates queried shards with valid UUIDs");
+                    // We now remove successful shards from the set of shards we want to query
+                    shard_nodes.remove(&shard_id);
+                }
+            }
+        }
+        debug_assert_eq!(
+            responses.len(),
+            shards.len(),
+            "we must have the same amount of responses as shards to succeed"
+        );
+
+        let merged = if responses.len() == 1 {
+            responses.pop().unwrap()
+        } else {
+            shard_merge::merge(
+                responses,
+                OrderBy::from(&request),
+                Limit(request.result_per_page as usize),
+            )
+        };
+        Ok(merged)
+    }
+
+    async fn local_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> Result<SearchResponse> {
+        let mut tasks = JoinSet::new();
+
+        for shard_id in shards {
+            tasks.spawn(shard_search::search(
+                shard_id,
+                Arc::clone(&self.index_cache),
+                request.clone(),
+            ));
+        }
+
+        let mut responses = vec![];
+        while let Some(join) = tasks.join_next().await {
+            match join {
+                Ok(Ok(response)) => {
+                    responses.push(response);
+                }
+                Ok(Err(search_error)) => {
+                    warn!("An error occurred while searching {search_error:?}");
+                }
+                Err(join_error) => {
+                    // Either a panic or a cancellation happened while searching
+                    warn!("A shard query failed in tokio: {:?}", join_error.to_string());
+                }
+            }
+        }
+
+        let merged = if responses.len() == 1 {
+            responses.pop().unwrap()
+        } else {
+            shard_merge::merge(
+                responses,
+                OrderBy::from(&request),
+                Limit(request.result_per_page as usize),
+            )
+        };
+        Ok(merged)
     }
 }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -26,11 +26,12 @@ use tonic::service::Interceptor;
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tonic::{Request, Response, Result, Status, service::Routes};
+use uuid::Uuid;
 
 use crate::NidxMetadata;
 use crate::errors::{NidxError, NidxResult};
 use crate::searcher::shard_merge::{Limit, OrderBy};
-use crate::searcher::shard_search::{PartialResult, SearchResult};
+use crate::searcher::shard_search::PartitionedResponse;
 use crate::searcher::shard_selector::SearcherNode;
 
 use super::shard_selector::ShardSelector;
@@ -288,22 +289,22 @@ impl SearchServer {
         // cycles is less time-efficient, as we wait for the slowest request, but we minimize the
         // amount of requests through the cluster.
         let mut responses = vec![];
-        while let Some(shard_groups) = partitioner.next_groups_by_node()? {
+        while let Some(groups) = partitioner.next_groups_by_node()? {
             let mut tasks = JoinSet::new();
-            for (node, shard_ids) in shard_groups {
+            for (node, shard_ids) in groups {
                 tasks.spawn(self.node_query(node, shard_ids, request.clone()).await?);
             }
 
             while let Some(join) = tasks.join_next().await {
                 match join {
                     Ok(Ok(result)) => {
-                        let response = result.into_value();
+                        let (response, shards) = match result {
+                            PartitionedResponse::Complete(response, shards) => (response, shards),
+                            PartitionedResponse::Partial(response, shards) => (response, shards),
+                        };
                         // The response includes a list of successful shards, that may be a subset of the
                         // requested ones. This is the way we communicate partial failures.
-                        for shard_id in &response.shard_ids {
-                            let shard_id = uuid::Uuid::parse_str(shard_id)
-                                .expect("we always populates queried shards with valid UUIDs");
-                            // We now remove successful shards from the set of shards we want to query
+                        for shard_id in shards {
                             partitioner.succeeded(&shard_id);
                         }
                         responses.push(response);
@@ -337,7 +338,8 @@ impl SearchServer {
         node: SearcherNode,
         shard_ids: Vec<uuid::Uuid>,
         request: SearchRequest,
-    ) -> NidxResult<Pin<Box<dyn Future<Output = NidxResult<SearchResult<SearchResponse>>> + Send + 'static>>> {
+    ) -> NidxResult<Pin<Box<dyn Future<Output = NidxResult<PartitionedResponse<SearchResponse>>> + Send + 'static>>>
+    {
         match node {
             SearcherNode::This => {
                 let index_cache = Arc::clone(&self.index_cache);
@@ -371,7 +373,7 @@ impl SearchServer {
         mut client: SearcherClient,
         request: SearchRequest,
         shards: Vec<uuid::Uuid>,
-    ) -> NidxResult<SearchResult<SearchResponse>> {
+    ) -> NidxResult<PartitionedResponse<SearchResponse>> {
         // Send the query to a different node specifying only a subset of shards
         let mut search_request = request.clone();
         search_request.shard_ids = shards.iter().map(|x| x.to_string()).collect();
@@ -387,9 +389,14 @@ impl SearchServer {
             Ok(response) => {
                 let response = response.into_inner();
                 let result = if response.shard_ids.len() == shards.len() {
-                    SearchResult::Complete(response)
+                    PartitionedResponse::Complete(response, shards)
                 } else {
-                    SearchResult::Partial(PartialResult { part: response })
+                    let successful_shards = response
+                        .shard_ids
+                        .iter()
+                        .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
+                        .collect();
+                    PartitionedResponse::Partial(response, successful_shards)
                 };
                 Ok(result)
             }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -152,15 +152,74 @@ macro_rules! shard_request {
 impl NidxSearcher for SearchServer {
     async fn search(&self, request: Request<SearchRequest>) -> Result<Response<SearchResponse>> {
         let message = request.get_ref();
-        let shard_id = uuid::Uuid::parse_str(&message.shard).map_err(NidxError::from)?;
-        shard_request! {
-            "search",
-            self,
-            request,
-            shard_id,
-            LOCAL => shard_search::search(Arc::clone(&self.index_cache), message.clone()).await,
-            REMOTE => search
+
+        let mut errors = Vec::new();
+        let mut responses = Vec::with_capacity(message.shard_ids.len());
+
+        let local_only = request.metadata().contains_key(HEADER_LOCAL_ONLY);
+        for shard_id in &message.shard_ids {
+            let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
+
+            let nodes = if local_only {
+                vec![SearcherNode::This]
+            } else {
+                self.shard_selector.nodes_for_shard(&shard_id)
+            };
+
+            for node in &nodes {
+                debug!(?node, ?shard_id, "Attempting search");
+                let result = match node {
+                    SearcherNode::This => {
+                        shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone())
+                            .await
+                            .map(Response::new)
+                    }
+                    SearcherNode::Remote(hostname) => match self.get_client(hostname).await {
+                        Ok(mut client) => {
+                            let mut request = Request::new(message.clone());
+                            request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
+                            client.search(request).await.map_err(|e| match e.code() {
+                                tonic::Code::NotFound => NidxError::NotFound,
+                                _ => NidxError::Unknown(anyhow::Error::from(e)),
+                            })
+                        }
+                        Err(e) => Err(e),
+                    },
+                };
+                match result {
+                    Ok(response) => {
+                        responses.push(response);
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            ?node,
+                            ?shard_id,
+                            concat!("Error in search, trying with next node: {:?}"),
+                            e
+                        );
+                        errors.push(e);
+                    }
+                }
+            }
+
+            if !errors.is_empty() {
+                error!(
+                    ?errors,
+                    ?nodes,
+                    ?shard_id,
+                    "Error in search, exhausted all availabled nodes"
+                );
+                if let Some(reported_error) = errors.pop() {
+                    return Err(reported_error.into());
+                } else {
+                    return Err(Status::internal("Unknown search error"));
+                }
+            }
         }
+
+        let merged = shard_search::merge(responses.into_iter().map(|r| r.into_inner()).collect());
+        Ok(Response::new(merged))
     }
 
     async fn suggest(&self, request: Request<SuggestRequest>) -> Result<Response<SuggestResponse>> {

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -30,6 +30,7 @@ use tonic::{Request, Response, Result, Status, service::Routes};
 use crate::NidxMetadata;
 use crate::errors::{NidxError, NidxResult};
 use crate::searcher::shard_merge::{Limit, OrderBy};
+use crate::searcher::shard_search::{PartialResult, SearchResult};
 use crate::searcher::shard_selector::SearcherNode;
 
 use super::shard_selector::ShardSelector;
@@ -169,7 +170,9 @@ impl NidxSearcher for SearchServer {
             // This is a hopped node, i.e., another searcher has delegated this part of the query to
             // us. We must query our shards and return either a full or partial response or an error.
             // We won't hop to any other node
-            self.local_query(request, shards).await?
+            shard_search::search(shards, Arc::clone(&self.index_cache), request)
+                .await?
+                .into_value()
         } else {
             // A query that may need to be distributed across nodes in order to search in all partitions.
 
@@ -317,46 +320,26 @@ impl SearchServer {
             for (node, shard_ids) in shard_groups {
                 match node {
                     SearcherNode::This => {
-                        // TODO: if we pass down the list of shard ids, we'll be able to reuse the
-                        // query plan for all of them
-                        for shard_id in shard_ids.into_iter() {
-                            tasks.spawn(shard_search::search(
-                                shard_id,
-                                Arc::clone(&self.index_cache),
-                                request.clone(),
-                            ));
-                        }
+                        tasks.spawn(shard_search::search(
+                            shard_ids,
+                            Arc::clone(&self.index_cache),
+                            request.clone(),
+                        ));
                     }
                     SearcherNode::Remote(ref hostname) => {
                         match self.get_client(hostname).await {
-                            Ok(mut client) => {
-                                // Send the query to a different node specifying only a subset of shards
-                                let mut search_request = request.clone();
-                                search_request.shard_ids = shard_ids.into_iter().map(|x| x.to_string()).collect();
-
-                                // We do include a marker header to indicate we already hopped in
-                                // the cluster. This avoids an infinite loop across nodes
-                                let mut request = Request::new(search_request);
-                                request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
-                                tasks.spawn(async move {
-                                    client.search(request).await.map(|resp| resp.into_inner()).map_err(|e| {
-                                        match e.code() {
-                                            tonic::Code::NotFound => NidxError::NotFound,
-                                            _ => NidxError::Unknown(anyhow::Error::from(e)),
-                                        }
-                                    })
-                                });
+                            Ok(client) => {
+                                tasks.spawn(Self::remote_query(client, request.clone(), shard_ids));
                             }
                             Err(e) => {
-                                // A client for this shard is not available. This is probably a bad
-                                // sign, as we haven't connected to it yet, so it's a problem on our
-                                // side. However, if we manage to get a client for another node for
-                                // this shards, we can still complete the request
+                                // A client for this node is not available, although we've seen it
+                                // in the k8s cluster. We skip it and will retry those shards on
+                                // another node to complete the request
                                 warn!(
                                     ?node,
                                     ?shard_ids,
-                                    concat!("Error in search, trying with next node: {:?}"),
-                                    e
+                                    "{}",
+                                    format!("Error getting a client for node '{hostname}': {e}")
                                 );
                             }
                         }
@@ -371,9 +354,7 @@ impl SearchServer {
 
             while let Some(join) = tasks.join_next().await {
                 match join {
-                    Ok(Ok(response)) => {
-                        responses.push(response);
-                    }
+                    Ok(Ok(result)) => responses.push(result.into_value()),
                     Ok(Err(search_error)) => {
                         warn!("An error occurred while searching: {search_error:?}");
                     }
@@ -408,42 +389,39 @@ impl SearchServer {
         Ok(merged)
     }
 
-    async fn local_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> Result<SearchResponse> {
-        let mut tasks = JoinSet::new();
+    async fn remote_query(
+        mut client: SearcherClient,
+        request: SearchRequest,
+        shards: Vec<uuid::Uuid>,
+    ) -> NidxResult<SearchResult<SearchResponse>> {
+        // Send the query to a different node specifying only a subset of shards
+        let mut search_request = request.clone();
+        search_request.shard_ids = shards.iter().map(|x| x.to_string()).collect();
 
-        for shard_id in shards {
-            tasks.spawn(shard_search::search(
-                shard_id,
-                Arc::clone(&self.index_cache),
-                request.clone(),
-            ));
-        }
+        // We do include a marker header to indicate we already hopped in
+        // the cluster. This avoids an infinite loop across nodes
+        let mut request = Request::new(search_request);
+        request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
 
-        let mut responses = vec![];
-        while let Some(join) = tasks.join_next().await {
-            match join {
-                Ok(Ok(response)) => {
-                    responses.push(response);
-                }
-                Ok(Err(search_error)) => {
-                    warn!("An error occurred while searching {search_error:?}");
-                }
-                Err(join_error) => {
-                    // Either a panic or a cancellation happened while searching
-                    warn!("A shard query failed in tokio: {:?}", join_error.to_string());
-                }
+        let response = client.search(request).await;
+
+        match response {
+            Ok(response) => {
+                let response = response.into_inner();
+                let result = if response.shard_ids.len() == shards.len() {
+                    SearchResult::Complete(response)
+                } else {
+                    SearchResult::Partial(PartialResult { part: response })
+                };
+                Ok(result)
+            }
+            Err(status) => {
+                let error = match status.code() {
+                    tonic::Code::NotFound => NidxError::NotFound,
+                    _ => NidxError::Unknown(anyhow::Error::from(status)),
+                };
+                Err(error)
             }
         }
-
-        let merged = if responses.len() == 1 {
-            responses.pop().unwrap()
-        } else {
-            shard_merge::merge(
-                responses,
-                OrderBy::from(&request),
-                Limit(request.result_per_page as usize),
-            )
-        };
-        Ok(merged)
     }
 }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -29,7 +29,6 @@ use tonic::transport::Channel;
 use tonic::{Request, Response, Result, Status, service::Routes};
 use uuid::Uuid;
 
-use crate::NidxMetadata;
 use crate::errors::{NidxError, NidxResult};
 use crate::searcher::shard_merge::{Limit, OrderBy};
 use crate::searcher::shard_search::PartialResponse;
@@ -61,16 +60,14 @@ impl Interceptor for TelemetryInterceptor {
 type SearcherClient = NidxSearcherClient<InterceptedService<Channel, TelemetryInterceptor>>;
 
 pub struct SearchServer {
-    meta: NidxMetadata,
     index_cache: Arc<IndexCache>,
     shard_selector: ShardSelector,
     clients: Arc<RwLock<HashMap<String, SearcherClient>>>,
 }
 
 impl SearchServer {
-    pub fn new(meta: NidxMetadata, index_cache: Arc<IndexCache>, shard_selector: ShardSelector) -> Self {
+    pub fn new(index_cache: Arc<IndexCache>, shard_selector: ShardSelector) -> Self {
         SearchServer {
-            meta,
             index_cache,
             shard_selector,
             clients: Arc::new(RwLock::new(HashMap::new())),
@@ -170,7 +167,6 @@ impl NidxSearcher for SearchServer {
 
         let response = if coordinator {
             // We are the requested searcher to perform a distributed query
-            check_shards_exist(&self.meta, &shards).await?;
             self.distributed_query(request, shards).await?
         } else {
             // This is a hopped node, i.e., another searcher has delegated this part of the query to
@@ -293,9 +289,11 @@ impl SearchServer {
                 let Some(node) = partitioner.next_node_for_shard(shard_id) else {
                     // A shard doesn't have more nodes to query but we haven't finished yet. We
                     // won't be able to complete the request in all partitions, so we abort
-                    return Err(NidxError::QueryError(format!(
-                        "Error in search, exhausted all available nodes for shard {shard_id}"
-                    )));
+                    error!(?shard_id, "Error in search, exhausted all available nodes for shard");
+                    // Propagate a NotFound error. Note that we can only arrive here due to NotFound
+                    // errors as they are the only ones we retry. If at some point we handle more,
+                    // this will be an incorrect assumption
+                    return Err(NidxError::NotFound);
                 };
                 groups
                     .entry(node)
@@ -450,16 +448,4 @@ impl QueryPartitioner {
         let nodes = self.shard_nodes.get_mut(shard).unwrap();
         if !nodes.is_empty() { Some(nodes.remove(0)) } else { None }
     }
-}
-
-async fn check_shards_exist(meta: &NidxMetadata, shards: &[Uuid]) -> NidxResult<()> {
-    let existing_shards = crate::metadata::Shard::exist_many(&meta.pool, shards)
-        .await
-        .map_err(NidxError::from)?;
-
-    if existing_shards.len() < shards.len() {
-        return Err(NidxError::NotFound);
-    }
-
-    Ok(())
 }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -354,7 +354,18 @@ impl SearchServer {
 
             while let Some(join) = tasks.join_next().await {
                 match join {
-                    Ok(Ok(result)) => responses.push(result.into_value()),
+                    Ok(Ok(result)) => {
+                        let response = result.into_value();
+                        // The response includes a list of successful shards, that may be a subset of the
+                        // requested ones. This is the way we communicate partial failures.
+                        for shard_id in &response.shard_ids {
+                            let shard_id = uuid::Uuid::parse_str(shard_id)
+                                .expect("we always populates queried shards with valid UUIDs");
+                            // We now remove successful shards from the set of shards we want to query
+                            shard_nodes.remove(&shard_id);
+                        }
+                        responses.push(response);
+                    }
                     Ok(Err(search_error)) => {
                         warn!("An error occurred while searching: {search_error:?}");
                     }
@@ -362,17 +373,6 @@ impl SearchServer {
                         // Either a panic or a cancellation happened while searching
                         warn!("A shard query failed in tokio: {:?}", join_error.to_string());
                     }
-                }
-            }
-
-            for response in &responses {
-                // The response includes a list of successful shards, that may be a subset of the
-                // requested ones. This is the way we communicate partial failures.
-                for shard_id in &response.shard_ids {
-                    let shard_id =
-                        uuid::Uuid::parse_str(shard_id).expect("we always populates queried shards with valid UUIDs");
-                    // We now remove successful shards from the set of shards we want to query
-                    shard_nodes.remove(&shard_id);
                 }
             }
         }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -382,11 +382,6 @@ impl SearchServer {
                 }
             }
         }
-        debug_assert_eq!(
-            responses.len(),
-            shards.len(),
-            "we must have the same amount of responses as shards to succeed"
-        );
 
         let merged = if responses.len() == 1 {
             responses.pop().unwrap()

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -323,11 +323,17 @@ impl SearchServer {
                         }
                         responses.push(response);
                     }
-                    Ok(Err(NidxError::NotFound)) => {}
-                    Ok(Err(NidxError::GrpcError(status))) if status.code() == Code::NotFound => {}
-                    Ok(Err(NidxError::GrpcError(status))) if status.code() == Code::Unavailable => {}
+                    Ok(Err(NidxError::NotFound)) => {
+                        // shard not found in searcher, probably due to a
+                        // topology change the shard is not yet where it should
+                    }
+                    Ok(Err(NidxError::GrpcError(status))) if status.code() == Code::NotFound => {
+                        // same as above
+                    }
+                    Ok(Err(NidxError::GrpcError(status))) if status.code() == Code::Unavailable => {
+                        // searcher peer temporarily unavailable, will retry with another node
+                    }
                     Ok(Err(search_error)) => return Err(search_error),
-                    // Ok(Err(search_error)) => return Err(search_error),
                     Err(join_error) => {
                         // Either a panic or a cancellation happened while searching
                         return Err(NidxError::from(join_error));

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -27,11 +27,12 @@ use tonic::transport::Channel;
 use tonic::{Request, Response, Result, Status, service::Routes};
 
 use crate::errors::{NidxError, NidxResult};
+use crate::searcher::shard_merge::{Limit, OrderBy};
 use crate::searcher::shard_selector::SearcherNode;
 
 use super::shard_selector::ShardSelector;
 use super::streams;
-use super::{index_cache::IndexCache, shard_search, shard_suggest, shard_text};
+use super::{index_cache::IndexCache, shard_merge, shard_search, shard_suggest, shard_text};
 use tracing::*;
 
 /// When this header is set, we only try to serve the request from the local node
@@ -218,7 +219,11 @@ impl NidxSearcher for SearchServer {
             }
         }
 
-        let merged = shard_search::merge(responses.into_iter().map(|r| r.into_inner()).collect());
+        let merged = shard_merge::merge(
+            responses.into_iter().map(|r| r.into_inner()).collect(),
+            OrderBy::from(message),
+            Limit(message.result_per_page as usize),
+        );
         Ok(Response::new(merged))
     }
 

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -291,8 +291,7 @@ impl SearchServer {
         while let Some(shard_groups) = partitioner.next_groups_by_node()? {
             let mut tasks = JoinSet::new();
             for (node, shard_ids) in shard_groups {
-                self.spawn_node_search(&mut tasks, node, shard_ids, request.clone())
-                    .await;
+                tasks.spawn(self.node_query(node, shard_ids, request.clone()).await?);
             }
 
             while let Some(join) = tasks.join_next().await {
@@ -333,22 +332,24 @@ impl SearchServer {
         Ok(merged)
     }
 
-    async fn spawn_node_search(
+    async fn node_query(
         &self,
-        tasks: &mut JoinSet<NidxResult<SearchResult<SearchResponse>>>,
         node: SearcherNode,
         shard_ids: Vec<uuid::Uuid>,
         request: SearchRequest,
-    ) {
+    ) -> NidxResult<Pin<Box<dyn Future<Output = NidxResult<SearchResult<SearchResponse>>> + Send + 'static>>> {
         match node {
             SearcherNode::This => {
-                tasks.spawn(shard_search::search(shard_ids, Arc::clone(&self.index_cache), request));
+                let index_cache = Arc::clone(&self.index_cache);
+                Ok(Box::pin(async move {
+                    shard_search::search(shard_ids, index_cache, request).await
+                }))
             }
             SearcherNode::Remote(ref hostname) => {
                 match self.get_client(hostname).await {
-                    Ok(client) => {
-                        tasks.spawn(Self::remote_query(client, request, shard_ids));
-                    }
+                    Ok(client) => Ok(Box::pin(
+                        async move { Self::remote_query(client, request, shard_ids).await },
+                    )),
                     Err(e) => {
                         // A client for this node is not available, although we've seen it
                         // in the k8s cluster. We skip it and will retry those shards on
@@ -359,6 +360,7 @@ impl SearchServer {
                             "{}",
                             format!("Error getting a client for node '{hostname}': {e}")
                         );
+                        Err(e)
                     }
                 }
             }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 use std::{pin::Pin, sync::Arc};
 
-use axum::http::request;
 use futures::Stream;
 use nidx_protos::nidx::nidx_searcher_client::NidxSearcherClient;
 use nidx_protos::nidx::nidx_searcher_server::{NidxSearcher, NidxSearcherServer};
@@ -270,55 +269,6 @@ impl NidxSearcher for SearchServer {
     }
 }
 
-struct DistributedQuery {
-    shard_nodes: HashMap<uuid::Uuid, Vec<SearcherNode>>,
-}
-
-impl DistributedQuery {
-    fn new(shard_selector: &ShardSelector, shards: Vec<uuid::Uuid>) -> NidxResult<Self> {
-        let mut shard_nodes = HashMap::new();
-        for shard_id in &shards {
-            let nodes = shard_selector.nodes_for_shard(shard_id);
-            if nodes.is_empty() {
-                // We haven't found any node with this shard. As we'll never be able to return a
-                // full result, we fail fast
-                return Err(NidxError::NotFound);
-            }
-
-            shard_nodes.insert(*shard_id, nodes);
-        }
-
-        Ok(Self { shard_nodes })
-    }
-
-    fn next_queries(&mut self) -> Result<Option<HashMap<SearcherNode, Vec<uuid::Uuid>>>, NidxError> {
-        if self.shard_nodes.is_empty() {
-            return Ok(None);
-        }
-        let mut shard_groups = HashMap::new();
-        for (shard_id, nodes) in self.shard_nodes.iter_mut() {
-            if nodes.is_empty() {
-                // A shard doesn't have more nodes to query but we haven't finished yet. We
-                // won't be able to complete the request in all partitions, so we abort
-                return Err(NidxError::QueryError(format!(
-                    "Error in search, exhausted all available nodes for shard {shard_id}"
-                )));
-            }
-
-            let node = nodes.remove(0);
-            shard_groups
-                .entry(node)
-                .and_modify(|shards: &mut Vec<uuid::Uuid>| shards.push(*shard_id))
-                .or_insert(vec![*shard_id]);
-        }
-        Ok(Some(shard_groups))
-    }
-
-    fn ok(&mut self, shard_id: &uuid::Uuid) {
-        self.shard_nodes.remove(shard_id);
-    }
-}
-
 impl SearchServer {
     /// Perform a distributed query over a partitioned dataset across a cluster of nodes.
     ///
@@ -332,13 +282,13 @@ impl SearchServer {
     ///
     async fn distributed_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> NidxResult<SearchResponse> {
         // Locate which nodes contain each shard and get a list by preference
-        let mut queryer = DistributedQuery::new(&self.shard_selector, shards)?;
+        let mut partitioner = QueryPartitioner::new(&self.shard_selector, shards)?;
 
         // Now, we'll do scatter-gather cycles using the most preferred node per shard. Grouping
         // cycles is less time-efficient, as we wait for the slowest request, but we minimize the
         // amount of requests through the cluster.
         let mut responses = vec![];
-        while let Some(shard_groups) = queryer.next_queries()? {
+        while let Some(shard_groups) = partitioner.next_groups_by_node()? {
             let mut tasks = JoinSet::new();
             for (node, shard_ids) in shard_groups {
                 self.spawn_node_search(&mut tasks, node, shard_ids, request.clone())
@@ -355,7 +305,7 @@ impl SearchServer {
                             let shard_id = uuid::Uuid::parse_str(shard_id)
                                 .expect("we always populates queried shards with valid UUIDs");
                             // We now remove successful shards from the set of shards we want to query
-                            queryer.ok(&shard_id);
+                            partitioner.succeeded(&shard_id);
                         }
                         responses.push(response);
                     }
@@ -449,5 +399,53 @@ impl SearchServer {
                 Err(error)
             }
         }
+    }
+}
+
+struct QueryPartitioner {
+    shard_nodes: HashMap<uuid::Uuid, Vec<SearcherNode>>,
+}
+
+impl QueryPartitioner {
+    fn new(shard_selector: &ShardSelector, shards: Vec<uuid::Uuid>) -> NidxResult<Self> {
+        let mut shard_nodes = HashMap::new();
+        for shard_id in &shards {
+            let nodes = shard_selector.nodes_for_shard(shard_id);
+            if nodes.is_empty() {
+                // We haven't found any node with this shard. As we'll never be able to return a
+                // full result, we fail fast
+                return Err(NidxError::NotFound);
+            }
+            shard_nodes.insert(*shard_id, nodes);
+        }
+        Ok(Self { shard_nodes })
+    }
+
+    fn next_groups_by_node(&mut self) -> Result<Option<HashMap<SearcherNode, Vec<uuid::Uuid>>>, NidxError> {
+        if self.shard_nodes.is_empty() {
+            return Ok(None);
+        }
+
+        let mut shard_groups = HashMap::new();
+        for (shard_id, nodes) in self.shard_nodes.iter_mut() {
+            if nodes.is_empty() {
+                // A shard doesn't have more nodes to query but we haven't finished yet. We
+                // won't be able to complete the request in all partitions, so we abort
+                return Err(NidxError::QueryError(format!(
+                    "Error in search, exhausted all available nodes for shard {shard_id}"
+                )));
+            }
+
+            let node = nodes.remove(0);
+            shard_groups
+                .entry(node)
+                .and_modify(|shards: &mut Vec<uuid::Uuid>| shards.push(*shard_id))
+                .or_insert(vec![*shard_id]);
+        }
+        Ok(Some(shard_groups))
+    }
+
+    fn succeeded(&mut self, shard_id: &uuid::Uuid) {
+        self.shard_nodes.remove(shard_id);
     }
 }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -154,19 +154,11 @@ impl NidxSearcher for SearchServer {
     async fn search(&self, request: Request<SearchRequest>) -> Result<Response<SearchResponse>> {
         let message = request.get_ref();
 
-        if !message.multi_shard_search {
-            // Former single-shard request
-
-            if message.shard_ids.is_empty() {
-                return Err(NidxError::invalid("requests must contain at least a shard id").into());
-            }
+        if message.shard_ids.len() == 1 {
             let shard_id = uuid::Uuid::parse_str(&message.shard_ids[0]).map_err(NidxError::from)?;
             self.shard_search(shard_id, &request).await
         } else {
-            // New multi-shard request. gRPC call contains the list of all
-            // shards we have to search. We now can decide the most efficient
-            // way to perform the distributed query
-
+            // Distributed query across multiple shards
             let mut responses = Vec::with_capacity(message.shard_ids.len());
 
             for shard_id in &message.shard_ids {

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 use crate::NidxMetadata;
 use crate::errors::{NidxError, NidxResult};
 use crate::searcher::shard_merge::{Limit, OrderBy};
-use crate::searcher::shard_search::PartitionedResponse;
+use crate::searcher::shard_search::PartialResponse;
 use crate::searcher::shard_selector::SearcherNode;
 
 use super::shard_selector::ShardSelector;
@@ -169,7 +169,6 @@ impl NidxSearcher for SearchServer {
 
         let response = if coordinator {
             // We are the requested searcher to perform a distributed query
-
             check_shards_exist(&self.meta, &shards).await?;
             self.distributed_query(request, shards).await?
         } else {
@@ -178,7 +177,7 @@ impl NidxSearcher for SearchServer {
             // We won't hop to any other node
             shard_search::search(shards, Arc::clone(&self.index_cache), request)
                 .await?
-                .into_value()
+                .data
         };
 
         Ok(Response::new(response))
@@ -293,10 +292,7 @@ impl SearchServer {
             while let Some(join) = tasks.join_next().await {
                 match join {
                     Ok(Ok(response)) => {
-                        if response.is_partial() {
-                            warn!("A node responded with partial results");
-                        }
-                        let PartitionedResponse {
+                        let PartialResponse {
                             data: response, shards, ..
                         } = response;
                         // The response includes a list of successful shards, that may be a subset of the
@@ -333,8 +329,7 @@ impl SearchServer {
         node: SearcherNode,
         shard_ids: Vec<uuid::Uuid>,
         request: SearchRequest,
-    ) -> NidxResult<Pin<Box<dyn Future<Output = NidxResult<PartitionedResponse<SearchResponse>>> + Send + 'static>>>
-    {
+    ) -> NidxResult<Pin<Box<dyn Future<Output = NidxResult<PartialResponse<SearchResponse>>> + Send + 'static>>> {
         match node {
             SearcherNode::This => {
                 let index_cache = Arc::clone(&self.index_cache);
@@ -368,7 +363,7 @@ impl SearchServer {
         mut client: SearcherClient,
         request: SearchRequest,
         shards: Vec<uuid::Uuid>,
-    ) -> NidxResult<PartitionedResponse<SearchResponse>> {
+    ) -> NidxResult<PartialResponse<SearchResponse>> {
         // Send the query to a different node specifying only a subset of shards
         let mut search_request = request.clone();
         search_request.shard_ids = shards.iter().map(|x| x.to_string()).collect();
@@ -384,14 +379,17 @@ impl SearchServer {
             Ok(response) => {
                 let response = response.into_inner();
                 let result = if response.shard_ids.len() == shards.len() {
-                    PartitionedResponse::complete(response, shards)
+                    PartialResponse { data: response, shards }
                 } else {
                     let successful_shards = response
                         .shard_ids
                         .iter()
                         .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
                         .collect();
-                    PartitionedResponse::partial(response, successful_shards)
+                    PartialResponse {
+                        data: response,
+                        shards: successful_shards,
+                    }
                 };
                 Ok(result)
             }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -27,6 +27,7 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::Channel;
 use tonic::{Request, Response, Result, Status, service::Routes};
 
+use crate::NidxMetadata;
 use crate::errors::{NidxError, NidxResult};
 use crate::searcher::shard_merge::{Limit, OrderBy};
 use crate::searcher::shard_selector::SearcherNode;
@@ -57,14 +58,16 @@ impl Interceptor for TelemetryInterceptor {
 type SearcherClient = NidxSearcherClient<InterceptedService<Channel, TelemetryInterceptor>>;
 
 pub struct SearchServer {
+    meta: NidxMetadata,
     index_cache: Arc<IndexCache>,
     shard_selector: ShardSelector,
     clients: Arc<RwLock<HashMap<String, SearcherClient>>>,
 }
 
 impl SearchServer {
-    pub fn new(index_cache: Arc<IndexCache>, shard_selector: ShardSelector) -> Self {
+    pub fn new(meta: NidxMetadata, index_cache: Arc<IndexCache>, shard_selector: ShardSelector) -> Self {
         SearchServer {
+            meta,
             index_cache,
             shard_selector,
             clients: Arc::new(RwLock::new(HashMap::new())),
@@ -168,7 +171,17 @@ impl NidxSearcher for SearchServer {
             // We won't hop to any other node
             self.local_query(request, shards).await?
         } else {
-            // A query may need to be distributed across nodes in order to search in all partitions.
+            // A query that may need to be distributed across nodes in order to search in all partitions.
+
+            // Before doing any work, validate shards exist
+            let existing_shards = crate::metadata::Shard::exist_many(&self.meta.pool, &shards)
+                .await
+                .map_err(NidxError::from)?;
+            for shard_id in &shards {
+                if !existing_shards.contains(shard_id) {
+                    return Err(NidxError::NotFound.into());
+                }
+            }
             self.distributed_query(request, shards).await?
         };
         Ok(Response::new(response))

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -158,7 +158,7 @@ macro_rules! shard_request {
 #[tonic::async_trait]
 impl NidxSearcher for SearchServer {
     async fn search(&self, request: Request<SearchRequest>) -> Result<Response<SearchResponse>> {
-        let local_only = request.metadata().contains_key(HEADER_LOCAL_ONLY);
+        let coordinator = !request.metadata().contains_key(HEADER_LOCAL_ONLY);
         let request = request.into_inner();
 
         let mut shards = vec![];
@@ -167,27 +167,20 @@ impl NidxSearcher for SearchServer {
             shards.push(shard_id);
         }
 
-        let response = if local_only {
+        let response = if coordinator {
+            // We are the requested searcher to perform a distributed query
+
+            check_shards_exist(&self.meta, &shards).await?;
+            self.distributed_query(request, shards).await?
+        } else {
             // This is a hopped node, i.e., another searcher has delegated this part of the query to
             // us. We must query our shards and return either a full or partial response or an error.
             // We won't hop to any other node
             shard_search::search(shards, Arc::clone(&self.index_cache), request)
                 .await?
                 .into_value()
-        } else {
-            // A query that may need to be distributed across nodes in order to search in all partitions.
-
-            // Before doing any work, validate shards exist
-            let existing_shards = crate::metadata::Shard::exist_many(&self.meta.pool, &shards)
-                .await
-                .map_err(NidxError::from)?;
-            for shard_id in &shards {
-                if !existing_shards.contains(shard_id) {
-                    return Err(NidxError::NotFound.into());
-                }
-            }
-            self.distributed_query(request, shards).await?
         };
+
         Ok(Response::new(response))
     }
 
@@ -282,12 +275,14 @@ impl SearchServer {
     /// partial result and is our responsibility to retry on other nodes.
     ///
     async fn distributed_query(&self, request: SearchRequest, shards: Vec<uuid::Uuid>) -> NidxResult<SearchResponse> {
-        // Locate which nodes contain each shard and get a list by preference
         let mut partitioner = QueryPartitioner::new(&self.shard_selector, shards)?;
 
-        // Now, we'll do scatter-gather cycles using the most preferred node per shard. Grouping
-        // cycles is less time-efficient, as we wait for the slowest request, but we minimize the
-        // amount of requests through the cluster.
+        // Use the query partitioner to group requests by the most preferred
+        // node per shard. We'll then do scatter-gather cycles until we complete
+        // the distributed query or fail.
+        //
+        // NOTE that grouping cycles is less time-efficient, as tail latency can
+        // increase due to slow/faulty nodes
         let mut responses = vec![];
         while let Some(groups) = partitioner.next_groups_by_node()? {
             let mut tasks = JoinSet::new();
@@ -309,13 +304,11 @@ impl SearchServer {
                         }
                         responses.push(response);
                     }
-                    Ok(Err(search_error)) => {
-                        warn!("An error occurred while searching: {search_error:?}");
-                    }
+                    Ok(Err(NidxError::NotFound)) => {}
+                    Ok(Err(search_error)) => return Err(search_error),
                     Err(join_error) => {
                         // Either a panic or a cancellation happened while searching
-                        error!("A shard query failed in tokio: {:?}", join_error.to_string());
-                        return Err(join_error.into());
+                        return Err(NidxError::from(join_error));
                     }
                 }
             }
@@ -457,4 +450,17 @@ impl QueryPartitioner {
     fn succeeded(&mut self, shard_id: &uuid::Uuid) {
         self.shard_nodes.remove(shard_id);
     }
+}
+
+
+async fn check_shards_exist(meta: &NidxMetadata, shards: &[Uuid]) -> NidxResult<()> {
+    let existing_shards = crate::metadata::Shard::exist_many(&meta.pool, shards)
+        .await
+        .map_err(NidxError::from)?;
+
+    if existing_shards.len() < shards.len() {
+        return Err(NidxError::NotFound);
+    }
+
+    Ok(())
 }

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -292,11 +292,13 @@ impl SearchServer {
 
             while let Some(join) = tasks.join_next().await {
                 match join {
-                    Ok(Ok(result)) => {
-                        let (response, shards) = match result {
-                            PartitionedResponse::Complete(response, shards) => (response, shards),
-                            PartitionedResponse::Partial(response, shards) => (response, shards),
-                        };
+                    Ok(Ok(response)) => {
+                        if response.is_partial() {
+                            warn!("A node responded with partial results");
+                        }
+                        let PartitionedResponse {
+                            data: response, shards, ..
+                        } = response;
                         // The response includes a list of successful shards, that may be a subset of the
                         // requested ones. This is the way we communicate partial failures.
                         for shard_id in shards {
@@ -382,14 +384,14 @@ impl SearchServer {
             Ok(response) => {
                 let response = response.into_inner();
                 let result = if response.shard_ids.len() == shards.len() {
-                    PartitionedResponse::Complete(response, shards)
+                    PartitionedResponse::complete(response, shards)
                 } else {
                     let successful_shards = response
                         .shard_ids
                         .iter()
                         .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
                         .collect();
-                    PartitionedResponse::Partial(response, successful_shards)
+                    PartitionedResponse::partial(response, successful_shards)
                 };
                 Ok(result)
             }
@@ -451,7 +453,6 @@ impl QueryPartitioner {
         self.shard_nodes.remove(shard_id);
     }
 }
-
 
 async fn check_shards_exist(meta: &NidxMetadata, shards: &[Uuid]) -> NidxResult<()> {
     let existing_shards = crate::metadata::Shard::exist_many(&meta.pool, shards)

--- a/nidx/src/searcher/grpc.rs
+++ b/nidx/src/searcher/grpc.rs
@@ -154,77 +154,92 @@ impl NidxSearcher for SearchServer {
     async fn search(&self, request: Request<SearchRequest>) -> Result<Response<SearchResponse>> {
         let message = request.get_ref();
 
-        let mut errors = Vec::new();
-        let mut responses = Vec::with_capacity(message.shard_ids.len());
-
-        let local_only = request.metadata().contains_key(HEADER_LOCAL_ONLY);
-        for shard_id in &message.shard_ids {
-            let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
-
-            let nodes = if local_only {
-                vec![SearcherNode::This]
-            } else {
-                self.shard_selector.nodes_for_shard(&shard_id)
-            };
-
-            for node in &nodes {
-                debug!(?node, ?shard_id, "Attempting search");
-                let result = match node {
-                    SearcherNode::This => {
-                        shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone())
-                            .await
-                            .map(Response::new)
-                    }
-                    SearcherNode::Remote(hostname) => match self.get_client(hostname).await {
-                        Ok(mut client) => {
-                            let mut request = Request::new(message.clone());
-                            request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
-                            client.search(request).await.map_err(|e| match e.code() {
-                                tonic::Code::NotFound => NidxError::NotFound,
-                                _ => NidxError::Unknown(anyhow::Error::from(e)),
-                            })
-                        }
-                        Err(e) => Err(e),
-                    },
-                };
-                match result {
-                    Ok(response) => {
-                        responses.push(response);
-                        break;
-                    }
-                    Err(e) => {
-                        warn!(
-                            ?node,
-                            ?shard_id,
-                            concat!("Error in search, trying with next node: {:?}"),
-                            e
-                        );
-                        errors.push(e);
-                    }
-                }
+        if !message.multi_shard_search {
+            if message.shard_ids.is_empty() {
+                return Err(NidxError::invalid("requests must contain at least a shard id").into());
             }
+            let shard_id = uuid::Uuid::parse_str(&message.shard_ids[0]).map_err(NidxError::from)?;
+            shard_request! {
+                "search",
+                self,
+                request,
+                shard_id,
+                LOCAL => shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone()).await,
+                REMOTE => search
+            }
+        } else {
+            let mut errors = Vec::new();
+            let mut responses = Vec::with_capacity(message.shard_ids.len());
 
-            if !errors.is_empty() {
-                error!(
-                    ?errors,
-                    ?nodes,
-                    ?shard_id,
-                    "Error in search, exhausted all availabled nodes"
-                );
-                if let Some(reported_error) = errors.pop() {
-                    return Err(reported_error.into());
+            let local_only = request.metadata().contains_key(HEADER_LOCAL_ONLY);
+            for shard_id in &message.shard_ids {
+                let shard_id = uuid::Uuid::parse_str(shard_id).map_err(NidxError::from)?;
+
+                let nodes = if local_only {
+                    vec![SearcherNode::This]
                 } else {
-                    return Err(Status::internal("Unknown search error"));
+                    self.shard_selector.nodes_for_shard(&shard_id)
+                };
+
+                for node in &nodes {
+                    debug!(?node, ?shard_id, "Attempting search");
+                    let result = match node {
+                        SearcherNode::This => {
+                            shard_search::search(shard_id, Arc::clone(&self.index_cache), message.clone())
+                                .await
+                                .map(Response::new)
+                        }
+                        SearcherNode::Remote(hostname) => match self.get_client(hostname).await {
+                            Ok(mut client) => {
+                                let mut request = Request::new(message.clone());
+                                request.metadata_mut().insert(HEADER_LOCAL_ONLY, "1".parse().unwrap());
+                                client.search(request).await.map_err(|e| match e.code() {
+                                    tonic::Code::NotFound => NidxError::NotFound,
+                                    _ => NidxError::Unknown(anyhow::Error::from(e)),
+                                })
+                            }
+                            Err(e) => Err(e),
+                        },
+                    };
+                    match result {
+                        Ok(response) => {
+                            responses.push(response);
+                            break;
+                        }
+                        Err(e) => {
+                            warn!(
+                                ?node,
+                                ?shard_id,
+                                concat!("Error in search, trying with next node: {:?}"),
+                                e
+                            );
+                            errors.push(e);
+                        }
+                    }
+                }
+
+                if !errors.is_empty() {
+                    error!(
+                        ?errors,
+                        ?nodes,
+                        ?shard_id,
+                        "Error in search, exhausted all availabled nodes"
+                    );
+                    if let Some(reported_error) = errors.pop() {
+                        return Err(reported_error.into());
+                    } else {
+                        return Err(Status::internal("Unknown search error"));
+                    }
                 }
             }
-        }
 
-        let merged = shard_merge::merge(
-            responses.into_iter().map(|r| r.into_inner()).collect(),
-            OrderBy::from(message),
-            Limit(message.result_per_page as usize),
-        );
-        Ok(Response::new(merged))
+            let merged = shard_merge::merge(
+                responses.into_iter().map(|r| r.into_inner()).collect(),
+                OrderBy::from(message),
+                Limit(message.result_per_page as usize),
+            );
+            Ok(Response::new(merged))
+        }
     }
 
     async fn suggest(&self, request: Request<SuggestRequest>) -> Result<Response<SuggestResponse>> {

--- a/nidx/src/searcher/query_planner.rs
+++ b/nidx/src/searcher/query_planner.rs
@@ -165,6 +165,7 @@ impl IndexQueries {
 
 /// A shard reader will use this plan to produce search results as efficiently as
 /// possible.
+#[derive(Clone)]
 pub struct QueryPlan {
     pub prefilter: Option<PreFilterRequest>,
     pub index_queries: IndexQueries,

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -93,27 +93,30 @@ fn merge_document_responses(
     let mut merged = DocumentSearchResponse::default();
 
     let mut facets = vec![];
+    let mut results = vec![];
     for response in responses {
         merged.total += response.total;
-        merged.results.extend(response.results);
         merged.query = response.query;
         merged.next_page = merged.next_page || response.next_page;
 
+        results.push(response.results.into_iter());
         facets.push(response.facets);
     }
+    merged.results = results
+        .into_iter()
+        .kmerge_by(sort_documents_fn(order_by))
+        .take(limit.0)
+        .collect();
     merged.facets = merge_facets(facets);
-
-    sort_documents(&mut merged.results, order_by);
-    merged.results.truncate(limit.0);
-
     merged
 }
 
-fn sort_documents(items: &mut [DocumentResult], order_by: OrderBy) {
+#[allow(clippy::type_complexity)]
+fn sort_documents_fn(order_by: OrderBy) -> Box<dyn Fn(&DocumentResult, &DocumentResult) -> bool> {
     match order_by.expr {
         SortExpr::Score => {
             debug_assert!(order_by.descending, "order by ascending score is not implemented");
-            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
+            Box::new(|a, b| match (a.sort_value, b.sort_value) {
                 (
                     Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: a_bm25,
@@ -123,26 +126,26 @@ fn sort_documents(items: &mut [DocumentResult], order_by: OrderBy) {
                         bm25: b_bm25,
                         booster: b_booster,
                     })),
-                ) => b_bm25.total_cmp(&a_bm25).then(b_booster.total_cmp(&a_booster)),
+                ) => a_bm25.total_cmp(&b_bm25).then(a_booster.total_cmp(&b_booster)).is_gt(),
                 _ => {
-                    unreachable!("index must return values with the same order_by as we have")
+                    unreachable!("index always return values with the same order_by as we have")
                 }
-            });
+            })
         }
-        SortExpr::Date => {
-            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
-                (Some(document_result::SortValue::Date(a)), Some(document_result::SortValue::Date(b))) => {
-                    if order_by.descending {
-                        b.seconds.cmp(&a.seconds).then(b.nanos.cmp(&a.nanos))
-                    } else {
-                        a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos))
-                    }
+        SortExpr::Date => Box::new(move |a, b| match (a.sort_value, b.sort_value) {
+            (Some(document_result::SortValue::Date(a)), Some(document_result::SortValue::Date(b))) => {
+                if order_by.descending {
+                    // Descending order: from future to past
+                    a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos)).is_gt()
+                } else {
+                    // Ascending order: from past to future
+                    a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos)).is_lt()
                 }
-                _ => {
-                    unreachable!("nidx_texts always indexes dates");
-                }
-            });
-        }
+            }
+            _ => {
+                unreachable!("index always return dates as always indexes them");
+            }
+        }),
     }
 }
 
@@ -154,31 +157,35 @@ fn merge_paragraph_responses(
     debug_assert!(!responses.is_empty(), "must pass at least 1 shard response");
     let mut merged = ParagraphSearchResponse::default();
 
+    let mut results = vec![];
     let mut facets = vec![];
     let mut ematches = HashSet::new();
     for response in responses {
         merged.total += response.total;
-        merged.results.extend(response.results);
         merged.query = response.query;
         merged.next_page = merged.next_page || response.next_page;
 
+        results.push(response.results.into_iter());
         ematches.extend(response.ematches);
         facets.push(response.facets);
     }
+    merged.results = results
+        .into_iter()
+        .kmerge_by(sort_paragraphs_fn(order_by))
+        .take(limit.0)
+        .collect();
     merged.facets = merge_facets(facets);
     merged.ematches = ematches.into_iter().collect();
-
-    sort_paragraphs(&mut merged.results, order_by);
-    merged.results.truncate(limit.0);
 
     merged
 }
 
-fn sort_paragraphs(items: &mut [ParagraphResult], order_by: OrderBy) {
+#[allow(clippy::type_complexity)]
+fn sort_paragraphs_fn(order_by: OrderBy) -> Box<dyn Fn(&ParagraphResult, &ParagraphResult) -> bool> {
     match order_by.expr {
         SortExpr::Score => {
             debug_assert!(order_by.descending, "order by ascending score is not implemented");
-            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
+            Box::new(|a, b| match (a.sort_value, b.sort_value) {
                 (
                     Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: a_bm25,
@@ -188,25 +195,27 @@ fn sort_paragraphs(items: &mut [ParagraphResult], order_by: OrderBy) {
                         bm25: b_bm25,
                         booster: b_booster,
                     })),
-                ) => b_bm25.total_cmp(&a_bm25).then(b_booster.total_cmp(&a_booster)),
+                ) => a_bm25.total_cmp(&b_bm25).then(a_booster.total_cmp(&b_booster)).is_gt(),
                 _ => {
-                    unreachable!("index must return values with the same order_by as we have")
+                    unreachable!("index always return values with the same order_by as we have")
                 }
-            });
+            })
         }
         SortExpr::Date => {
-            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
+            Box::new(move |a, b| match (a.sort_value, b.sort_value) {
                 (Some(paragraph_result::SortValue::Date(a)), Some(paragraph_result::SortValue::Date(b))) => {
                     if order_by.descending {
-                        b.seconds.cmp(&a.seconds).then(b.nanos.cmp(&a.nanos))
+                        // Descending order: from future to past
+                        a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos)).is_gt()
                     } else {
-                        a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos))
+                        // Ascending order: from past to future
+                        a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos)).is_lt()
                     }
                 }
                 _ => {
-                    unreachable!("nidx_paragraph always indexes dates");
+                    unreachable!("index always return dates as always indexes them");
                 }
-            });
+            })
         }
     }
 }
@@ -564,13 +573,11 @@ mod tests {
                 ..Default::default()
             };
 
-            let shards = vec![
-                response(vec![document("foo", 3, 1), document("bar", 2, 2)]),
-                response(vec![document("baz", 4, 1), document("quux", 2, 1)]),
-            ];
-
             let merged = merge(
-                shards.clone(),
+                vec![
+                    response(vec![document("foo", 3, 1), document("bar", 2, 2)]),
+                    response(vec![document("baz", 4, 1), document("quux", 2, 1)]),
+                ],
                 OrderBy {
                     expr: SortExpr::Date,
                     descending: true,
@@ -586,7 +593,10 @@ mod tests {
             assert_eq!(merged.results[3].uuid, "quux");
 
             let merged = merge(
-                shards,
+                vec![
+                    response(vec![document("bar", 2, 2), document("foo", 3, 1)]),
+                    response(vec![document("quux", 2, 1), document("baz", 4, 1)]),
+                ],
                 OrderBy {
                     expr: SortExpr::Date,
                     descending: false,
@@ -851,13 +861,11 @@ mod tests {
                 ..Default::default()
             };
 
-            let shards = vec![
-                response(vec![paragraph("foo", 3, 1), paragraph("bar", 2, 2)]),
-                response(vec![paragraph("baz", 4, 1), paragraph("quux", 2, 1)]),
-            ];
-
             let merged = merge(
-                shards.clone(),
+                vec![
+                    response(vec![paragraph("foo", 3, 1), paragraph("bar", 2, 2)]),
+                    response(vec![paragraph("baz", 4, 1), paragraph("quux", 2, 1)]),
+                ],
                 OrderBy {
                     expr: SortExpr::Date,
                     descending: true,
@@ -873,7 +881,10 @@ mod tests {
             assert_eq!(merged.results[3].uuid, "quux");
 
             let merged = merge(
-                shards,
+                vec![
+                    response(vec![paragraph("bar", 2, 2), paragraph("foo", 3, 1)]),
+                    response(vec![paragraph("quux", 2, 1), paragraph("baz", 4, 1)]),
+                ],
                 OrderBy {
                     expr: SortExpr::Date,
                     descending: false,

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -15,6 +15,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use itertools::Itertools;
 use nidx_protos::{
     DocumentResult, DocumentSearchResponse, FacetResult, FacetResults, GraphSearchResponse, ParagraphResult,
     ParagraphSearchResponse, SearchRequest, SearchResponse, VectorSearchResponse, document_result, order_by,
@@ -212,16 +213,13 @@ fn sort_paragraphs(items: &mut [ParagraphResult], order_by: OrderBy) {
 
 fn merge_vector_responses(responses: Vec<VectorSearchResponse>, limit: Limit) -> VectorSearchResponse {
     debug_assert!(!responses.is_empty(), "must pass at least 1 shard response");
-    let mut merged = VectorSearchResponse::default();
-
-    // TODO: sort-merge and stop when limit is reached would be faster
-    for response in responses {
-        merged.documents.extend(response.documents);
-    }
-    merged.documents.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
-    merged.documents.truncate(limit.0);
-
-    merged
+    let merged = responses
+        .into_iter()
+        .map(|response| response.documents)
+        .kmerge_by(|a, b| a.score >= b.score)
+        .take(limit.0)
+        .collect();
+    VectorSearchResponse { documents: merged }
 }
 
 fn merge_graph_responses(responses: Vec<GraphSearchResponse>, _limit: Limit) -> GraphSearchResponse {

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -44,12 +44,15 @@ pub struct Limit(pub usize);
 /// (this is validated before searching, so we don't care much here)
 ///
 pub fn merge(shard_responses: Vec<SearchResponse>, order_by: OrderBy, limit: Limit) -> SearchResponse {
+    let mut shard_ids = vec![];
     let mut document_responses = Vec::with_capacity(shard_responses.len());
     let mut paragraph_responses = Vec::with_capacity(shard_responses.len());
     let mut vector_responses = Vec::with_capacity(shard_responses.len());
     let mut graph_responses = Vec::with_capacity(shard_responses.len());
 
     for response in shard_responses {
+        shard_ids.extend(response.shard_ids);
+
         if let Some(document) = response.document {
             document_responses.push(document);
         }
@@ -72,6 +75,7 @@ pub fn merge(shard_responses: Vec<SearchResponse>, order_by: OrderBy, limit: Lim
     let graph = (!graph_responses.is_empty()).then(|| merge_graph_responses(graph_responses, limit));
 
     SearchResponse {
+        shard_ids,
         document,
         paragraph,
         vector,
@@ -334,6 +338,7 @@ mod tests {
         assert!(merged.graph.is_none());
 
         let empty = SearchResponse {
+            shard_ids: vec![],
             document: None,
             paragraph: None,
             vector: None,

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -289,7 +289,7 @@ impl From<&SearchRequest> for OrderBy {
             Some(order) => {
                 let descending = match order.r#type() {
                     order_by::OrderType::Desc => true,
-                    order_by::OrderType::Asc => true,
+                    order_by::OrderType::Asc => false,
                 };
                 Self {
                     expr: SortExpr::Date,

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -112,7 +112,7 @@ fn sort_documents(items: &mut [DocumentResult], order_by: OrderBy) {
     match order_by.expr {
         SortExpr::Score => {
             debug_assert!(order_by.descending, "order by ascending score is not implemented");
-            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
                 (
                     Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: a_bm25,
@@ -129,7 +129,7 @@ fn sort_documents(items: &mut [DocumentResult], order_by: OrderBy) {
             });
         }
         SortExpr::Date => {
-            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
                 (Some(document_result::SortValue::Date(a)), Some(document_result::SortValue::Date(b))) => {
                     if order_by.descending {
                         b.seconds.cmp(&a.seconds).then(b.nanos.cmp(&a.nanos))
@@ -177,7 +177,7 @@ fn sort_paragraphs(items: &mut [ParagraphResult], order_by: OrderBy) {
     match order_by.expr {
         SortExpr::Score => {
             debug_assert!(order_by.descending, "order by ascending score is not implemented");
-            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
                 (
                     Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: a_bm25,
@@ -194,7 +194,7 @@ fn sort_paragraphs(items: &mut [ParagraphResult], order_by: OrderBy) {
             });
         }
         SortExpr::Date => {
-            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+            items.sort_by(|a, b| match (a.sort_value, b.sort_value) {
                 (Some(paragraph_result::SortValue::Date(a)), Some(paragraph_result::SortValue::Date(b))) => {
                     if order_by.descending {
                         b.seconds.cmp(&a.seconds).then(b.nanos.cmp(&a.nanos))

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -1,0 +1,1069 @@
+// Copyright 2021 Bosutech XXI S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::{HashMap, HashSet};
+
+use nidx_protos::{
+    DocumentResult, DocumentSearchResponse, FacetResult, FacetResults, GraphSearchResponse, ParagraphResult,
+    ParagraphSearchResponse, SearchRequest, SearchResponse, VectorSearchResponse, document_result, order_by,
+    paragraph_result,
+};
+
+#[derive(Clone, Copy)]
+pub struct OrderBy {
+    expr: SortExpr,
+    descending: bool,
+}
+
+#[derive(Clone, Copy)]
+pub enum SortExpr {
+    Score,
+    Date,
+}
+
+#[derive(Clone, Copy)]
+pub struct Limit(pub usize);
+
+/// Merge mulitiple shard responses into a single one. During the process,
+/// results keep the original request sort order and an extra limit is applied
+/// to remove unnecessary results
+///
+/// Note however that date ordering is only possible on fulltext/keyword search
+/// (this is validated before searching, so we don't care much here)
+///
+pub fn merge(shard_responses: Vec<SearchResponse>, order_by: OrderBy, limit: Limit) -> SearchResponse {
+    let mut document_responses = Vec::with_capacity(shard_responses.len());
+    let mut paragraph_responses = Vec::with_capacity(shard_responses.len());
+    let mut vector_responses = Vec::with_capacity(shard_responses.len());
+    let mut graph_responses = Vec::with_capacity(shard_responses.len());
+
+    for response in shard_responses {
+        if let Some(document) = response.document {
+            document_responses.push(document);
+        }
+        if let Some(paragraph) = response.paragraph {
+            paragraph_responses.push(paragraph);
+        }
+        if let Some(vector) = response.vector {
+            vector_responses.push(vector);
+        }
+        if let Some(graph) = response.graph {
+            graph_responses.push(graph);
+        }
+    }
+
+    let document =
+        (!document_responses.is_empty()).then(|| merge_document_responses(document_responses, order_by, limit));
+    let paragraph =
+        (!paragraph_responses.is_empty()).then(|| merge_paragraph_responses(paragraph_responses, order_by, limit));
+    let vector = (!vector_responses.is_empty()).then(|| merge_vector_responses(vector_responses, limit));
+    let graph = (!graph_responses.is_empty()).then(|| merge_graph_responses(graph_responses, limit));
+
+    SearchResponse {
+        document,
+        paragraph,
+        vector,
+        graph,
+    }
+}
+
+fn merge_document_responses(
+    responses: Vec<DocumentSearchResponse>,
+    order_by: OrderBy,
+    limit: Limit,
+) -> DocumentSearchResponse {
+    debug_assert!(!responses.is_empty(), "must pass at least 1 shard response");
+    let mut merged = DocumentSearchResponse::default();
+
+    let mut facets = vec![];
+    for response in responses {
+        merged.total += response.total;
+        merged.results.extend(response.results);
+        merged.query = response.query;
+        merged.next_page = merged.next_page || response.next_page;
+
+        facets.push(response.facets);
+    }
+    merged.facets = merge_facets(facets);
+
+    sort_documents(&mut merged.results, order_by);
+    merged.results.truncate(limit.0);
+
+    merged
+}
+
+fn sort_documents(items: &mut [DocumentResult], order_by: OrderBy) {
+    match order_by.expr {
+        SortExpr::Score => {
+            debug_assert!(order_by.descending, "order by ascending score is not implemented");
+            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+                (
+                    Some(document_result::SortValue::Score(nidx_protos::ResultScore {
+                        bm25: a_bm25,
+                        booster: a_booster,
+                    })),
+                    Some(document_result::SortValue::Score(nidx_protos::ResultScore {
+                        bm25: b_bm25,
+                        booster: b_booster,
+                    })),
+                ) => b_bm25.total_cmp(&a_bm25).then(b_booster.total_cmp(&a_booster)),
+                _ => {
+                    unreachable!("index must return values with the same order_by as we have")
+                }
+            });
+        }
+        SortExpr::Date => {
+            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+                (Some(document_result::SortValue::Date(a)), Some(document_result::SortValue::Date(b))) => {
+                    if order_by.descending {
+                        b.seconds.cmp(&a.seconds).then(b.nanos.cmp(&a.nanos))
+                    } else {
+                        a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos))
+                    }
+                }
+                _ => {
+                    unreachable!("nidx_texts always indexes dates");
+                }
+            });
+        }
+    }
+}
+
+fn merge_paragraph_responses(
+    responses: Vec<ParagraphSearchResponse>,
+    order_by: OrderBy,
+    limit: Limit,
+) -> ParagraphSearchResponse {
+    debug_assert!(!responses.is_empty(), "must pass at least 1 shard response");
+    let mut merged = ParagraphSearchResponse::default();
+
+    let mut facets = vec![];
+    let mut ematches = HashSet::new();
+    for response in responses {
+        merged.total += response.total;
+        merged.results.extend(response.results);
+        merged.query = response.query;
+        merged.next_page = merged.next_page || response.next_page;
+
+        ematches.extend(response.ematches);
+        facets.push(response.facets);
+    }
+    merged.facets = merge_facets(facets);
+    merged.ematches = ematches.into_iter().collect();
+
+    sort_paragraphs(&mut merged.results, order_by);
+    merged.results.truncate(limit.0);
+
+    merged
+}
+
+fn sort_paragraphs(items: &mut [ParagraphResult], order_by: OrderBy) {
+    match order_by.expr {
+        SortExpr::Score => {
+            debug_assert!(order_by.descending, "order by ascending score is not implemented");
+            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+                (
+                    Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
+                        bm25: a_bm25,
+                        booster: a_booster,
+                    })),
+                    Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
+                        bm25: b_bm25,
+                        booster: b_booster,
+                    })),
+                ) => b_bm25.total_cmp(&a_bm25).then(b_booster.total_cmp(&a_booster)),
+                _ => {
+                    unreachable!("index must return values with the same order_by as we have")
+                }
+            });
+        }
+        SortExpr::Date => {
+            items.sort_unstable_by(|a, b| match (a.sort_value, b.sort_value) {
+                (Some(paragraph_result::SortValue::Date(a)), Some(paragraph_result::SortValue::Date(b))) => {
+                    if order_by.descending {
+                        b.seconds.cmp(&a.seconds).then(b.nanos.cmp(&a.nanos))
+                    } else {
+                        a.seconds.cmp(&b.seconds).then(a.nanos.cmp(&b.nanos))
+                    }
+                }
+                _ => {
+                    unreachable!("nidx_paragraph always indexes dates");
+                }
+            });
+        }
+    }
+}
+
+fn merge_vector_responses(responses: Vec<VectorSearchResponse>, limit: Limit) -> VectorSearchResponse {
+    debug_assert!(!responses.is_empty(), "must pass at least 1 shard response");
+    let mut merged = VectorSearchResponse::default();
+
+    // TODO: sort-merge and stop when limit is reached would be faster
+    for response in responses {
+        merged.documents.extend(response.documents);
+    }
+    merged.documents.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
+    merged.documents.truncate(limit.0);
+
+    merged
+}
+
+fn merge_graph_responses(responses: Vec<GraphSearchResponse>, _limit: Limit) -> GraphSearchResponse {
+    debug_assert!(!responses.is_empty(), "must pass at least 1 shard response");
+    let mut merged = GraphSearchResponse::default();
+
+    for response in responses {
+        let nodes_offset = merged.nodes.len() as u32;
+        let relations_offset = merged.relations.len() as u32;
+
+        // paths contain indexes to nodes and relations, we must offset them
+        // while merging responses to maintain valid data
+        for mut path in response.graph {
+            path.source += nodes_offset;
+            path.relation += relations_offset;
+            path.destination += nodes_offset;
+            merged.graph.push(path);
+        }
+
+        merged.nodes.extend(response.nodes);
+        merged.relations.extend(response.relations);
+        merged.scores.extend(response.scores);
+    }
+
+    // TODO: now that we have scores, we can cut. This is not implemented in Python though
+
+    merged
+}
+
+fn merge_facets(shards_facets: Vec<HashMap<String, FacetResults>>) -> HashMap<String, FacetResults> {
+    // Each shard produces a hashmap of the facet root to counts per actual
+    // facet, i.e., {"/l": [{tag: "/l/mylabel", total: 2}, ...], ...}.
+    //
+    // We must merge updating counts for the same facet in different shards
+
+    let mut counts = HashMap::new();
+    for facets in shards_facets {
+        for (group, values) in facets {
+            for facet_result in values.facetresults {
+                counts
+                    .entry((group.clone(), facet_result.tag))
+                    .and_modify(|total| *total += facet_result.total)
+                    .or_insert(facet_result.total);
+            }
+        }
+    }
+
+    let mut merged = HashMap::new();
+    for ((group, tag), total) in counts {
+        merged
+            .entry(group)
+            .and_modify(|facet_results: &mut FacetResults| {
+                facet_results.facetresults.push(FacetResult {
+                    tag: tag.clone(),
+                    total,
+                })
+            })
+            .or_insert(FacetResults {
+                facetresults: vec![FacetResult { tag, total }],
+            });
+    }
+
+    merged
+}
+
+impl From<&SearchRequest> for OrderBy {
+    fn from(value: &SearchRequest) -> Self {
+        match value.order {
+            Some(order) => {
+                let descending = match order.r#type() {
+                    order_by::OrderType::Desc => true,
+                    order_by::OrderType::Asc => true,
+                };
+                Self {
+                    expr: SortExpr::Date,
+                    descending,
+                }
+            }
+            // without explicit order, the greater the score, the most important
+            None => Self {
+                expr: SortExpr::Score,
+                descending: true,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+impl Default for OrderBy {
+    fn default() -> Self {
+        Self {
+            expr: SortExpr::Score,
+            descending: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use nidx_protos::{FacetResult, FacetResults, SearchResponse};
+
+    use crate::searcher::shard_merge::{Limit, OrderBy};
+
+    use super::merge;
+
+    #[test]
+    fn test_merge_nothing() {
+        let merged = merge(vec![], OrderBy::default(), Limit(20));
+        assert!(merged.document.is_none());
+        assert!(merged.paragraph.is_none());
+        assert!(merged.vector.is_none());
+        assert!(merged.graph.is_none());
+
+        let empty = SearchResponse {
+            document: None,
+            paragraph: None,
+            vector: None,
+            graph: None,
+        };
+        let merged = merge(vec![empty.clone(), empty], OrderBy::default(), Limit(20));
+        assert!(merged.document.is_none());
+        assert!(merged.paragraph.is_none());
+        assert!(merged.vector.is_none());
+        assert!(merged.graph.is_none());
+    }
+
+    mod documents {
+        use nidx_protos::document_result;
+        use nidx_protos::prost_types::Timestamp;
+        use nidx_protos::{DocumentResult, DocumentSearchResponse, FacetResult, SearchResponse};
+
+        use crate::searcher::shard_merge::OrderBy;
+        use crate::searcher::shard_merge::{Limit, SortExpr};
+
+        use super::merge;
+        use super::proto_facets;
+
+        #[test]
+        fn test_merge_documents_query() {
+            let document = |query: &str| SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    query: query.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `query` is taken from any request. As the fulltext query is common
+            // across shards, it shouldn't mind which one to pick
+
+            let merged = merge(
+                vec![document("my query"), document("my query")],
+                OrderBy::default(),
+                Limit(20),
+            );
+            assert_eq!(merged.document.unwrap().query, "my query");
+
+            let merged = merge(
+                vec![document("my query"), document("my second query")],
+                OrderBy::default(),
+                Limit(20),
+            );
+            assert!(
+                merged.document.as_ref().unwrap().query == "my query"
+                    || merged.document.as_ref().unwrap().query == "my second query"
+            )
+        }
+
+        #[test]
+        fn test_merge_documents_total() {
+            let document = |total: i32| SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    total,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `total` is the count of matched documents (not necessarily
+            // returned). The merged value is the sum of all
+
+            let merged = merge(vec![document(10), document(15)], OrderBy::default(), Limit(20));
+            assert_eq!(merged.document.unwrap().total, 25);
+
+            let merged = merge(vec![document(0), document(15)], OrderBy::default(), Limit(20));
+            assert_eq!(merged.document.unwrap().total, 15);
+
+            let merged = merge(vec![document(0), document(0)], OrderBy::default(), Limit(20));
+            assert_eq!(merged.document.unwrap().total, 0);
+        }
+
+        #[test]
+        fn test_merge_documents_next_page() {
+            let document = |next_page: bool| SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    next_page,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `next_page` is true if any shard has next_page as true
+            for a in [false, true] {
+                for b in [false, true] {
+                    let merged = merge(vec![document(a), document(b)], OrderBy::default(), Limit(20));
+                    assert_eq!(merged.document.unwrap().next_page, a | b);
+                }
+            }
+        }
+
+        #[test]
+        fn test_merge_documents_facets() {
+            let document = |facets: Vec<(&str, i32)>| SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    facets: proto_facets(facets),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `facets` are aggregated and counts are added together
+
+            let merged = merge(
+                vec![
+                    document(vec![("/l/label-A", 10), ("/l/label-B", 5)]),
+                    document(vec![("/l/label-A", 3), ("/l/label-C", 7), ("/e/table", 12)]),
+                    document(vec![("/e/chair", 3), ("/e/table", 20)]),
+                ],
+                OrderBy::default(),
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.facets["/l"].facetresults.len(), 3);
+            assert!(merged.facets["/l"].facetresults.contains(&FacetResult {
+                tag: "/l/label-A".to_string(),
+                total: 13
+            }));
+            assert!(merged.facets["/l"].facetresults.contains(&FacetResult {
+                tag: "/l/label-B".to_string(),
+                total: 5
+            }));
+            assert!(merged.facets["/l"].facetresults.contains(&FacetResult {
+                tag: "/l/label-C".to_string(),
+                total: 7
+            }));
+            assert_eq!(merged.facets["/e"].facetresults.len(), 2);
+            assert!(merged.facets["/e"].facetresults.contains(&FacetResult {
+                tag: "/e/chair".to_string(),
+                total: 3
+            }));
+            assert!(merged.facets["/e"].facetresults.contains(&FacetResult {
+                tag: "/e/table".to_string(),
+                total: 32
+            }));
+        }
+
+        #[test]
+        fn test_merge_documents_with_limit() {
+            let shard = SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    results: vec![
+                        DocumentResult {
+                            sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore::default())),
+                            ..Default::default()
+                        };
+                        20
+                    ],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let merged = merge(vec![shard.clone(), shard.clone()], OrderBy::default(), Limit(50))
+                .document
+                .unwrap();
+            assert_eq!(merged.results.len(), 40);
+
+            let merged = merge(vec![shard.clone(), shard.clone()], OrderBy::default(), Limit(20))
+                .document
+                .unwrap();
+            assert_eq!(merged.results.len(), 20);
+        }
+
+        #[test]
+        fn test_merge_document_results_by_score() {
+            let document = |rid: &str, score: f32, booster: f32| DocumentResult {
+                uuid: rid.to_string(),
+                field: "a/title".to_string(),
+                sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore {
+                    bm25: score,
+                    booster,
+                })),
+                ..Default::default()
+            };
+            let response = |documents: Vec<DocumentResult>| SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    total: 100,
+                    results: documents,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let merged = merge(
+                vec![
+                    response(vec![document("foo", 3.0, 1.0), document("bar", 2.0, 2.0)]),
+                    response(vec![document("baz", 4.0, 1.0), document("quux", 2.0, 1.0)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.results.len(), 4);
+            assert_eq!(merged.results[0].uuid, "baz");
+            assert_eq!(merged.results[1].uuid, "foo");
+            assert_eq!(merged.results[2].uuid, "bar");
+            assert_eq!(merged.results[3].uuid, "quux");
+        }
+
+        #[test]
+        fn test_merge_document_results_by_date() {
+            let document = |rid: &str, seconds: i64, nanos: i32| DocumentResult {
+                uuid: rid.to_string(),
+                field: "a/title".to_string(),
+                sort_value: Some(document_result::SortValue::Date(Timestamp { seconds, nanos })),
+                ..Default::default()
+            };
+            let response = |documents: Vec<DocumentResult>| SearchResponse {
+                document: Some(DocumentSearchResponse {
+                    total: 100,
+                    results: documents,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let shards = vec![
+                response(vec![document("foo", 3, 1), document("bar", 2, 2)]),
+                response(vec![document("baz", 4, 1), document("quux", 2, 1)]),
+            ];
+
+            let merged = merge(
+                shards.clone(),
+                OrderBy {
+                    expr: SortExpr::Date,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.results.len(), 4);
+            assert_eq!(merged.results[0].uuid, "baz");
+            assert_eq!(merged.results[1].uuid, "foo");
+            assert_eq!(merged.results[2].uuid, "bar");
+            assert_eq!(merged.results[3].uuid, "quux");
+
+            let merged = merge(
+                shards,
+                OrderBy {
+                    expr: SortExpr::Date,
+                    descending: false,
+                },
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.results.len(), 4);
+            assert_eq!(merged.results[0].uuid, "quux");
+            assert_eq!(merged.results[1].uuid, "bar");
+            assert_eq!(merged.results[2].uuid, "foo");
+            assert_eq!(merged.results[3].uuid, "baz");
+        }
+    }
+
+    mod paragraphs {
+        use nidx_protos::prost_types::Timestamp;
+        use nidx_protos::{FacetResult, ParagraphSearchResponse, SearchResponse};
+        use nidx_protos::{ParagraphResult, paragraph_result};
+
+        use crate::searcher::shard_merge::OrderBy;
+        use crate::searcher::shard_merge::{Limit, SortExpr};
+
+        use super::merge;
+        use super::proto_facets;
+
+        #[test]
+        fn test_merge_paragraphs_query() {
+            let paragraph = |query: &str| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    query: query.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `query` is taken from any request. As the keyword query is common
+            // across shards, it shouldn't mind which one to pick
+
+            let merged = merge(
+                vec![paragraph("my query"), paragraph("my query")],
+                OrderBy::default(),
+                Limit(20),
+            );
+            assert_eq!(merged.paragraph.unwrap().query, "my query");
+
+            let merged = merge(
+                vec![paragraph("my query"), paragraph("my second query")],
+                OrderBy::default(),
+                Limit(20),
+            );
+            assert!(
+                merged.paragraph.as_ref().unwrap().query == "my query"
+                    || merged.paragraph.as_ref().unwrap().query == "my second query"
+            )
+        }
+
+        #[test]
+        fn test_merge_paragraphs_total() {
+            let paragraph = |total: i32| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    total,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `total` is the count of matched paragraphs (not necessarily
+            // returned). The merged value is the sum of all
+
+            let merged = merge(vec![paragraph(10), paragraph(15)], OrderBy::default(), Limit(20));
+            assert_eq!(merged.paragraph.unwrap().total, 25);
+
+            let merged = merge(vec![paragraph(0), paragraph(15)], OrderBy::default(), Limit(20));
+            assert_eq!(merged.paragraph.unwrap().total, 15);
+
+            let merged = merge(vec![paragraph(0), paragraph(0)], OrderBy::default(), Limit(20));
+            assert_eq!(merged.paragraph.unwrap().total, 0);
+        }
+
+        #[test]
+        fn test_merge_paragraphs_next_page() {
+            let paragraph = |next_page: bool| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    next_page,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `next_page` is true if any shard has next_page as true
+            for a in [false, true] {
+                for b in [false, true] {
+                    let merged = merge(vec![paragraph(a), paragraph(b)], OrderBy::default(), Limit(20));
+                    assert_eq!(merged.paragraph.unwrap().next_page, a | b);
+                }
+            }
+        }
+
+        #[test]
+        fn test_merge_paragraphs_facets() {
+            let paragraph = |facets: Vec<(&str, i32)>| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    facets: proto_facets(facets),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `facets` are aggregated and counts are added together
+
+            let merged = merge(
+                vec![
+                    paragraph(vec![("/l/label-A", 10), ("/l/label-B", 5)]),
+                    paragraph(vec![("/l/label-A", 3), ("/l/label-C", 7), ("/e/table", 12)]),
+                    paragraph(vec![("/e/chair", 3), ("/e/table", 20)]),
+                ],
+                OrderBy::default(),
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.facets["/l"].facetresults.len(), 3);
+            assert!(merged.facets["/l"].facetresults.contains(&FacetResult {
+                tag: "/l/label-A".to_string(),
+                total: 13
+            }));
+            assert!(merged.facets["/l"].facetresults.contains(&FacetResult {
+                tag: "/l/label-B".to_string(),
+                total: 5
+            }));
+            assert!(merged.facets["/l"].facetresults.contains(&FacetResult {
+                tag: "/l/label-C".to_string(),
+                total: 7
+            }));
+            assert_eq!(merged.facets["/e"].facetresults.len(), 2);
+            assert!(merged.facets["/e"].facetresults.contains(&FacetResult {
+                tag: "/e/chair".to_string(),
+                total: 3
+            }));
+            assert!(merged.facets["/e"].facetresults.contains(&FacetResult {
+                tag: "/e/table".to_string(),
+                total: 32
+            }));
+        }
+
+        #[test]
+        fn test_merge_paragraphs_ematches() {
+            let paragraph = |ematches: Vec<String>| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    ematches,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // `ematches` are aggregated without repetition
+
+            let merged = merge(
+                vec![
+                    paragraph(vec!["A".to_string(), "B".to_string(), "C".to_string()]),
+                    paragraph(vec!["A".to_string(), "D".to_string(), "E".to_string()]),
+                    paragraph(vec!["F".to_string(), "G".to_string(), "A".to_string()]),
+                ],
+                OrderBy::default(),
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.ematches.len(), 7);
+            assert!(merged.ematches.contains(&"A".to_string()));
+            assert!(merged.ematches.contains(&"B".to_string()));
+            assert!(merged.ematches.contains(&"C".to_string()));
+            assert!(merged.ematches.contains(&"D".to_string()));
+            assert!(merged.ematches.contains(&"E".to_string()));
+            assert!(merged.ematches.contains(&"F".to_string()));
+            assert!(merged.ematches.contains(&"G".to_string()));
+        }
+
+        #[test]
+        fn test_merge_paragraphs_with_limit() {
+            let shard = SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    results: vec![
+                        ParagraphResult {
+                            sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore::default())),
+                            ..Default::default()
+                        };
+                        20
+                    ],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let merged = merge(vec![shard.clone(), shard.clone()], OrderBy::default(), Limit(50))
+                .paragraph
+                .unwrap();
+            assert_eq!(merged.results.len(), 40);
+
+            let merged = merge(vec![shard.clone(), shard.clone()], OrderBy::default(), Limit(20))
+                .paragraph
+                .unwrap();
+            assert_eq!(merged.results.len(), 20);
+        }
+
+        #[test]
+        fn test_merge_paragraph_results_by_score() {
+            let paragraph = |rid: &str, score: f32, booster: f32| ParagraphResult {
+                uuid: rid.to_string(),
+                field: "a/title".to_string(),
+                sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
+                    bm25: score,
+                    booster,
+                })),
+                ..Default::default()
+            };
+            let response = |paragraphs: Vec<ParagraphResult>| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    total: 100,
+                    results: paragraphs,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let merged = merge(
+                vec![
+                    response(vec![paragraph("foo", 3.0, 1.0), paragraph("bar", 2.0, 2.0)]),
+                    response(vec![paragraph("baz", 4.0, 1.0), paragraph("quux", 2.0, 1.0)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.results.len(), 4);
+            assert_eq!(merged.results[0].uuid, "baz");
+            assert_eq!(merged.results[1].uuid, "foo");
+            assert_eq!(merged.results[2].uuid, "bar");
+            assert_eq!(merged.results[3].uuid, "quux");
+        }
+
+        #[test]
+        fn test_merge_paragraph_results_by_date() {
+            let paragraph = |rid: &str, seconds: i64, nanos: i32| ParagraphResult {
+                uuid: rid.to_string(),
+                field: "a/title".to_string(),
+                sort_value: Some(paragraph_result::SortValue::Date(Timestamp { seconds, nanos })),
+                ..Default::default()
+            };
+            let response = |paragraphs: Vec<ParagraphResult>| SearchResponse {
+                paragraph: Some(ParagraphSearchResponse {
+                    total: 100,
+                    results: paragraphs,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let shards = vec![
+                response(vec![paragraph("foo", 3, 1), paragraph("bar", 2, 2)]),
+                response(vec![paragraph("baz", 4, 1), paragraph("quux", 2, 1)]),
+            ];
+
+            let merged = merge(
+                shards.clone(),
+                OrderBy {
+                    expr: SortExpr::Date,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.results.len(), 4);
+            assert_eq!(merged.results[0].uuid, "baz");
+            assert_eq!(merged.results[1].uuid, "foo");
+            assert_eq!(merged.results[2].uuid, "bar");
+            assert_eq!(merged.results[3].uuid, "quux");
+
+            let merged = merge(
+                shards,
+                OrderBy {
+                    expr: SortExpr::Date,
+                    descending: false,
+                },
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.results.len(), 4);
+            assert_eq!(merged.results[0].uuid, "quux");
+            assert_eq!(merged.results[1].uuid, "bar");
+            assert_eq!(merged.results[2].uuid, "foo");
+            assert_eq!(merged.results[3].uuid, "baz");
+        }
+    }
+
+    mod vectors {
+        use nidx_protos::{DocumentScored, DocumentVectorIdentifier, SearchResponse, VectorSearchResponse};
+
+        use crate::searcher::shard_merge::{Limit, OrderBy};
+
+        use super::merge;
+
+        #[test]
+        fn test_merge_vector_results() {
+            let vector = |id: &str, score: f32| DocumentScored {
+                doc_id: Some(DocumentVectorIdentifier { id: id.to_string() }),
+                score,
+                metadata: None,
+                labels: vec![],
+            };
+            let response = |documents: Vec<DocumentScored>| SearchResponse {
+                vector: Some(VectorSearchResponse { documents }),
+                ..Default::default()
+            };
+
+            // merged results keep scoring order
+
+            let shards = vec![
+                response(vec![vector("a", 1.0), vector("b", 0.5)]),
+                response(vec![vector("c", 3.2), vector("d", 0.9)]),
+            ];
+
+            let merged = merge(shards.clone(), OrderBy::default(), Limit(20)).vector.unwrap();
+            assert_eq!(merged.documents[0].doc_id.as_ref().unwrap().id, "c");
+            assert_eq!(merged.documents[1].doc_id.as_ref().unwrap().id, "a");
+            assert_eq!(merged.documents[2].doc_id.as_ref().unwrap().id, "d");
+            assert_eq!(merged.documents[3].doc_id.as_ref().unwrap().id, "b");
+
+            let merged = merge(shards.clone(), OrderBy::default(), Limit(2)).vector.unwrap();
+            assert_eq!(merged.documents[0].doc_id.as_ref().unwrap().id, "c");
+            assert_eq!(merged.documents[1].doc_id.as_ref().unwrap().id, "a");
+        }
+    }
+
+    mod graphs {
+        use nidx_protos::{
+            GraphSearchResponse, RelationNode, SearchResponse, graph_search_response, relation::RelationType,
+            relation_node,
+        };
+
+        use crate::searcher::shard_merge::{Limit, OrderBy};
+
+        use super::merge;
+
+        #[test]
+        fn test_merge_graph_results() {
+            let cat = RelationNode {
+                value: "cat".to_string(),
+                ntype: relation_node::NodeType::Entity.into(),
+                subtype: "animals".to_string(),
+            };
+            let dog = RelationNode {
+                value: "dog".to_string(),
+                ntype: relation_node::NodeType::Entity.into(),
+                subtype: "animals".to_string(),
+            };
+            let table = RelationNode {
+                value: "table".to_string(),
+                ntype: relation_node::NodeType::Entity.into(),
+                subtype: "objects".to_string(),
+            };
+
+            let love = graph_search_response::Relation {
+                relation_type: RelationType::Entity.into(),
+                label: "love".to_string(),
+            };
+            let jump = graph_search_response::Relation {
+                relation_type: RelationType::Entity.into(),
+                label: "jump".to_string(),
+            };
+
+            let path = |source, relation, destination| graph_search_response::Path {
+                source,
+                relation,
+                destination,
+                ..Default::default()
+            };
+
+            let merged = merge(
+                vec![
+                    SearchResponse {
+                        graph: Some(GraphSearchResponse {
+                            nodes: vec![cat.clone(), dog.clone()],
+                            relations: vec![love.clone()],
+                            graph: vec![
+                                // cat -love-> dog
+                                path(0, 0, 1),
+                                // dog -love-> cat
+                                path(1, 0, 1),
+                            ],
+                            scores: vec![0.5, 0.8],
+                        }),
+                        ..Default::default()
+                    },
+                    SearchResponse {
+                        graph: Some(GraphSearchResponse {
+                            nodes: vec![table, cat, dog],
+                            relations: vec![jump, love],
+                            graph: vec![
+                                // cat -love-> dog
+                                path(1, 1, 2),
+                                // cat -love-> table
+                                path(1, 1, 0),
+                                // cat -jump-> table
+                                path(1, 0, 0),
+                            ],
+                            scores: vec![0.3, 0.9, 0.7],
+                        }),
+                        ..Default::default()
+                    },
+                ],
+                OrderBy::default(),
+                Limit(20),
+            )
+            .graph
+            .unwrap();
+
+            assert_eq!(merged.nodes.len(), 2 + 3);
+            assert_eq!(merged.nodes[0].value, "cat");
+            assert_eq!(merged.nodes[0].ntype, relation_node::NodeType::Entity as i32);
+            assert_eq!(merged.nodes[0].subtype, "animals");
+            assert_eq!(merged.nodes[1].value, "dog");
+            assert_eq!(merged.nodes[2].value, "table");
+            // merging doesn't dedup nodes
+            assert_eq!(merged.nodes[3].value, "cat");
+            assert_eq!(merged.nodes[4].value, "dog");
+
+            assert_eq!(merged.relations.len(), 1 + 2);
+            assert_eq!(merged.relations[0].label, "love");
+            assert_eq!(merged.relations[1].label, "jump");
+            // nor relations
+            assert_eq!(merged.relations[2].label, "love");
+
+            assert_eq!(merged.graph.len(), 2 + 3);
+            let path_indexes = |path: &graph_search_response::Path| (path.source, path.relation, path.destination);
+            assert_eq!(path_indexes(&merged.graph[0]), (0, 0, 1));
+            assert_eq!(path_indexes(&merged.graph[1]), (1, 0, 1));
+            // merge has offset the node/relation index for this shard paths
+            assert_eq!(path_indexes(&merged.graph[2]), (3, 2, 4));
+            assert_eq!(path_indexes(&merged.graph[3]), (3, 2, 2));
+            assert_eq!(path_indexes(&merged.graph[4]), (3, 1, 2));
+
+            assert_eq!(merged.scores.len(), 2 + 3);
+            assert_eq!(merged.scores, vec![0.5, 0.8, 0.3, 0.9, 0.7]);
+        }
+    }
+
+    // Given a list of facets and counts, extract the root and mount the proto result.
+    //
+    // Example:
+    // proto_facets(vec![("/l/label", 20)]) will produce {"/l": {tag: "/l/label", total: 20}}
+    fn proto_facets(entries: Vec<(&str, i32)>) -> HashMap<String, FacetResults> {
+        let mut tmp = HashMap::new();
+        for (facet, count) in entries {
+            let root = facet[..2].to_string();
+            tmp.entry(root.to_string())
+                .and_modify(|l: &mut Vec<(String, i32)>| l.push((facet.to_string(), count)))
+                .or_insert(vec![(facet.to_string(), count)]);
+        }
+
+        let mut r = HashMap::new();
+        for (root, facets) in tmp {
+            r.insert(
+                root,
+                FacetResults {
+                    facetresults: facets
+                        .into_iter()
+                        .map(|(tag, total)| FacetResult { tag, total })
+                        .collect(),
+                },
+            );
+        }
+        r
+    }
+}

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -36,10 +36,12 @@ use super::{
     query_planner::{self, QueryPlan},
 };
 
-#[instrument(skip_all, fields(shard_id = search_request.shard))]
-pub async fn search(index_cache: Arc<IndexCache>, search_request: SearchRequest) -> NidxResult<SearchResponse> {
-    let shard_id = uuid::Uuid::parse_str(&search_request.shard)?;
-
+#[instrument(skip_all, fields(shard_id = shard_id.to_string()))]
+pub async fn search(
+    shard_id: uuid::Uuid,
+    index_cache: Arc<IndexCache>,
+    search_request: SearchRequest,
+) -> NidxResult<SearchResponse> {
     let query_plan = query_planner::build_query_plan(search_request.clone())?;
 
     let Some(indexes) = index_cache.get_shard_indexes(&shard_id).await else {
@@ -427,4 +429,8 @@ fn run_semantic_graph_queries(
 
         Ok(context)
     })
+}
+
+pub fn merge(_shard_responses: Vec<SearchResponse>) -> SearchResponse {
+    todo!("merge multiple shard responses into one")
 }

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -430,7 +430,3 @@ fn run_semantic_graph_queries(
         Ok(context)
     })
 }
-
-pub fn merge(_shard_responses: Vec<SearchResponse>) -> SearchResponse {
-    todo!("merge multiple shard responses into one")
-}

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -83,10 +83,11 @@ pub async fn search(
     while let Some(join) = tasks.join_next().await {
         match join {
             Ok(Ok(response)) => responses.push(response),
-            Ok(Err(search_error)) => {
-                warn!("An error occurred while searching: {search_error:?}");
+            Ok(Err(NidxError::NotFound)) => {
+                warn!("An error occurred while searching: NotFound");
                 errors += 1;
             }
+            Ok(Err(search_error)) => return Err(search_error),
             Err(join_error) => {
                 // Either a panic or a cancellation happened while searching
                 warn!("A shard query failed in tokio: {:?}", join_error.to_string());

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -130,7 +130,7 @@ pub async fn search(
         };
 
     let current = Span::current();
-    let search_results = tokio::task::spawn_blocking(move || {
+    let mut search_results = tokio::task::spawn_blocking(move || {
         current.in_scope(|| {
             blocking_search(
                 query_plan,
@@ -145,6 +145,7 @@ pub async fn search(
         })
     })
     .await??;
+    search_results.shard_ids.push(shard_id.to_string());
     Ok(search_results)
 }
 
@@ -250,6 +251,7 @@ fn run_index_searches(
     });
 
     Ok(SearchResponse {
+        shard_ids: vec![], // populated later
         document: rtext.transpose()?,
         paragraph: rparagraph.transpose()?,
         vector: rvector.transpose()?,

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -37,36 +37,9 @@ use super::index_cache::IndexCache;
 use super::query_planner;
 use super::query_planner::QueryPlan;
 
-pub struct PartitionedResponse<T> {
+pub struct PartialResponse<T> {
     pub data: T,
     pub shards: Vec<Uuid>,
-    partial: bool,
-}
-
-impl<T> PartitionedResponse<T> {
-    pub fn complete(data: T, shards: Vec<Uuid>) -> Self {
-        Self {
-            data,
-            shards,
-            partial: false,
-        }
-    }
-
-    pub fn partial(data: T, shards: Vec<Uuid>) -> Self {
-        Self {
-            data,
-            shards,
-            partial: true,
-        }
-    }
-
-    pub fn into_value(self) -> T {
-        self.data
-    }
-
-    pub fn is_partial(&self) -> bool {
-        self.partial
-    }
 }
 
 /// Search in multiple shards and return either the full response, partial
@@ -76,7 +49,7 @@ pub async fn search(
     shards: Vec<uuid::Uuid>,
     index_cache: Arc<IndexCache>,
     search_request: SearchRequest,
-) -> NidxResult<PartitionedResponse<SearchResponse>> {
+) -> NidxResult<PartialResponse<SearchResponse>> {
     let order_by = OrderBy::from(&search_request);
     let limit = Limit(search_request.result_per_page as usize);
     let query_plan = query_planner::build_query_plan(search_request)?;
@@ -84,7 +57,10 @@ pub async fn search(
     let response = if shards.len() == 1 {
         let shard_id = shards[0];
         let response = shard_search(shard_id, Arc::clone(&index_cache), query_plan).await?;
-        PartitionedResponse::complete(response, vec![shard_id])
+        PartialResponse {
+            data: response,
+            shards: vec![shard_id],
+        }
     } else {
         let mut tasks = JoinSet::new();
         for shard_id in &shards {
@@ -114,14 +90,17 @@ pub async fn search(
         };
 
         if merged.shard_ids.len() == shards.len() {
-            PartitionedResponse::complete(merged, shards)
+            PartialResponse { data: merged, shards }
         } else {
             let successful_shards = merged
                 .shard_ids
                 .iter()
                 .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
                 .collect();
-            PartitionedResponse::partial(merged, successful_shards)
+            PartialResponse {
+                data: merged,
+                shards: successful_shards,
+            }
         }
     };
     Ok(response)

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -37,17 +37,35 @@ use super::index_cache::IndexCache;
 use super::query_planner;
 use super::query_planner::QueryPlan;
 
-pub enum PartitionedResponse<T> {
-    Complete(T, Vec<Uuid>),
-    Partial(T, Vec<Uuid>),
+pub struct PartitionedResponse<T> {
+    pub data: T,
+    pub shards: Vec<Uuid>,
+    partial: bool,
 }
 
 impl<T> PartitionedResponse<T> {
-    pub fn into_value(self) -> T {
-        match self {
-            Self::Complete(data, _) => data,
-            Self::Partial(data, _) => data,
+    pub fn complete(data: T, shards: Vec<Uuid>) -> Self {
+        Self {
+            data,
+            shards,
+            partial: false,
         }
+    }
+
+    pub fn partial(data: T, shards: Vec<Uuid>) -> Self {
+        Self {
+            data,
+            shards,
+            partial: true,
+        }
+    }
+
+    pub fn into_value(self) -> T {
+        self.data
+    }
+
+    pub fn is_partial(&self) -> bool {
+        self.partial
     }
 }
 
@@ -66,7 +84,7 @@ pub async fn search(
     let response = if shards.len() == 1 {
         let shard_id = shards[0];
         let response = shard_search(shard_id, Arc::clone(&index_cache), query_plan).await?;
-        PartitionedResponse::Complete(response, vec![shard_id])
+        PartitionedResponse::complete(response, vec![shard_id])
     } else {
         let mut tasks = JoinSet::new();
         for shard_id in &shards {
@@ -96,14 +114,14 @@ pub async fn search(
         };
 
         if merged.shard_ids.len() == shards.len() {
-            PartitionedResponse::Complete(merged, shards)
+            PartitionedResponse::complete(merged, shards)
         } else {
             let successful_shards = merged
                 .shard_ids
                 .iter()
                 .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
                 .collect();
-            PartitionedResponse::Partial(merged, successful_shards)
+            PartitionedResponse::partial(merged, successful_shards)
         }
     };
     Ok(response)

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -24,7 +24,7 @@ use nidx_text::{TextSearcher, prefilter::PreFilterRequest};
 use nidx_types::prefilter::PrefilterResult;
 use nidx_vector::VectorSearcher;
 use tokio::task::JoinSet;
-use tracing::{Span, instrument, warn};
+use tracing::{Span, instrument};
 use uuid::Uuid;
 
 use crate::errors::{NidxError, NidxResult};
@@ -63,52 +63,50 @@ pub async fn search(
     let limit = Limit(search_request.result_per_page as usize);
     let query_plan = query_planner::build_query_plan(search_request)?;
 
-    if shards.len() == 1 {
+    let response = if shards.len() == 1 {
         let shard_id = shards[0];
         let response = shard_search(shard_id, Arc::clone(&index_cache), query_plan).await?;
-        return Ok(PartitionedResponse::Complete(response, vec![shard_id]));
-    }
+        PartitionedResponse::Complete(response, vec![shard_id])
+    } else {
+        let mut tasks = JoinSet::new();
+        for shard_id in &shards {
+            tasks.spawn(shard_search(*shard_id, Arc::clone(&index_cache), query_plan.clone()));
+        }
 
-    let mut tasks = JoinSet::new();
-    for shard_id in &shards {
-        tasks.spawn(shard_search(*shard_id, Arc::clone(&index_cache), query_plan.clone()));
-    }
-
-    let mut responses = vec![];
-    let mut errors = 0;
-    while let Some(join) = tasks.join_next().await {
-        match join {
-            Ok(Ok(response)) => responses.push(response),
-            Ok(Err(NidxError::NotFound)) => {
-                warn!("An error occurred while searching: NotFound");
-                errors += 1;
-            }
-            Ok(Err(search_error)) => return Err(search_error),
-            Err(join_error) => {
-                // Either a panic or a cancellation happened while searching
-                warn!("A shard query failed in tokio: {:?}", join_error.to_string());
-                errors += 1;
+        let mut responses = vec![];
+        while let Some(join) = tasks.join_next().await {
+            match join {
+                Ok(Ok(response)) => responses.push(response),
+                Ok(Err(NidxError::NotFound)) => {}
+                Ok(Err(search_error)) => return Err(search_error),
+                Err(join_error) => {
+                    // Either a panic or a cancellation happened while searching
+                    return Err(NidxError::from(join_error));
+                }
             }
         }
-    }
+        if responses.is_empty() {
+            return Err(NidxError::NotFound);
+        }
 
-    let merged = if responses.len() == 1 {
-        responses.pop().unwrap()
-    } else {
-        shard_merge::merge(responses, order_by, limit)
+        let merged = if responses.len() == 1 {
+            responses.pop().unwrap()
+        } else {
+            shard_merge::merge(responses, order_by, limit)
+        };
+
+        if merged.shard_ids.len() == shards.len() {
+            PartitionedResponse::Complete(merged, shards)
+        } else {
+            let successful_shards = merged
+                .shard_ids
+                .iter()
+                .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
+                .collect();
+            PartitionedResponse::Partial(merged, successful_shards)
+        }
     };
-
-    if errors == 0 {
-        Ok(PartitionedResponse::Complete(merged, shards))
-    } else {
-        let successful_shards = merged
-            .shard_ids
-            .iter()
-            .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
-            .collect();
-        // TODO: errors
-        Ok(PartitionedResponse::Partial(merged, successful_shards))
-    }
+    Ok(response)
 }
 
 #[instrument(skip_all, fields(shard_id = shard_id.to_string()))]

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -23,27 +23,97 @@ use nidx_relation::{RelationSearcher, graph_query_parser::VectorQueryResults};
 use nidx_text::{TextSearcher, prefilter::PreFilterRequest};
 use nidx_types::prefilter::PrefilterResult;
 use nidx_vector::VectorSearcher;
-use tracing::{Span, instrument};
+use tokio::task::JoinSet;
+use tracing::{Span, instrument, warn};
 use uuid::Uuid;
 
-use crate::{
-    errors::{NidxError, NidxResult},
-    searcher::query_planner::{GraphIndexQueries, IndexQueries},
-};
+use crate::errors::{NidxError, NidxResult};
+use crate::searcher::query_planner::{GraphIndexQueries, IndexQueries};
+use crate::searcher::shard_merge;
+use crate::searcher::shard_merge::Limit;
+use crate::searcher::shard_merge::OrderBy;
 
-use super::{
-    index_cache::IndexCache,
-    query_planner::{self, QueryPlan},
-};
+use super::index_cache::IndexCache;
+use super::query_planner;
+use super::query_planner::QueryPlan;
 
-#[instrument(skip_all, fields(shard_id = shard_id.to_string()))]
+pub enum SearchResult<T> {
+    Complete(T),
+    Partial(PartialResult<T>),
+}
+
+pub struct PartialResult<T> {
+    pub part: T,
+}
+
+impl<T> SearchResult<T> {
+    pub fn into_value(self) -> T {
+        match self {
+            Self::Complete(v) => v,
+            Self::Partial(PartialResult { part, .. }) => part,
+        }
+    }
+}
+
+/// Search in multiple shards and return either the full response, partial
+/// results or an error
+///
 pub async fn search(
-    shard_id: uuid::Uuid,
+    shards: Vec<uuid::Uuid>,
     index_cache: Arc<IndexCache>,
     search_request: SearchRequest,
-) -> NidxResult<SearchResponse> {
-    let query_plan = query_planner::build_query_plan(search_request.clone())?;
+) -> NidxResult<SearchResult<SearchResponse>> {
+    let order_by = OrderBy::from(&search_request);
+    let limit = Limit(search_request.result_per_page as usize);
+    let query_plan = query_planner::build_query_plan(search_request)?;
 
+    if shards.len() == 1 {
+        let shard_id = shards[0];
+        let response = shard_search(shard_id, Arc::clone(&index_cache), query_plan).await?;
+        return Ok(SearchResult::Complete(response));
+    }
+
+    let mut tasks = JoinSet::new();
+    for shard_id in shards {
+        tasks.spawn(shard_search(shard_id, Arc::clone(&index_cache), query_plan.clone()));
+    }
+
+    let mut responses = vec![];
+    let mut errors = 0;
+    while let Some(join) = tasks.join_next().await {
+        match join {
+            Ok(Ok(response)) => responses.push(response),
+            Ok(Err(search_error)) => {
+                warn!("An error occurred while searching: {search_error:?}");
+                errors += 1;
+            }
+            Err(join_error) => {
+                // Either a panic or a cancellation happened while searching
+                warn!("A shard query failed in tokio: {:?}", join_error.to_string());
+                errors += 1;
+            }
+        }
+    }
+
+    let merged = if responses.len() == 1 {
+        responses.pop().unwrap()
+    } else {
+        shard_merge::merge(responses, order_by, limit)
+    };
+
+    if errors == 0 {
+        Ok(SearchResult::Complete(merged))
+    } else {
+        Ok(SearchResult::Partial(PartialResult { part: merged }))
+    }
+}
+
+#[instrument(skip_all, fields(shard_id = shard_id.to_string()))]
+async fn shard_search(
+    shard_id: uuid::Uuid,
+    index_cache: Arc<IndexCache>,
+    query_plan: QueryPlan,
+) -> NidxResult<SearchResponse> {
     let Some(indexes) = index_cache.get_shard_indexes(&shard_id).await else {
         return Err(NidxError::NotFound);
     };
@@ -86,11 +156,11 @@ pub async fn search(
     };
 
     // Do not require the vectorset parameter if it's not going to be used
-    let vector_seach = if query_plan.index_queries.vectors_request.is_some() {
-        if search_request.vectorset.is_empty() {
+    let vector_search = if let Some(vector_request) = &query_plan.index_queries.vectors_request {
+        if vector_request.vector_set.is_empty() {
             return Err(NidxError::invalid("Vectorset is required"));
         }
-        let Some(vector_index) = indexes.vector_index(&search_request.vectorset) else {
+        let Some(vector_index) = indexes.vector_index(&vector_request.vector_set) else {
             return Err(NidxError::NotFound);
         };
         Some(index_cache.get(&vector_index).await?)
@@ -138,7 +208,7 @@ pub async fn search(
                 paragraph_search.as_ref().map(|v| v.as_ref().into()),
                 relation_search.as_ref().map(|v| v.as_ref().into()),
                 text_search.as_ref().map(|v| v.as_ref().into()),
-                vector_seach.as_ref().map(|v| v.as_ref().into()),
+                vector_search.as_ref().map(|v| v.as_ref().into()),
                 node_semantic_index.as_ref().map(|v| v.as_ref().into()),
                 edge_semantic_index.as_ref().map(|v| v.as_ref().into()),
             )

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -37,20 +37,16 @@ use super::index_cache::IndexCache;
 use super::query_planner;
 use super::query_planner::QueryPlan;
 
-pub enum SearchResult<T> {
-    Complete(T),
-    Partial(PartialResult<T>),
+pub enum PartitionedResponse<T> {
+    Complete(T, Vec<Uuid>),
+    Partial(T, Vec<Uuid>),
 }
 
-pub struct PartialResult<T> {
-    pub part: T,
-}
-
-impl<T> SearchResult<T> {
+impl<T> PartitionedResponse<T> {
     pub fn into_value(self) -> T {
         match self {
-            Self::Complete(v) => v,
-            Self::Partial(PartialResult { part, .. }) => part,
+            Self::Complete(data, _) => data,
+            Self::Partial(data, _) => data,
         }
     }
 }
@@ -62,7 +58,7 @@ pub async fn search(
     shards: Vec<uuid::Uuid>,
     index_cache: Arc<IndexCache>,
     search_request: SearchRequest,
-) -> NidxResult<SearchResult<SearchResponse>> {
+) -> NidxResult<PartitionedResponse<SearchResponse>> {
     let order_by = OrderBy::from(&search_request);
     let limit = Limit(search_request.result_per_page as usize);
     let query_plan = query_planner::build_query_plan(search_request)?;
@@ -70,12 +66,12 @@ pub async fn search(
     if shards.len() == 1 {
         let shard_id = shards[0];
         let response = shard_search(shard_id, Arc::clone(&index_cache), query_plan).await?;
-        return Ok(SearchResult::Complete(response));
+        return Ok(PartitionedResponse::Complete(response, vec![shard_id]));
     }
 
     let mut tasks = JoinSet::new();
-    for shard_id in shards {
-        tasks.spawn(shard_search(shard_id, Arc::clone(&index_cache), query_plan.clone()));
+    for shard_id in &shards {
+        tasks.spawn(shard_search(*shard_id, Arc::clone(&index_cache), query_plan.clone()));
     }
 
     let mut responses = vec![];
@@ -103,9 +99,15 @@ pub async fn search(
     };
 
     if errors == 0 {
-        Ok(SearchResult::Complete(merged))
+        Ok(PartitionedResponse::Complete(merged, shards))
     } else {
-        Ok(SearchResult::Partial(PartialResult { part: merged }))
+        let successful_shards = merged
+            .shard_ids
+            .iter()
+            .map(|s| Uuid::parse_str(s).expect("This is an internal response, we always send valid UUIDs"))
+            .collect();
+        // TODO: errors
+        Ok(PartitionedResponse::Partial(merged, successful_shards))
     }
 }
 

--- a/nidx/src/searcher/shard_selector.rs
+++ b/nidx/src/searcher/shard_selector.rs
@@ -187,7 +187,7 @@ impl Scored<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum SearcherNode {
     This,
     Remote(String),

--- a/nidx/tests/common/cluster.rs
+++ b/nidx/tests/common/cluster.rs
@@ -1,0 +1,193 @@
+// Copyright 2021 Bosutech XXI S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use nidx::Settings;
+use nidx::grpc_server::GrpcServer;
+use nidx::searcher::{ListNodes, SyncedSearcher, grpc::SearchServer, shard_selector::ShardSelector};
+use nidx::settings::SearcherSettings;
+
+use std::sync::Mutex;
+use std::{sync::Arc, time::Duration};
+use tempfile::tempdir;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug)]
+pub struct ManualListNodes(Arc<Mutex<Vec<String>>>, usize);
+impl ListNodes for ManualListNodes {
+    fn list_nodes(&self) -> Vec<String> {
+        self.0.lock().unwrap().clone()
+    }
+
+    fn this_node(&self) -> String {
+        self.list_nodes()
+            .get(self.1)
+            .cloned()
+            .unwrap_or("out_of_cluster".to_string())
+    }
+}
+
+pub struct SearcherCluster {
+    pub searchers: Vec<Option<Searcher>>,
+    nodes: Arc<Mutex<Vec<String>>>,
+    settings: Settings,
+    shard_replication: usize,
+}
+
+pub type SearcherId = usize;
+
+// Each searcher has it's own view on the cluster, not shared with the rest
+#[derive(Debug)]
+pub struct Searcher {
+    port: u16,
+    shutdown: CancellationToken,
+}
+
+pub struct Topology {
+    // Number of nodes in the cluster
+    pub nodes: usize,
+
+    // Number of nodes that have a replica of a shard
+    pub shard_replication: usize,
+
+    // When defined, the network describes which nodes are reachable from every
+    // node in the cluster. By default, everyone sees everyone.
+    //
+    // Changes on the network can be used to simluate network partitions, nodes
+    // being down...
+    pub network: Vec<NetworkAvailability>,
+}
+
+#[derive(Clone, Debug)]
+pub enum NetworkAvailability {
+    Connected,
+    Isolated,
+}
+
+impl SearcherCluster {
+    pub async fn new(settings: Settings, topology: Topology) -> anyhow::Result<Self> {
+        assert_eq!(
+            topology.nodes,
+            topology.network.len(),
+            "number of nodes and network configurations mismatch"
+        );
+
+        let mut cluster = Self {
+            searchers: Vec::new(),
+            nodes: Arc::new(Mutex::new(Vec::new())),
+            settings,
+            shard_replication: topology.shard_replication,
+        };
+
+        for availability in topology.network {
+            cluster.grow(availability).await?;
+        }
+        tokio::time::sleep(cluster.refresh_interval()).await;
+
+        Ok(cluster)
+    }
+
+    pub fn size(&self) -> usize {
+        self.searchers.len()
+    }
+
+    pub async fn grow(&mut self, availability: NetworkAvailability) -> anyhow::Result<()> {
+        let server = GrpcServer::new("localhost:0").await?;
+        let port = server.port()?;
+
+        let work_dir = tempdir()?;
+        let searcher = SyncedSearcher::new(self.settings.metadata.clone(), work_dir.path());
+
+        let address = match availability {
+            NetworkAvailability::Connected => format!("localhost:{port}"),
+            NetworkAvailability::Isolated => format!("unreachable:{port}"),
+        };
+        let node_id = {
+            let mut nodes = self.nodes.lock().unwrap();
+            nodes.push(address);
+            nodes.len() - 1
+        };
+        let list_nodes = Arc::new(ManualListNodes(self.nodes.clone(), node_id));
+
+        let searcher_api = SearchServer::new(
+            self.settings.metadata.clone(),
+            searcher.index_cache(),
+            ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, self.shard_replication),
+        );
+        let shutdown = CancellationToken::new();
+        {
+            let settings = self.settings.clone();
+            let shutdown = shutdown.clone();
+            let num_replicas = self.shard_replication;
+            tokio::task::spawn(server.serve(searcher_api.into_router(), shutdown.clone()));
+            tokio::task::spawn(async move {
+                searcher
+                    .run(
+                        settings.storage.as_ref().unwrap().object_store.clone(),
+                        settings.searcher.clone().unwrap_or_default(),
+                        shutdown,
+                        ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, num_replicas),
+                        None,
+                        None,
+                    )
+                    .await
+            });
+        }
+
+        self.searchers.push(Some(Searcher { port, shutdown }));
+        Ok(())
+    }
+
+    /// Grow the cluster adding a fake node. This will cause shards to be repartitioned with the new
+    /// node, but it's not accessible (there's no gRPC server)
+    pub fn grow_fake(&mut self, name: String) {
+        self.nodes.lock().unwrap().push(name);
+        self.searchers.push(None);
+    }
+
+    /// Gracefully shutdown a searcher node. This will keep it part of the cluster but unavailable
+    /// to the rest. This operation can't be reversed
+    pub fn shutdown_node(&mut self, id: SearcherId) {
+        self.searchers
+            .get(id)
+            .unwrap()
+            .as_ref()
+            .expect("can't shutdown a fake node")
+            .shutdown
+            .cancel();
+    }
+
+    /// Shrink the cluster by scaling down. This will remove a node from the cluster and shards will
+    /// be repartitioned across the rest.
+    pub fn shrink(&mut self) -> Option<Searcher> {
+        assert!(!self.searchers.is_empty(), "can't shrink an empty cluster");
+        let searcher = self.searchers.pop().unwrap();
+        self.nodes.lock().unwrap().pop().unwrap();
+        searcher
+    }
+
+    pub fn refresh_interval(&self) -> Duration {
+        let refresh_interval = self.settings.searcher.as_ref().map_or_else(
+            || SearcherSettings::default().metadata_refresh_interval,
+            |s| s.metadata_refresh_interval,
+        );
+        Duration::from_secs_f32(refresh_interval + 0.1)
+    }
+}
+
+impl Searcher {
+    pub fn address(&self) -> String {
+        format!("localhost:{}", self.port)
+    }
+}

--- a/nidx/tests/common/cluster.rs
+++ b/nidx/tests/common/cluster.rs
@@ -121,7 +121,6 @@ impl SearcherCluster {
         let list_nodes = Arc::new(ManualListNodes(self.nodes.clone(), node_id));
 
         let searcher_api = SearchServer::new(
-            self.settings.metadata.clone(),
             searcher.index_cache(),
             ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, self.shard_replication),
         );

--- a/nidx/tests/common/mod.rs
+++ b/nidx/tests/common/mod.rs
@@ -15,7 +15,9 @@
 
 #![allow(dead_code)] // clippy doesn't check for usage in other tests modules
 
+pub mod cluster;
 pub mod services;
+pub mod utils;
 
 pub mod metadata {
     use sqlx::{Executor, Postgres};

--- a/nidx/tests/common/services.rs
+++ b/nidx/tests/common/services.rs
@@ -80,7 +80,11 @@ impl NidxFixture {
         // Searcher API
         let work_dir = tempdir()?;
         let searcher = SyncedSearcher::new(settings.metadata.clone(), work_dir.path());
-        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new_single());
+        let searcher_api = SearchServer::new(
+            settings.metadata.clone(),
+            searcher.index_cache(),
+            ShardSelector::new_single(),
+        );
         let searcher_server = GrpcServer::new("localhost:0").await?;
         let searcher_port = searcher_server.port()?;
         tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));

--- a/nidx/tests/common/services.rs
+++ b/nidx/tests/common/services.rs
@@ -80,11 +80,7 @@ impl NidxFixture {
         // Searcher API
         let work_dir = tempdir()?;
         let searcher = SyncedSearcher::new(settings.metadata.clone(), work_dir.path());
-        let searcher_api = SearchServer::new(
-            settings.metadata.clone(),
-            searcher.index_cache(),
-            ShardSelector::new_single(),
-        );
+        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new_single());
         let searcher_server = GrpcServer::new("localhost:0").await?;
         let searcher_port = searcher_server.port()?;
         tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));

--- a/nidx/tests/common/services.rs
+++ b/nidx/tests/common/services.rs
@@ -22,7 +22,7 @@ use nidx::indexer::{delete_resource, index_resource};
 use nidx::searcher::SyncedSearcher;
 use nidx::searcher::grpc::SearchServer;
 use nidx::searcher::shard_selector::ShardSelector;
-use nidx::settings::{EnvSettings, MetadataSettings, StorageSettings};
+use nidx::settings::{EnvSettings, MetadataSettings, SearcherSettings, StorageSettings};
 use nidx::{NidxMetadata, Settings};
 use nidx_protos::Resource;
 use nidx_protos::nidx::nidx_api_client::NidxApiClient;
@@ -63,7 +63,11 @@ impl NidxFixture {
                 telemetry: Default::default(),
                 work_path: None,
                 control_socket: None,
-                searcher: Default::default(),
+                searcher: Some(SearcherSettings {
+                    // tests can take advantage of faster refresh intervals
+                    metadata_refresh_interval: 0.1,
+                    ..Default::default()
+                }),
                 audit: None,
             },
         };

--- a/nidx/tests/common/utils.rs
+++ b/nidx/tests/common/utils.rs
@@ -1,0 +1,43 @@
+// Copyright 2021 Bosutech XXI S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use nidx_protos::nidx_api_client::NidxApiClient;
+use nidx_protos::{NewShardRequest, VectorIndexConfig};
+
+use std::collections::HashMap;
+use tonic::Request;
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+pub async fn create_shards(api_client: &mut NidxApiClient<Channel>, count: usize) -> anyhow::Result<Vec<Uuid>> {
+    let mut shards = Vec::with_capacity(count);
+    for _ in 0..count {
+        let response = api_client
+            .new_shard(Request::new(NewShardRequest {
+                kbid: "aabbccddeeff11223344556677889900".to_string(),
+                vectorsets_configs: HashMap::from([(
+                    "english".to_string(),
+                    VectorIndexConfig {
+                        vector_dimension: Some(3),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }))
+            .await?;
+        shards.push(uuid::Uuid::parse_str(&response.into_inner().id).unwrap());
+    }
+    Ok(shards)
+}

--- a/nidx/tests/integration/date_range_search.rs
+++ b/nidx/tests/integration/date_range_search.rs
@@ -126,7 +126,7 @@ async fn test_date_range_search(pool: PgPool) -> Result<(), Box<dyn std::error::
     populate(&mut fixture, shard_id.clone(), metadata).await;
 
     let request = SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         order: None,
         vectorset: "english".to_string(),
         vector: vec![4.0, 6.0, 7.0],

--- a/nidx/tests/integration/distributed_search.rs
+++ b/nidx/tests/integration/distributed_search.rs
@@ -88,12 +88,7 @@ async fn test_searchers_with_1_shard_replica(pool: PgPool) -> anyhow::Result<()>
             .await;
         assert!(response.is_err());
         let error = response.unwrap_err();
-        assert_eq!(error.code(), Code::Internal);
-        assert!(
-            error
-                .message()
-                .contains("Error in search, exhausted all available nodes for shard"),
-        );
+        assert_eq!(error.code(), Code::NotFound);
     }
 
     Ok(())
@@ -176,12 +171,7 @@ async fn test_searchers_with_2_shard_replica(pool: PgPool) -> anyhow::Result<()>
         .await;
     assert!(response.is_err());
     let error = response.unwrap_err();
-    assert_eq!(error.code(), Code::Internal);
-    assert!(
-        error
-            .message()
-            .contains("Error in search, exhausted all available nodes for shard")
-    );
+    assert_eq!(error.code(), Code::NotFound);
 
     Ok(())
 }

--- a/nidx/tests/integration/distributed_search.rs
+++ b/nidx/tests/integration/distributed_search.rs
@@ -92,7 +92,7 @@ async fn test_searchers_with_1_shard_replica(pool: PgPool) -> anyhow::Result<()>
         assert!(
             error
                 .message()
-                .contains("Error in search, exhausted all available nodes for shard")
+                .contains("Error in search, exhausted all available nodes for shard"),
         );
     }
 
@@ -248,11 +248,7 @@ async fn test_searchers_partial_results(pool: PgPool) -> anyhow::Result<()> {
     assert!(response.is_err());
     let error = response.unwrap_err();
     assert_eq!(error.code(), Code::Internal);
-    assert!(
-        error
-            .message()
-            .contains("Error in search, exhausted all available nodes for shard")
-    );
+    assert!(error.message().contains("transport error"));
 
     // But a local-only request will return partial results for all its shards
     let mut request = Request::new(SearchRequest {

--- a/nidx/tests/integration/distributed_search.rs
+++ b/nidx/tests/integration/distributed_search.rs
@@ -206,11 +206,32 @@ async fn test_searchers_partial_results(pool: PgPool) -> anyhow::Result<()> {
         },
     )
     .await?;
-    // but one is not available
+
+    let mut counts = Vec::with_capacity(2);
+    for searcher in &cluster.searchers {
+        let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+        let mut request = Request::new(SearchRequest {
+            shard_ids: shards.clone(),
+            result_per_page: 20,
+            body: "Hola".into(),
+            paragraph: true,
+            ..Default::default()
+        });
+        request.metadata_mut().insert("nidx-local-only", "1".parse().unwrap());
+        let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
+            .await?
+            .search(request)
+            .await?
+            .into_inner();
+        counts.push(response.shard_ids.len());
+    }
+    assert_eq!(counts.iter().sum::<usize>(), 10);
+
+    // Make a one unavailable
     cluster.shutdown_node(1);
 
-    // The remaining searcher has only 1/2 of the shards. Performing a Search for all shards will
-    // fail
+    // The remaining searcher has only ~1/2 of the shards. Performing a Search
+    // for all shards will fail
     let searcher = cluster.searchers[0]
         .as_ref()
         .expect("we don't have any fake node configured");
@@ -233,7 +254,7 @@ async fn test_searchers_partial_results(pool: PgPool) -> anyhow::Result<()> {
             .contains("Error in search, exhausted all available nodes for shard")
     );
 
-    // But a local-only request will return partial results
+    // But a local-only request will return partial results for all its shards
     let mut request = Request::new(SearchRequest {
         shard_ids: shards.clone(),
         result_per_page: 20,
@@ -243,7 +264,7 @@ async fn test_searchers_partial_results(pool: PgPool) -> anyhow::Result<()> {
     });
     request.metadata_mut().insert("nidx-local-only", "1".parse().unwrap());
     let response = client.search(request).await?.into_inner();
-    assert_eq!(response.shard_ids.len(), 5);
+    assert_eq!(response.shard_ids.len(), counts[0]);
 
     Ok(())
 }

--- a/nidx/tests/integration/distributed_search.rs
+++ b/nidx/tests/integration/distributed_search.rs
@@ -1,0 +1,249 @@
+// Copyright 2021 Bosutech XXI S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//! Distributed (multi-shard) Search() tests
+//!
+//! This module tests how a nidx-searcher cluster handles Search to a batch of shards. As queries
+//! are distributed across searchers, these tests try to emulate failure situations in the cluster.
+//!
+
+use itertools::Itertools;
+use nidx_protos::SearchRequest;
+use nidx_protos::nidx::nidx_searcher_client::NidxSearcherClient;
+
+use sqlx::PgPool;
+use tonic::{Code, Request};
+
+use crate::common::cluster::{NetworkAvailability, SearcherCluster, Topology};
+use crate::common::services::NidxFixture;
+use crate::common::utils::create_shards;
+
+#[sqlx::test]
+async fn test_searchers_with_1_shard_replica(pool: PgPool) -> anyhow::Result<()> {
+    let mut fixture = NidxFixture::new(pool).await?;
+    let shards: Vec<String> = create_shards(&mut fixture.api_client, 10)
+        .await?
+        .iter()
+        .map(|s| s.to_string())
+        .sorted()
+        .collect();
+
+    // Create a cluster with 3 nodes and 1 replica
+    let mut cluster = SearcherCluster::new(
+        fixture.settings.clone(),
+        Topology {
+            nodes: 3,
+            shard_replication: 1,
+            network: vec![NetworkAvailability::Connected; 3],
+        },
+    )
+    .await?;
+
+    // Each searcher has 1/3 of the total shards. As everyone is available, the queried searcher
+    // will request the other two for the missing 2/3 of shards
+    for searcher in &cluster.searchers {
+        let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+        let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
+            .await?
+            .search(Request::new(SearchRequest {
+                shard_ids: shards.clone(),
+                result_per_page: 20,
+                body: "Hola".into(),
+                paragraph: true,
+                ..Default::default()
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(response.shard_ids.into_iter().sorted().collect::<Vec<_>>(), shards);
+    }
+
+    // Shutdown one of the searchers so his 1/3 of shards is not available anymore
+    cluster.shutdown_node(2);
+
+    // Each searcher has 1/3 of the total shards. As everyone is available, the queried searcher
+    // will request the other two for the missing 2/3 of shards
+    for searcher in &cluster.searchers[0..2] {
+        let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+        let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
+            .await?
+            .search(Request::new(SearchRequest {
+                shard_ids: shards.clone(),
+                result_per_page: 20,
+                body: "Hola".into(),
+                paragraph: true,
+                ..Default::default()
+            }))
+            .await;
+        assert!(response.is_err());
+        let error = response.unwrap_err();
+        assert_eq!(error.code(), Code::Internal);
+        assert!(
+            error
+                .message()
+                .contains("Error in search, exhausted all available nodes for shard")
+        );
+    }
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn test_searchers_with_2_shard_replica(pool: PgPool) -> anyhow::Result<()> {
+    let mut fixture = NidxFixture::new(pool).await?;
+    let shards: Vec<String> = create_shards(&mut fixture.api_client, 10)
+        .await?
+        .iter()
+        .map(|s| s.to_string())
+        .sorted()
+        .collect();
+
+    // Create a cluster with 3 nodes and 2 replica
+    let mut cluster = SearcherCluster::new(
+        fixture.settings.clone(),
+        Topology {
+            nodes: 3,
+            shard_replication: 2,
+            network: vec![NetworkAvailability::Connected; 3],
+        },
+    )
+    .await?;
+
+    // Each searcher has 2/3 of the total shards. As everyone is available, the queried searcher
+    // will request the other two for the missing 1/3 of shards
+    for searcher in &cluster.searchers {
+        let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+        let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
+            .await?
+            .search(Request::new(SearchRequest {
+                shard_ids: shards.clone(),
+                result_per_page: 20,
+                body: "Hola".into(),
+                paragraph: true,
+                ..Default::default()
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(response.shard_ids.into_iter().sorted().collect::<Vec<_>>(), shards);
+    }
+
+    // Shutdown one of the searchers so his 2/3 of shards is not available anymore
+    cluster.shutdown_node(2);
+
+    // As each searcher has 2/3 of the total shards, 2 is enough to still answer for all shards.
+    for searcher in &cluster.searchers[0..2] {
+        let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+        let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
+            .await?
+            .search(Request::new(SearchRequest {
+                shard_ids: shards.clone(),
+                result_per_page: 20,
+                body: "Hola".into(),
+                paragraph: true,
+                ..Default::default()
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(response.shard_ids.into_iter().sorted().collect::<Vec<_>>(), shards);
+    }
+
+    // If we make a second node unavilable, we won't be able to answer
+    cluster.shutdown_node(1);
+
+    let searcher = cluster.searchers[0]
+        .as_ref()
+        .expect("we don't have any fake node configured");
+    let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
+        .await?
+        .search(Request::new(SearchRequest {
+            shard_ids: shards.clone(),
+            result_per_page: 20,
+            body: "Hola".into(),
+            paragraph: true,
+            ..Default::default()
+        }))
+        .await;
+    assert!(response.is_err());
+    let error = response.unwrap_err();
+    assert_eq!(error.code(), Code::Internal);
+    assert!(
+        error
+            .message()
+            .contains("Error in search, exhausted all available nodes for shard")
+    );
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn test_searchers_partial_results(pool: PgPool) -> anyhow::Result<()> {
+    let mut fixture = NidxFixture::new(pool).await?;
+    let shards: Vec<String> = create_shards(&mut fixture.api_client, 10)
+        .await?
+        .iter()
+        .map(|s| s.to_string())
+        .sorted()
+        .collect();
+
+    // Create a cluster with 2 nodes and 1 replica
+    let mut cluster = SearcherCluster::new(
+        fixture.settings.clone(),
+        Topology {
+            nodes: 2,
+            shard_replication: 1,
+            network: vec![NetworkAvailability::Connected; 2],
+        },
+    )
+    .await?;
+    // but one is not available
+    cluster.shutdown_node(1);
+
+    // The remaining searcher has only 1/2 of the shards. Performing a Search for all shards will
+    // fail
+    let searcher = cluster.searchers[0]
+        .as_ref()
+        .expect("we don't have any fake node configured");
+    let mut client = NidxSearcherClient::connect(format!("http://{}", searcher.address())).await?;
+    let response = client
+        .search(Request::new(SearchRequest {
+            shard_ids: shards.clone(),
+            result_per_page: 20,
+            body: "Hola".into(),
+            paragraph: true,
+            ..Default::default()
+        }))
+        .await;
+    assert!(response.is_err());
+    let error = response.unwrap_err();
+    assert_eq!(error.code(), Code::Internal);
+    assert!(
+        error
+            .message()
+            .contains("Error in search, exhausted all available nodes for shard")
+    );
+
+    // But a local-only request will return partial results
+    let mut request = Request::new(SearchRequest {
+        shard_ids: shards.clone(),
+        result_per_page: 20,
+        body: "Hola".into(),
+        paragraph: true,
+        ..Default::default()
+    });
+    request.metadata_mut().insert("nidx-local-only", "1".parse().unwrap());
+    let response = client.search(request).await?.into_inner();
+    assert_eq!(response.shard_ids.len(), 5);
+
+    Ok(())
+}

--- a/nidx/tests/integration/mod.rs
+++ b/nidx/tests/integration/mod.rs
@@ -14,6 +14,7 @@
 //
 
 mod date_range_search;
+mod distributed_search;
 mod initial_sync;
 mod search_filtering;
 mod search_json_filter;

--- a/nidx/tests/integration/search_filtering.rs
+++ b/nidx/tests/integration/search_filtering.rs
@@ -112,7 +112,7 @@ async fn test_search_fields_filtering(pool: PgPool) -> Result<(), Box<dyn std::e
     let query_vector = vec![17.0 / magnitude; VECTOR_DIMENSION];
 
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         field_filter: Some(file_field_filter_expression(&["foobar"])),
         vector: query_vector.clone(),
         vectorset: "english".to_string(),
@@ -134,7 +134,7 @@ async fn test_search_fields_filtering(pool: PgPool) -> Result<(), Box<dyn std::e
 
     // Search filtering with a real field, to check that the vector is returned
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         vector: query_vector.clone(),
         vectorset: "english".to_string(),
         field_filter: Some(file_field_filter_expression(&["field1", "unexisting"])),
@@ -161,7 +161,7 @@ async fn test_search_fields_filtering(pool: PgPool) -> Result<(), Box<dyn std::e
 
     // Search filtering with multiple fields, to check that the OR is applied
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         vector: query_vector.clone(),
         vectorset: "english".to_string(),
         field_filter: Some(file_field_filter_expression(&["field1", "field2"])),
@@ -285,7 +285,7 @@ async fn test_search_key_filtering(pool: PgPool) -> Result<(), Box<dyn std::erro
 
     // Without filters, finds everything
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -301,7 +301,7 @@ async fn test_search_key_filtering(pool: PgPool) -> Result<(), Box<dyn std::erro
 
     // Finds resource 1 by uuid
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -322,7 +322,7 @@ async fn test_search_key_filtering(pool: PgPool) -> Result<(), Box<dyn std::erro
 
     // Finds resource 1 by uuid and field
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -342,7 +342,7 @@ async fn test_search_key_filtering(pool: PgPool) -> Result<(), Box<dyn std::erro
 
     // Finds resource 1 or 2 by uuid
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -362,7 +362,7 @@ async fn test_search_key_filtering(pool: PgPool) -> Result<(), Box<dyn std::erro
 
     // Finds nothing with fake id
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -408,7 +408,7 @@ async fn test_search_keyword_filtering(pool: PgPool) -> Result<(), Box<dyn std::
 
     // Without filters, finds everything
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -424,7 +424,7 @@ async fn test_search_keyword_filtering(pool: PgPool) -> Result<(), Box<dyn std::
 
     // With keyword filter, finds the resource
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -441,7 +441,7 @@ async fn test_search_keyword_filtering(pool: PgPool) -> Result<(), Box<dyn std::
 
     // With keyword filter, finds the resource
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -458,7 +458,7 @@ async fn test_search_keyword_filtering(pool: PgPool) -> Result<(), Box<dyn std::
 
     // With not keyword filter, finds the resource
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,
@@ -475,7 +475,7 @@ async fn test_search_keyword_filtering(pool: PgPool) -> Result<(), Box<dyn std::
 
     // With not keyword filter, finds the resource
     let search_request = nodereader::SearchRequest {
-        shard: shard_id.clone(),
+        shard_ids: vec![shard_id.clone()],
         result_per_page: 10,
         min_score_bm25: 0.0,
         paragraph: true,

--- a/nidx/tests/integration/search_json_filter.rs
+++ b/nidx/tests/integration/search_json_filter.rs
@@ -182,7 +182,7 @@ async fn test_json_exact_match(pool: PgPool) -> Result<(), Box<dyn std::error::E
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -212,7 +212,7 @@ async fn test_json_no_match(pool: PgPool) -> Result<(), Box<dyn std::error::Erro
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -240,7 +240,7 @@ async fn test_json_int_range(pool: PgPool) -> Result<(), Box<dyn std::error::Err
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -275,7 +275,7 @@ async fn test_json_bool_match(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -305,7 +305,7 @@ async fn test_json_and_filter(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -340,7 +340,7 @@ async fn test_json_or_filter(pool: PgPool) -> Result<(), Box<dyn std::error::Err
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -410,7 +410,7 @@ async fn test_json_filter_combined_with_security(pool: PgPool) -> Result<(), Box
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,
@@ -451,7 +451,7 @@ async fn test_json_not_filter(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let results = fixture
         .searcher_client
         .search(Request::new(nodereader::SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             paragraph: true,
             body: String::new(),
             result_per_page: 10,

--- a/nidx/tests/integration/search_sorting.rs
+++ b/nidx/tests/integration/search_sorting.rs
@@ -102,7 +102,7 @@ async fn test_search_sorting(pool: PgPool) -> Result<(), Box<dyn std::error::Err
         let response = fixture
             .searcher_client
             .search(SearchRequest {
-                shard: shard_id.clone(),
+                shard_ids: vec![shard_id.clone()],
                 order,
                 document: true,
                 vectorset: "english".to_string(),

--- a/nidx/tests/integration/searcher_cluster.rs
+++ b/nidx/tests/integration/searcher_cluster.rs
@@ -13,40 +13,18 @@
 // limitations under the License.
 //
 
-use crate::common::services::NidxFixture;
-use nidx::Settings;
-use nidx::grpc_server::GrpcServer;
-use nidx::searcher::{ListNodes, SyncedSearcher, grpc::SearchServer, shard_selector::ShardSelector};
-use nidx::settings::SearcherSettings;
 use nidx_protos::SearchRequest;
 use nidx_protos::nidx::nidx_searcher_client::NidxSearcherClient;
-use nidx_protos::nidx_api_client::NidxApiClient;
-use nidx_protos::{NewShardRequest, VectorIndexConfig};
 
 use sqlx::PgPool;
 use std::collections::HashMap;
-use std::sync::Mutex;
-use std::{sync::Arc, time::Duration};
-use tempfile::tempdir;
-use tokio_util::sync::CancellationToken;
+use std::time::Duration;
 use tonic::Request;
-use tonic::transport::Channel;
 use uuid::Uuid;
 
-#[derive(Debug)]
-struct ManualListNodes(Arc<Mutex<Vec<String>>>, usize);
-impl ListNodes for ManualListNodes {
-    fn list_nodes(&self) -> Vec<String> {
-        self.0.lock().unwrap().clone()
-    }
-
-    fn this_node(&self) -> String {
-        self.list_nodes()
-            .get(self.1)
-            .cloned()
-            .unwrap_or("out_of_cluster".to_string())
-    }
-}
+use crate::common::cluster::{NetworkAvailability, SearcherCluster, Topology};
+use crate::common::services::NidxFixture;
+use crate::common::utils::create_shards;
 
 #[sqlx::test]
 async fn test_search_cluster_all_shards_accessible(pool: PgPool) -> anyhow::Result<()> {
@@ -292,172 +270,4 @@ async fn test_search_cluster_shards_not_accessible(pool: PgPool) -> anyhow::Resu
     }
 
     Ok(())
-}
-
-struct SearcherCluster {
-    pub searchers: Vec<Option<Searcher>>,
-    nodes: Arc<Mutex<Vec<String>>>,
-    settings: Settings,
-    shard_replication: usize,
-}
-
-type SearcherId = usize;
-
-// Each searcher has it's own view on the cluster, not shared with the rest
-#[derive(Debug)]
-struct Searcher {
-    port: u16,
-    shutdown: CancellationToken,
-}
-
-struct Topology {
-    // Number of nodes in the cluster
-    nodes: usize,
-
-    // Number of nodes that have a replica of a shard
-    shard_replication: usize,
-
-    // When defined, the network describes which nodes are reachable from every
-    // node in the cluster. By default, everyone sees everyone.
-    //
-    // Changes on the network can be used to simluate network partitions, nodes
-    // being down...
-    network: Vec<NetworkAvailability>,
-}
-
-#[derive(Clone, Debug)]
-enum NetworkAvailability {
-    Connected,
-    Isolated,
-}
-
-impl SearcherCluster {
-    pub async fn new(settings: Settings, topology: Topology) -> anyhow::Result<Self> {
-        assert_eq!(
-            topology.nodes,
-            topology.network.len(),
-            "number of nodes and network configurations mismatch"
-        );
-
-        let mut cluster = Self {
-            searchers: Vec::new(),
-            nodes: Arc::new(Mutex::new(Vec::new())),
-            settings,
-            shard_replication: topology.shard_replication,
-        };
-
-        for availability in topology.network {
-            cluster.grow(availability).await?;
-        }
-        tokio::time::sleep(cluster.refresh_interval()).await;
-
-        Ok(cluster)
-    }
-
-    pub fn size(&self) -> usize {
-        self.searchers.len()
-    }
-
-    pub async fn grow(&mut self, availability: NetworkAvailability) -> anyhow::Result<()> {
-        let server = GrpcServer::new("localhost:0").await?;
-        let port = server.port()?;
-
-        let work_dir = tempdir()?;
-        let searcher = SyncedSearcher::new(self.settings.metadata.clone(), work_dir.path());
-
-        let address = match availability {
-            NetworkAvailability::Connected => format!("localhost:{port}"),
-            NetworkAvailability::Isolated => format!("unreachable:{port}"),
-        };
-        let node_id = {
-            let mut nodes = self.nodes.lock().unwrap();
-            nodes.push(address);
-            nodes.len() - 1
-        };
-        let list_nodes = Arc::new(ManualListNodes(self.nodes.clone(), node_id));
-
-        let searcher_api = SearchServer::new(
-            searcher.index_cache(),
-            ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, self.shard_replication),
-        );
-        let shutdown = CancellationToken::new();
-        {
-            let settings = self.settings.clone();
-            let shutdown = shutdown.clone();
-            let num_replicas = self.shard_replication;
-            tokio::task::spawn(server.serve(searcher_api.into_router(), shutdown.clone()));
-            tokio::task::spawn(async move {
-                searcher
-                    .run(
-                        settings.storage.as_ref().unwrap().object_store.clone(),
-                        settings.searcher.clone().unwrap_or_default(),
-                        shutdown,
-                        ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, num_replicas),
-                        None,
-                        None,
-                    )
-                    .await
-            });
-        }
-
-        self.searchers.push(Some(Searcher { port, shutdown }));
-        Ok(())
-    }
-
-    /// Grow the cluster adding a fake node. This will cause shards to be repartitioned with the new
-    /// node, but it's not accessible (there's no gRPC server)
-    pub fn grow_fake(&mut self, name: String) {
-        self.nodes.lock().unwrap().push(name);
-        self.searchers.push(None);
-    }
-
-    /// Gracefully shutdown a searcher node. This will keep it part of the cluster but unavailable
-    /// to the rest. This operation can't be reversed
-    pub async fn shutdown(&mut self, id: SearcherId) {
-        todo!()
-    }
-
-    /// Shrink the cluster by scaling down. This will remove a node from the cluster and shards will
-    /// be repartitioned across the rest.
-    pub fn shrink(&mut self) -> Option<Searcher> {
-        assert!(!self.searchers.is_empty(), "can't shrink an empty cluster");
-        let searcher = self.searchers.pop().unwrap();
-        self.nodes.lock().unwrap().pop().unwrap();
-        searcher
-    }
-
-    pub fn refresh_interval(&self) -> Duration {
-        let refresh_interval = self.settings.searcher.as_ref().map_or_else(
-            || SearcherSettings::default().metadata_refresh_interval,
-            |s| s.metadata_refresh_interval,
-        );
-        Duration::from_secs_f32(refresh_interval + 0.1)
-    }
-}
-
-impl Searcher {
-    pub fn address(&self) -> String {
-        format!("localhost:{}", self.port)
-    }
-}
-
-async fn create_shards(api_client: &mut NidxApiClient<Channel>, count: usize) -> anyhow::Result<Vec<Uuid>> {
-    let mut shards = Vec::with_capacity(count);
-    for _ in 0..count {
-        let response = api_client
-            .new_shard(Request::new(NewShardRequest {
-                kbid: "aabbccddeeff11223344556677889900".to_string(),
-                vectorsets_configs: HashMap::from([(
-                    "english".to_string(),
-                    VectorIndexConfig {
-                        vector_dimension: Some(3),
-                        ..Default::default()
-                    },
-                )]),
-                ..Default::default()
-            }))
-            .await?;
-        shards.push(uuid::Uuid::parse_str(&response.into_inner().id).unwrap());
-    }
-    Ok(shards)
 }

--- a/nidx/tests/integration/searcher_cluster.rs
+++ b/nidx/tests/integration/searcher_cluster.rs
@@ -102,7 +102,7 @@ async fn test_search_cluster_all_shards_accessible(pool: PgPool) -> anyhow::Resu
             NidxSearcherClient::connect(format!("http://{searcher}"))
                 .await?
                 .search(Request::new(SearchRequest {
-                    shard: shard.to_string(),
+                    shard_ids: vec![shard.to_string()],
                     result_per_page: 20,
                     body: "Hola".into(),
                     paragraph: true,
@@ -120,7 +120,7 @@ async fn test_search_cluster_all_shards_accessible(pool: PgPool) -> anyhow::Resu
             NidxSearcherClient::connect(format!("http://{searcher}"))
                 .await?
                 .search(Request::new(SearchRequest {
-                    shard: shard.to_string(),
+                    shard_ids: vec![shard.to_string()],
                     result_per_page: 20,
                     body: "Hola".into(),
                     paragraph: true,
@@ -195,7 +195,7 @@ async fn test_search_cluster_shard_distribution(pool: PgPool) -> anyhow::Result<
             let result = NidxSearcherClient::connect(format!("http://{searcher}"))
                 .await?
                 .search(Request::new(SearchRequest {
-                    shard: shard.to_string(),
+                    shard_ids: vec![shard.to_string()],
                     result_per_page: 20,
                     body: "Hola".into(),
                     paragraph: true,
@@ -225,7 +225,7 @@ async fn test_search_cluster_shard_distribution(pool: PgPool) -> anyhow::Result<
             let result = NidxSearcherClient::connect(format!("http://{searcher}"))
                 .await?
                 .search(Request::new(SearchRequest {
-                    shard: shard.to_string(),
+                    shard_ids: vec![shard.to_string()],
                     result_per_page: 20,
                     body: "Hola".into(),
                     paragraph: true,
@@ -263,7 +263,7 @@ async fn test_search_cluster_shard_distribution(pool: PgPool) -> anyhow::Result<
             let result = NidxSearcherClient::connect(format!("http://{searcher}"))
                 .await?
                 .search(Request::new(SearchRequest {
-                    shard: shard.to_string(),
+                    shard_ids: vec![shard.to_string()],
                     result_per_page: 20,
                     body: "Hola".into(),
                     paragraph: true,
@@ -348,7 +348,7 @@ async fn test_search_cluster_shards_not_accessible(pool: PgPool) -> anyhow::Resu
     let fake_uuid = Uuid::new_v4();
     for searcher in &searchers {
         let mut request = Request::new(SearchRequest {
-            shard: fake_uuid.to_string(),
+            shard_ids: vec![fake_uuid.to_string()],
             result_per_page: 20,
             body: "Hola".into(),
             paragraph: true,

--- a/nidx/tests/integration/searcher_cluster.rs
+++ b/nidx/tests/integration/searcher_cluster.rs
@@ -14,10 +14,13 @@
 //
 
 use crate::common::services::NidxFixture;
+use nidx::Settings;
 use nidx::grpc_server::GrpcServer;
 use nidx::searcher::{ListNodes, SyncedSearcher, grpc::SearchServer, shard_selector::ShardSelector};
+use nidx::settings::SearcherSettings;
 use nidx_protos::SearchRequest;
 use nidx_protos::nidx::nidx_searcher_client::NidxSearcherClient;
+use nidx_protos::nidx_api_client::NidxApiClient;
 use nidx_protos::{NewShardRequest, VectorIndexConfig};
 
 use sqlx::PgPool;
@@ -27,8 +30,10 @@ use std::{sync::Arc, time::Duration};
 use tempfile::tempdir;
 use tokio_util::sync::CancellationToken;
 use tonic::Request;
+use tonic::transport::Channel;
 use uuid::Uuid;
 
+#[derive(Debug)]
 struct ManualListNodes(Arc<Mutex<Vec<String>>>, usize);
 impl ListNodes for ManualListNodes {
     fn list_nodes(&self) -> Vec<String> {
@@ -45,61 +50,25 @@ impl ListNodes for ManualListNodes {
 
 #[sqlx::test]
 async fn test_search_cluster_all_shards_accessible(pool: PgPool) -> anyhow::Result<()> {
-    let mut shards = Vec::new();
     let mut fixture = NidxFixture::new(pool).await?;
-    for _ in 0..10 {
-        let response = fixture
-            .api_client
-            .new_shard(Request::new(NewShardRequest {
-                kbid: "aabbccddeeff11223344556677889900".to_string(),
-                vectorsets_configs: HashMap::from([(
-                    "english".to_string(),
-                    VectorIndexConfig {
-                        vector_dimension: Some(3),
-                        ..Default::default()
-                    },
-                )]),
-                ..Default::default()
-            }))
-            .await?;
-        shards.push(uuid::Uuid::parse_str(&response.into_inner().id).unwrap());
-    }
+    let shards = create_shards(&mut fixture.api_client, 10).await?;
 
     // Create a cluster with 3 nodes
-    let nodes = Arc::new(Mutex::new(Vec::new()));
-    let mut searchers = Vec::new();
-    for i in 0..3 {
-        let searcher_server = GrpcServer::new("localhost:0").await?;
-        let searcher_port = searcher_server.port()?;
-        nodes.lock().unwrap().push(format!("localhost:{searcher_port}"));
-        let list_nodes = ManualListNodes(nodes.clone(), i);
-        let work_dir = tempdir()?;
-        let searcher = SyncedSearcher::new(fixture.settings.metadata.clone(), work_dir.path());
-        let arc_list_nodes = Arc::new(list_nodes);
-        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new(arc_list_nodes.clone(), 1));
-        searchers.push(format!("localhost:{searcher_port}"));
-        let settings_copy = fixture.settings.clone();
-        let shutdown = CancellationToken::new();
-        tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));
-        tokio::task::spawn(async move {
-            searcher
-                .run(
-                    settings_copy.storage.as_ref().unwrap().object_store.clone(),
-                    settings_copy.searcher.clone().unwrap_or_default(),
-                    shutdown.clone(),
-                    ShardSelector::new(arc_list_nodes, 1),
-                    None,
-                    None,
-                )
-                .await
-        });
-    }
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    let mut cluster = SearcherCluster::new(
+        fixture.settings.clone(),
+        Topology {
+            nodes: 3,
+            shard_replication: 1,
+            network: vec![NetworkAvailability::Connected; 3],
+        },
+    )
+    .await?;
 
     // All shards are accessible from all nodes
     for shard in &shards {
-        for searcher in &searchers {
-            NidxSearcherClient::connect(format!("http://{searcher}"))
+        for searcher in &cluster.searchers {
+            let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+            NidxSearcherClient::connect(format!("http://{}", searcher.address()))
                 .await?
                 .search(Request::new(SearchRequest {
                     shard_ids: vec![shard.to_string()],
@@ -113,11 +82,13 @@ async fn test_search_cluster_all_shards_accessible(pool: PgPool) -> anyhow::Resu
     }
 
     // Remove one node from the cluster and wait for sync, searches should still work
-    nodes.lock().unwrap().remove(2);
-    tokio::time::sleep(Duration::from_secs_f32(1.2)).await;
+    let _ = cluster.shrink();
+    assert_eq!(cluster.size(), 2);
+    tokio::time::sleep(cluster.refresh_interval()).await;
     for shard in &shards {
-        for searcher in &searchers[0..2] {
-            NidxSearcherClient::connect(format!("http://{searcher}"))
+        for searcher in &cluster.searchers {
+            let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+            NidxSearcherClient::connect(format!("http://{}", searcher.address()))
                 .await?
                 .search(Request::new(SearchRequest {
                     shard_ids: vec![shard.to_string()],
@@ -135,64 +106,28 @@ async fn test_search_cluster_all_shards_accessible(pool: PgPool) -> anyhow::Resu
 
 #[sqlx::test]
 async fn test_search_cluster_shard_distribution(pool: PgPool) -> anyhow::Result<()> {
-    let mut shards = Vec::new();
     let mut fixture = NidxFixture::new(pool).await?;
-    for _ in 0..30 {
-        let response = fixture
-            .api_client
-            .new_shard(Request::new(NewShardRequest {
-                kbid: "aabbccddeeff11223344556677889900".to_string(),
-                vectorsets_configs: HashMap::from([(
-                    "english".to_string(),
-                    VectorIndexConfig {
-                        vector_dimension: Some(3),
-                        ..Default::default()
-                    },
-                )]),
-                ..Default::default()
-            }))
-            .await?;
-        shards.push(uuid::Uuid::parse_str(&response.into_inner().id).unwrap());
-    }
+    let shards = create_shards(&mut fixture.api_client, 30).await?;
 
     // Create a cluster with 3 nodes, set an invalid entrypoint so they cannot communicate among them
-    let nodes = Arc::new(Mutex::new(Vec::new()));
-    let mut searchers = Vec::new();
-    for i in 0..3 {
-        let searcher_server = GrpcServer::new("localhost:0").await?;
-        let searcher_port = searcher_server.port()?;
-        nodes.lock().unwrap().push(format!("fake_{searcher_port}"));
-        let list_nodes = ManualListNodes(nodes.clone(), i);
-        let work_dir = tempdir()?;
-        let searcher = SyncedSearcher::new(fixture.settings.metadata.clone(), work_dir.path());
-        let arc_list_nodes = Arc::new(list_nodes);
-        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new(arc_list_nodes.clone(), 1));
-        searchers.push(format!("localhost:{searcher_port}"));
-        let settings_copy = fixture.settings.clone();
-        let shutdown = CancellationToken::new();
-        tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));
-        tokio::task::spawn(async move {
-            searcher
-                .run(
-                    settings_copy.storage.as_ref().unwrap().object_store.clone(),
-                    settings_copy.searcher.clone().unwrap_or_default(),
-                    shutdown.clone(),
-                    ShardSelector::new(arc_list_nodes, 1),
-                    None,
-                    None,
-                )
-                .await
-        });
-    }
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    let mut cluster = SearcherCluster::new(
+        fixture.settings.clone(),
+        Topology {
+            nodes: 3,
+            shard_replication: 1,
+            network: vec![NetworkAvailability::Isolated; 3],
+        },
+    )
+    .await?;
 
     // Each shard is only accessible from a single node
     let mut node_for_shard_original = HashMap::new();
     let mut shards_per_node = vec![0, 0, 0];
     for shard in &shards {
         let mut success = 0;
-        for (i, searcher) in searchers.iter().enumerate() {
-            let result = NidxSearcherClient::connect(format!("http://{searcher}"))
+        for (i, searcher) in cluster.searchers.iter().enumerate() {
+            let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+            let result = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
                 .await?
                 .search(Request::new(SearchRequest {
                     shard_ids: vec![shard.to_string()],
@@ -215,14 +150,16 @@ async fn test_search_cluster_shard_distribution(pool: PgPool) -> anyhow::Result<
     }
 
     // Remove one node from the cluster, we expect shards to rebalance among the remaining nodes
-    nodes.lock().unwrap().remove(2);
-    tokio::time::sleep(Duration::from_secs_f32(1.2)).await;
+    let node_2 = cluster.shrink();
+    assert_eq!(cluster.size(), 2);
+    tokio::time::sleep(cluster.refresh_interval()).await;
 
     let mut node_for_shard_scale_down = HashMap::new();
     for shard in &shards {
         let mut success = 0;
-        for (i, searcher) in searchers[0..2].iter().enumerate() {
-            let result = NidxSearcherClient::connect(format!("http://{searcher}"))
+        for (i, searcher) in cluster.searchers[0..2].iter().enumerate() {
+            let searcher = searcher.as_ref().expect("we don't have any fake node configured");
+            let result = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
                 .await?
                 .search(Request::new(SearchRequest {
                     shard_ids: vec![shard.to_string()],
@@ -253,14 +190,16 @@ async fn test_search_cluster_shard_distribution(pool: PgPool) -> anyhow::Result<
     // Add a new node again, shards should split up again
     // This node will have a different ID, so shard split
     // should be different than originally
-    nodes.lock().unwrap().push("fake_new_node".to_string());
-    tokio::time::sleep(Duration::from_secs_f32(1.2)).await;
+    cluster.grow_fake("fake_new_node".to_string());
+    assert_eq!(cluster.size(), 3);
+    tokio::time::sleep(cluster.refresh_interval()).await;
 
     let mut node_for_shard_scale_up = HashMap::new();
     for shard in &shards {
         let mut success = 0;
-        for (i, searcher) in searchers.iter().enumerate() {
-            let result = NidxSearcherClient::connect(format!("http://{searcher}"))
+        for (i, searcher) in cluster.searchers[0..2].iter().chain([&node_2]).enumerate() {
+            let searcher = searcher.as_ref().expect("fake node is 2");
+            let result = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
                 .await?
                 .search(Request::new(SearchRequest {
                     shard_ids: vec![shard.to_string()],
@@ -314,39 +253,20 @@ async fn test_search_cluster_shards_not_accessible(pool: PgPool) -> anyhow::Resu
     let fixture = NidxFixture::new(pool).await?;
 
     // Create a cluster with 3 nodes and 2 replicas for each shard
-    let nodes = Arc::new(Mutex::new(Vec::new()));
-    let mut searchers = Vec::new();
-    for i in 0..3 {
-        let searcher_server = GrpcServer::new("localhost:0").await?;
-        let searcher_port = searcher_server.port()?;
-        nodes.lock().unwrap().push(format!("localhost:{searcher_port}"));
-        let list_nodes = ManualListNodes(nodes.clone(), i);
-        let work_dir = tempdir()?;
-        let searcher = SyncedSearcher::new(fixture.settings.metadata.clone(), work_dir.path());
-        let arc_list_nodes = Arc::new(list_nodes);
-        let searcher_api = SearchServer::new(searcher.index_cache(), ShardSelector::new(arc_list_nodes.clone(), 2));
-        searchers.push(format!("localhost:{searcher_port}"));
-        let settings_copy = fixture.settings.clone();
-        let shutdown = CancellationToken::new();
-        tokio::task::spawn(searcher_server.serve(searcher_api.into_router(), shutdown.clone()));
-        tokio::task::spawn(async move {
-            searcher
-                .run(
-                    settings_copy.storage.as_ref().unwrap().object_store.clone(),
-                    settings_copy.searcher.clone().unwrap_or_default(),
-                    shutdown.clone(),
-                    ShardSelector::new(arc_list_nodes, 2),
-                    None,
-                    None,
-                )
-                .await
-        });
-    }
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    let cluster = SearcherCluster::new(
+        fixture.settings.clone(),
+        Topology {
+            nodes: 3,
+            shard_replication: 2,
+            network: vec![NetworkAvailability::Connected; 3],
+        },
+    )
+    .await?;
 
     // Same behaviour from all nodes
     let fake_uuid = Uuid::new_v4();
-    for searcher in &searchers {
+    for searcher in &cluster.searchers {
+        let searcher = searcher.as_ref().expect("we don't have any fake node configured");
         let mut request = Request::new(SearchRequest {
             shard_ids: vec![fake_uuid.to_string()],
             result_per_page: 20,
@@ -356,7 +276,7 @@ async fn test_search_cluster_shards_not_accessible(pool: PgPool) -> anyhow::Resu
         });
         request.set_timeout(Duration::from_secs(1));
 
-        let response = NidxSearcherClient::connect(format!("http://{searcher}"))
+        let response = NidxSearcherClient::connect(format!("http://{}", searcher.address()))
             .await?
             .search(request)
             .await;
@@ -372,4 +292,172 @@ async fn test_search_cluster_shards_not_accessible(pool: PgPool) -> anyhow::Resu
     }
 
     Ok(())
+}
+
+struct SearcherCluster {
+    pub searchers: Vec<Option<Searcher>>,
+    nodes: Arc<Mutex<Vec<String>>>,
+    settings: Settings,
+    shard_replication: usize,
+}
+
+type SearcherId = usize;
+
+// Each searcher has it's own view on the cluster, not shared with the rest
+#[derive(Debug)]
+struct Searcher {
+    port: u16,
+    shutdown: CancellationToken,
+}
+
+struct Topology {
+    // Number of nodes in the cluster
+    nodes: usize,
+
+    // Number of nodes that have a replica of a shard
+    shard_replication: usize,
+
+    // When defined, the network describes which nodes are reachable from every
+    // node in the cluster. By default, everyone sees everyone.
+    //
+    // Changes on the network can be used to simluate network partitions, nodes
+    // being down...
+    network: Vec<NetworkAvailability>,
+}
+
+#[derive(Clone, Debug)]
+enum NetworkAvailability {
+    Connected,
+    Isolated,
+}
+
+impl SearcherCluster {
+    pub async fn new(settings: Settings, topology: Topology) -> anyhow::Result<Self> {
+        assert_eq!(
+            topology.nodes,
+            topology.network.len(),
+            "number of nodes and network configurations mismatch"
+        );
+
+        let mut cluster = Self {
+            searchers: Vec::new(),
+            nodes: Arc::new(Mutex::new(Vec::new())),
+            settings,
+            shard_replication: topology.shard_replication,
+        };
+
+        for availability in topology.network {
+            cluster.grow(availability).await?;
+        }
+        tokio::time::sleep(cluster.refresh_interval()).await;
+
+        Ok(cluster)
+    }
+
+    pub fn size(&self) -> usize {
+        self.searchers.len()
+    }
+
+    pub async fn grow(&mut self, availability: NetworkAvailability) -> anyhow::Result<()> {
+        let server = GrpcServer::new("localhost:0").await?;
+        let port = server.port()?;
+
+        let work_dir = tempdir()?;
+        let searcher = SyncedSearcher::new(self.settings.metadata.clone(), work_dir.path());
+
+        let address = match availability {
+            NetworkAvailability::Connected => format!("localhost:{port}"),
+            NetworkAvailability::Isolated => format!("unreachable:{port}"),
+        };
+        let node_id = {
+            let mut nodes = self.nodes.lock().unwrap();
+            nodes.push(address);
+            nodes.len() - 1
+        };
+        let list_nodes = Arc::new(ManualListNodes(self.nodes.clone(), node_id));
+
+        let searcher_api = SearchServer::new(
+            searcher.index_cache(),
+            ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, self.shard_replication),
+        );
+        let shutdown = CancellationToken::new();
+        {
+            let settings = self.settings.clone();
+            let shutdown = shutdown.clone();
+            let num_replicas = self.shard_replication;
+            tokio::task::spawn(server.serve(searcher_api.into_router(), shutdown.clone()));
+            tokio::task::spawn(async move {
+                searcher
+                    .run(
+                        settings.storage.as_ref().unwrap().object_store.clone(),
+                        settings.searcher.clone().unwrap_or_default(),
+                        shutdown,
+                        ShardSelector::new(Arc::clone(&list_nodes) as Arc<dyn ListNodes>, num_replicas),
+                        None,
+                        None,
+                    )
+                    .await
+            });
+        }
+
+        self.searchers.push(Some(Searcher { port, shutdown }));
+        Ok(())
+    }
+
+    /// Grow the cluster adding a fake node. This will cause shards to be repartitioned with the new
+    /// node, but it's not accessible (there's no gRPC server)
+    pub fn grow_fake(&mut self, name: String) {
+        self.nodes.lock().unwrap().push(name);
+        self.searchers.push(None);
+    }
+
+    /// Gracefully shutdown a searcher node. This will keep it part of the cluster but unavailable
+    /// to the rest. This operation can't be reversed
+    pub async fn shutdown(&mut self, id: SearcherId) {
+        todo!()
+    }
+
+    /// Shrink the cluster by scaling down. This will remove a node from the cluster and shards will
+    /// be repartitioned across the rest.
+    pub fn shrink(&mut self) -> Option<Searcher> {
+        assert!(!self.searchers.is_empty(), "can't shrink an empty cluster");
+        let searcher = self.searchers.pop().unwrap();
+        self.nodes.lock().unwrap().pop().unwrap();
+        searcher
+    }
+
+    pub fn refresh_interval(&self) -> Duration {
+        let refresh_interval = self.settings.searcher.as_ref().map_or_else(
+            || SearcherSettings::default().metadata_refresh_interval,
+            |s| s.metadata_refresh_interval,
+        );
+        Duration::from_secs_f32(refresh_interval + 0.1)
+    }
+}
+
+impl Searcher {
+    pub fn address(&self) -> String {
+        format!("localhost:{}", self.port)
+    }
+}
+
+async fn create_shards(api_client: &mut NidxApiClient<Channel>, count: usize) -> anyhow::Result<Vec<Uuid>> {
+    let mut shards = Vec::with_capacity(count);
+    for _ in 0..count {
+        let response = api_client
+            .new_shard(Request::new(NewShardRequest {
+                kbid: "aabbccddeeff11223344556677889900".to_string(),
+                vectorsets_configs: HashMap::from([(
+                    "english".to_string(),
+                    VectorIndexConfig {
+                        vector_dimension: Some(3),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }))
+            .await?;
+        shards.push(uuid::Uuid::parse_str(&response.into_inner().id).unwrap());
+    }
+    Ok(shards)
 }

--- a/nidx/tests/integration/security_search.rs
+++ b/nidx/tests/integration/security_search.rs
@@ -135,7 +135,7 @@ async fn test_security_search(pool: PgPool) -> Result<(), Box<dyn std::error::Er
         .searcher_client
         .search(SearchRequest {
             body: "text".to_string(),
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             document: true,
             vectorset: "english".to_string(),
             security: None,
@@ -164,7 +164,7 @@ async fn test_security_search(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let response = fixture
         .searcher_client
         .search(SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             document: true,
             vectorset: "english".to_string(),
             security: Some(Security {
@@ -197,7 +197,7 @@ async fn test_security_search(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let response = fixture
         .searcher_client
         .search(SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             document: true,
             vectorset: "english".to_string(),
             security: Some(Security { access_groups: vec![] }),
@@ -226,7 +226,7 @@ async fn test_security_search(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let response = fixture
         .searcher_client
         .search(SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             document: true,
             vectorset: "english".to_string(),
             security: Some(Security {
@@ -260,7 +260,7 @@ async fn test_security_search(pool: PgPool) -> Result<(), Box<dyn std::error::Er
     let response = fixture
         .searcher_client
         .search(SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             document: true,
             vectorset: "english".to_string(),
             security: Some(Security {
@@ -320,7 +320,7 @@ async fn test_security_search_public_resource(pool: PgPool) -> Result<(), Box<dy
         .search(SearchRequest {
             body: "text".to_string(),
             vectorset: "english".to_string(),
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             document: true,
             security: Some(Security { access_groups: vec![] }),
             ..Default::default()
@@ -334,7 +334,7 @@ async fn test_security_search_public_resource(pool: PgPool) -> Result<(), Box<dy
     let response = fixture
         .searcher_client
         .search(SearchRequest {
-            shard: shard_id.clone(),
+            shard_ids: vec![shard_id.clone()],
             vectorset: "english".to_string(),
             document: true,
             security: Some(Security {

--- a/nidx/tests/integration/vector_normalization.rs
+++ b/nidx/tests/integration/vector_normalization.rs
@@ -68,7 +68,7 @@ async fn test_vector_normalization_shard(pool: PgPool) -> Result<(), Box<dyn std
     let query_vector = vec![17.0 / magnitude; VECTOR_DIMENSION];
 
     let search_request = nodereader::SearchRequest {
-        shard: shard.id.clone(),
+        shard_ids: vec![shard.id.clone()],
         vector: query_vector,
         vectorset: "english".to_string(),
         with_duplicates: true,

--- a/nidx/tests/integration/vector_relation_index.rs
+++ b/nidx/tests/integration/vector_relation_index.rs
@@ -269,7 +269,7 @@ async fn test_relation_path_search(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let results = fixture
         .searcher_client
         .search(SearchRequest {
-            shard: shard_id,
+            shard_ids: vec![shard_id],
             graph_search: Some(nidx_protos::search_request::GraphSearch {
                 query: Some(graph_query),
             }),

--- a/nucliadb/src/nucliadb/common/cluster/rebalance.py
+++ b/nucliadb/src/nucliadb/common/cluster/rebalance.py
@@ -364,7 +364,7 @@ async def get_resource_paragraphs_count(resource_id: str, nidx_shard_id: str) ->
     # Do a search on the fields (paragraph) index and return the number of paragraphs this resource has
     try:
         request = nodereader_pb2.SearchRequest(
-            shard=nidx_shard_id,
+            shard_ids=[nidx_shard_id],
             paragraph=True,
             document=False,
             result_per_page=0,
@@ -427,7 +427,7 @@ async def get_shard_paragraph_count(nidx_shard_id: str) -> int:
     # Do a search on the fields (paragraph) index
     try:
         request = nodereader_pb2.SearchRequest(
-            shard=nidx_shard_id,
+            shard_ids=[nidx_shard_id],
             paragraph=True,
             document=False,
             result_per_page=0,

--- a/nucliadb/src/nucliadb/common/filter_expression.py
+++ b/nucliadb/src/nucliadb/common/filter_expression.py
@@ -143,7 +143,7 @@ async def parse_expression(
             f.date.until.FromDatetime(expr.until)
     elif isinstance(expr, FacetFilter):
         f.facet.facet = facet_from_filter(expr)
-    else:
+    else:  # pragma: no cover
         assert_never(expr)
 
     return f
@@ -266,7 +266,7 @@ def _set_range_bound(
             path.date_range.lower.FromDatetime(value)
         else:
             path.date_range.upper.FromDatetime(value)
-    else:
+    else:  # pragma: no cover
         assert_never(value)
 
 
@@ -306,7 +306,7 @@ def _parse_kv_expression(
                 json_filter.path.int = expr.eq
             case datetime():
                 json_filter.path.date.FromDatetime(expr.eq)
-            case _:
+            case _:  # pragma: no cover
                 assert_never(expr.eq)
 
     elif isinstance(expr, Inequalities):
@@ -343,7 +343,7 @@ def _parse_kv_expression(
 
             json_filter.bool_and.operands.extend([lower_bound, upper_bound])
 
-    else:
+    else:  # pragma: no cover
         assert_never(expr)
 
     return json_filter
@@ -397,7 +397,7 @@ def facet_from_filter(expr: FacetFilter) -> str:
             facet += f"/{expr.id}"
     elif isinstance(expr, Status):
         facet = f"/n/s/{expr.status.value}"
-    else:
+    else:  # pragma: no cover
         assert_never(expr)
 
     return facet

--- a/nucliadb/src/nucliadb/ingest/fields/key_value.py
+++ b/nucliadb/src/nucliadb/ingest/fields/key_value.py
@@ -94,7 +94,7 @@ def check_kv_type(schema_name: str, schema_field: KVSchemaField, key: str, value
                 ok = False
         else:
             ok = is_datetime(value)
-    else:
+    else:  # pragma: no cover
         assert_never(expected)
     if not ok:
         if expected is KVFieldType.TEXT and isinstance(value, str):

--- a/nucliadb/src/nucliadb/ingest/orm/entities.py
+++ b/nucliadb/src/nucliadb/ingest/orm/entities.py
@@ -32,7 +32,7 @@ from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.settings import settings
-from nucliadb.search.search.shards import graph_search_shard, query_shards
+from nucliadb.search.search.shards import graph_search_shard, query_shard
 from nucliadb_protos.knowledgebox_pb2 import (
     EntitiesGroup,
     EntitiesGroupSummary,
@@ -135,29 +135,37 @@ class EntitiesManager:
             yield group
             visited_groups.add(group)
 
-    async def get_indexed_entities_groups_names(self) -> set[str]:
+    async def get_indexed_entities_groups_names(
+        self,
+    ) -> set[str]:
         shard_manager = get_shard_manager()
-        shard_ids = [
-            shard_obj.nidx_shard_id for shard_obj in await shard_manager.get_shards_by_kbid(self.kbid)
-        ]
 
-        # search all relation types
-        request = SearchRequest(
-            shard_ids=shard_ids,
-            result_per_page=0,
-            body="",
-            document=True,
-            paragraph=False,
-            faceted=Faceted(labels=["/e"]),
+        async def query_indexed_entities_group_names(shard_id: str) -> set[str]:
+            """Search all relation types"""
+            request = SearchRequest(
+                shard_ids=[shard_id],
+                result_per_page=0,
+                body="",
+                document=True,
+                paragraph=False,
+                faceted=Faceted(labels=["/e"]),
+            )
+            response: SearchResponse = await query_shard(shard_id, request)
+            try:
+                facetresults = response.document.facets["/e"].facetresults
+            except KeyError:
+                # No entities found
+                return set()
+            else:
+                return {facet.tag.split("/")[-1] for facet in facetresults}
+
+        results = await shard_manager.apply_for_all_shards(
+            self.kbid, query_indexed_entities_group_names, settings.relation_types_timeout
         )
-        response: SearchResponse = await query_shards(shard_ids, request)
-        try:
-            facetresults = response.document.facets["/e"].facetresults
-        except KeyError:
-            # No entities found
+
+        if not results:
             return set()
-        else:
-            return {facet.tag.split("/")[-1] for facet in facetresults}
+        return set.union(*results)
 
     @staticmethod
     def merge_entities_groups(indexed: EntitiesGroup, stored: EntitiesGroup):

--- a/nucliadb/src/nucliadb/ingest/orm/entities.py
+++ b/nucliadb/src/nucliadb/ingest/orm/entities.py
@@ -32,7 +32,7 @@ from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.settings import settings
-from nucliadb.search.search.shards import graph_search_shard, query_shard
+from nucliadb.search.search.shards import graph_search_shard, query_shards
 from nucliadb_protos.knowledgebox_pb2 import (
     EntitiesGroup,
     EntitiesGroupSummary,
@@ -135,37 +135,29 @@ class EntitiesManager:
             yield group
             visited_groups.add(group)
 
-    async def get_indexed_entities_groups_names(
-        self,
-    ) -> set[str]:
+    async def get_indexed_entities_groups_names(self) -> set[str]:
         shard_manager = get_shard_manager()
+        shard_ids = [
+            shard_obj.nidx_shard_id for shard_obj in await shard_manager.get_shards_by_kbid(self.kbid)
+        ]
 
-        async def query_indexed_entities_group_names(shard_id: str) -> set[str]:
-            """Search all relation types"""
-            request = SearchRequest(
-                shard=shard_id,
-                result_per_page=0,
-                body="",
-                document=True,
-                paragraph=False,
-                faceted=Faceted(labels=["/e"]),
-            )
-            response: SearchResponse = await query_shard(shard_id, request)
-            try:
-                facetresults = response.document.facets["/e"].facetresults
-            except KeyError:
-                # No entities found
-                return set()
-            else:
-                return {facet.tag.split("/")[-1] for facet in facetresults}
-
-        results = await shard_manager.apply_for_all_shards(
-            self.kbid, query_indexed_entities_group_names, settings.relation_types_timeout
+        # search all relation types
+        request = SearchRequest(
+            shard_ids=shard_ids,
+            result_per_page=0,
+            body="",
+            document=True,
+            paragraph=False,
+            faceted=Faceted(labels=["/e"]),
         )
-
-        if not results:
+        response: SearchResponse = await query_shards(shard_ids, request)
+        try:
+            facetresults = response.document.facets["/e"].facetresults
+        except KeyError:
+            # No entities found
             return set()
-        return set.union(*results)
+        else:
+            return {facet.tag.split("/")[-1] for facet in facetresults}
 
     @staticmethod
     def merge_entities_groups(indexed: EntitiesGroup, stored: EntitiesGroup):

--- a/nucliadb/src/nucliadb/search/augmentor/resources.py
+++ b/nucliadb/src/nucliadb/search/augmentor/resources.py
@@ -104,7 +104,7 @@ async def db_augment_resource(
         elif isinstance(prop, ResourceClassificationLabels):
             labels = await classification_labels(resource)
 
-        else:
+        else:  # pragma: no cover
             assert_never(prop)
 
     augmented = AugmentedResource(

--- a/nucliadb/src/nucliadb/search/requesters/utils.py
+++ b/nucliadb/src/nucliadb/search/requesters/utils.py
@@ -21,7 +21,7 @@ import asyncio
 import json
 from collections.abc import Sequence
 from enum import Enum, auto
-from typing import TypeVar, overload
+from typing import Any, Callable, Coroutine, TypeVar, overload
 
 from fastapi import HTTPException
 from google.protobuf.json_format import MessageToDict
@@ -35,18 +35,17 @@ from nidx_protos.nodereader_pb2 import (
     SuggestRequest,
     SuggestResponse,
 )
+from typing_extensions import assert_never
 
 from nucliadb.common.cluster.exceptions import ShardsNotFound
 from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.search import logger
-from nucliadb.search.search.shards import (
-    graph_search_shard,
-    query_shard,
-    suggest_shard,
-)
+from nucliadb.search.search.shards import graph_search_shard, query_shard, suggest_shard
 from nucliadb.search.settings import settings
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from nucliadb_telemetry import errors
+from nucliadb_utils import const
+from nucliadb_utils.utilities import has_feature
 
 
 class Method(Enum):
@@ -54,12 +53,6 @@ class Method(Enum):
     SUGGEST = auto()
     GRAPH = auto()
 
-
-METHODS = {
-    Method.SEARCH: query_shard,
-    Method.SUGGEST: suggest_shard,
-    Method.GRAPH: graph_search_shard,
-}
 
 REQUEST_TYPE = SuggestRequest | SearchRequest | GraphSearchRequest
 
@@ -117,14 +110,39 @@ async def nidx_query(
     ops = []
     queried_shards = []
 
-    for shard_obj in shard_groups:
-        shard_id = shard_obj.nidx_shard_id
-        if shard_id is not None:
-            # At least one node is alive for this shard group
-            # let's add it ot the query list if has a valid value
-            func = METHODS[method]
-            ops.append(func(shard_id, pb_query))  # type: ignore
-            queried_shards.append(shard_id)
+    func: (
+        Callable[[list[str], SearchRequest], Coroutine[Any, Any, SearchResponse]]
+        | Callable[[str, SuggestRequest], Coroutine[Any, Any, SuggestResponse]]
+        | Callable[[str, GraphSearchRequest], Coroutine[Any, Any, GraphSearchResponse]]
+    )
+
+    if method == Method.SEARCH:
+        assert isinstance(pb_query, SearchRequest), "type checked constraint"
+
+        # TODO: refactor this to send 1 request for N shards
+        multi_shard_search = has_feature(
+            const.Features.BETTER_MULTI_SHARD_SEARCH, context={"kbid": kbid}
+        )
+        for shard_obj in shard_groups:
+            if shard_obj.nidx_shard_id is not None:
+                pb_query.multi_shard_search = multi_shard_search
+                ops.append(query_shard(shard_obj.nidx_shard_id, pb_query))
+                queried_shards.append(shard_obj.nidx_shard_id)
+    else:
+        if method == Method.SUGGEST:
+            func = suggest_shard
+        elif method == Method.GRAPH:
+            func = graph_search_shard
+        else:  # pragma: no cover
+            assert_never(method)
+
+        for shard_obj in shard_groups:
+            shard_id = shard_obj.nidx_shard_id
+            if shard_id is not None:
+                # At least one node is alive for this shard group
+                # let's add it ot the query list if has a valid value
+                ops.append(func(shard_id, pb_query))  # type: ignore
+                queried_shards.append(shard_id)
 
     if not ops:
         logger.warning(f"No shards found for kb", extra={"kbid": kbid})
@@ -135,7 +153,7 @@ async def nidx_query(
 
     try:
         results: list[T | BaseException] = await asyncio.wait_for(  # type: ignore
-            asyncio.gather(*ops, return_exceptions=True),
+            asyncio.gather(*ops, return_exceptions=True),  # type: ignore[arg-type]
             timeout=timeout,
         )
     except asyncio.TimeoutError as exc:  # pragma: no cover

--- a/nucliadb/src/nucliadb/search/requesters/utils.py
+++ b/nucliadb/src/nucliadb/search/requesters/utils.py
@@ -40,7 +40,7 @@ from typing_extensions import assert_never
 from nucliadb.common.cluster.exceptions import ShardsNotFound
 from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.search import logger
-from nucliadb.search.search.shards import graph_search_shard, query_shard, suggest_shard
+from nucliadb.search.search.shards import graph_search_shard, query_shard, query_shards, suggest_shard
 from nucliadb.search.settings import settings
 from nucliadb_protos.writer_pb2 import ShardObject as PBShardObject
 from nucliadb_telemetry import errors
@@ -119,15 +119,20 @@ async def nidx_query(
     if method == Method.SEARCH:
         assert isinstance(pb_query, SearchRequest), "type checked constraint"
 
-        # TODO: refactor this to send 1 request for N shards
-        multi_shard_search = has_feature(
-            const.Features.BETTER_MULTI_SHARD_SEARCH, context={"kbid": kbid}
-        )
-        for shard_obj in shard_groups:
-            if shard_obj.nidx_shard_id is not None:
-                pb_query.multi_shard_search = multi_shard_search
-                ops.append(query_shard(shard_obj.nidx_shard_id, pb_query))
-                queried_shards.append(shard_obj.nidx_shard_id)
+        if has_feature(const.Features.BETTER_MULTI_SHARD_SEARCH, context={"kbid": kbid}):
+            for shard_obj in shard_groups:
+                if shard_obj.nidx_shard_id is not None:
+                    queried_shards.append(shard_obj.nidx_shard_id)
+
+            pb_query.multi_shard_search = True
+            ops.append(query_shards(queried_shards, pb_query))
+
+        else:
+            for shard_obj in shard_groups:
+                if shard_obj.nidx_shard_id is not None:
+                    ops.append(query_shard(shard_obj.nidx_shard_id, pb_query))
+                    queried_shards.append(shard_obj.nidx_shard_id)
+
     else:
         if method == Method.SUGGEST:
             func = suggest_shard

--- a/nucliadb/src/nucliadb/search/requesters/utils.py
+++ b/nucliadb/src/nucliadb/search/requesters/utils.py
@@ -123,8 +123,6 @@ async def nidx_query(
             for shard_obj in shard_groups:
                 if shard_obj.nidx_shard_id is not None:
                     queried_shards.append(shard_obj.nidx_shard_id)
-
-            pb_query.multi_shard_search = True
             ops.append(query_shards(queried_shards, pb_query))
 
         else:

--- a/nucliadb/src/nucliadb/search/search/chat/ask.py
+++ b/nucliadb/src/nucliadb/search/search/chat/ask.py
@@ -246,7 +246,7 @@ class AskResult:
                     if not first_reasoning_chunk_yielded:
                         self.metrics.record_first_reasoning_chunk_yielded()
                         first_reasoning_chunk_yielded = True
-                else:
+                else:  # pragma: no cover
                     assert_never(answer_chunk)
 
         if self._object is not None:

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/graph.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/graph.py
@@ -423,5 +423,5 @@ def _extract_semantic_terms(
             pass
         case None:
             pass
-        case _:
+        case _:  # pragma: no cover
             assert_never(query)

--- a/nucliadb/src/nucliadb/search/search/shards.py
+++ b/nucliadb/src/nucliadb/search/search/shards.py
@@ -41,13 +41,17 @@ def should_giveup(e: Exception):
     return False
 
 
+async def query_shard(shard: str, query: SearchRequest) -> SearchResponse:
+    return await query_shards([shard], query)
+
+
 @backoff.on_exception(
     backoff.expo, Exception, jitter=None, factor=0.1, max_tries=3, giveup=should_giveup
 )
-async def query_shard(shard: str, query: SearchRequest) -> SearchResponse:
+async def query_shards(shards: list[str], query: SearchRequest) -> SearchResponse:
     req = SearchRequest()
     req.CopyFrom(query)
-    req.shard = shard
+    req.shard_ids[:] = shards
     return await get_nidx_searcher_client().Search(req)
 
 

--- a/nucliadb/tests/nucliadb/integration/common/cluster/test_rebalance.py
+++ b/nucliadb/tests/nucliadb/integration/common/cluster/test_rebalance.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -36,6 +35,7 @@ from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.context import ApplicationContext
 from nucliadb.common.maindb.driver import Driver
 from nucliadb_protos import writer_pb2
+from tests.utils.dirty_index import mark_dirty, wait_for_sync
 
 
 @pytest.fixture()
@@ -192,8 +192,8 @@ async def create_shard_for_kb(kbid: str):
         await sm.create_shard_by_kbid(txn, kbid, prewarm_enabled=False)
         await txn.commit()
 
-    sync_refresh_interval = 1
-    await asyncio.sleep(sync_refresh_interval)
+    await mark_dirty()
+    await wait_for_sync()
 
 
 async def get_kb_shards(kbid: str) -> writer_pb2.Shards:

--- a/nucliadb/tests/nucliadb/integration/common/cluster/test_rebalance.py
+++ b/nucliadb/tests/nucliadb/integration/common/cluster/test_rebalance.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -49,10 +50,9 @@ async def app_context(natsd, storage, nucliadb):
 
 @pytest.mark.deploy_modes("standalone")
 async def test_rebalance_splits_kb_shards(
-    app_context,
-    standalone_knowledgebox,
+    app_context: ApplicationContext,
+    standalone_knowledgebox: str,
     nucliadb_writer: AsyncClient,
-    nucliadb_reader_manager: AsyncClient,
 ):
     total_resources = 10
     total_paragraphs = total_resources
@@ -102,8 +102,8 @@ async def test_rebalance_splits_kb_shards(
 
 @pytest.mark.deploy_modes("standalone")
 async def test_rebalance_merges_kb_shards(
-    app_context,
-    standalone_knowledgebox,
+    app_context: ApplicationContext,
+    standalone_knowledgebox: str,
     nucliadb_writer: AsyncClient,
     nucliadb_reader_manager: AsyncClient,
 ):
@@ -191,6 +191,9 @@ async def create_shard_for_kb(kbid: str):
         sm = get_shard_manager()
         await sm.create_shard_by_kbid(txn, kbid, prewarm_enabled=False)
         await txn.commit()
+
+    sync_refresh_interval = 1
+    await asyncio.sleep(sync_refresh_interval)
 
 
 async def get_kb_shards(kbid: str) -> writer_pb2.Shards:

--- a/nucliadb/tests/nucliadb/integration/test_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_vectorsets.py
@@ -34,7 +34,6 @@ from nucliadb.common.maindb.driver import Driver
 from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.search.predict import DummyPredictEngine
-from nucliadb.search.requesters import utils
 from nucliadb_models.internal.predict import (
     QueryInfo,
 )
@@ -291,48 +290,46 @@ async def test_querying_kb_with_vectorsets(
     await inject_message(nucliadb_ingest_grpc, bm)
 
     with (
-        patch.dict(utils.METHODS, {utils.Method.SEARCH: query_shard_wrapper}, clear=True),
+        patch("nucliadb.search.requesters.utils.query_shard", query_shard_wrapper),
+        patch.object(
+            dummy_predict,
+            "query",
+            side_effect=predict_query_wrapper(dummy_predict.query, 768, {"model": 768}),
+        ),
     ):
-        with (
-            patch.object(
-                dummy_predict,
-                "query",
-                side_effect=predict_query_wrapper(dummy_predict.query, 768, {"model": 768}),
-            ),
-        ):
-            resp = await nucliadb_reader.post(
-                f"/kb/{kbid}/find",
-                json={
-                    "query": "foo",
-                },
-            )
-            assert resp.status_code == 200
+        resp = await nucliadb_reader.post(
+            f"/kb/{kbid}/find",
+            json={
+                "query": "foo",
+            },
+        )
+        assert resp.status_code == 200
 
-            node_search_spy, result, error = query
-            assert result is not None
-            assert error is None
+        node_search_spy, result, error = query
+        assert result is not None
+        assert error is None
 
-            request = node_search_spy.call_args[0][0]
-            # there's only one model and we get it as the default
-            assert request.vectorset == "model"
-            assert len(request.vector) == 768
+        request = node_search_spy.call_args[0][0]
+        # there's only one model and we get it as the default
+        assert request.vectorset == "model"
+        assert len(request.vector) == 768
 
-            resp = await nucliadb_reader.post(
-                f"/kb/{kbid}/find",
-                json={
-                    "query": "foo",
-                    "vectorset": "model",
-                },
-            )
-            assert resp.status_code == 200
+        resp = await nucliadb_reader.post(
+            f"/kb/{kbid}/find",
+            json={
+                "query": "foo",
+                "vectorset": "model",
+            },
+        )
+        assert resp.status_code == 200
 
-            node_search_spy, result, error = query
-            assert result is not None
-            assert error is None
+        node_search_spy, result, error = query
+        assert result is not None
+        assert error is None
 
-            request = node_search_spy.call_args[0][0]
-            assert request.vectorset == "model"
-            assert len(request.vector) == 768
+        request = node_search_spy.call_args[0][0]
+        assert request.vectorset == "model"
+        assert len(request.vector) == 768
 
     # KB with 2 vectorsets
 
@@ -358,9 +355,7 @@ async def test_querying_kb_with_vectorsets(
     )
     await inject_message(nucliadb_ingest_grpc, bm)
 
-    with (
-        patch.dict(utils.METHODS, {utils.Method.SEARCH: query_shard_wrapper}, clear=True),
-    ):
+    with patch("nucliadb.search.requesters.utils.query_shard", query_shard_wrapper):
         with (
             patch.object(
                 dummy_predict,

--- a/nucliadb/tests/nucliadb/integration/test_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_vectorsets.py
@@ -239,10 +239,10 @@ async def test_querying_kb_with_vectorsets(
     """
     query: tuple[Any, nodereader_pb2.SearchResponse | None, Exception | None] = (None, None, None)
 
-    async def query_shard_wrapper(shard: str, pb_query: nodereader_pb2.SearchRequest):
+    async def query_shards_wrapper(shards: list[str], pb_query: nodereader_pb2.SearchRequest):
         nonlocal query
 
-        from nucliadb.search.search.shards import query_shard
+        from nucliadb.search.search.shards import query_shards
 
         # this avoids problems with spying an object twice
         nidx = get_nidx_searcher_client()
@@ -252,7 +252,7 @@ async def test_querying_kb_with_vectorsets(
             spy = nidx.Search
 
         try:
-            result = await query_shard(shard, pb_query)
+            result = await query_shards(shards, pb_query)
         except Exception as exc:
             query = (spy, None, exc)
             raise
@@ -290,7 +290,7 @@ async def test_querying_kb_with_vectorsets(
     await inject_message(nucliadb_ingest_grpc, bm)
 
     with (
-        patch("nucliadb.search.requesters.utils.query_shard", query_shard_wrapper),
+        patch("nucliadb.search.requesters.utils.query_shards", query_shards_wrapper),
         patch.object(
             dummy_predict,
             "query",
@@ -355,7 +355,7 @@ async def test_querying_kb_with_vectorsets(
     )
     await inject_message(nucliadb_ingest_grpc, bm)
 
-    with patch("nucliadb.search.requesters.utils.query_shard", query_shard_wrapper):
+    with patch("nucliadb.search.requesters.utils.query_shards", query_shards_wrapper):
         with (
             patch.object(
                 dummy_predict,

--- a/nucliadb/tests/nucliadb/integration/test_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_vectorsets.py
@@ -83,7 +83,7 @@ async def test_vectorsets_work_on_a_kb_with_a_single_vectorset(
 
     for dimension, vectorset in test_cases:
         query_pb = nodereader_pb2.SearchRequest(
-            shard=shard_id,
+            shard_ids=[shard_id],
             body="this is a query for my vectorset",
             vector=[1.23] * dimension,
             vectorset=vectorset,
@@ -99,7 +99,7 @@ async def test_vectorsets_work_on_a_kb_with_a_single_vectorset(
     ]
     for dimension, vectorset in test_cases:
         query_pb = nodereader_pb2.SearchRequest(
-            shard=shard_id,
+            shard_ids=[shard_id],
             body="this is a query for my vectorset",
             vector=[1.23] * dimension,
             vectorset=vectorset,

--- a/nucliadb/tests/search/integration/api/v1/test_search.py
+++ b/nucliadb/tests/search/integration/api/v1/test_search.py
@@ -99,7 +99,7 @@ async def test_search_resource_all(
 
             request = SearchRequest()
             request.vectorset = "my-semantic-model"
-            request.shard = shard_id
+            request.shard_ids[:] = [shard_id]
             request.body = "Ramon"
             request.result_per_page = 20
             request.document = True

--- a/nucliadb/tests/search/unit/search/requesters/test_utils.py
+++ b/nucliadb/tests/search/unit/search/requesters/test_utils.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import HTTPException
@@ -50,13 +50,6 @@ def shard_manager():
         clean_utility(Utility.SHARD_MANAGER)
     else:
         set_utility(Utility.SHARD_MANAGER, original)
-
-
-@pytest.fixture()
-def mocked_search_methods():
-    methods = {utils.Method.SEARCH: AsyncMock()}
-    with patch.dict(utils.METHODS, methods, clear=True):
-        yield methods
 
 
 def test_validate_nidx_query_results():

--- a/nucliadb_telemetry/src/nucliadb_telemetry/metrics.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/metrics.py
@@ -299,7 +299,7 @@ class GarbageCollectorObserver:
             gc_collection_time.observe(collection_time_s)
             self.collection_start = None
 
-        else:
+        else:  # pragma: no cover
             assert_never(phase)
 
 

--- a/nucliadb_utils/src/nucliadb_utils/const.py
+++ b/nucliadb_utils/src/nucliadb_utils/const.py
@@ -37,6 +37,12 @@ class Features:
     IGNORE_EXTRACTED_IN_SEARCH = "nucliadb_ignore_extracted_in_search"
     SEMANTIC_GRAPH = "nucliadb_semantic_graph"
     AUDIT_RETRIEVE_AND_AUGMENT = "nucliadb_audit_retrieve_and_augment"
+    # Flipt features
+    BETTER_MULTI_SHARD_SEARCH = "nucliadb_better_multi_shard_search"
 
 
-_FliptFeatures: set[str] = set([])
+_FliptFeatures = set(
+    [
+        Features.BETTER_MULTI_SHARD_SEARCH,
+    ]
+)

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -60,6 +60,10 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },
+    const.Features.BETTER_MULTI_SHARD_SEARCH: {
+        "rollout": 0,
+        "variants": {"environment": ["local"]},
+    },
 }
 
 


### PR DESCRIPTION
### Description
This is the first part of a series of PRs to improve how internal gRPC search requests are done through the cluster. We currently send 1 gRPC request per shard, but we could instead send 1 per searcher (containing a KB shard).

In this PR, we implement multi-shard requests and shard response merging in Rust, although Python will still request 1 per shard.

The change on the proto is bw/c compatible (see https://protobuf.dev/programming-guides/proto3/#wire-safe-changes). Python sends 1 shard id string as a string/list and nidx parses 1 shard id string as a string/list. 

### How was this PR tested?
New Rust tests on merging 
