### PR TITLE
ORM pg tables

### DIFF
--- a/nucliadb/src/migrations/0039_backfill_converation_splits_metadata.py
+++ b/nucliadb/src/migrations/0039_backfill_converation_splits_metadata.py
@@ -101,6 +101,9 @@ async def build_splits_metadata(
         field_id, resources_pb2.FieldType.CONVERSATION, load=False
     )
     conv_metadata = await field_obj.get_metadata()
+    if conv_metadata is None:
+        return splits_metadata
+
     for i in range(1, conv_metadata.pages + 1):
         page = await field_obj.get_value(page=i)
         if page is None:

--- a/nucliadb/src/migrations/0043_backfill_conversation_splits_page.py
+++ b/nucliadb/src/migrations/0043_backfill_conversation_splits_page.py
@@ -96,6 +96,9 @@ async def backfill_splits_page(txn: Transaction, storage, kbid: str, rid: str, f
     )
     splits_metadata = await field_obj.get_splits_metadata()
     conv_metadata = await field_obj.get_metadata()
+    if conv_metadata is None:
+        return
+
     for page_number in range(1, conv_metadata.pages + 1):
         page = await field_obj.get_value(page=page_number)
         if page is None:

--- a/nucliadb/src/migrations/backfill_orm_tables.py
+++ b/nucliadb/src/migrations/backfill_orm_tables.py
@@ -1,0 +1,280 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Backfill: copy data from the v1 key-value store into the new ORM tables
+(kbs, kb_resources, kb_fields, kb_conversations) created by migration 0016.
+
+Hierarchy
+---------
+  backfill_all_kbs
+  └── backfill_kb                  (shards, slug, config)
+      └── backfill_resource        (basic, slug, shard, origin, extra,
+      │                             security, user_relations)
+          └── backfill_field       (value, status, md5)
+              └── backfill_conversation_field  (metadata + every page
+                                               + splits_metadata)
+
+Each level reads from v1 (raw KV) and writes to v2 (pg tables) inside its own
+read-write transaction, so a failure in one resource/field does not roll back
+the whole KB.
+"""
+
+import logging
+
+from nucliadb.common import datamanagers, file_md5_v2, locking
+from nucliadb.common.datamanagers import (
+    conversations as conversations_v1,
+)
+from nucliadb.common.datamanagers import (
+    conversations_v2,
+    fields_v2,
+    kb_v2,
+    resources_v2,
+)
+from nucliadb.common.datamanagers import (
+    fields as fields_v1,
+)
+from nucliadb.common.datamanagers import (
+    kb as kb_v1,
+)
+from nucliadb.common.datamanagers import (
+    resources as resources_v1,
+)
+from nucliadb.common.datamanagers.utils import with_ro_transaction, with_rw_transaction
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.models_utils import from_proto
+from nucliadb_protos import resources_pb2
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def backfill_all_kbs() -> None:
+    """Iterate every KB in v1 and backfill it into the ORM tables."""
+    kbids_and_slugs = []
+    async with with_ro_transaction() as txn:
+        async for kbid, slug in kb_v1.get_kbs(txn):
+            kbids_and_slugs.append((kbid, slug))
+    for kbid, slug in kbids_and_slugs:
+        try:
+            await backfill_kb(kbid=kbid, slug=slug)
+        except Exception:
+            logger.exception("Failed to backfill KB %s (%s), continuing", kbid, slug)
+
+
+# ---------------------------------------------------------------------------
+# KB
+# ---------------------------------------------------------------------------
+
+
+async def backfill_kb(*, kbid: str, slug: str) -> None:
+    """Backfill one KB row and all of its resources."""
+    logger.info(f"Backfilling KB {kbid}")
+    async with with_rw_transaction() as txn:
+        try:
+            await backfill_kb_metadata(txn, kbid=kbid, slug=slug)
+            await txn.commit()
+        except Exception:
+            logger.exception(f"Failed to backfill KB metadata for {kbid}, skipping")
+            return
+
+    # Iterate resources in their own transactions
+    async for rid in datamanagers.resources.iterate_resource_ids(kbid=kbid):
+        try:
+            await backfill_resource(kbid=kbid, rid=rid)
+        except Exception:
+            logger.exception(f"Failed to backfill resource {kbid}/{rid}, continuing")
+
+
+async def backfill_kb_metadata(txn: Transaction, *, kbid: str, slug: str) -> None:
+    # slug
+    await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=slug)
+
+    config = await datamanagers.kb.get_config(txn, kbid=kbid, for_update=True)
+    if config is None:
+        raise ValueError(f"KB {kbid} has no config, skipping backfill of config and shards")
+
+    assert slug == config.slug, f"Slug mismatch for KB {kbid}: slug={slug}, config.slug={config.slug}"
+
+    # config
+    await kb_v2.set_config(txn, kbid=kbid, config=config)
+
+    # shards
+    shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid, for_update=True)
+    if shards is None:
+        raise ValueError(f"KB {kbid} has no shards, skipping backfill of shards")
+
+    await kb_v2.update_kb_shards(txn, kbid=kbid, shards=shards)
+
+
+# ---------------------------------------------------------------------------
+# Resource
+# ---------------------------------------------------------------------------
+
+
+async def backfill_resource(*, kbid: str, rid: str) -> None:
+    """Backfill one kb_resources row and all of its fields."""
+    logger.info(f"Backfilling resource {kbid}/{rid}")
+
+    async with locking.distributed_lock(locking.RESOURCE_LOCK.format(kbid=kbid, resource_id=rid)):
+        async with with_rw_transaction() as txn:
+            await backfill_resource_metadata(txn, kbid=kbid, rid=rid)
+            await txn.commit()
+
+        async with with_ro_transaction() as txn:
+            all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
+            for field in all_fields.fields if all_fields is not None else []:
+                field_type_str = from_proto.field_type_name(field.field_type).abbreviation()
+                try:
+                    await backfill_field(
+                        kbid=kbid, rid=rid, field_type=field_type_str, field_id=field.field
+                    )
+                except Exception:
+                    logger.exception(
+                        f"Failed to backfill field {kbid}/{rid}/{field_type_str}/{field.field}, continuing"
+                    )
+
+
+async def backfill_resource_metadata(txn: Transaction, *, kbid: str, rid: str) -> None:
+    basic = await resources_v1.get_basic(txn, kbid=kbid, rid=rid)
+    if basic is None:
+        raise ValueError(f"Resource {kbid}/{rid} has no basic metadata, skipping backfill")
+
+    # slug
+    await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=basic.slug)
+
+    # basic
+    await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+
+    # shard
+    shard = await resources_v1.get_resource_shard_id(txn, kbid=kbid, rid=rid)
+    if shard is None:
+        raise ValueError(f"Resource {kbid}/{rid} has no shard, skipping backfill")
+
+    await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
+
+    # origin
+    origin = await resources_v1.get_origin(txn, kbid=kbid, rid=rid)
+    if origin is not None:
+        await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
+
+    # extra
+    extra = await resources_v1.get_extra(txn, kbid=kbid, rid=rid)
+    if extra is not None:
+        await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
+
+    # security
+    security = await resources_v1.get_security(txn, kbid=kbid, rid=rid)
+    if security is not None:
+        await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
+
+
+# ---------------------------------------------------------------------------
+# Field
+# ---------------------------------------------------------------------------
+
+
+async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str) -> None:
+    """Backfill one kb_fields row (value, status, md5)."""
+    logger.info(f"Backfilling field {kbid}/{rid}/{field_type}/{field_id}")
+
+    async with with_rw_transaction() as txn:
+        # status
+        status = await fields_v1.get_status(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
+        )
+        if status is not None:
+            await fields_v2.set_status(
+                txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
+            )
+
+        # value
+        value = await fields_v1.get_raw(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
+        )
+        if value is not None:
+            await fields_v2.set(
+                txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
+            )
+
+        # md5 — only file fields (field_type == 'f') have an md5 in the v1 table
+        if field_type == "f" and value is not None:
+            field_file = resources_pb2.FieldFile()
+            field_file.ParseFromString(value)
+            if field_file.file.md5:
+                await file_md5_v2.set(
+                    txn, kbid=kbid, md5=field_file.file.md5, rid=rid, field_id=field_id
+                )
+        await txn.commit()
+
+    # Conversation fields need their own dedicated backfill
+    if field_type == "c":
+        await backfill_conversation_field(kbid=kbid, rid=rid, field_id=field_id)
+
+
+# ---------------------------------------------------------------------------
+# Conversation field
+# ---------------------------------------------------------------------------
+
+
+async def backfill_conversation_field(*, kbid: str, rid: str, field_id: str) -> None:
+    """
+    Backfill FieldConversation metadata, all pages, and SplitsMetadata
+
+    Conversation metadata has already been backfilled in backfill_field in the kb_fields table.
+    We need to backfill the conversation pages and splits metadata into the kb_conversations table.
+    """
+    logger.info(f"Backfilling conversation {kbid}/{rid}/c/{field_id}")
+
+    async with with_rw_transaction() as txn:
+        metadata = await conversations_v1.get_metadata(
+            txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id
+        )
+        if metadata is None:
+            raise ValueError(
+                f"Conversation {kbid}/{rid}/c/{field_id} has no metadata, skipping backfill"
+            )
+        splits_metadata = await conversations_v1.get_splits_metadata(
+            txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id
+        )
+        if splits_metadata is not None:
+            await conversations_v2.set_splits_metadata(
+                txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits_metadata
+            )
+        await txn.commit()
+
+    async with with_rw_transaction() as txn:
+        for page_n in range(1, metadata.pages + 1):
+            page = await conversations_v1.get_page(
+                txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id, page=page_n
+            )
+            if page is None:
+                logger.warning(
+                    f"Conversation {kbid}/{rid}/c/{field_id} page {page_n} is missing, skipping"
+                )
+                continue
+            await conversations_v2.set_page(
+                txn, kbid=kbid, rid=rid, field_id=field_id, page=page_n, value=page
+            )
+            await txn.commit()

--- a/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
+++ b/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
@@ -23,7 +23,7 @@ from nucliadb.common.maindb.pg import PGTransaction
 
 async def migrate(txn: PGTransaction) -> None:
     """
-    Create kbs, kb_resources and kb_fields tables.
+    Create kbs, kb_resources, kb_fields and kb_conversations tables.
 
     kbs
     ---
@@ -49,7 +49,7 @@ async def migrate(txn: PGTransaction) -> None:
       - user_relations Serialised resources_pb2.Relations
 
     kb_fields
-    ------
+    ---------
     One row per field in a resource.  Foreign-keyed to kb_resources so that
     deleting a resource (or its parent KB) cascades into kb_fields automatically.
       - kbid       FK → kb_resources.kbid
@@ -59,9 +59,27 @@ async def migrate(txn: PGTransaction) -> None:
       - field_id   User-defined field name
       - status     Serialised writer_pb2.FieldStatus protobuf bytes; NULL when
                    not yet set
-      - value      Serialised protobuf bytes (excludes object-store data)
+      - value      Serialised protobuf bytes (excludes object-store data); for
+                   conversation fields this holds the FieldConversation metadata
+                   (page count, total messages, page size, extract/split strategy)
       - md5        Optional content hash; NULL when not provided; used for
                    duplicate detection within a knowledge box
+
+    kb_conversations
+    ----------------
+    One row per page of a conversation field.  Foreign-keyed to kb_resources so
+    that deleting a resource (or its parent KB) cascades automatically.
+    The FieldConversation metadata is kept in kb_fields.value; this table holds
+    only the paginated message data and the splits index.
+      - kbid       FK → kb_resources.kbid
+      - rid        FK → kb_resources.rid
+      - field_id   User-defined conversation field name
+      - page       Page number (1-based).  The sentinel value 0 stores the
+                   serialised SplitsMetadata protobuf (maps message ident →
+                   page number, tracks deleted splits).
+      - value      Serialised protobuf bytes:
+                     page = 0  → resources_pb2.SplitsMetadata
+                     page >= 1 → resources_pb2.Conversation (~200 messages each)
     """
     async with txn.connection.cursor() as cur:
         # ------------------------------------------------------------------
@@ -146,4 +164,26 @@ async def migrate(txn: PGTransaction) -> None:
             CREATE INDEX IF NOT EXISTS idx_kb_fields_md5
             ON kb_fields(kbid, md5)
             WHERE md5 IS NOT NULL;
+        """)
+
+        # ------------------------------------------------------------------
+        # kb_conversations
+        # ------------------------------------------------------------------
+        await cur.execute("""
+            CREATE TABLE IF NOT EXISTS kb_conversations (
+                kbid     UUID    NOT NULL,
+                rid      UUID    NOT NULL,
+                field_id TEXT    NOT NULL,
+                page     INTEGER NOT NULL,
+                value    BYTEA,
+                PRIMARY KEY (kbid, rid, field_id, page),
+                FOREIGN KEY (kbid, rid)
+                    REFERENCES kb_resources (kbid, rid) ON DELETE CASCADE
+            );
+        """)
+
+        # Fast lookup / deletion of all pages belonging to a conversation field
+        await cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_kb_conversations_field
+            ON kb_conversations(kbid, rid, field_id);
         """)

--- a/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
+++ b/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from nucliadb.common.maindb.pg import PGTransaction
+
+
+async def migrate(txn: PGTransaction) -> None:
+    """
+    Create kbs, kb_resources and kb_fields tables.
+
+    kbs
+    ---
+    One row per knowledge box.
+      - kbid          Primary key
+      - slug          Human-readable unique identifier (unique, nullable)
+      - title         Display name
+      - shards        Serialised protobuf — list of shard IDs
+      - config        Serialised protobuf — KnowledgeBoxConfig
+
+    kb_resources
+    ------------
+    One row per resource.  Foreign-keyed to kbs so that deleting a KB row
+    removes all its resources automatically (ON DELETE CASCADE).
+      - kbid          FK → kbs.kbid
+      - rid           Resource UUID
+      - slug          Optional human-readable slug
+      - shard         Shard ID the resource belongs to
+      - basic         Serialised resources_pb2.Basic
+      - origin        Serialised resources_pb2.Origin
+      - security      Serialised utils_pb2.Security
+      - extra         Serialised resources_pb2.Extra
+      - user_relations Serialised resources_pb2.Relations
+
+    kb_fields
+    ------
+    One row per field in a resource.  Foreign-keyed to kb_resources so that
+    deleting a resource (or its parent KB) cascades into kb_fields automatically.
+      - kbid       FK → kb_resources.kbid
+      - rid        FK → kb_resources.rid
+      - field_type Single-char abbreviation: t=text, f=file, u=link,
+                   c=conversation, a=generic, k=key_value
+      - field_id   User-defined field name
+      - status     Processing status matching FieldStatus.Status in writer.proto:
+                   0=PENDING, 1=PROCESSED, 2=ERROR
+      - value      Serialised protobuf bytes (excludes object-store data)
+      - md5        Optional content hash; NULL when not provided; used for
+                   duplicate detection within a knowledge box
+    """
+    async with txn.connection.cursor() as cur:
+        # ------------------------------------------------------------------
+        # kbs
+        # ------------------------------------------------------------------
+        await cur.execute("""
+            CREATE TABLE IF NOT EXISTS kbs (
+                kbid   UUID NOT NULL,
+                slug   TEXT,
+                title  TEXT,
+                shards BYTEA,
+                config BYTEA,
+                PRIMARY KEY (kbid)
+            );
+        """)
+
+        await cur.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_kbs_slug
+            ON kbs(slug)
+            WHERE slug IS NOT NULL;
+        """)
+
+        # ------------------------------------------------------------------
+        # kb_resources
+        # ------------------------------------------------------------------
+        await cur.execute("""
+            CREATE TABLE IF NOT EXISTS kb_resources (
+                kbid           UUID NOT NULL,
+                rid            UUID NOT NULL,
+                slug           TEXT,
+                shard          TEXT,
+                basic          BYTEA,
+                origin         BYTEA,
+                security       BYTEA,
+                extra          BYTEA,
+                user_relations BYTEA,
+                PRIMARY KEY (kbid, rid),
+                FOREIGN KEY (kbid) REFERENCES kbs (kbid) ON DELETE CASCADE
+            );
+        """)
+
+        # Fast slug-based lookups within a knowledge box
+        await cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_kb_resources_slug
+            ON kb_resources(kbid, slug)
+            WHERE slug IS NOT NULL;
+        """)
+
+        # ------------------------------------------------------------------
+        # kb_fields
+        # ------------------------------------------------------------------
+        await cur.execute("""
+            CREATE TABLE IF NOT EXISTS kb_fields (
+                kbid       UUID     NOT NULL,
+                rid        UUID     NOT NULL,
+                field_type TEXT     NOT NULL,
+                field_id   TEXT     NOT NULL,
+                status     SMALLINT NOT NULL DEFAULT 0,
+                value      BYTEA,
+                md5        TEXT,
+                PRIMARY KEY (kbid, rid, field_type, field_id),
+                FOREIGN KEY (kbid, rid)
+                    REFERENCES kb_resources (kbid, rid) ON DELETE CASCADE
+            );
+        """)
+
+        # Fast lookup / deletion of all fields belonging to a resource
+        await cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_kb_fields_resource
+            ON kb_fields(kbid, rid);
+        """)
+
+        # Fast lookup of fields by type within a knowledge box
+        await cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_kb_fields_kbid_type
+            ON kb_fields(kbid, field_type);
+        """)
+
+        # Fast duplicate detection by MD5 within a knowledge box
+        await cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_kb_fields_md5
+            ON kb_fields(kbid, md5)
+            WHERE md5 IS NOT NULL;
+        """)

--- a/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
+++ b/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
@@ -67,12 +67,15 @@ async def migrate(txn: PGTransaction) -> None:
 
     kb_conversations
     ----------------
-    One row per page of a conversation field.  Foreign-keyed to kb_resources so
-    that deleting a resource (or its parent KB) cascades automatically.
+    One row per page of a conversation field.  Foreign-keyed to kb_fields on
+    (kbid, rid, field_type, field_id) so that deleting a conversation field row
+    from kb_fields automatically removes all its pages (ON DELETE CASCADE).
     The FieldConversation metadata is kept in kb_fields.value; this table holds
     only the paginated message data and the splits index.
-      - kbid       FK → kb_resources.kbid
-      - rid        FK → kb_resources.rid
+      - kbid       FK → kb_fields.kbid
+      - rid        FK → kb_fields.rid
+      - field_type Always 'c' (enforced by CHECK constraint); included so the
+                   FK can reference the full kb_fields primary key
       - field_id   User-defined conversation field name
       - page       Page number (1-based).  The sentinel value 0 stores the
                    serialised SplitsMetadata protobuf (maps message ident →
@@ -171,14 +174,15 @@ async def migrate(txn: PGTransaction) -> None:
         # ------------------------------------------------------------------
         await cur.execute("""
             CREATE TABLE IF NOT EXISTS kb_conversations (
-                kbid     UUID    NOT NULL,
-                rid      UUID    NOT NULL,
-                field_id TEXT    NOT NULL,
-                page     INTEGER NOT NULL,
-                value    BYTEA,
+                kbid       UUID    NOT NULL,
+                rid        UUID    NOT NULL,
+                field_type TEXT    NOT NULL DEFAULT 'c' CHECK (field_type = 'c'),
+                field_id   TEXT    NOT NULL,
+                page       INTEGER NOT NULL,
+                value      BYTEA,
                 PRIMARY KEY (kbid, rid, field_id, page),
-                FOREIGN KEY (kbid, rid)
-                    REFERENCES kb_resources (kbid, rid) ON DELETE CASCADE
+                FOREIGN KEY (kbid, rid, field_type, field_id)
+                    REFERENCES kb_fields (kbid, rid, field_type, field_id) ON DELETE CASCADE
             );
         """)
 

--- a/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
+++ b/nucliadb/src/migrations/pg/0016_kbs_and_resources_tables.py
@@ -57,8 +57,8 @@ async def migrate(txn: PGTransaction) -> None:
       - field_type Single-char abbreviation: t=text, f=file, u=link,
                    c=conversation, a=generic, k=key_value
       - field_id   User-defined field name
-      - status     Processing status matching FieldStatus.Status in writer.proto:
-                   0=PENDING, 1=PROCESSED, 2=ERROR
+      - status     Serialised writer_pb2.FieldStatus protobuf bytes; NULL when
+                   not yet set
       - value      Serialised protobuf bytes (excludes object-store data)
       - md5        Optional content hash; NULL when not provided; used for
                    duplicate detection within a knowledge box
@@ -103,9 +103,10 @@ async def migrate(txn: PGTransaction) -> None:
             );
         """)
 
-        # Fast slug-based lookups within a knowledge box
+        # Unique slug lookups within a knowledge box (NULL slugs are excluded
+        # so that resources without a slug can coexist freely)
         await cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_kb_resources_slug
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_kb_resources_slug
             ON kb_resources(kbid, slug)
             WHERE slug IS NOT NULL;
         """)
@@ -119,7 +120,7 @@ async def migrate(txn: PGTransaction) -> None:
                 rid        UUID     NOT NULL,
                 field_type TEXT     NOT NULL,
                 field_id   TEXT     NOT NULL,
-                status     SMALLINT NOT NULL DEFAULT 0,
+                status     BYTEA,
                 value      BYTEA,
                 md5        TEXT,
                 PRIMARY KEY (kbid, rid, field_type, field_id),

--- a/nucliadb/src/migrations/pg/0016_orm_tables.py
+++ b/nucliadb/src/migrations/pg/0016_orm_tables.py
@@ -130,7 +130,6 @@ async def migrate(txn: PGTransaction) -> None:
                 origin         BYTEA,
                 security       BYTEA,
                 extra          BYTEA,
-                user_relations BYTEA,
                 PRIMARY KEY (kbid, rid),
                 FOREIGN KEY (kbid) REFERENCES kbs (kbid) ON DELETE CASCADE
             );

--- a/nucliadb/src/migrations/pg/0016_orm_tables.py
+++ b/nucliadb/src/migrations/pg/0016_orm_tables.py
@@ -30,14 +30,16 @@ async def migrate(txn: PGTransaction) -> None:
     One row per knowledge box.
       - kbid          Primary key
       - slug          Human-readable unique identifier (unique, nullable)
-      - title         Display name
       - shards        Serialised protobuf — list of shard IDs
       - config        Serialised protobuf — KnowledgeBoxConfig
+      - deleted_at    Set when the KB is soft-deleted; NULL means active
+                    Indexed (partial, WHERE deleted_at IS NOT NULL) so that
+                    the purge command can efficiently find stale deleted KBs
 
     kb_resources
     ------------
-    One row per resource.  Foreign-keyed to kbs so that deleting a KB row
-    removes all its resources automatically (ON DELETE CASCADE).
+    One row per resource.  Foreign-keyed to kbs; deleting a KB row removes all
+    its resources automatically (ON DELETE CASCADE).
       - kbid          FK → kbs.kbid
       - rid           Resource UUID
       - slug          Optional human-readable slug
@@ -50,8 +52,8 @@ async def migrate(txn: PGTransaction) -> None:
 
     kb_fields
     ---------
-    One row per field in a resource.  Foreign-keyed to kb_resources so that
-    deleting a resource (or its parent KB) cascades into kb_fields automatically.
+    One row per field in a resource.  Foreign-keyed to kb_resources; deleting a
+    resource (or its parent KB) cascades into kb_fields automatically (ON DELETE CASCADE).
       - kbid       FK → kb_resources.kbid
       - rid        FK → kb_resources.rid
       - field_type Single-char abbreviation: t=text, f=file, u=link,
@@ -68,8 +70,8 @@ async def migrate(txn: PGTransaction) -> None:
     kb_conversations
     ----------------
     One row per page of a conversation field.  Foreign-keyed to kb_fields on
-    (kbid, rid, field_type, field_id) so that deleting a conversation field row
-    from kb_fields automatically removes all its pages (ON DELETE CASCADE).
+    (kbid, rid, field_type, field_id); deleting a conversation field row cascades
+    into all its pages automatically (ON DELETE CASCADE).
     The FieldConversation metadata is kept in kb_fields.value; this table holds
     only the paginated message data and the splits index.
       - kbid       FK → kb_fields.kbid
@@ -90,11 +92,11 @@ async def migrate(txn: PGTransaction) -> None:
         # ------------------------------------------------------------------
         await cur.execute("""
             CREATE TABLE IF NOT EXISTS kbs (
-                kbid   UUID NOT NULL,
-                slug   TEXT,
-                title  TEXT,
-                shards BYTEA,
-                config BYTEA,
+                kbid       UUID NOT NULL,
+                slug       TEXT,
+                shards     BYTEA,
+                config     BYTEA,
+                deleted_at TIMESTAMPTZ,
                 PRIMARY KEY (kbid)
             );
         """)
@@ -103,6 +105,16 @@ async def migrate(txn: PGTransaction) -> None:
             CREATE UNIQUE INDEX IF NOT EXISTS idx_kbs_slug
             ON kbs(slug)
             WHERE slug IS NOT NULL;
+        """)
+
+        # Partial index used by the purge command to efficiently find
+        # soft-deleted KBs (deleted_at IS NOT NULL AND deleted_at < threshold).
+        # Only indexes the small subset of deleted rows, so maintenance cost
+        # is negligible.
+        await cur.execute("""
+            CREATE INDEX IF NOT EXISTS idx_kbs_deleted_at
+            ON kbs(deleted_at)
+            WHERE deleted_at IS NOT NULL;
         """)
 
         # ------------------------------------------------------------------
@@ -150,18 +162,6 @@ async def migrate(txn: PGTransaction) -> None:
             );
         """)
 
-        # Fast lookup / deletion of all fields belonging to a resource
-        await cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_kb_fields_resource
-            ON kb_fields(kbid, rid);
-        """)
-
-        # Fast lookup of fields by type within a knowledge box
-        await cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_kb_fields_kbid_type
-            ON kb_fields(kbid, field_type);
-        """)
-
         # Fast duplicate detection by MD5 within a knowledge box
         await cur.execute("""
             CREATE INDEX IF NOT EXISTS idx_kb_fields_md5
@@ -180,14 +180,30 @@ async def migrate(txn: PGTransaction) -> None:
                 field_id   TEXT    NOT NULL,
                 page       INTEGER NOT NULL,
                 value      BYTEA,
-                PRIMARY KEY (kbid, rid, field_id, page),
+                PRIMARY KEY (kbid, rid, field_type, field_id, page),
                 FOREIGN KEY (kbid, rid, field_type, field_id)
                     REFERENCES kb_fields (kbid, rid, field_type, field_id) ON DELETE CASCADE
             );
         """)
 
-        # Fast lookup / deletion of all pages belonging to a conversation field
-        await cur.execute("""
-            CREATE INDEX IF NOT EXISTS idx_kb_conversations_field
-            ON kb_conversations(kbid, rid, field_id);
-        """)
+
+"""
+@Javitonino:
+
+- Why not DELETE CASCADE on the foreign keys?  It would simplify the code and avoid orphaned rows.
+- For KB deletion:
+  - Delete the KB row (kbs) → cascades to kb_resources → cascades to kb_fields → cascades to kb_conversations.
+  - Storage bucket is managed via lifecycle and the purge cronjob.
+
+- For Resource deletion:
+  - Delete the resource row (kb_resources) → cascades to kb_fields → cascades to kb_conversations.
+  - Objects in storage are deleted via the purge cronjob.
+  - File_md5 are simply deleted by the ON DELETE CASCADE on kb_fields.
+
+- For Field deletion:
+  - Delete the field row (kb_fields) → cascades to kb_conversations.
+  - Objects in storage are deleted synchronously in the processor transaction.
+
+- Conversation pages are append only for now. Deletions are simply annotations on the splits metadata.
+
+"""

--- a/nucliadb/src/migrations/pg/0016_orm_tables.py
+++ b/nucliadb/src/migrations/pg/0016_orm_tables.py
@@ -184,25 +184,3 @@ async def migrate(txn: PGTransaction) -> None:
                     REFERENCES kb_fields (kbid, rid, field_type, field_id) ON DELETE CASCADE
             );
         """)
-
-
-"""
-@Javitonino:
-
-- Why not DELETE CASCADE on the foreign keys?  It would simplify the code and avoid orphaned rows.
-- For KB deletion:
-  - Delete the KB row (kbs) → cascades to kb_resources → cascades to kb_fields → cascades to kb_conversations.
-  - Storage bucket is managed via lifecycle and the purge cronjob.
-
-- For Resource deletion:
-  - Delete the resource row (kb_resources) → cascades to kb_fields → cascades to kb_conversations.
-  - Objects in storage are deleted via the purge cronjob.
-  - File_md5 are simply deleted by the ON DELETE CASCADE on kb_fields.
-
-- For Field deletion:
-  - Delete the field row (kb_fields) → cascades to kb_conversations.
-  - Objects in storage are deleted synchronously in the processor transaction.
-
-- Conversation pages are append only for now. Deletions are simply annotations on the splits metadata.
-
-"""

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -368,48 +368,6 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
                     )
 
 
-async def _backfill_field_in_txn(
-    txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str
-) -> None:
-    """
-    Backfill a single field row (and its conversation pages if applicable) in a single transaction.
-    """
-    status = await fields_v1.get_status(
-        txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
-    )
-    value = await fields_v1.get_raw(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
-
-    md5 = None
-    if field_type == "f":
-        md5 = await file_md5.get(txn, kbid=kbid, rid=rid, field_id=field_id)
-
-    if field_type == "t" and value is not None:
-        field_text = resources_pb2.FieldText()
-        field_text.ParseFromString(value)
-        md5 = field_text.md5 or None
-
-    async with _pg_cursor(txn) as cur:
-        await cur.execute(
-            """
-            INSERT INTO kb_fields (kbid, rid, field_type, field_id, value, md5, status)
-            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(value)s, %(md5)s, %(status)s)
-            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
-                value  = EXCLUDED.value,
-                md5     = EXCLUDED.md5,
-                status = EXCLUDED.status
-            """,
-            {
-                "kbid": kbid,
-                "rid": rid,
-                "field_type": field_type,
-                "field_id": field_id,
-                "value": value,
-                "md5": md5,
-                "status": status.SerializeToString() if status is not None else None,
-            },
-        )
-
-
 async def _main():
     import argparse
 

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -61,7 +61,7 @@ from nucliadb.common.datamanagers import (
 from nucliadb.common.datamanagers.utils import _pg_cursor, with_ro_transaction, with_rw_transaction
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.models_utils import from_proto
-from nucliadb_protos import resources_pb2
+from nucliadb_protos import resources_pb2, writer_pb2
 from nucliadb_telemetry.logs import setup_logging
 from nucliadb_telemetry.settings import LogLevel, LogSettings
 
@@ -259,37 +259,19 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
             },
         )
 
-    # --- Title and Summary fields (special case) ---
-    # These are stored in the kb_resources.basic protobuf, but also need to be in the kb_fields table for the status API to work correctly.
-    for field_id, field_value in (("title", basic.title), ("summary", basic.summary)):
-        if not field_value:
-            continue
-        field_type_str = "a"
-        status = await fields_v1.get_status(
-            txn, kbid=kbid, rid=rid, field_type=field_type_str, field_id=field_id
-        )
-        if status is not None:
-            async with _pg_cursor(txn) as cur:
-                await cur.execute(
-                    """
-                    INSERT INTO kb_fields (kbid, rid, field_type, field_id, status)
-                    VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s)
-                    ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
-                        status = EXCLUDED.status
-                    """,
-                    {
-                        "kbid": kbid,
-                        "rid": rid,
-                        "field_type": field_type_str,
-                        "field_id": field_id,
-                        "status": status.SerializeToString() if status is not None else None,
-                    },
-                )
-
     # --- Collect all field and conversation rows ---
     all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
     if all_fields is None:
         return
+
+    # Add title and summary in the fields table, even though they are stored in the kb_resources.basic column.
+    # We need to do this to have the status API work correctly for title and summary fields.
+    title_field = resources_pb2.FieldID(field_type=writer_pb2.FieldType.GENERIC, field="title")
+    summary_field = resources_pb2.FieldID(field_type=writer_pb2.FieldType.GENERIC, field="summary")
+    if basic.title and title_field not in all_fields.fields:
+        all_fields.fields.append(title_field)
+    if basic.summary and summary_field not in all_fields.fields:
+        all_fields.fields.append(summary_field)
 
     for field in all_fields.fields:
         field_type_str = from_proto.field_type_name(field.field_type).abbreviation()
@@ -384,6 +366,48 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
                             "value": page.SerializeToString(),
                         },
                     )
+
+
+async def _backfill_field_in_txn(
+    txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str
+) -> None:
+    """
+    Backfill a single field row (and its conversation pages if applicable) in a single transaction.
+    """
+    status = await fields_v1.get_status(
+        txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
+    )
+    value = await fields_v1.get_raw(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
+
+    md5 = None
+    if field_type == "f":
+        md5 = await file_md5.get(txn, kbid=kbid, rid=rid, field_id=field_id)
+
+    if field_type == "t" and value is not None:
+        field_text = resources_pb2.FieldText()
+        field_text.ParseFromString(value)
+        md5 = field_text.md5 or None
+
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_fields (kbid, rid, field_type, field_id, value, md5, status)
+            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(value)s, %(md5)s, %(status)s)
+            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                value  = EXCLUDED.value,
+                md5     = EXCLUDED.md5,
+                status = EXCLUDED.status
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+                "value": value,
+                "md5": md5,
+                "status": status.SerializeToString() if status is not None else None,
+            },
+        )
 
 
 async def _main():

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -39,6 +39,7 @@ end of the migration run.
 
 import asyncio
 import logging
+import time
 
 from nucliadb.common import datamanagers, file_md5, locking
 from nucliadb.common.context import ApplicationContext
@@ -71,6 +72,8 @@ logger = logging.getLogger("backfill_orm_tables")
 # conservative enough not to saturate the connection pool.
 _MAX_CONCURRENT_RESOURCES = 10
 
+# Maximum number of reconciliation iterations to perform for each KB.
+_MAX_RECONCILIATION_ITERATIONS = 2
 
 # ---------------------------------------------------------------------------
 # Entry point
@@ -103,7 +106,7 @@ async def backfill_kb(*, kbid: str) -> None:
     migration run.
     """
     logger.info(f"Backfilling KB {kbid}")
-    start_time = asyncio.get_event_loop().time()
+    start_time = time.monotonic()
 
     async with with_rw_transaction() as txn:
         try:
@@ -120,7 +123,15 @@ async def backfill_kb(*, kbid: str) -> None:
 
     await _backfill_resources(kbid=kbid, rids=v1_rids)
 
+    iteration = 0
     while True:
+        if iteration >= _MAX_RECONCILIATION_ITERATIONS:
+            logger.warning(
+                f"Reconciliation: reached max iterations ({_MAX_RECONCILIATION_ITERATIONS}) for KB {kbid}, stopping"
+            )
+            break
+        iteration += 1
+
         # Reconciliation: find resources present in v1 but absent from v2.
         # These are resources that were created after our initial v1 snapshot was
         # taken and would have been missed by the main loop above.
@@ -141,7 +152,7 @@ async def backfill_kb(*, kbid: str) -> None:
         else:
             break
 
-    elapsed = asyncio.get_event_loop().time() - start_time
+    elapsed = time.monotonic() - start_time
     logger.info(f"Backfilled KB {kbid} in {elapsed:.2f} seconds")
 
 
@@ -207,8 +218,8 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
     Read all data for a resource from v1 (metadata, fields, conversation pages)
     and write everything to the ORM tables in one shot:
       - one INSERT for the kb_resources row
-      - one executemany for all kb_fields rows
-      - one executemany for all kb_conversations rows (pages + splits sentinel)
+      - one INSERT for each kb_fields row (including the FieldConversation metadata for conversation fields)
+      - one INSERT for each kb_conversations rows (pages + splits sentinel)
     """
     # --- Resource row ---
     basic = await resources_v1.get_basic(txn, kbid=kbid, rid=rid)

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -268,22 +268,23 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
         status = await fields_v1.get_status(
             txn, kbid=kbid, rid=rid, field_type=field_type_str, field_id=field_id
         )
-        async with _pg_cursor(txn) as cur:
-            await cur.execute(
-                """
-                INSERT INTO kb_fields (kbid, rid, field_type, field_id, status)
-                VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s)
-                ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
-                    status = EXCLUDED.status
-                """,
-                {
-                    "kbid": kbid,
-                    "rid": rid,
-                    "field_type": field_type_str,
-                    "field_id": field_id,
-                    "status": status.SerializeToString() if status is not None else None,
-                },
-            )
+        if status is not None:
+            async with _pg_cursor(txn) as cur:
+                await cur.execute(
+                    """
+                    INSERT INTO kb_fields (kbid, rid, field_type, field_id, status)
+                    VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s)
+                    ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                        status = EXCLUDED.status
+                    """,
+                    {
+                        "kbid": kbid,
+                        "rid": rid,
+                        "field_type": field_type_str,
+                        "field_id": field_id,
+                        "status": status.SerializeToString() if status is not None else None,
+                    },
+                )
 
     # --- Collect all field and conversation rows ---
     all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -259,6 +259,32 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
             },
         )
 
+    # --- Title and Summary fields (special case) ---
+    # These are stored in the kb_resources.basic protobuf, but also need to be in the kb_fields table for the status API to work correctly.
+    for field_id, field_value in (("title", basic.title), ("summary", basic.summary)):
+        if not field_value:
+            continue
+        field_type_str = "a"
+        status = await fields_v1.get_status(
+            txn, kbid=kbid, rid=rid, field_type=field_type_str, field_id=field_id
+        )
+        async with _pg_cursor(txn) as cur:
+            await cur.execute(
+                """
+                INSERT INTO kb_fields (kbid, rid, field_type, field_id, status)
+                VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s)
+                ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                    status = EXCLUDED.status
+                """,
+                {
+                    "kbid": kbid,
+                    "rid": rid,
+                    "field_type": field_type_str,
+                    "field_id": field_id,
+                    "status": status.SerializeToString() if status is not None else None,
+                },
+            )
+
     # --- Collect all field and conversation rows ---
     all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
     if all_fields is None:
@@ -278,6 +304,11 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
         md5 = None
         if field_type_str == "f":
             md5 = await file_md5.get(txn, kbid=kbid, rid=rid, field_id=field_id)
+
+        if field_type_str == "t" and value is not None:
+            field_text = resources_pb2.FieldText()
+            field_text.ParseFromString(value)
+            md5 = field_text.md5 or None
 
         async with _pg_cursor(txn) as cur:
             await cur.execute(

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -26,7 +26,7 @@ Hierarchy
   backfill_all_kbs
   └── backfill_kb                  (shards, slug, config)
       └── backfill_resource        (basic, slug, shard, origin, extra,
-      │                             security, user_relations)
+      │                             security)
           └── backfill_field       (value, status, md5)
               └── backfill_conversation_field  (metadata + every page
                                                + splits_metadata)
@@ -39,6 +39,7 @@ the whole KB.
 import logging
 
 from nucliadb.common import datamanagers, file_md5_v2, locking
+from nucliadb.common.context import ApplicationContext
 from nucliadb.common.datamanagers import (
     conversations as conversations_v1,
 )
@@ -62,7 +63,7 @@ from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.models_utils import from_proto
 from nucliadb_protos import resources_pb2
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 
 
 # ---------------------------------------------------------------------------
@@ -70,15 +71,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-async def backfill_all_kbs() -> None:
+async def backfill_all_kbs(minimal: bool) -> None:
     """Iterate every KB in v1 and backfill it into the ORM tables."""
     kbids_and_slugs = []
     async with with_ro_transaction() as txn:
         async for kbid, slug in kb_v1.get_kbs(txn):
             kbids_and_slugs.append((kbid, slug))
-    for kbid, slug in kbids_and_slugs:
+    for kbid, _ in kbids_and_slugs:
         try:
-            await backfill_kb(kbid=kbid, slug=slug)
+            await backfill_kb(kbid=kbid, minimal=minimal)
         except Exception:
             logger.exception("Failed to backfill KB %s (%s), continuing", kbid, slug)
 
@@ -88,12 +89,13 @@ async def backfill_all_kbs() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def backfill_kb(*, kbid: str, slug: str) -> None:
+async def backfill_kb(*, kbid: str, minimal: bool) -> None:
     """Backfill one KB row and all of its resources."""
     logger.info(f"Backfilling KB {kbid}")
+    start_time = asyncio.get_event_loop().time()
     async with with_rw_transaction() as txn:
         try:
-            await backfill_kb_metadata(txn, kbid=kbid, slug=slug)
+            await backfill_kb_metadata(txn, kbid=kbid, minimal=minimal)
             await txn.commit()
         except Exception:
             logger.exception(f"Failed to backfill KB metadata for {kbid}, skipping")
@@ -102,20 +104,25 @@ async def backfill_kb(*, kbid: str, slug: str) -> None:
     # Iterate resources in their own transactions
     async for rid in datamanagers.resources.iterate_resource_ids(kbid=kbid):
         try:
-            await backfill_resource(kbid=kbid, rid=rid)
+            await backfill_resource(kbid=kbid, rid=rid, minimal=minimal)
         except Exception:
             logger.exception(f"Failed to backfill resource {kbid}/{rid}, continuing")
+    elapsed = asyncio.get_event_loop().time() - start_time
+    logger.info(f"Backfilled KB {kbid} in {elapsed} seconds")
 
 
-async def backfill_kb_metadata(txn: Transaction, *, kbid: str, slug: str) -> None:
-    # slug
-    await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=slug)
-
+async def backfill_kb_metadata(txn: Transaction, *, kbid: str, minimal: bool) -> None:
     config = await datamanagers.kb.get_config(txn, kbid=kbid, for_update=True)
     if config is None:
         raise ValueError(f"KB {kbid} has no config, skipping backfill of config and shards")
 
-    assert slug == config.slug, f"Slug mismatch for KB {kbid}: slug={slug}, config.slug={config.slug}"
+    # slug
+    slug = config.slug
+    await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=slug)
+
+    if minimal:
+        logger.info(f"Minimal backfill for KB {kbid}, skipping config and shards")
+        return
 
     # config
     await kb_v2.set_config(txn, kbid=kbid, config=config)
@@ -133,13 +140,13 @@ async def backfill_kb_metadata(txn: Transaction, *, kbid: str, slug: str) -> Non
 # ---------------------------------------------------------------------------
 
 
-async def backfill_resource(*, kbid: str, rid: str) -> None:
+async def backfill_resource(*, kbid: str, rid: str, minimal: bool) -> None:
     """Backfill one kb_resources row and all of its fields."""
     logger.info(f"Backfilling resource {kbid}/{rid}")
 
     async with locking.distributed_lock(locking.RESOURCE_LOCK.format(kbid=kbid, resource_id=rid)):
         async with with_rw_transaction() as txn:
-            await backfill_resource_metadata(txn, kbid=kbid, rid=rid)
+            await backfill_resource_metadata(txn, kbid=kbid, rid=rid, minimal=minimal)
             await txn.commit()
 
         async with with_ro_transaction() as txn:
@@ -148,7 +155,11 @@ async def backfill_resource(*, kbid: str, rid: str) -> None:
                 field_type_str = from_proto.field_type_name(field.field_type).abbreviation()
                 try:
                     await backfill_field(
-                        kbid=kbid, rid=rid, field_type=field_type_str, field_id=field.field
+                        kbid=kbid,
+                        rid=rid,
+                        field_type=field_type_str,
+                        field_id=field.field,
+                        minimal=minimal,
                     )
                 except Exception:
                     logger.exception(
@@ -156,13 +167,18 @@ async def backfill_resource(*, kbid: str, rid: str) -> None:
                     )
 
 
-async def backfill_resource_metadata(txn: Transaction, *, kbid: str, rid: str) -> None:
+async def backfill_resource_metadata(txn: Transaction, *, kbid: str, rid: str, minimal: bool) -> None:
     basic = await resources_v1.get_basic(txn, kbid=kbid, rid=rid)
     if basic is None:
         raise ValueError(f"Resource {kbid}/{rid} has no basic metadata, skipping backfill")
 
     # slug
     await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=basic.slug)
+    if minimal:
+        logger.info(
+            f"Minimal backfill for resource {kbid}/{rid}, skipping shard, origin, extra, and security"
+        )
+        return
 
     # basic
     await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
@@ -195,7 +211,7 @@ async def backfill_resource_metadata(txn: Transaction, *, kbid: str, rid: str) -
 # ---------------------------------------------------------------------------
 
 
-async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str) -> None:
+async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str, minimal: bool) -> None:
     """Backfill one kb_fields row (value, status, md5)."""
     logger.info(f"Backfilling field {kbid}/{rid}/{field_type}/{field_id}")
 
@@ -208,6 +224,12 @@ async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str)
             await fields_v2.set_status(
                 txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
             )
+            if minimal:
+                logger.info(
+                    f"Minimal backfill for field {kbid}/{rid}/{field_type}/{field_id}, skipping value and md5"
+                )
+                await txn.commit()
+                return
 
         # value
         value = await fields_v1.get_raw(
@@ -217,6 +239,12 @@ async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str)
             await fields_v2.set(
                 txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
             )
+            if minimal:
+                logger.info(
+                    f"Minimal backfill for field {kbid}/{rid}/{field_type}/{field_id}, skipping md5"
+                )
+                await txn.commit()
+                return
 
         # md5 — only file fields (field_type == 'f') have an md5 in the v1 table
         if field_type == "f" and value is not None:
@@ -226,11 +254,18 @@ async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str)
                 await file_md5_v2.set(
                     txn, kbid=kbid, md5=field_file.file.md5, rid=rid, field_id=field_id
                 )
+                if minimal:
+                    logger.info(
+                        f"Minimal backfill for field {kbid}/{rid}/{field_type}/{field_id}, skipping md5"
+                    )
+                    await txn.commit()
+                    return
+
         await txn.commit()
 
     # Conversation fields need their own dedicated backfill
     if field_type == "c":
-        await backfill_conversation_field(kbid=kbid, rid=rid, field_id=field_id)
+        await backfill_conversation_field(kbid=kbid, rid=rid, field_id=field_id, minimal=minimal)
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +273,7 @@ async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str)
 # ---------------------------------------------------------------------------
 
 
-async def backfill_conversation_field(*, kbid: str, rid: str, field_id: str) -> None:
+async def backfill_conversation_field(*, kbid: str, rid: str, field_id: str, minimal: bool) -> None:
     """
     Backfill FieldConversation metadata, all pages, and SplitsMetadata
 
@@ -264,6 +299,10 @@ async def backfill_conversation_field(*, kbid: str, rid: str, field_id: str) -> 
             )
         await txn.commit()
 
+        if minimal:
+            logger.info(f"Minimal backfill for conversation {kbid}/{rid}/c/{field_id}, skipping pages")
+            return
+
     async with with_rw_transaction() as txn:
         for page_n in range(1, metadata.pages + 1):
             page = await conversations_v1.get_page(
@@ -278,3 +317,42 @@ async def backfill_conversation_field(*, kbid: str, rid: str, field_id: str) -> 
                 txn, kbid=kbid, rid=rid, field_id=field_id, page=page_n, value=page
             )
             await txn.commit()
+
+
+async def _main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Backfill ORM tables from the v1 KV store")
+    parser.add_argument(
+        "--kbid", help="Backfill a single KB by its UUID (default: all KBs)", required=True
+    )
+    parser.add_argument(
+        "--minimal",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Skip heavy fields (config, shards, origin, extra, security, conversation pages). Default: True",
+    )
+    args = parser.parse_args()
+
+    logger.setLevel(logging.DEBUG)
+    context = ApplicationContext(
+        kv_driver=True,
+        blob_storage=False,
+        shard_manager=False,
+        partitioning=False,
+        nats_manager=False,
+        transaction=False,
+        nidx=False,
+    )
+    await context.initialize()
+
+    try:
+        await backfill_kb(kbid=args.kbid, minimal=args.minimal)
+    finally:
+        await context.finalize()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(_main())

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -62,8 +62,10 @@ from nucliadb.common.datamanagers.utils import with_ro_transaction, with_rw_tran
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.models_utils import from_proto
 from nucliadb_protos import resources_pb2
+from nucliadb_telemetry.logs import setup_logging
+from nucliadb_telemetry.settings import LogLevel, LogSettings
 
-logger = logging.getLogger()
+logger = logging.getLogger("backfill_orm_tables")
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +110,7 @@ async def backfill_kb(*, kbid: str, minimal: bool) -> None:
         except Exception:
             logger.exception(f"Failed to backfill resource {kbid}/{rid}, continuing")
     elapsed = asyncio.get_event_loop().time() - start_time
-    logger.info(f"Backfilled KB {kbid} in {elapsed} seconds")
+    logger.info(f"Backfilled KB {kbid} in {elapsed:.2f} seconds")
 
 
 async def backfill_kb_metadata(txn: Transaction, *, kbid: str, minimal: bool) -> None:
@@ -333,8 +335,15 @@ async def _main():
         help="Skip heavy fields (config, shards, origin, extra, security, conversation pages). Default: True",
     )
     args = parser.parse_args()
-
-    logger.setLevel(logging.DEBUG)
+    setup_logging(
+        settings=LogSettings(
+            debug=True,
+            log_level=LogLevel.INFO,
+            logger_levels={
+                "backfill_orm_tables": LogLevel.INFO,
+            },
+        )
+    )
     context = ApplicationContext(
         kv_driver=True,
         blob_storage=False,

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -24,30 +24,26 @@ Backfill: copy data from the v1 key-value store into the new ORM tables
 Hierarchy
 ---------
   backfill_all_kbs
-  └── backfill_kb                  (shards, slug, config)
-      └── backfill_resource        (basic, slug, shard, origin, extra,
-      │                             security)
-          └── backfill_field       (value, status, md5)
-              └── backfill_conversation_field  (metadata + every page
-                                               + splits_metadata)
+  └── backfill_kb                  (slug, config, shards)
+      └── backfill_resource        (slug, shard, basic, origin, extra, security,
+                                    all fields, all conversation pages)
+          └── [reconciliation]     compare v1 vs v2 resource listings and
+                                   backfill any resource added during migration
 
-Each level reads from v1 (raw KV) and writes to v2 (pg tables) inside its own
-read-write transaction, so a failure in one resource/field does not roll back
-the whole KB.
+Each KB's metadata is written in its own transaction.  Each resource (and all of
+its fields and conversation pages) is migrated in a single transaction under a
+distributed lock.  After all resources are processed, a reconciliation pass
+catches any resource created concurrently between the initial v1 snapshot and the
+end of the migration run.
 """
 
+import asyncio
 import logging
 
-from nucliadb.common import datamanagers, file_md5_v2, locking
+from nucliadb.common import datamanagers, file_md5, locking
 from nucliadb.common.context import ApplicationContext
 from nucliadb.common.datamanagers import (
     conversations as conversations_v1,
-)
-from nucliadb.common.datamanagers import (
-    conversations_v2,
-    fields_v2,
-    kb_v2,
-    resources_v2,
 )
 from nucliadb.common.datamanagers import (
     fields as fields_v1,
@@ -58,7 +54,10 @@ from nucliadb.common.datamanagers import (
 from nucliadb.common.datamanagers import (
     resources as resources_v1,
 )
-from nucliadb.common.datamanagers.utils import with_ro_transaction, with_rw_transaction
+from nucliadb.common.datamanagers import (
+    resources_v2,
+)
+from nucliadb.common.datamanagers.utils import _pg_cursor, with_ro_transaction, with_rw_transaction
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.models_utils import from_proto
 from nucliadb_protos import resources_pb2
@@ -67,31 +66,26 @@ from nucliadb_telemetry.settings import LogLevel, LogSettings
 
 logger = logging.getLogger("backfill_orm_tables")
 
+# Maximum number of resources migrated concurrently within a single KB backfill.
+# Each slot holds one distributed lock + one PG transaction, so keep this
+# conservative enough not to saturate the connection pool.
+_MAX_CONCURRENT_RESOURCES = 10
+
 
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
-async def backfill_all_kbs(minimal: bool) -> None:
-    """Iterate every KB in v1 and backfill it into the ORM tables.
-
-    Args:
-        minimal: When True, only the bare-minimum rows are written (slug, status).
-            Use this mode to safely activate the write feature flag: it ensures every
-            existing resource and field already has an entry in the ORM tables, so an
-            in-flight write that arrives before the full backfill completes will not
-            fail due to a missing row.  Heavy data (config, shards, origin, extra,
-            security, conversation pages) can then be populated in a follow-up run
-            with minimal=False.
-    """
+async def backfill_all_kbs() -> None:
+    """Iterate every KB in v1 and backfill it into the ORM tables."""
     kbids_and_slugs = []
     async with with_ro_transaction() as txn:
         async for kbid, slug in kb_v1.get_kbs(txn):
             kbids_and_slugs.append((kbid, slug))
-    for kbid, _ in kbids_and_slugs:
+    for kbid, slug in kbids_and_slugs:
         try:
-            await backfill_kb(kbid=kbid, minimal=minimal)
+            await backfill_kb(kbid=kbid)
         except Exception:
             logger.exception("Failed to backfill KB %s (%s), continuing", kbid, slug)
 
@@ -101,58 +95,97 @@ async def backfill_all_kbs(minimal: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def backfill_kb(*, kbid: str, minimal: bool) -> None:
+async def backfill_kb(*, kbid: str) -> None:
     """Backfill one KB row and all of its resources.
 
-    Args:
-        minimal: See :func:`backfill_all_kbs` for a full description.  In short,
-            set this to True when populating the ORM tables just before enabling the
-            write feature flag, so that any concurrent write for an already-existing
-            resource or field finds a row to update instead of failing with a
-            missing-entry error.
+    After migrating all resources, a reconciliation pass compares the v1 and v2
+    resource listings to catch any resources created concurrently during the
+    migration run.
     """
     logger.info(f"Backfilling KB {kbid}")
     start_time = asyncio.get_event_loop().time()
+
     async with with_rw_transaction() as txn:
         try:
-            await backfill_kb_metadata(txn, kbid=kbid, minimal=minimal)
+            await _backfill_kb_metadata(txn, kbid=kbid)
             await txn.commit()
         except Exception:
             logger.exception(f"Failed to backfill KB metadata for {kbid}, skipping")
             return
 
-    # Iterate resources in their own transactions
+    # Snapshot v1 resource IDs before starting the migration
+    v1_rids: set[str] = set()
     async for rid in datamanagers.resources.iterate_resource_ids(kbid=kbid):
-        try:
-            await backfill_resource(kbid=kbid, rid=rid, minimal=minimal)
-        except Exception:
-            logger.exception(f"Failed to backfill resource {kbid}/{rid}, continuing")
+        v1_rids.add(rid)
+
+    await _backfill_resources(kbid=kbid, rids=v1_rids)
+
+    while True:
+        # Reconciliation: find resources present in v1 but absent from v2.
+        # These are resources that were created after our initial v1 snapshot was
+        # taken and would have been missed by the main loop above.
+        v2_rids: set[str] = set()
+        async for rid in resources_v2.iterate_resource_ids(kbid=kbid):
+            v2_rids.add(rid)
+
+        v1_rids_now: set[str] = set()
+        async for rid in datamanagers.resources.iterate_resource_ids(kbid=kbid):
+            v1_rids_now.add(rid)
+
+        missed = v1_rids_now - v2_rids
+        if missed:
+            logger.info(
+                f"Reconciliation: {len(missed)} resource(s) missing from v2 for KB {kbid}, backfilling"
+            )
+            await _backfill_resources(kbid=kbid, rids=missed)
+        else:
+            break
+
     elapsed = asyncio.get_event_loop().time() - start_time
     logger.info(f"Backfilled KB {kbid} in {elapsed:.2f} seconds")
 
 
-async def backfill_kb_metadata(txn: Transaction, *, kbid: str, minimal: bool) -> None:
+async def _backfill_kb_metadata(txn: Transaction, *, kbid: str) -> None:
+    """Read all KB metadata from v1 and write it to the kbs table in a single INSERT."""
     config = await datamanagers.kb.get_config(txn, kbid=kbid, for_update=True)
     if config is None:
-        raise ValueError(f"KB {kbid} has no config, skipping backfill of config and shards")
+        raise ValueError(f"KB {kbid} has no config, skipping backfill")
 
-    # slug
-    slug = config.slug
-    await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=slug)
-
-    if minimal:
-        logger.info(f"Minimal backfill for KB {kbid}, skipping config and shards")
-        return
-
-    # config
-    await kb_v2.set_config(txn, kbid=kbid, config=config)
-
-    # shards
     shards = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid, for_update=True)
     if shards is None:
-        raise ValueError(f"KB {kbid} has no shards, skipping backfill of shards")
+        raise ValueError(f"KB {kbid} has no shards, skipping backfill")
 
-    await kb_v2.update_kb_shards(txn, kbid=kbid, shards=shards)
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            INSERT INTO kbs (kbid, slug, config, shards)
+            VALUES (%(kbid)s, %(slug)s, %(config)s, %(shards)s)
+            ON CONFLICT (kbid) DO UPDATE SET
+                slug   = EXCLUDED.slug,
+                config = EXCLUDED.config,
+                shards = EXCLUDED.shards
+            """,
+            {
+                "kbid": kbid,
+                "slug": config.slug,
+                "config": config.SerializeToString(),
+                "shards": shards.SerializeToString(),
+            },
+        )
+
+
+async def _backfill_resources(*, kbid: str, rids: set[str]) -> None:
+    """Backfill a set of resources concurrently, bounded by _MAX_CONCURRENT_RESOURCES."""
+    semaphore = asyncio.Semaphore(_MAX_CONCURRENT_RESOURCES)
+
+    async def _guarded(rid: str) -> None:
+        async with semaphore:
+            try:
+                await backfill_resource(kbid=kbid, rid=rid)
+            except Exception:
+                logger.exception(f"Failed to backfill resource {kbid}/{rid}, continuing")
+
+    await asyncio.gather(*(_guarded(rid) for rid in rids))
 
 
 # ---------------------------------------------------------------------------
@@ -160,204 +193,160 @@ async def backfill_kb_metadata(txn: Transaction, *, kbid: str, minimal: bool) ->
 # ---------------------------------------------------------------------------
 
 
-async def backfill_resource(*, kbid: str, rid: str, minimal: bool) -> None:
-    """Backfill one kb_resources row and all of its fields."""
+async def backfill_resource(*, kbid: str, rid: str) -> None:
+    """Backfill one kb_resources row and all of its fields in a single transaction."""
     logger.info(f"Backfilling resource {kbid}/{rid}")
-
     async with locking.distributed_lock(locking.RESOURCE_LOCK.format(kbid=kbid, resource_id=rid)):
         async with with_rw_transaction() as txn:
-            await backfill_resource_metadata(txn, kbid=kbid, rid=rid, minimal=minimal)
+            await _backfill_resource_in_txn(txn, kbid=kbid, rid=rid)
             await txn.commit()
 
-        async with with_ro_transaction() as txn:
-            all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
-            for field in all_fields.fields if all_fields is not None else []:
-                field_type_str = from_proto.field_type_name(field.field_type).abbreviation()
-                try:
-                    await backfill_field(
-                        kbid=kbid,
-                        rid=rid,
-                        field_type=field_type_str,
-                        field_id=field.field,
-                        minimal=minimal,
-                    )
-                except Exception:
-                    logger.exception(
-                        f"Failed to backfill field {kbid}/{rid}/{field_type_str}/{field.field}, continuing"
-                    )
 
-
-async def backfill_resource_metadata(txn: Transaction, *, kbid: str, rid: str, minimal: bool) -> None:
+async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) -> None:
+    """
+    Read all data for a resource from v1 (metadata, fields, conversation pages)
+    and write everything to the ORM tables in one shot:
+      - one INSERT for the kb_resources row
+      - one executemany for all kb_fields rows
+      - one executemany for all kb_conversations rows (pages + splits sentinel)
+    """
+    # --- Resource row ---
     basic = await resources_v1.get_basic(txn, kbid=kbid, rid=rid)
     if basic is None:
         raise ValueError(f"Resource {kbid}/{rid} has no basic metadata, skipping backfill")
 
-    # slug
-    await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=basic.slug)
-    if minimal:
-        logger.info(
-            f"Minimal backfill for resource {kbid}/{rid}, skipping shard, origin, extra, and security"
-        )
-        return
-
-    # basic
-    await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
-
-    # shard
     shard = await resources_v1.get_resource_shard_id(txn, kbid=kbid, rid=rid)
     if shard is None:
         raise ValueError(f"Resource {kbid}/{rid} has no shard, skipping backfill")
 
-    await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
-
-    # origin
     origin = await resources_v1.get_origin(txn, kbid=kbid, rid=rid)
-    if origin is not None:
-        await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
-
-    # extra
     extra = await resources_v1.get_extra(txn, kbid=kbid, rid=rid)
-    if extra is not None:
-        await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
-
-    # security
     security = await resources_v1.get_security(txn, kbid=kbid, rid=rid)
-    if security is not None:
-        await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
 
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_resources (kbid, rid, slug, shard, basic, origin, extra, security)
+            VALUES (%(kbid)s, %(rid)s, %(slug)s, %(shard)s, %(basic)s, %(origin)s, %(extra)s, %(security)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                slug     = EXCLUDED.slug,
+                shard    = EXCLUDED.shard,
+                basic    = EXCLUDED.basic,
+                origin   = EXCLUDED.origin,
+                extra    = EXCLUDED.extra,
+                security = EXCLUDED.security
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "slug": basic.slug,
+                "shard": shard,
+                "basic": basic.SerializeToString(),
+                "origin": origin.SerializeToString() if origin is not None else None,
+                "extra": extra.SerializeToString() if extra is not None else None,
+                "security": security.SerializeToString() if security is not None else None,
+            },
+        )
 
-# ---------------------------------------------------------------------------
-# Field
-# ---------------------------------------------------------------------------
+    # --- Collect all field and conversation rows ---
+    all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
+    if all_fields is None:
+        return
 
+    for field in all_fields.fields:
+        field_type_str = from_proto.field_type_name(field.field_type).abbreviation()
+        field_id = field.field
 
-async def backfill_field(*, kbid: str, rid: str, field_type: str, field_id: str, minimal: bool) -> None:
-    """Backfill one kb_fields row (value, status, md5)."""
-    logger.info(f"Backfilling field {kbid}/{rid}/{field_type}/{field_id}")
-
-    async with with_rw_transaction() as txn:
-        # status
         status = await fields_v1.get_status(
-            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
+            txn, kbid=kbid, rid=rid, field_type=field_type_str, field_id=field_id
         )
-        if status is not None:
-            await fields_v2.set_status(
-                txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
-            )
-            if minimal:
-                logger.info(
-                    f"Minimal backfill for field {kbid}/{rid}/{field_type}/{field_id}, skipping value and md5"
-                )
-                await txn.commit()
-                return
-
-        # value
         value = await fields_v1.get_raw(
-            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
+            txn, kbid=kbid, rid=rid, field_type=field_type_str, field_id=field_id
         )
-        if value is not None:
-            await fields_v2.set(
-                txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
-            )
-            if minimal:
-                logger.info(
-                    f"Minimal backfill for field {kbid}/{rid}/{field_type}/{field_id}, skipping md5"
-                )
-                await txn.commit()
-                return
 
-        # md5 — only file fields (field_type == 'f') have an md5 in the v1 table
-        if field_type == "f" and value is not None:
-            field_file = resources_pb2.FieldFile()
-            field_file.ParseFromString(value)
-            if field_file.file.md5:
-                await file_md5_v2.set(
-                    txn, kbid=kbid, md5=field_file.file.md5, rid=rid, field_id=field_id
-                )
-                if minimal:
-                    logger.info(
-                        f"Minimal backfill for field {kbid}/{rid}/{field_type}/{field_id}, skipping md5"
+        md5 = None
+        if field_type_str == "f":
+            md5 = await file_md5.get(txn, kbid=kbid, rid=rid, field_id=field_id)
+
+        async with _pg_cursor(txn) as cur:
+            await cur.execute(
+                """
+                INSERT INTO kb_fields (kbid, rid, field_type, field_id, value, status)
+                VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(value)s, %(status)s)
+                ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                    value  = EXCLUDED.value,
+                    status = EXCLUDED.status
+                """,
+                {
+                    "kbid": kbid,
+                    "rid": rid,
+                    "field_type": field_type_str,
+                    "field_id": field_id,
+                    "value": value,
+                    "md5": md5,
+                    "status": status.SerializeToString() if status is not None else None,
+                },
+            )
+
+        # Conversation fields: insert splits metadata sentinel + each page individually
+        if field_type_str == "c" and value is not None:
+            # Parse page count directly from the already-fetched field value
+            # (FieldConversation is stored at the same KV key as the field value)
+            conv_metadata = resources_pb2.FieldConversation()
+            conv_metadata.ParseFromString(value)
+
+            splits_metadata = await conversations_v1.get_splits_metadata(
+                txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id
+            )
+            if splits_metadata is not None:
+                async with _pg_cursor(txn) as cur:
+                    await cur.execute(
+                        """
+                        INSERT INTO kb_conversations (kbid, rid, field_type, field_id, page, value)
+                        VALUES (%(kbid)s, %(rid)s, 'c', %(field_id)s, 0, %(value)s)
+                        ON CONFLICT (kbid, rid, field_type, field_id, page) DO UPDATE SET
+                            value = EXCLUDED.value
+                        """,
+                        {
+                            "kbid": kbid,
+                            "rid": rid,
+                            "field_id": field_id,
+                            "value": splits_metadata.SerializeToString(),
+                        },
                     )
-                    await txn.commit()
-                    return
 
-        await txn.commit()
-
-    # Conversation fields need their own dedicated backfill
-    if field_type == "c":
-        await backfill_conversation_field(kbid=kbid, rid=rid, field_id=field_id, minimal=minimal)
-
-
-# ---------------------------------------------------------------------------
-# Conversation field
-# ---------------------------------------------------------------------------
-
-
-async def backfill_conversation_field(*, kbid: str, rid: str, field_id: str, minimal: bool) -> None:
-    """
-    Backfill FieldConversation metadata, all pages, and SplitsMetadata
-
-    Conversation metadata has already been backfilled in backfill_field in the kb_fields table.
-    We need to backfill the conversation pages and splits metadata into the kb_conversations table.
-    """
-    logger.info(f"Backfilling conversation {kbid}/{rid}/c/{field_id}")
-
-    async with with_rw_transaction() as txn:
-        metadata = await conversations_v1.get_metadata(
-            txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id
-        )
-        if metadata is None:
-            raise ValueError(
-                f"Conversation {kbid}/{rid}/c/{field_id} has no metadata, skipping backfill"
-            )
-        splits_metadata = await conversations_v1.get_splits_metadata(
-            txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id
-        )
-        if splits_metadata is not None:
-            await conversations_v2.set_splits_metadata(
-                txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits_metadata
-            )
-        await txn.commit()
-
-        if minimal:
-            logger.info(f"Minimal backfill for conversation {kbid}/{rid}/c/{field_id}, skipping pages")
-            return
-
-    async with with_rw_transaction() as txn:
-        for page_n in range(1, metadata.pages + 1):
-            page = await conversations_v1.get_page(
-                txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id, page=page_n
-            )
-            if page is None:
-                logger.warning(
-                    f"Conversation {kbid}/{rid}/c/{field_id} page {page_n} is missing, skipping"
+            for page_n in range(1, conv_metadata.pages + 1):
+                page = await conversations_v1.get_page(
+                    txn, kbid=kbid, rid=rid, field_type="c", field_id=field_id, page=page_n
                 )
-                continue
-            await conversations_v2.set_page(
-                txn, kbid=kbid, rid=rid, field_id=field_id, page=page_n, value=page
-            )
-            await txn.commit()
+                if page is None:
+                    logger.warning(
+                        f"Conversation {kbid}/{rid}/c/{field_id} page {page_n} missing, skipping"
+                    )
+                    continue
+                async with _pg_cursor(txn) as cur:
+                    await cur.execute(
+                        """
+                        INSERT INTO kb_conversations (kbid, rid, field_type, field_id, page, value)
+                        VALUES (%(kbid)s, %(rid)s, 'c', %(field_id)s, %(page)s, %(value)s)
+                        ON CONFLICT (kbid, rid, field_type, field_id, page) DO UPDATE SET
+                            value = EXCLUDED.value
+                        """,
+                        {
+                            "kbid": kbid,
+                            "rid": rid,
+                            "field_id": field_id,
+                            "page": page_n,
+                            "value": page.SerializeToString(),
+                        },
+                    )
 
 
 async def _main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Backfill ORM tables from the v1 KV store")
-    parser.add_argument(
-        "--kbid", help="Backfill a single KB by its UUID (default: all KBs)", required=True
-    )
-    parser.add_argument(
-        "--minimal",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help=(
-            "When set, write only the bare-minimum rows (slug, status) needed to activate the "
-            "write feature flag safely. Any in-flight write for an already-existing resource or "
-            "field will find an ORM entry to update instead of failing. "
-            "Heavy data (config, shards, origin, extra, security, conversation pages) is skipped "
-            "and must be backfilled in a follow-up run with --no-minimal. Default: True"
-        ),
-    )
+    parser.add_argument("--kbid", help="Backfill a single KB by its UUID", required=True)
     args = parser.parse_args()
     setup_logging(
         settings=LogSettings(
@@ -380,12 +369,10 @@ async def _main():
     await context.initialize()
 
     try:
-        await backfill_kb(kbid=args.kbid, minimal=args.minimal)
+        await backfill_kb(kbid=args.kbid)
     finally:
         await context.finalize()
 
 
 if __name__ == "__main__":
-    import asyncio
-
     asyncio.run(_main())

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -271,10 +271,11 @@ async def _backfill_resource_in_txn(txn: Transaction, *, kbid: str, rid: str) ->
         async with _pg_cursor(txn) as cur:
             await cur.execute(
                 """
-                INSERT INTO kb_fields (kbid, rid, field_type, field_id, value, status)
-                VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(value)s, %(status)s)
+                INSERT INTO kb_fields (kbid, rid, field_type, field_id, value, md5, status)
+                VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(value)s, %(md5)s, %(status)s)
                 ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
                     value  = EXCLUDED.value,
+                    md5     = EXCLUDED.md5,
                     status = EXCLUDED.status
                 """,
                 {

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -74,7 +74,17 @@ logger = logging.getLogger("backfill_orm_tables")
 
 
 async def backfill_all_kbs(minimal: bool) -> None:
-    """Iterate every KB in v1 and backfill it into the ORM tables."""
+    """Iterate every KB in v1 and backfill it into the ORM tables.
+
+    Args:
+        minimal: When True, only the bare-minimum rows are written (slug, status).
+            Use this mode to safely activate the write feature flag: it ensures every
+            existing resource and field already has an entry in the ORM tables, so an
+            in-flight write that arrives before the full backfill completes will not
+            fail due to a missing row.  Heavy data (config, shards, origin, extra,
+            security, conversation pages) can then be populated in a follow-up run
+            with minimal=False.
+    """
     kbids_and_slugs = []
     async with with_ro_transaction() as txn:
         async for kbid, slug in kb_v1.get_kbs(txn):
@@ -92,7 +102,15 @@ async def backfill_all_kbs(minimal: bool) -> None:
 
 
 async def backfill_kb(*, kbid: str, minimal: bool) -> None:
-    """Backfill one KB row and all of its resources."""
+    """Backfill one KB row and all of its resources.
+
+    Args:
+        minimal: See :func:`backfill_all_kbs` for a full description.  In short,
+            set this to True when populating the ORM tables just before enabling the
+            write feature flag, so that any concurrent write for an already-existing
+            resource or field finds a row to update instead of failing with a
+            missing-entry error.
+    """
     logger.info(f"Backfilling KB {kbid}")
     start_time = asyncio.get_event_loop().time()
     async with with_rw_transaction() as txn:
@@ -332,7 +350,13 @@ async def _main():
         "--minimal",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Skip heavy fields (config, shards, origin, extra, security, conversation pages). Default: True",
+        help=(
+            "When set, write only the bare-minimum rows (slug, status) needed to activate the "
+            "write feature flag safely. Any in-flight write for an already-existing resource or "
+            "field will find an ORM entry to update instead of failing. "
+            "Heavy data (config, shards, origin, extra, security, conversation pages) is skipped "
+            "and must be backfilled in a follow-up run with --no-minimal. Default: True"
+        ),
     )
     args = parser.parse_args()
     setup_logging(

--- a/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/backfill_orm_tables.py
@@ -346,7 +346,11 @@ async def _main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Backfill ORM tables from the v1 KV store")
-    parser.add_argument("--kbid", help="Backfill a single KB by its UUID", required=True)
+    parser.add_argument(
+        "--kbid",
+        help="KB UUID to backfill, or the special value 'ALL_KBS' to backfill every KB.",
+        required=True,
+    )
     args = parser.parse_args()
     setup_logging(
         settings=LogSettings(
@@ -369,7 +373,10 @@ async def _main():
     await context.initialize()
 
     try:
-        await backfill_kb(kbid=args.kbid)
+        if args.kbid == "ALL_KBS":
+            await backfill_all_kbs()
+        else:
+            await backfill_kb(kbid=args.kbid)
     finally:
         await context.finalize()
 

--- a/nucliadb/src/nucliadb/common/datamanagers/cluster.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/cluster.py
@@ -19,10 +19,11 @@
 #
 import logging
 
+from nucliadb.common.datamanagers import kb_v2
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import writer_pb2
 
-from .utils import get_kv_pb
+from .utils import datamanagers_v2_read, datamanagers_v2_write, get_kv_pb
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +34,15 @@ KB_SHARDS = "/kbs/{kbid}/shards"
 async def get_kb_shards(
     txn: Transaction, *, kbid: str, for_update: bool = False
 ) -> writer_pb2.Shards | None:
+    if datamanagers_v2_read(kbid):
+        return await kb_v2.get_kb_shards(txn, kbid=kbid, for_update=for_update)
+
     key = KB_SHARDS.format(kbid=kbid)
     return await get_kv_pb(txn, key, writer_pb2.Shards, for_update=for_update)
 
 
-async def is_kb_shard(txn: Transaction, *, kbid: str, shard_id: str, for_update: bool = False) -> bool:
-    shards = await get_kb_shards(txn, kbid=kbid, for_update=for_update)
+async def is_kb_shard(txn: Transaction, *, kbid: str, shard_id: str) -> bool:
+    shards = await get_kb_shards(txn, kbid=kbid)
     if shards is None:
         return False
     for shard in shards.shards:
@@ -50,3 +54,6 @@ async def is_kb_shard(txn: Transaction, *, kbid: str, shard_id: str, for_update:
 async def update_kb_shards(txn: Transaction, *, kbid: str, shards: writer_pb2.Shards) -> None:
     key = KB_SHARDS.format(kbid=kbid)
     await txn.set(key, shards.SerializeToString())
+
+    if datamanagers_v2_write(kbid):
+        await kb_v2.update_kb_shards(txn, kbid=kbid, shards=shards)

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+from nucliadb.common.datamanagers import conversations_v2
+from nucliadb.common.datamanagers.utils import datamanagers_v2_migrating, datamanagers_v2_read
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_protos.resources_pb2 import FieldConversation, SplitsMetadata
@@ -37,6 +39,10 @@ async def get_page(
 ) -> PBConversation | None:
     if page <= 0:
         raise ValueError("Conversation pages start at index 1")
+
+    if datamanagers_v2_read(kbid):
+        return await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=page)
+
     key = KB_CONVERSATION_PAGE.format(kbid=kbid, uuid=rid, type=field_type, field=field_id, page=page)
     payload = await txn.get(key)
     if payload is None:
@@ -56,8 +62,19 @@ async def set_page(
     page: int,
     value: PBConversation,
 ) -> None:
+    if datamanagers_v2_read(kbid):
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=page, value=value
+        )
+        return
+
     key = KB_CONVERSATION_PAGE.format(kbid=kbid, uuid=rid, type=field_type, field=field_id, page=page)
     await txn.set(key, value.SerializeToString())
+
+    if datamanagers_v2_migrating(kbid):
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=page, value=value
+        )
 
 
 async def get_metadata(
@@ -68,6 +85,9 @@ async def get_metadata(
     field_type: str,
     field_id: str,
 ) -> FieldConversation | None:
+    if datamanagers_v2_read(kbid):
+        return await conversations_v2.get_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+
     key = KB_CONVERSATION_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     payload = await txn.get(key)
     if payload is None:
@@ -86,8 +106,19 @@ async def set_metadata(
     field_id: str,
     metadata: FieldConversation,
 ) -> None:
+    if datamanagers_v2_read(kbid):
+        await conversations_v2.set_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, metadata=metadata
+        )
+        return
+
     key = KB_CONVERSATION_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, metadata.SerializeToString())
+
+    if datamanagers_v2_migrating(kbid):
+        await conversations_v2.set_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, metadata=metadata
+        )
 
 
 async def delete_field(
@@ -98,8 +129,15 @@ async def delete_field(
     field_type: str,
     field_id: str,
 ) -> None:
+    if datamanagers_v2_read(kbid):
+        await conversations_v2.delete_field(txn, kbid=kbid, rid=rid, field_id=field_id)
+        return
+
     base_key = KB_CONVERSATION_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.delete_by_prefix(base_key)
+
+    if datamanagers_v2_migrating(kbid):
+        await conversations_v2.delete_field(txn, kbid=kbid, rid=rid, field_id=field_id)
 
 
 async def get_splits_metadata(
@@ -110,6 +148,9 @@ async def get_splits_metadata(
     field_type: str,
     field_id: str,
 ) -> SplitsMetadata | None:
+    if datamanagers_v2_read(kbid):
+        return await conversations_v2.get_splits_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+
     key = KB_CONVERSATION_SPLITS_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     payload = await txn.get(key)
     if payload is None:
@@ -128,5 +169,16 @@ async def set_splits_metadata(
     field_id: str,
     splits_metadata: SplitsMetadata,
 ) -> None:
+    if datamanagers_v2_read(kbid):
+        await conversations_v2.set_splits_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits_metadata
+        )
+        return
+
     key = KB_CONVERSATION_SPLITS_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, splits_metadata.SerializeToString())
+
+    if datamanagers_v2_migrating(kbid):
+        await conversations_v2.set_splits_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits_metadata
+        )

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations.py
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 from nucliadb.common.datamanagers import conversations_v2
-from nucliadb.common.datamanagers.utils import datamanagers_v2_migrating, datamanagers_v2_read
+from nucliadb.common.datamanagers.utils import datamanagers_v2_read, datamanagers_v2_write
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_protos.resources_pb2 import FieldConversation, SplitsMetadata
@@ -62,16 +62,10 @@ async def set_page(
     page: int,
     value: PBConversation,
 ) -> None:
-    if datamanagers_v2_read(kbid):
-        await conversations_v2.set_page(
-            txn, kbid=kbid, rid=rid, field_id=field_id, page=page, value=value
-        )
-        return
-
     key = KB_CONVERSATION_PAGE.format(kbid=kbid, uuid=rid, type=field_type, field=field_id, page=page)
     await txn.set(key, value.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await conversations_v2.set_page(
             txn, kbid=kbid, rid=rid, field_id=field_id, page=page, value=value
         )
@@ -106,16 +100,10 @@ async def set_metadata(
     field_id: str,
     metadata: FieldConversation,
 ) -> None:
-    if datamanagers_v2_read(kbid):
-        await conversations_v2.set_metadata(
-            txn, kbid=kbid, rid=rid, field_id=field_id, metadata=metadata
-        )
-        return
-
     key = KB_CONVERSATION_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, metadata.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await conversations_v2.set_metadata(
             txn, kbid=kbid, rid=rid, field_id=field_id, metadata=metadata
         )
@@ -129,14 +117,10 @@ async def delete_field(
     field_type: str,
     field_id: str,
 ) -> None:
-    if datamanagers_v2_read(kbid):
-        await conversations_v2.delete_field(txn, kbid=kbid, rid=rid, field_id=field_id)
-        return
-
     base_key = KB_CONVERSATION_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.delete_by_prefix(base_key)
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await conversations_v2.delete_field(txn, kbid=kbid, rid=rid, field_id=field_id)
 
 
@@ -169,16 +153,10 @@ async def set_splits_metadata(
     field_id: str,
     splits_metadata: SplitsMetadata,
 ) -> None:
-    if datamanagers_v2_read(kbid):
-        await conversations_v2.set_splits_metadata(
-            txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits_metadata
-        )
-        return
-
     key = KB_CONVERSATION_SPLITS_METADATA.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, splits_metadata.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await conversations_v2.set_splits_metadata(
             txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits_metadata
         )

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -41,6 +41,7 @@ because there is no FK from kb_conversations to kb_fields.
 
 from typing import cast
 
+from nucliadb.common.datamanagers.utils import _pg_cursor
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
@@ -68,7 +69,7 @@ async def get_metadata(
     field_id: str,
 ) -> FieldConversation | None:
     """Return the FieldConversation metadata for a conversation field, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT value FROM kb_fields
@@ -94,7 +95,7 @@ async def set_metadata(
     metadata: FieldConversation,
 ) -> None:
     """Upsert the FieldConversation metadata row in kb_fields."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             INSERT INTO kb_fields (kbid, rid, field_type, field_id, value)
@@ -127,7 +128,7 @@ async def get_page(
     """Return one page of a conversation field, or None if not found."""
     if page <= 0:
         raise ValueError("Conversation pages start at index 1")
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT value FROM kb_conversations
@@ -156,7 +157,7 @@ async def set_page(
     """Upsert one page of a conversation field."""
     if page <= 0:
         raise ValueError("Conversation pages start at index 1")
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             INSERT INTO kb_conversations (kbid, rid, field_id, page, value)
@@ -187,7 +188,7 @@ async def get_splits_metadata(
     field_id: str,
 ) -> SplitsMetadata | None:
     """Return the SplitsMetadata for a conversation field, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT value FROM kb_conversations
@@ -213,7 +214,7 @@ async def set_splits_metadata(
     splits_metadata: SplitsMetadata,
 ) -> None:
     """Upsert the SplitsMetadata sentinel row (page = 0) for a conversation field."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             INSERT INTO kb_conversations (kbid, rid, field_id, page, value)
@@ -249,7 +250,7 @@ async def delete_field(
     is handled by the fields datamanager; cascading from kb_resources only
     fires when the whole resource or KB is deleted.
     """
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             DELETE FROM kb_conversations

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -232,7 +232,6 @@ async def set_splits_metadata(
 # ---------------------------------------------------------------------------
 
 
-@logs_foreign_key_error
 async def delete_field(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -160,9 +160,9 @@ async def set_page(
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            INSERT INTO kb_conversations (kbid, rid, field_id, page, value)
-            VALUES (%(kbid)s, %(rid)s, %(field_id)s, %(page)s, %(value)s)
-            ON CONFLICT (kbid, rid, field_id, page) DO UPDATE SET
+            INSERT INTO kb_conversations (kbid, rid, field_type, field_id, page, value)
+            VALUES (%(kbid)s, %(rid)s, 'c', %(field_id)s, %(page)s, %(value)s)
+            ON CONFLICT (kbid, rid, field_type, field_id, page) DO UPDATE SET
                 value = EXCLUDED.value
             """,
             {
@@ -217,9 +217,9 @@ async def set_splits_metadata(
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            INSERT INTO kb_conversations (kbid, rid, field_id, page, value)
-            VALUES (%(kbid)s, %(rid)s, %(field_id)s, %(page)s, %(value)s)
-            ON CONFLICT (kbid, rid, field_id, page) DO UPDATE SET
+            INSERT INTO kb_conversations (kbid, rid, field_type, field_id, page, value)
+            VALUES (%(kbid)s, %(rid)s, 'c', %(field_id)s, %(page)s, %(value)s)
+            ON CONFLICT (kbid, rid, field_type, field_id, page) DO UPDATE SET
                 value = EXCLUDED.value
             """,
             {

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -1,0 +1,259 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Datamanager for the `kb_conversations` PostgreSQL table (migration 0016).
+
+Each row stores one page of a conversation field, or the SplitsMetadata sentinel:
+  - kbid     - FK → kb_resources.kbid (ON DELETE CASCADE)
+  - rid      - FK → kb_resources.rid  (ON DELETE CASCADE)
+  - field_id - user-defined conversation field name
+  - page     - 1-based page number; the sentinel value 0 stores SplitsMetadata
+  - value    - serialised protobuf bytes:
+                 page = 0  → resources_pb2.SplitsMetadata
+                 page >= 1 → resources_pb2.Conversation (~200 messages each)
+
+The FieldConversation metadata (page count, total, page size, extract/split strategy)
+is stored in kb_fields.value for the corresponding 'c'-type field row and is written
+directly here to avoid a cross-module import cycle with fields_v2.
+
+NOTE: deleting a kb_resources row (or its parent kbs row) automatically removes all
+related kb_conversations rows via the ON DELETE CASCADE foreign key.
+Deleting a single conversation field requires an explicit DELETE by (kbid, rid, field_id)
+because there is no FK from kb_conversations to kb_fields.
+"""
+
+from typing import cast
+
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction
+from nucliadb_protos.resources_pb2 import Conversation as PBConversation
+from nucliadb_protos.resources_pb2 import FieldConversation, SplitsMetadata
+
+# Sentinel page number used to store SplitsMetadata in the kb_conversations table.
+# Real conversation pages are 1-based, so 0 is always free.
+_SPLITS_METADATA_PAGE = 0
+
+
+def _pg(txn: Transaction) -> PGTransaction:
+    return cast(PGTransaction, txn)
+
+
+# ---------------------------------------------------------------------------
+# FieldConversation metadata  (stored in kb_fields, field_type = 'c')
+# ---------------------------------------------------------------------------
+
+
+async def get_metadata(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+) -> FieldConversation | None:
+    """Return the FieldConversation metadata for a conversation field, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT value FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = 'c' AND field_id = %(field_id)s
+            """,
+            {"kbid": kbid, "rid": rid, "field_id": field_id},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = FieldConversation()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def set_metadata(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+    metadata: FieldConversation,
+) -> None:
+    """Upsert the FieldConversation metadata row in kb_fields."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_fields (kbid, rid, field_type, field_id, value)
+            VALUES (%(kbid)s, %(rid)s, 'c', %(field_id)s, %(value)s)
+            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                value = EXCLUDED.value
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_id": field_id,
+                "value": metadata.SerializeToString(),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Conversation pages  (stored in kb_conversations, page >= 1)
+# ---------------------------------------------------------------------------
+
+
+async def get_page(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+    page: int,
+) -> PBConversation | None:
+    """Return one page of a conversation field, or None if not found."""
+    if page <= 0:
+        raise ValueError("Conversation pages start at index 1")
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT value FROM kb_conversations
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_id = %(field_id)s AND page = %(page)s
+            """,
+            {"kbid": kbid, "rid": rid, "field_id": field_id, "page": page},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = PBConversation()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def set_page(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+    page: int,
+    value: PBConversation,
+) -> None:
+    """Upsert one page of a conversation field."""
+    if page <= 0:
+        raise ValueError("Conversation pages start at index 1")
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_conversations (kbid, rid, field_id, page, value)
+            VALUES (%(kbid)s, %(rid)s, %(field_id)s, %(page)s, %(value)s)
+            ON CONFLICT (kbid, rid, field_id, page) DO UPDATE SET
+                value = EXCLUDED.value
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_id": field_id,
+                "page": page,
+                "value": value.SerializeToString(),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# SplitsMetadata  (stored in kb_conversations at sentinel page = 0)
+# ---------------------------------------------------------------------------
+
+
+async def get_splits_metadata(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+) -> SplitsMetadata | None:
+    """Return the SplitsMetadata for a conversation field, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT value FROM kb_conversations
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_id = %(field_id)s AND page = %(page)s
+            """,
+            {"kbid": kbid, "rid": rid, "field_id": field_id, "page": _SPLITS_METADATA_PAGE},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = SplitsMetadata()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def set_splits_metadata(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+    splits_metadata: SplitsMetadata,
+) -> None:
+    """Upsert the SplitsMetadata sentinel row (page = 0) for a conversation field."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_conversations (kbid, rid, field_id, page, value)
+            VALUES (%(kbid)s, %(rid)s, %(field_id)s, %(page)s, %(value)s)
+            ON CONFLICT (kbid, rid, field_id, page) DO UPDATE SET
+                value = EXCLUDED.value
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_id": field_id,
+                "page": _SPLITS_METADATA_PAGE,
+                "value": splits_metadata.SerializeToString(),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+async def delete_field(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_id: str,
+) -> None:
+    """
+    Delete all kb_conversations rows for this field (all pages + the
+    SplitsMetadata sentinel).  The kb_fields row for the 'c'-type field
+    is handled by the fields datamanager; cascading from kb_resources only
+    fires when the whole resource or KB is deleted.
+    """
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            DELETE FROM kb_conversations
+            WHERE kbid = %(kbid)s AND rid = %(rid)s AND field_id = %(field_id)s
+            """,
+            {"kbid": kbid, "rid": rid, "field_id": field_id},
+        )

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -133,7 +133,7 @@ async def get_page(
             """
             SELECT value FROM kb_conversations
             WHERE kbid = %(kbid)s AND rid = %(rid)s
-              AND field_id = %(field_id)s AND page = %(page)s
+              AND field_type = 'c' AND field_id = %(field_id)s AND page = %(page)s
             """,
             {"kbid": kbid, "rid": rid, "field_id": field_id, "page": page},
         )
@@ -193,7 +193,7 @@ async def get_splits_metadata(
             """
             SELECT value FROM kb_conversations
             WHERE kbid = %(kbid)s AND rid = %(rid)s
-              AND field_id = %(field_id)s AND page = %(page)s
+              AND field_type = 'c' AND field_id = %(field_id)s AND page = %(page)s
             """,
             {"kbid": kbid, "rid": rid, "field_id": field_id, "page": _SPLITS_METADATA_PAGE},
         )
@@ -254,7 +254,7 @@ async def delete_field(
         await cur.execute(
             """
             DELETE FROM kb_conversations
-            WHERE kbid = %(kbid)s AND rid = %(rid)s AND field_id = %(field_id)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s AND field_type = 'c' AND field_id = %(field_id)s
             """,
             {"kbid": kbid, "rid": rid, "field_id": field_id},
         )

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -39,22 +39,14 @@ Deleting a single conversation field requires an explicit DELETE by (kbid, rid, 
 because there is no FK from kb_conversations to kb_fields.
 """
 
-from typing import cast
-
-from nucliadb.common.datamanagers.utils import _pg_cursor
+from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error
 from nucliadb.common.maindb.driver import Transaction
-from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_protos.resources_pb2 import FieldConversation, SplitsMetadata
 
 # Sentinel page number used to store SplitsMetadata in the kb_conversations table.
 # Real conversation pages are 1-based, so 0 is always free.
 _SPLITS_METADATA_PAGE = 0
-
-
-def _pg(txn: Transaction) -> PGTransaction:
-    return cast(PGTransaction, txn)
-
 
 # ---------------------------------------------------------------------------
 # FieldConversation metadata  (stored in kb_fields, field_type = 'c')
@@ -86,6 +78,7 @@ async def get_metadata(
         return pb
 
 
+@logs_foreign_key_error
 async def set_metadata(
     txn: Transaction,
     *,
@@ -145,6 +138,7 @@ async def get_page(
         return pb
 
 
+@logs_foreign_key_error
 async def set_page(
     txn: Transaction,
     *,
@@ -205,6 +199,7 @@ async def get_splits_metadata(
         return pb
 
 
+@logs_foreign_key_error
 async def set_splits_metadata(
     txn: Transaction,
     *,
@@ -237,6 +232,7 @@ async def set_splits_metadata(
 # ---------------------------------------------------------------------------
 
 
+@logs_foreign_key_error
 async def delete_field(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/fields.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields.py
@@ -37,6 +37,9 @@ KB_RESOURCE_FIELD_STATUS = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/status"
 async def get_raw(
     txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str
 ) -> bytes | None:
+    if datamanagers_v2_read(kbid):
+        return await fields_v2.get_raw(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
+
     key = KB_RESOURCE_FIELD.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     return await txn.get(key)
 

--- a/nucliadb/src/nucliadb/common/datamanagers/fields.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields.py
@@ -24,13 +24,12 @@ from typing import Sequence
 from google.protobuf.message import Message
 
 from nucliadb.common.datamanagers import fields_v2
-from nucliadb.common.datamanagers.utils import datamanagers_v2_migrating, datamanagers_v2_read, get_kv_pb
+from nucliadb.common.datamanagers.utils import datamanagers_v2_read, datamanagers_v2_write, get_kv_pb
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import writer_pb2
 
 KB_RESOURCE_FIELD = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}"
-KB_RESOURCE_FIELD_ERROR = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/error"
 KB_RESOURCE_FIELD_STATUS = "/kbs/{kbid}/r/{uuid}/f/{type}/{field}/status"
 
 
@@ -53,57 +52,24 @@ async def set(
     field_id: str,
     value: Message,
 ):
-    if datamanagers_v2_read(kbid):
-        await fields_v2.set(
-            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
-        )
-        return
-
     key = KB_RESOURCE_FIELD.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, value.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await fields_v2.set(
             txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
         )
 
 
 async def delete(txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str):
-    if datamanagers_v2_read(kbid):
-        await fields_v2.delete(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
-        return
-
     base_key = KB_RESOURCE_FIELD.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.delete_by_prefix(base_key)
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await fields_v2.delete(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
 
 
-# Error
-
-
-async def get_error(
-    txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str
-) -> writer_pb2.Error | None:
-    key = KB_RESOURCE_FIELD_ERROR.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
-    return await get_kv_pb(txn, key, writer_pb2.Error)
-
-
-async def set_error(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-    field_type: str,
-    field_id: str,
-    error: writer_pb2.Error,
-):
-    key = KB_RESOURCE_FIELD_ERROR.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
-    await txn.set(key, error.SerializeToString())
-
-
-# Status, replaces error
+# Status
 
 
 async def get_status(
@@ -152,16 +118,10 @@ async def set_status(
     field_id: str,
     status: writer_pb2.FieldStatus,
 ):
-    if datamanagers_v2_read(kbid):
-        await fields_v2.set_status(
-            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
-        )
-        return
-
     key = KB_RESOURCE_FIELD_STATUS.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, status.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await fields_v2.set_status(
             txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
         )

--- a/nucliadb/src/nucliadb/common/datamanagers/fields.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields.py
@@ -23,7 +23,8 @@ from typing import Sequence
 
 from google.protobuf.message import Message
 
-from nucliadb.common.datamanagers.utils import get_kv_pb
+from nucliadb.common.datamanagers import fields_v2
+from nucliadb.common.datamanagers.utils import datamanagers_v2_migrating, datamanagers_v2_read, get_kv_pb
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import writer_pb2
@@ -49,13 +50,31 @@ async def set(
     field_id: str,
     value: Message,
 ):
+    if datamanagers_v2_read(kbid):
+        await fields_v2.set(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
+        )
+        return
+
     key = KB_RESOURCE_FIELD.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, value.SerializeToString())
 
+    if datamanagers_v2_migrating(kbid):
+        await fields_v2.set(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, value=value
+        )
+
 
 async def delete(txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str):
+    if datamanagers_v2_read(kbid):
+        await fields_v2.delete(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
+        return
+
     base_key = KB_RESOURCE_FIELD.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.delete_by_prefix(base_key)
+
+    if datamanagers_v2_migrating(kbid):
+        await fields_v2.delete(txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id)
 
 
 # Error
@@ -87,6 +106,11 @@ async def set_error(
 async def get_status(
     txn: Transaction, *, kbid: str, rid: str, field_type: str, field_id: str
 ) -> writer_pb2.FieldStatus | None:
+    if datamanagers_v2_read(kbid):
+        return await fields_v2.get_status(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id
+        )
+
     key = KB_RESOURCE_FIELD_STATUS.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     return await get_kv_pb(txn, key, writer_pb2.FieldStatus)
 
@@ -94,6 +118,9 @@ async def get_status(
 async def get_statuses(
     txn: Transaction, *, kbid: str, rid: str, fields: Sequence[writer_pb2.FieldID]
 ) -> list[writer_pb2.FieldStatus]:
+    if datamanagers_v2_read(kbid):
+        return await fields_v2.get_statuses(txn, kbid=kbid, rid=rid, fields=fields)
+
     keys = [
         KB_RESOURCE_FIELD_STATUS.format(
             kbid=kbid, uuid=rid, type=FIELD_TYPE_PB_TO_STR[fid.field_type], field=fid.field
@@ -122,5 +149,16 @@ async def set_status(
     field_id: str,
     status: writer_pb2.FieldStatus,
 ):
+    if datamanagers_v2_read(kbid):
+        await fields_v2.set_status(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
+        )
+        return
+
     key = KB_RESOURCE_FIELD_STATUS.format(kbid=kbid, uuid=rid, type=field_type, field=field_id)
     await txn.set(key, status.SerializeToString())
+
+    if datamanagers_v2_migrating(kbid):
+        await fields_v2.set_status(
+            txn, kbid=kbid, rid=rid, field_type=field_type, field_id=field_id, status=status
+        )

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -268,6 +268,7 @@ async def get_all_field_ids(
             """
             SELECT field_type, field_id FROM kb_fields
             WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND NOT (field_type = 'a' AND field_id IN ('title', 'summary'))
             """,
             {"kbid": kbid, "rid": rid},
         )

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -26,8 +26,7 @@ Each row represents one field in a resource and stores:
   - field_type - single-char abbreviation: t=text, f=file, u=link,
                  c=conversation, a=generic, k=key_value
   - field_id   - user-defined field name
-  - status     - processing status matching FieldStatus.Status in writer.proto:
-                 0=PENDING, 1=PROCESSED, 2=ERROR
+  - status     - serialised writer_pb2.FieldStatus protobuf bytes; NULL when not yet set
   - value      - serialised protobuf bytes (field payload, excluding
                  anything stored in object storage)
   - md5        - optional content hash; NULL when not provided; used for
@@ -40,12 +39,15 @@ there is no need for explicit bulk-delete helpers here.
 
 import dataclasses
 from collections.abc import AsyncIterator
-from typing import cast
+from typing import Sequence, cast
+
+from google.protobuf.message import Message
 
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.pg import PGTransaction
-from nucliadb.common.models_utils import to_proto
+from nucliadb.common.models_utils import from_proto, to_proto
 from nucliadb_protos import resources_pb2 as rpb2
+from nucliadb_protos import writer_pb2 as wpb2
 
 # ---------------------------------------------------------------------------
 # Row model
@@ -58,7 +60,7 @@ class FieldRow:
     rid: str
     field_type: str  # single-char abbreviation: t, f, u, c, a, k
     field_id: str
-    status: int  # writer_pb2.FieldStatus.Status value
+    status: bytes | None  # serialised writer_pb2.FieldStatus
     value: bytes | None
     md5: str | None
 
@@ -79,7 +81,7 @@ def _row_to_field(row: tuple) -> FieldRow:
         rid=str(rid),
         field_type=field_type,
         field_id=field_id,
-        status=status,
+        status=bytes(status) if status is not None else None,
         value=bytes(value) if value is not None else None,
         md5=md5,
     )
@@ -100,7 +102,7 @@ async def upsert(
     rid: str,
     field_type: str,
     field_id: str,
-    status: int = 0,
+    status: bytes | None = None,
     value: bytes | None = None,
     md5: str | None = None,
 ) -> None:
@@ -134,7 +136,7 @@ async def set_status(
     rid: str,
     field_type: str,
     field_id: str,
-    status: int,
+    status: wpb2.FieldStatus,
 ) -> None:
     """Update only the status column. Does nothing if the row does not exist."""
     async with _pg(txn).connection.cursor() as cur:
@@ -149,36 +151,28 @@ async def set_status(
                 "rid": rid,
                 "field_type": field_type,
                 "field_id": field_id,
-                "status": status,
+                "status": status.SerializeToString(),
             },
         )
 
 
-async def set_value(
+async def set(
     txn: Transaction,
     *,
     kbid: str,
     rid: str,
     field_type: str,
     field_id: str,
-    value: bytes,
+    value: Message,
 ) -> None:
-    """Update only the value column. Does nothing if the row does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            UPDATE kb_fields SET value = %(value)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-              AND field_type = %(field_type)s AND field_id = %(field_id)s
-            """,
-            {
-                "kbid": kbid,
-                "rid": rid,
-                "field_type": field_type,
-                "field_id": field_id,
-                "value": value,
-            },
-        )
+    await upsert(
+        txn,
+        kbid=kbid,
+        rid=rid,
+        field_type=field_type,
+        field_id=field_id,
+        value=value.SerializeToString(),
+    )
 
 
 async def delete(
@@ -275,8 +269,8 @@ async def get_status(
     rid: str,
     field_type: str,
     field_id: str,
-) -> int | None:
-    """Return only the status integer for a field, or None if the row does not exist."""
+) -> wpb2.FieldStatus | None:
+    """Return the deserialised FieldStatus for a field, or None if the row does not exist."""
     async with _pg(txn).connection.cursor() as cur:
         await cur.execute(
             """
@@ -292,7 +286,53 @@ async def get_status(
             },
         )
         row = await cur.fetchone()
-        return row[0] if row is not None else None
+        if row is None or row[0] is None:
+            return None
+        pb = wpb2.FieldStatus()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def get_statuses(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    fields: Sequence[rpb2.FieldID],
+) -> list[wpb2.FieldStatus]:
+    """Return the deserialised FieldStatus for a list of fields, in the same order."""
+    if not fields:
+        return []
+
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT field_type, field_id, status
+            FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND (field_type, field_id) IN (
+                {",".join(["(%s, %s)"] * len(fields))}
+              )
+            """,
+            [kbid, rid]
+            + [(from_proto.field_type_name(f.field_type).abbreviation(), f.field) for f in fields],
+        )
+        rows = await cur.fetchall()
+
+    # Build a lookup dict for fast access
+    status_lookup = {(row[0], row[1]): bytes(row[2]) if row[2] is not None else None for row in rows}
+
+    result = []
+    for f in fields:
+        status_bytes = status_lookup.get((f.field_type, f.field))
+        if status_bytes is None:
+            result.append(wpb2.FieldStatus())  # Default empty status
+        else:
+            pb = wpb2.FieldStatus()
+            pb.ParseFromString(status_bytes)
+            result.append(pb)
+
+    return result
 
 
 async def get_all_for_resource(
@@ -382,13 +422,12 @@ async def get_all_field_ids(
         return pb
 
 
-async def exists(
+async def has_field(
     txn: Transaction,
     *,
     kbid: str,
     rid: str,
-    field_type: str,
-    field_id: str,
+    field_id: rpb2.FieldID,
 ) -> bool:
     """Return True if a field row exists, False otherwise."""
     async with _pg(txn).connection.cursor() as cur:
@@ -401,8 +440,8 @@ async def exists(
             {
                 "kbid": kbid,
                 "rid": rid,
-                "field_type": field_type,
-                "field_id": field_id,
+                "field_type": from_proto.field_type_name(field_id.field_type).abbreviation(),
+                "field_id": field_id.field,
             },
         )
         return await cur.fetchone() is not None

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -41,6 +41,7 @@ from typing import Sequence, cast
 
 from google.protobuf.message import Message
 
+from nucliadb.common.datamanagers.utils import _pg_cursor
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb.common.models_utils import from_proto, to_proto
@@ -71,7 +72,7 @@ async def set_status(
     status: wpb2.FieldStatus,
 ) -> None:
     """Update only the status column. Does nothing if the row does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kb_fields SET status = %(status)s
@@ -100,7 +101,7 @@ async def set(
     """
     Set the value of a field row, creating it if it does not exist. This is an upsert operation.
     """
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             INSERT INTO kb_fields (kbid, rid, field_type, field_id, value)
@@ -127,7 +128,7 @@ async def delete(
     field_id: str,
 ) -> None:
     """Delete a single field row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             DELETE FROM kb_fields
@@ -157,7 +158,7 @@ async def get_raw(
     field_id: str,
 ) -> bytes | None:
     """Return only the serialised value bytes for a field, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT value FROM kb_fields
@@ -186,7 +187,7 @@ async def get_status(
     field_id: str,
 ) -> wpb2.FieldStatus | None:
     """Return the deserialised FieldStatus for a field, or None if the row does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT status FROM kb_fields
@@ -219,18 +220,22 @@ async def get_statuses(
     if not fields:
         return []
 
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             f"""
             SELECT field_type, field_id, status
             FROM kb_fields
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            WHERE kbid = %s AND rid = %s
               AND (field_type, field_id) IN (
                 {",".join(["(%s, %s)"] * len(fields))}
               )
             """,
             [kbid, rid]
-            + [(from_proto.field_type_name(f.field_type).abbreviation(), f.field) for f in fields],
+            + [
+                item
+                for f in fields
+                for item in (from_proto.field_type_name(f.field_type).abbreviation(), f.field)
+            ],
         )
         rows = await cur.fetchall()
 
@@ -257,7 +262,7 @@ async def get_all_field_ids(
     rid: str,
 ) -> rpb2.AllFieldIDs | None:
     """Return the AllFieldIDs protobuf for a resource, or None if not set."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT field_type, field_id FROM kb_fields
@@ -284,7 +289,7 @@ async def has_field(
     field_id: rpb2.FieldID,
 ) -> bool:
     """Return True if a field row exists, False otherwise."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT 1 FROM kb_fields

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -75,9 +75,10 @@ async def set_status(
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_fields SET status = %(status)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            INSERT INTO kb_fields (kbid, rid, field_type, field_id, status)
+            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s)
+            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                status = EXCLUDED.status
             """,
             {
                 "kbid": kbid,
@@ -230,12 +231,7 @@ async def get_statuses(
                 {",".join(["(%s, %s)"] * len(fields))}
               )
             """,
-            [kbid, rid]
-            + [
-                item
-                for f in fields
-                for item in (from_proto.field_type_name(f.field_type).abbreviation(), f.field)
-            ],
+            [kbid, rid] + [item for f in fields for item in (_to_abbr(f.field_type), f.field)],
         )
         rows = await cur.fetchall()
 
@@ -244,7 +240,7 @@ async def get_statuses(
 
     result = []
     for f in fields:
-        status_bytes = status_lookup.get((f.field_type, f.field))
+        status_bytes = status_lookup.get((_to_abbr(f.field_type), f.field))
         if status_bytes is None:
             result.append(wpb2.FieldStatus())  # Default empty status
         else:
@@ -253,6 +249,11 @@ async def get_statuses(
             result.append(pb)
 
     return result
+
+
+def _to_abbr(field_type: rpb2.FieldType.ValueType) -> str:
+    """Convert a FieldType enum to its single-character abbreviation."""
+    return from_proto.field_type_name(field_type).abbreviation()
 
 
 async def get_all_field_ids(

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -1,0 +1,408 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Datamanager for the `fields` PostgreSQL table (migration 0016).
+
+Each row represents one field in a resource and stores:
+  - kbid       - FK → kb_resources.kbid (ON DELETE CASCADE)
+  - rid        - FK → kb_resources.rid  (ON DELETE CASCADE)
+  - field_type - single-char abbreviation: t=text, f=file, u=link,
+                 c=conversation, a=generic, k=key_value
+  - field_id   - user-defined field name
+  - status     - processing status matching FieldStatus.Status in writer.proto:
+                 0=PENDING, 1=PROCESSED, 2=ERROR
+  - value      - serialised protobuf bytes (field payload, excluding
+                 anything stored in object storage)
+  - md5        - optional content hash; NULL when not provided; used for
+                 duplicate detection within a knowledge box
+
+NOTE: deleting a kb_resources row (or its parent kbs row) automatically
+removes all related field rows via the ON DELETE CASCADE foreign key —
+there is no need for explicit bulk-delete helpers here.
+"""
+
+import dataclasses
+from collections.abc import AsyncIterator
+from typing import cast
+
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction
+from nucliadb.common.models_utils import to_proto
+from nucliadb_protos import resources_pb2 as rpb2
+
+# ---------------------------------------------------------------------------
+# Row model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class FieldRow:
+    kbid: str
+    rid: str
+    field_type: str  # single-char abbreviation: t, f, u, c, a, k
+    field_id: str
+    status: int  # writer_pb2.FieldStatus.Status value
+    value: bytes | None
+    md5: str | None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _pg(txn: Transaction) -> PGTransaction:
+    return cast(PGTransaction, txn)
+
+
+def _row_to_field(row: tuple) -> FieldRow:
+    kbid, rid, field_type, field_id, status, value, md5 = row
+    return FieldRow(
+        kbid=str(kbid),
+        rid=str(rid),
+        field_type=field_type,
+        field_id=field_id,
+        status=status,
+        value=bytes(value) if value is not None else None,
+        md5=md5,
+    )
+
+
+_SELECT_COLUMNS = "kbid, rid, field_type, field_id, status, value, md5"
+
+
+# ---------------------------------------------------------------------------
+# Write operations
+# ---------------------------------------------------------------------------
+
+
+async def upsert(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+    status: int = 0,
+    value: bytes | None = None,
+    md5: str | None = None,
+) -> None:
+    """Insert or fully replace a field row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_fields (kbid, rid, field_type, field_id, status, value, md5)
+            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s, %(value)s, %(md5)s)
+            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                status = EXCLUDED.status,
+                value  = EXCLUDED.value,
+                md5    = EXCLUDED.md5
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+                "status": status,
+                "value": value,
+                "md5": md5,
+            },
+        )
+
+
+async def set_status(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+    status: int,
+) -> None:
+    """Update only the status column. Does nothing if the row does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_fields SET status = %(status)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+                "status": status,
+            },
+        )
+
+
+async def set_value(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+    value: bytes,
+) -> None:
+    """Update only the value column. Does nothing if the row does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_fields SET value = %(value)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+                "value": value,
+            },
+        )
+
+
+async def delete(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+) -> None:
+    """Delete a single field row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            DELETE FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Read operations
+# ---------------------------------------------------------------------------
+
+
+async def get(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+) -> FieldRow | None:
+    """Return the full row for a single field, or None if it does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+            },
+        )
+        row = await cur.fetchone()
+        return _row_to_field(row) if row is not None else None
+
+
+async def get_value(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+) -> bytes | None:
+    """Return only the serialised value bytes for a field, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT value FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+            },
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return bytes(row[0])
+
+
+async def get_status(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+) -> int | None:
+    """Return only the status integer for a field, or None if the row does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT status FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+            },
+        )
+        row = await cur.fetchone()
+        return row[0] if row is not None else None
+
+
+async def get_all_for_resource(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+) -> list[FieldRow]:
+    """Return all field rows for a resource, ordered by (field_type, field_id)."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            ORDER BY field_type, field_id
+            """,
+            {"kbid": kbid, "rid": rid},
+        )
+        return [_row_to_field(row) for row in await cur.fetchall()]
+
+
+async def iter_by_type(
+    txn: Transaction,
+    *,
+    kbid: str,
+    field_type: str,
+) -> AsyncIterator[FieldRow]:
+    """Iterate over all fields of a given type within a knowledge box."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM kb_fields
+            WHERE kbid = %(kbid)s AND field_type = %(field_type)s
+            ORDER BY rid, field_id
+            """,
+            {"kbid": kbid, "field_type": field_type},
+        )
+        async for row in cur:
+            yield _row_to_field(row)
+
+
+async def get_by_md5(
+    txn: Transaction,
+    *,
+    kbid: str,
+    md5: str,
+) -> list[FieldRow]:
+    """Return all fields in a KB that match the given MD5 (duplicate detection)."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM kb_fields
+            WHERE kbid = %(kbid)s AND md5 = %(md5)s
+            ORDER BY rid, field_type, field_id
+            """,
+            {"kbid": kbid, "md5": md5},
+        )
+        return [_row_to_field(row) for row in await cur.fetchall()]
+
+
+async def get_all_field_ids(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+) -> rpb2.AllFieldIDs | None:
+    """Return the AllFieldIDs protobuf for a resource, or None if not set."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT field_type, field_id FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid},
+        )
+        rows = await cur.fetchall()
+        if not rows:
+            return None
+        pb = rpb2.AllFieldIDs()
+        for row in rows:
+            field = pb.fields.add()
+            field.field_type = to_proto.field_type(row[0])
+            field.field = row[1]
+        return pb
+
+
+async def exists(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    field_type: str,
+    field_id: str,
+) -> bool:
+    """Return True if a field row exists, False otherwise."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT 1 FROM kb_fields
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+            },
+        )
+        return await cur.fetchone() is not None

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -37,8 +37,6 @@ removes all related field rows via the ON DELETE CASCADE foreign key —
 there is no need for explicit bulk-delete helpers here.
 """
 
-import dataclasses
-from collections.abc import AsyncIterator
 from typing import Sequence, cast
 
 from google.protobuf.message import Message
@@ -50,44 +48,12 @@ from nucliadb_protos import resources_pb2 as rpb2
 from nucliadb_protos import writer_pb2 as wpb2
 
 # ---------------------------------------------------------------------------
-# Row model
-# ---------------------------------------------------------------------------
-
-
-@dataclasses.dataclass
-class FieldRow:
-    kbid: str
-    rid: str
-    field_type: str  # single-char abbreviation: t, f, u, c, a, k
-    field_id: str
-    status: bytes | None  # serialised writer_pb2.FieldStatus
-    value: bytes | None
-    md5: str | None
-
-
-# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
 def _pg(txn: Transaction) -> PGTransaction:
     return cast(PGTransaction, txn)
-
-
-def _row_to_field(row: tuple) -> FieldRow:
-    kbid, rid, field_type, field_id, status, value, md5 = row
-    return FieldRow(
-        kbid=str(kbid),
-        rid=str(rid),
-        field_type=field_type,
-        field_id=field_id,
-        status=bytes(status) if status is not None else None,
-        value=bytes(value) if value is not None else None,
-        md5=md5,
-    )
-
-
-_SELECT_COLUMNS = "kbid, rid, field_type, field_id, status, value, md5"
 
 
 # ---------------------------------------------------------------------------
@@ -205,35 +171,7 @@ async def delete(
 # ---------------------------------------------------------------------------
 
 
-async def get(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-    field_type: str,
-    field_id: str,
-) -> FieldRow | None:
-    """Return the full row for a single field, or None if it does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"""
-            SELECT {_SELECT_COLUMNS}
-            FROM kb_fields
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-              AND field_type = %(field_type)s AND field_id = %(field_id)s
-            """,
-            {
-                "kbid": kbid,
-                "rid": rid,
-                "field_type": field_type,
-                "field_id": field_id,
-            },
-        )
-        row = await cur.fetchone()
-        return _row_to_field(row) if row is not None else None
-
-
-async def get_value(
+async def get_raw(
     txn: Transaction,
     *,
     kbid: str,
@@ -333,67 +271,6 @@ async def get_statuses(
             result.append(pb)
 
     return result
-
-
-async def get_all_for_resource(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-) -> list[FieldRow]:
-    """Return all field rows for a resource, ordered by (field_type, field_id)."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"""
-            SELECT {_SELECT_COLUMNS}
-            FROM kb_fields
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-            ORDER BY field_type, field_id
-            """,
-            {"kbid": kbid, "rid": rid},
-        )
-        return [_row_to_field(row) for row in await cur.fetchall()]
-
-
-async def iter_by_type(
-    txn: Transaction,
-    *,
-    kbid: str,
-    field_type: str,
-) -> AsyncIterator[FieldRow]:
-    """Iterate over all fields of a given type within a knowledge box."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"""
-            SELECT {_SELECT_COLUMNS}
-            FROM kb_fields
-            WHERE kbid = %(kbid)s AND field_type = %(field_type)s
-            ORDER BY rid, field_id
-            """,
-            {"kbid": kbid, "field_type": field_type},
-        )
-        async for row in cur:
-            yield _row_to_field(row)
-
-
-async def get_by_md5(
-    txn: Transaction,
-    *,
-    kbid: str,
-    md5: str,
-) -> list[FieldRow]:
-    """Return all fields in a KB that match the given MD5 (duplicate detection)."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"""
-            SELECT {_SELECT_COLUMNS}
-            FROM kb_fields
-            WHERE kbid = %(kbid)s AND md5 = %(md5)s
-            ORDER BY rid, field_type, field_id
-            """,
-            {"kbid": kbid, "md5": md5},
-        )
-        return [_row_to_field(row) for row in await cur.fetchall()]
 
 
 async def get_all_field_ids(

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -61,40 +61,6 @@ def _pg(txn: Transaction) -> PGTransaction:
 # ---------------------------------------------------------------------------
 
 
-async def upsert(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-    field_type: str,
-    field_id: str,
-    status: bytes | None = None,
-    value: bytes | None = None,
-    md5: str | None = None,
-) -> None:
-    """Insert or fully replace a field row."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            INSERT INTO kb_fields (kbid, rid, field_type, field_id, status, value, md5)
-            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(status)s, %(value)s, %(md5)s)
-            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
-                status = EXCLUDED.status,
-                value  = EXCLUDED.value,
-                md5    = EXCLUDED.md5
-            """,
-            {
-                "kbid": kbid,
-                "rid": rid,
-                "field_type": field_type,
-                "field_id": field_id,
-                "status": status,
-                "value": value,
-                "md5": md5,
-            },
-        )
-
-
 async def set_status(
     txn: Transaction,
     *,
@@ -131,14 +97,25 @@ async def set(
     field_id: str,
     value: Message,
 ) -> None:
-    await upsert(
-        txn,
-        kbid=kbid,
-        rid=rid,
-        field_type=field_type,
-        field_id=field_id,
-        value=value.SerializeToString(),
-    )
+    """
+    Set the value of a field row, creating it if it does not exist. This is an upsert operation.
+    """
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_fields (kbid, rid, field_type, field_id, value)
+            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(value)s)
+            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                value = EXCLUDED.value
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "field_type": field_type,
+                "field_id": field_id,
+                "value": value.SerializeToString(),
+            },
+        )
 
 
 async def delete(

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -97,7 +97,7 @@ async def set(
     rid: str,
     field_type: str,
     field_id: str,
-    value: Message,
+    value: Message | bytes,
 ) -> None:
     """
     Set the value of a field row, creating it if it does not exist. This is an upsert operation.
@@ -115,7 +115,7 @@ async def set(
                 "rid": rid,
                 "field_type": field_type,
                 "field_id": field_id,
-                "value": value.SerializeToString(),
+                "value": value.SerializeToString() if isinstance(value, Message) else value,
             },
         )
 

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -260,7 +260,7 @@ async def get_all_field_ids(
     *,
     kbid: str,
     rid: str,
-) -> rpb2.AllFieldIDs | None:
+) -> rpb2.AllFieldIDs:
     """Return the AllFieldIDs protobuf for a resource, or None if not set."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
@@ -270,10 +270,8 @@ async def get_all_field_ids(
             """,
             {"kbid": kbid, "rid": rid},
         )
-        rows = await cur.fetchall()
-        if not rows:
-            return None
         pb = rpb2.AllFieldIDs()
+        rows = await cur.fetchall()
         for row in rows:
             field = pb.fields.add()
             field.field_type = to_proto.field_type(row[0])

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -37,31 +37,22 @@ removes all related field rows via the ON DELETE CASCADE foreign key —
 there is no need for explicit bulk-delete helpers here.
 """
 
-from typing import Sequence, cast
+from typing import Sequence
 
 from google.protobuf.message import Message
 
-from nucliadb.common.datamanagers.utils import _pg_cursor
+from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error
 from nucliadb.common.maindb.driver import Transaction
-from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb.common.models_utils import from_proto, to_proto
 from nucliadb_protos import resources_pb2 as rpb2
 from nucliadb_protos import writer_pb2 as wpb2
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _pg(txn: Transaction) -> PGTransaction:
-    return cast(PGTransaction, txn)
-
 
 # ---------------------------------------------------------------------------
 # Write operations
 # ---------------------------------------------------------------------------
 
 
+@logs_foreign_key_error
 async def set_status(
     txn: Transaction,
     *,
@@ -90,6 +81,7 @@ async def set_status(
         )
 
 
+@logs_foreign_key_error
 async def set(
     txn: Transaction,
     *,
@@ -120,6 +112,7 @@ async def set(
         )
 
 
+@logs_foreign_key_error
 async def delete(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -112,7 +112,6 @@ async def set(
         )
 
 
-@logs_foreign_key_error
 async def delete(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/kb.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb.py
@@ -20,7 +20,9 @@
 import logging
 from collections.abc import AsyncIterator
 
+from nucliadb.common.datamanagers import kb_v2
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
+from nucliadb.common.datamanagers.utils import datamanagers_v2_read, datamanagers_v2_write
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import knowledgebox_pb2
 
@@ -34,6 +36,11 @@ logger = logging.getLogger(__name__)
 
 
 async def get_kbs(txn: Transaction, *, prefix: str = "") -> AsyncIterator[tuple[str, str]]:
+    if datamanagers_v2_read("kbs"):
+        async for kbid, slug in kb_v2.get_kbs(txn, slug_prefix=prefix):
+            yield (kbid, slug)
+        return
+
     async for key in txn.keys(KB_SLUGS.format(slug=prefix)):
         slug = key.replace(KB_SLUGS_BASE, "")
         uuid = await get_kb_uuid(txn, slug=slug)
@@ -44,10 +51,16 @@ async def get_kbs(txn: Transaction, *, prefix: str = "") -> AsyncIterator[tuple[
 
 
 async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
+    if datamanagers_v2_read("kbs"):
+        return await kb_v2.exists_kb(txn, kbid=kbid)
+
     return await get_config(txn, kbid=kbid, for_update=False) is not None
 
 
 async def get_kb_uuid(txn: Transaction, *, slug: str) -> str | None:
+    if datamanagers_v2_read("kbs"):
+        return await kb_v2.get_kb_uuid(txn, slug=slug)
+
     uuid = await txn.get(KB_SLUGS.format(slug=slug), for_update=False)
     if uuid is not None:
         return uuid.decode()
@@ -59,6 +72,9 @@ async def set_kbid_for_slug(txn: Transaction, *, slug: str, kbid: str):
     key = KB_SLUGS.format(slug=slug)
     await txn.set(key, kbid.encode())
 
+    if datamanagers_v2_write("kbs"):
+        await kb_v2.set_kbid_for_slug(txn, slug=slug, kbid=kbid)
+
 
 async def delete_kb_slug(txn: Transaction, *, slug: str):
     key = KB_SLUGS.format(slug=slug)
@@ -68,6 +84,9 @@ async def delete_kb_slug(txn: Transaction, *, slug: str):
 async def get_config(
     txn: Transaction, *, kbid: str, for_update: bool = False
 ) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
+    if datamanagers_v2_read(kbid) or datamanagers_v2_read("kbs"):
+        return await kb_v2.get_config(txn, kbid=kbid)
+
     key = KB_UUID.format(kbid=kbid)
     payload = await txn.get(key, for_update=for_update)
     if payload is None:
@@ -80,6 +99,9 @@ async def get_config(
 async def set_config(txn: Transaction, *, kbid: str, config: knowledgebox_pb2.KnowledgeBoxConfig):
     key = KB_UUID.format(kbid=kbid)
     await txn.set(key, config.SerializeToString())
+
+    if datamanagers_v2_write(kbid) or datamanagers_v2_write("kbs"):
+        await kb_v2.set_config(txn, kbid=kbid, config=config)
 
 
 async def delete_config(txn: Transaction, *, kbid: str) -> None:

--- a/nucliadb/src/nucliadb/common/datamanagers/kb.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb.py
@@ -76,6 +76,17 @@ async def set_kbid_for_slug(txn: Transaction, *, slug: str, kbid: str):
         await kb_v2.set_kbid_for_slug(txn, slug=slug, kbid=kbid)
 
 
+async def modify_slug(txn: Transaction, *, kbid: str, old_slug: str, new_slug: str) -> None:
+    await txn.delete(KB_SLUGS.format(slug=old_slug))
+    await txn.set(
+        KB_SLUGS.format(slug=new_slug),
+        kbid.encode(),
+    )
+
+    if datamanagers_v2_write("kbs") or datamanagers_v2_write(kbid):
+        await kb_v2.set_kbid_for_slug(txn, slug=new_slug, kbid=kbid)
+
+
 async def delete_kb_slug(txn: Transaction, *, slug: str):
     key = KB_SLUGS.format(slug=slug)
     await txn.delete(key)

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -59,7 +59,7 @@ async def set_config(
 
 
 async def delete(txn: Transaction, *, kbid: str) -> None:
-    """Delete a KB row (cascades to kb_resources and fields)."""
+    """Fully delete a KB row and all its associated resources, fields, and conversations."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             "DELETE FROM kbs WHERE kbid = %(kbid)s",
@@ -68,10 +68,10 @@ async def delete(txn: Transaction, *, kbid: str) -> None:
 
 
 async def soft_delete(txn: Transaction, *, kbid: str) -> None:
-    """Soft delete a KB row by setting its slug to NULL"""
+    """Soft delete a KB row by clearing its slug and stamping deleted_at with the current time."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
-            "UPDATE kbs SET slug = NULL WHERE kbid = %(kbid)s",
+            "UPDATE kbs SET slug = NULL, deleted_at = NOW() WHERE kbid = %(kbid)s",
             {"kbid": kbid},
         )
 
@@ -115,15 +115,18 @@ async def update_kb_shards(
 
 
 async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
-    """Return True if a KB with the given kbid exists."""
+    """Return True if a KB with the given kbid exists, has a slug, and has not been soft-deleted."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
-            "SELECT slug FROM kbs WHERE kbid = %(kbid)s",
+            """
+            SELECT 1 FROM kbs
+            WHERE kbid = %(kbid)s
+              AND slug IS NOT NULL
+              AND deleted_at IS NULL
+            """,
             {"kbid": kbid},
         )
-        row = await cur.fetchone()
-        # Return False if row does not exist or if slug is NULL (KB has been deleted)
-        return row is not None and row[0] is not None
+        return await cur.fetchone() is not None
 
 
 async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -28,27 +28,12 @@ Each row represents one knowledge box and stores:
   - config  - serialised knowledgebox_pb2.KnowledgeBoxConfig protobuf
 """
 
-import dataclasses
 from collections.abc import AsyncIterator
 from typing import cast
 
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos import knowledgebox_pb2, writer_pb2
-
-# ---------------------------------------------------------------------------
-# Row model
-# ---------------------------------------------------------------------------
-
-
-@dataclasses.dataclass
-class KBRow:
-    kbid: str
-    slug: str | None
-    title: str | None
-    shards: bytes | None
-    config: bytes | None
-
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -59,51 +44,9 @@ def _pg(txn: Transaction) -> PGTransaction:
     return cast(PGTransaction, txn)
 
 
-def _row_to_kb(row: tuple) -> KBRow:
-    kbid, slug, title, shards, config = row
-    return KBRow(
-        kbid=str(kbid),
-        slug=slug,
-        title=title,
-        shards=bytes(shards) if shards is not None else None,
-        config=bytes(config) if config is not None else None,
-    )
-
-
 # ---------------------------------------------------------------------------
 # Write operations
 # ---------------------------------------------------------------------------
-
-
-async def upsert(
-    txn: Transaction,
-    *,
-    kbid: str,
-    slug: str | None = None,
-    title: str | None = None,
-    shards: writer_pb2.Shards | None = None,
-    config: knowledgebox_pb2.KnowledgeBoxConfig | None = None,
-) -> None:
-    """Insert or fully replace a KB row."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            INSERT INTO kbs (kbid, slug, title, shards, config)
-            VALUES (%(kbid)s, %(slug)s, %(title)s, %(shards)s, %(config)s)
-            ON CONFLICT (kbid) DO UPDATE SET
-                slug   = EXCLUDED.slug,
-                title  = EXCLUDED.title,
-                shards = EXCLUDED.shards,
-                config = EXCLUDED.config
-            """,
-            {
-                "kbid": kbid,
-                "slug": slug,
-                "title": title,
-                "shards": shards.SerializeToString() if shards is not None else None,
-                "config": config.SerializeToString() if config is not None else None,
-            },
-        )
 
 
 async def set_config(
@@ -123,23 +66,6 @@ async def set_config(
         )
 
 
-async def set_shards(
-    txn: Transaction,
-    *,
-    kbid: str,
-    shards: writer_pb2.Shards,
-) -> None:
-    """Update only the shards column of an existing KB row."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            UPDATE kbs SET shards = %(shards)s
-            WHERE kbid = %(kbid)s
-            """,
-            {"kbid": kbid, "shards": shards.SerializeToString()},
-        )
-
-
 async def delete(txn: Transaction, *, kbid: str) -> None:
     """Delete a KB row (cascades to kb_resources and fields)."""
     async with _pg(txn).connection.cursor() as cur:
@@ -153,21 +79,8 @@ async def delete(txn: Transaction, *, kbid: str) -> None:
 # Read operations
 # ---------------------------------------------------------------------------
 
-_SELECT_COLUMNS = "kbid, slug, title, shards, config"
 
-
-async def get(txn: Transaction, *, kbid: str) -> KBRow | None:
-    """Return the row for a single KB, or None if it does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"SELECT {_SELECT_COLUMNS} FROM kbs WHERE kbid = %(kbid)s",
-            {"kbid": kbid},
-        )
-        row = await cur.fetchone()
-        return _row_to_kb(row) if row is not None else None
-
-
-async def exists(txn: Transaction, *, kbid: str) -> bool:
+async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
     """Return True if a KB with the given kbid exists."""
     async with _pg(txn).connection.cursor() as cur:
         await cur.execute(
@@ -177,48 +90,92 @@ async def exists(txn: Transaction, *, kbid: str) -> bool:
         return await cur.fetchone() is not None
 
 
-async def get_by_slug(txn: Transaction, *, slug: str) -> KBRow | None:
-    """Return the KB row matching the given slug, or None."""
+async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
+    """Return the deserialised KnowledgeBoxConfig for a KB, or None."""
     async with _pg(txn).connection.cursor() as cur:
         await cur.execute(
-            f"SELECT {_SELECT_COLUMNS} FROM kbs WHERE slug = %(slug)s",
+            "SELECT config FROM kbs WHERE kbid = %(kbid)s",
+            {"kbid": kbid},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = knowledgebox_pb2.KnowledgeBoxConfig()
+        pb.ParseFromString(row[0])
+        return pb
+
+
+async def set_kbid_for_slug(txn: Transaction, *, slug: str, kbid: str) -> None:
+    """Set the slug for a given kbid, overwriting any existing slug. This is used when migrating from the old slug-based system to the new kbid-based system."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kbs SET slug = %(slug)s
+            WHERE kbid = %(kbid)s
+            """,
+            {"kbid": kbid, "slug": slug},
+        )
+
+
+async def get_kb_uuid(txn: Transaction, *, slug: str) -> str | None:
+    """Return the kbid for a given slug, or None if it does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT kbid FROM kbs WHERE slug = %(slug)s",
             {"slug": slug},
         )
         row = await cur.fetchone()
-        return _row_to_kb(row) if row is not None else None
+        return str(row[0]) if row is not None else None
 
 
-async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
-    """Return the deserialised KnowledgeBoxConfig for a KB, or None."""
-    row = await get(txn, kbid=kbid)
-    if row is None or row.config is None:
-        return None
-    pb = knowledgebox_pb2.KnowledgeBoxConfig()
-    pb.ParseFromString(row.config)
-    return pb
-
-
-async def get_shards(txn: Transaction, *, kbid: str) -> writer_pb2.Shards | None:
-    """Return the deserialised Shards for a KB, or None."""
-    row = await get(txn, kbid=kbid)
-    if row is None or row.shards is None:
-        return None
-    pb = writer_pb2.Shards()
-    pb.ParseFromString(row.shards)
-    return pb
-
-
-async def iter_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[KBRow]:
-    """Iterate over all KB rows, optionally filtering by slug prefix."""
+async def get_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[tuple[str, str]]:
+    """Iterate over all KBs, yielding (kbid, slug) tuples, optionally filtering by slug prefix."""
     async with _pg(txn).connection.cursor() as cur:
         if slug_prefix:
             await cur.execute(
-                f"SELECT {_SELECT_COLUMNS} FROM kbs WHERE slug LIKE %(prefix)s ORDER BY kbid",
+                "SELECT kbid, slug FROM kbs WHERE slug LIKE %(prefix)s ORDER BY kbid",
                 {"prefix": slug_prefix + "%"},
             )
         else:
             await cur.execute(
-                f"SELECT {_SELECT_COLUMNS} FROM kbs ORDER BY kbid",
+                "SELECT kbid, slug FROM kbs ORDER BY kbid",
             )
         async for row in cur:
-            yield _row_to_kb(row)
+            yield (str(row[0]), row[1])
+
+
+async def update_kb_shards(
+    txn: Transaction,
+    *,
+    kbid: str,
+    shards: writer_pb2.Shards,
+) -> None:
+    """Update the shards column of a KB row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kbs SET shards = %(shards)s
+            WHERE kbid = %(kbid)s
+            """,
+            {"kbid": kbid, "shards": shards.SerializeToString()},
+        )
+
+
+async def get_kb_shards(
+    txn: Transaction,
+    *,
+    kbid: str,
+    for_update: bool = False,
+) -> writer_pb2.Shards | None:
+    """Return the deserialised Shards for a KB, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        statement = "SELECT shards FROM kbs WHERE kbid = %(kbid)s"
+        if for_update:
+            statement += " FOR UPDATE"
+        await cur.execute(statement, {"kbid": kbid})
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = writer_pb2.Shards()
+        pb.ParseFromString(row[0])
+        return pb

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -29,20 +29,10 @@ Each row represents one knowledge box and stores:
 """
 
 from collections.abc import AsyncIterator
-from typing import cast
 
+from nucliadb.common.datamanagers.utils import _pg_cursor
 from nucliadb.common.maindb.driver import Transaction
-from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos import knowledgebox_pb2, writer_pb2
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _pg(txn: Transaction) -> PGTransaction:
-    return cast(PGTransaction, txn)
-
 
 # ---------------------------------------------------------------------------
 # Write operations
@@ -56,7 +46,7 @@ async def set_config(
     config: knowledgebox_pb2.KnowledgeBoxConfig,
 ) -> None:
     """Update only the config column of an existing KB row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kbs SET config = %(config)s
@@ -68,10 +58,41 @@ async def set_config(
 
 async def delete(txn: Transaction, *, kbid: str) -> None:
     """Delete a KB row (cascades to kb_resources and fields)."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "DELETE FROM kbs WHERE kbid = %(kbid)s",
             {"kbid": kbid},
+        )
+
+
+async def set_kbid_for_slug(txn: Transaction, *, slug: str, kbid: str) -> None:
+    """Set the slug for a given kbid, overwriting any existing slug. This is used when migrating from the old slug-based system to the new kbid-based system."""
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            INSERT INTO kbs (kbid, slug)
+            VALUES (%(kbid)s, %(slug)s)
+            ON CONFLICT (kbid) DO UPDATE SET
+                slug = EXCLUDED.slug
+            """,
+            {"kbid": kbid, "slug": slug},
+        )
+
+
+async def update_kb_shards(
+    txn: Transaction,
+    *,
+    kbid: str,
+    shards: writer_pb2.Shards,
+) -> None:
+    """Update the shards column of a KB row."""
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            UPDATE kbs SET shards = %(shards)s
+            WHERE kbid = %(kbid)s
+            """,
+            {"kbid": kbid, "shards": shards.SerializeToString()},
         )
 
 
@@ -82,7 +103,7 @@ async def delete(txn: Transaction, *, kbid: str) -> None:
 
 async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
     """Return True if a KB with the given kbid exists."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT 1 FROM kbs WHERE kbid = %(kbid)s",
             {"kbid": kbid},
@@ -92,7 +113,7 @@ async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
 
 async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
     """Return the deserialised KnowledgeBoxConfig for a KB, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT config FROM kbs WHERE kbid = %(kbid)s",
             {"kbid": kbid},
@@ -105,21 +126,9 @@ async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.Knowled
         return pb
 
 
-async def set_kbid_for_slug(txn: Transaction, *, slug: str, kbid: str) -> None:
-    """Set the slug for a given kbid, overwriting any existing slug. This is used when migrating from the old slug-based system to the new kbid-based system."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            UPDATE kbs SET slug = %(slug)s
-            WHERE kbid = %(kbid)s
-            """,
-            {"kbid": kbid, "slug": slug},
-        )
-
-
 async def get_kb_uuid(txn: Transaction, *, slug: str) -> str | None:
     """Return the kbid for a given slug, or None if it does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT kbid FROM kbs WHERE slug = %(slug)s",
             {"slug": slug},
@@ -130,7 +139,7 @@ async def get_kb_uuid(txn: Transaction, *, slug: str) -> str | None:
 
 async def get_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[tuple[str, str]]:
     """Iterate over all KBs, yielding (kbid, slug) tuples, optionally filtering by slug prefix."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         if slug_prefix:
             await cur.execute(
                 "SELECT kbid, slug FROM kbs WHERE slug LIKE %(prefix)s ORDER BY kbid",
@@ -144,23 +153,6 @@ async def get_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[t
             yield (str(row[0]), row[1])
 
 
-async def update_kb_shards(
-    txn: Transaction,
-    *,
-    kbid: str,
-    shards: writer_pb2.Shards,
-) -> None:
-    """Update the shards column of a KB row."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            UPDATE kbs SET shards = %(shards)s
-            WHERE kbid = %(kbid)s
-            """,
-            {"kbid": kbid, "shards": shards.SerializeToString()},
-        )
-
-
 async def get_kb_shards(
     txn: Transaction,
     *,
@@ -168,7 +160,7 @@ async def get_kb_shards(
     for_update: bool = False,
 ) -> writer_pb2.Shards | None:
     """Return the deserialised Shards for a KB, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         statement = "SELECT shards FROM kbs WHERE kbid = %(kbid)s"
         if for_update:
             statement += " FOR UPDATE"

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -67,6 +67,15 @@ async def delete(txn: Transaction, *, kbid: str) -> None:
         )
 
 
+async def soft_delete(txn: Transaction, *, kbid: str) -> None:
+    """Soft delete a KB row by setting its slug to NULL"""
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            "UPDATE kbs SET slug = NULL WHERE kbid = %(kbid)s",
+            {"kbid": kbid},
+        )
+
+
 async def set_kbid_for_slug(txn: Transaction, *, slug: str, kbid: str) -> None:
     """Set the slug for a given kbid, overwriting any existing slug. This is used when migrating from the old slug-based system to the new kbid-based system."""
     async with _pg_cursor(txn) as cur:
@@ -109,10 +118,12 @@ async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
     """Return True if a KB with the given kbid exists."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
-            "SELECT 1 FROM kbs WHERE kbid = %(kbid)s",
+            "SELECT slug FROM kbs WHERE kbid = %(kbid)s",
             {"kbid": kbid},
         )
-        return await cur.fetchone() is not None
+        row = await cur.fetchone()
+        # Return False if row does not exist or if slug is NULL (KB has been deleted)
+        return row is not None and row[0] is not None
 
 
 async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
@@ -154,7 +165,8 @@ async def get_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[t
                 "SELECT kbid, slug FROM kbs ORDER BY kbid",
             )
         async for row in cur:
-            yield (str(row[0]), row[1])
+            if row[1] is not None:  # Only yield KBs that have a slug (i.e., not soft-deleted)
+                yield (str(row[0]), row[1])
 
 
 async def get_kb_shards(

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -68,7 +68,10 @@ async def delete(txn: Transaction, *, kbid: str) -> None:
 
 
 async def soft_delete(txn: Transaction, *, kbid: str) -> None:
-    """Soft delete a KB row by clearing its slug and stamping deleted_at with the current time."""
+    """Soft delete a KB row by clearing its slug and stamping deleted_at with the current time.
+
+    No-op if the KB does not exist (UPDATE affects 0 rows without raising an error).
+    """
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             "UPDATE kbs SET slug = NULL, deleted_at = NOW() WHERE kbid = %(kbid)s",

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -45,12 +45,14 @@ async def set_config(
     kbid: str,
     config: knowledgebox_pb2.KnowledgeBoxConfig,
 ) -> None:
-    """Update only the config column of an existing KB row."""
+    """Upsert the config column, creating the KB row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kbs SET config = %(config)s
-            WHERE kbid = %(kbid)s
+            INSERT INTO kbs (kbid, config)
+            VALUES (%(kbid)s, %(config)s)
+            ON CONFLICT (kbid) DO UPDATE SET
+                config = EXCLUDED.config
             """,
             {"kbid": kbid, "config": config.SerializeToString()},
         )
@@ -85,12 +87,14 @@ async def update_kb_shards(
     kbid: str,
     shards: writer_pb2.Shards,
 ) -> None:
-    """Update the shards column of a KB row."""
+    """Upsert the shards column, creating the KB row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kbs SET shards = %(shards)s
-            WHERE kbid = %(kbid)s
+            INSERT INTO kbs (kbid, shards)
+            VALUES (%(kbid)s, %(shards)s)
+            ON CONFLICT (kbid) DO UPDATE SET
+                shards = EXCLUDED.shards
             """,
             {"kbid": kbid, "shards": shards.SerializeToString()},
         )

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -1,0 +1,224 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Datamanager for the `kbs` PostgreSQL table (migration 0016).
+
+Each row represents one knowledge box and stores:
+  - kbid    - primary key
+  - slug    - human-readable unique identifier (nullable)
+  - title   - display name (nullable)
+  - shards  - serialised writer_pb2.Shards protobuf
+  - config  - serialised knowledgebox_pb2.KnowledgeBoxConfig protobuf
+"""
+
+import dataclasses
+from collections.abc import AsyncIterator
+from typing import cast
+
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction
+from nucliadb_protos import knowledgebox_pb2, writer_pb2
+
+# ---------------------------------------------------------------------------
+# Row model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class KBRow:
+    kbid: str
+    slug: str | None
+    title: str | None
+    shards: bytes | None
+    config: bytes | None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _pg(txn: Transaction) -> PGTransaction:
+    return cast(PGTransaction, txn)
+
+
+def _row_to_kb(row: tuple) -> KBRow:
+    kbid, slug, title, shards, config = row
+    return KBRow(
+        kbid=str(kbid),
+        slug=slug,
+        title=title,
+        shards=bytes(shards) if shards is not None else None,
+        config=bytes(config) if config is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write operations
+# ---------------------------------------------------------------------------
+
+
+async def upsert(
+    txn: Transaction,
+    *,
+    kbid: str,
+    slug: str | None = None,
+    title: str | None = None,
+    shards: writer_pb2.Shards | None = None,
+    config: knowledgebox_pb2.KnowledgeBoxConfig | None = None,
+) -> None:
+    """Insert or fully replace a KB row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kbs (kbid, slug, title, shards, config)
+            VALUES (%(kbid)s, %(slug)s, %(title)s, %(shards)s, %(config)s)
+            ON CONFLICT (kbid) DO UPDATE SET
+                slug   = EXCLUDED.slug,
+                title  = EXCLUDED.title,
+                shards = EXCLUDED.shards,
+                config = EXCLUDED.config
+            """,
+            {
+                "kbid": kbid,
+                "slug": slug,
+                "title": title,
+                "shards": shards.SerializeToString() if shards is not None else None,
+                "config": config.SerializeToString() if config is not None else None,
+            },
+        )
+
+
+async def set_config(
+    txn: Transaction,
+    *,
+    kbid: str,
+    config: knowledgebox_pb2.KnowledgeBoxConfig,
+) -> None:
+    """Update only the config column of an existing KB row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kbs SET config = %(config)s
+            WHERE kbid = %(kbid)s
+            """,
+            {"kbid": kbid, "config": config.SerializeToString()},
+        )
+
+
+async def set_shards(
+    txn: Transaction,
+    *,
+    kbid: str,
+    shards: writer_pb2.Shards,
+) -> None:
+    """Update only the shards column of an existing KB row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kbs SET shards = %(shards)s
+            WHERE kbid = %(kbid)s
+            """,
+            {"kbid": kbid, "shards": shards.SerializeToString()},
+        )
+
+
+async def delete(txn: Transaction, *, kbid: str) -> None:
+    """Delete a KB row (cascades to kb_resources and fields)."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "DELETE FROM kbs WHERE kbid = %(kbid)s",
+            {"kbid": kbid},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Read operations
+# ---------------------------------------------------------------------------
+
+_SELECT_COLUMNS = "kbid, slug, title, shards, config"
+
+
+async def get(txn: Transaction, *, kbid: str) -> KBRow | None:
+    """Return the row for a single KB, or None if it does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"SELECT {_SELECT_COLUMNS} FROM kbs WHERE kbid = %(kbid)s",
+            {"kbid": kbid},
+        )
+        row = await cur.fetchone()
+        return _row_to_kb(row) if row is not None else None
+
+
+async def exists(txn: Transaction, *, kbid: str) -> bool:
+    """Return True if a KB with the given kbid exists."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT 1 FROM kbs WHERE kbid = %(kbid)s",
+            {"kbid": kbid},
+        )
+        return await cur.fetchone() is not None
+
+
+async def get_by_slug(txn: Transaction, *, slug: str) -> KBRow | None:
+    """Return the KB row matching the given slug, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"SELECT {_SELECT_COLUMNS} FROM kbs WHERE slug = %(slug)s",
+            {"slug": slug},
+        )
+        row = await cur.fetchone()
+        return _row_to_kb(row) if row is not None else None
+
+
+async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
+    """Return the deserialised KnowledgeBoxConfig for a KB, or None."""
+    row = await get(txn, kbid=kbid)
+    if row is None or row.config is None:
+        return None
+    pb = knowledgebox_pb2.KnowledgeBoxConfig()
+    pb.ParseFromString(row.config)
+    return pb
+
+
+async def get_shards(txn: Transaction, *, kbid: str) -> writer_pb2.Shards | None:
+    """Return the deserialised Shards for a KB, or None."""
+    row = await get(txn, kbid=kbid)
+    if row is None or row.shards is None:
+        return None
+    pb = writer_pb2.Shards()
+    pb.ParseFromString(row.shards)
+    return pb
+
+
+async def iter_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[KBRow]:
+    """Iterate over all KB rows, optionally filtering by slug prefix."""
+    async with _pg(txn).connection.cursor() as cur:
+        if slug_prefix:
+            await cur.execute(
+                f"SELECT {_SELECT_COLUMNS} FROM kbs WHERE slug LIKE %(prefix)s ORDER BY kbid",
+                {"prefix": slug_prefix + "%"},
+            )
+        else:
+            await cur.execute(
+                f"SELECT {_SELECT_COLUMNS} FROM kbs ORDER BY kbid",
+            )
+        async for row in cur:
+            yield _row_to_kb(row)

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -347,3 +347,13 @@ async def has_field(txn: Transaction, *, kbid: str, rid: str, field_id: resource
         if field_id == resource_field_id:
             return True
     return False
+
+
+async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
+    basic = await get_basic(txn, kbid=kbid, rid=rid)
+    if basic and basic.slug:
+        await txn.delete(KB_RESOURCE_SLUG.format(kbid=kbid, slug=basic.slug))
+    await txn.delete_by_prefix(KB_RESOURCE_BASIC.format(kbid=kbid, uuid=rid))
+
+    if datamanagers_v2_write(kbid):
+        await resources_v2.delete(txn, kbid=kbid, rid=rid)

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -21,13 +21,17 @@ from collections.abc import AsyncGenerator
 
 import backoff
 
+from nucliadb.common.datamanagers import fields_v2, resources_v2
 from nucliadb.common.datamanagers.utils import get_kv_pb
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 
 # These should be refactored
+from nucliadb.common.models_utils import from_proto
 from nucliadb.ingest.settings import settings as ingest_settings
 from nucliadb_protos import resources_pb2
+from nucliadb_utils import const
+from nucliadb_utils.utilities import has_feature
 
 from .utils import with_ro_transaction
 
@@ -49,6 +53,9 @@ KB_RESOURCE_SHARD = "/kbs/{kbid}/r/{uuid}/shard"
 
 
 async def resource_exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.exists(txn, kbid=kbid, rid=rid)
+
     basic = await get_basic_raw(txn, kbid=kbid, rid=rid)
     return basic is not None
 
@@ -57,6 +64,9 @@ async def resource_exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
 
 
 async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str) -> str | None:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.get_resource_uuid_from_slug(txn, kbid=kbid, slug=slug)
+
     encoded_uuid = await txn.get(KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug, for_update=False))
     if not encoded_uuid:
         return None
@@ -64,6 +74,9 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
 
 
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.slug_exists(txn, kbid=kbid, slug=slug)
+
     key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug)
     encoded_slug: bytes | None = await txn.get(key)
     return encoded_slug not in (None, b"")
@@ -94,6 +107,9 @@ async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -
     await txn.set(key, rid.encode())
     basic.slug = new_slug
     await set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+
+    await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=new_slug)
+
     return old_slug
 
 
@@ -104,6 +120,10 @@ async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -
 async def get_resource_shard_id(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> str | None:
+
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.get_resource_shard_id(txn, kbid=kbid, rid=rid, for_update=for_update)
+
     key = KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid)
     shard = await txn.get(key, for_update=for_update)
     if shard is not None:
@@ -115,11 +135,16 @@ async def get_resource_shard_id(
 async def set_resource_shard_id(txn: Transaction, *, kbid: str, rid: str, shard: str):
     await txn.set(KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid), shard.encode())
 
+    await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
+
 
 # Basic
 
 
 async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.get_basic(txn, kbid=kbid, rid=rid)
+
     raw = await get_basic_raw(txn, kbid=kbid, rid=rid)
     if raw is None:
         return None
@@ -148,11 +173,16 @@ async def set_basic(txn: Transaction, *, kbid: str, rid: str, basic: resources_p
             basic.SerializeToString(),
         )
 
+    await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+
 
 # Origin
 
 
 async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Origin | None:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.get_origin(txn, kbid=kbid, rid=rid)
+
     key = KB_RESOURCE_ORIGIN.format(kbid=kbid, uuid=rid)
     return await get_kv_pb(txn, key, resources_pb2.Origin)
 
@@ -161,11 +191,16 @@ async def set_origin(txn: Transaction, *, kbid: str, rid: str, origin: resources
     key = KB_RESOURCE_ORIGIN.format(kbid=kbid, uuid=rid)
     await txn.set(key, origin.SerializeToString())
 
+    await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
+
 
 # Extra
 
 
 async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Extra | None:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.get_extra(txn, kbid=kbid, rid=rid)
+
     key = KB_RESOURCE_EXTRA.format(kbid=kbid, uuid=rid)
     return await get_kv_pb(txn, key, resources_pb2.Extra)
 
@@ -174,11 +209,16 @@ async def set_extra(txn: Transaction, *, kbid: str, rid: str, extra: resources_p
     key = KB_RESOURCE_EXTRA.format(kbid=kbid, uuid=rid)
     await txn.set(key, extra.SerializeToString())
 
+    await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
+
 
 # Security
 
 
 async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Security | None:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.get_security(txn, kbid=kbid, rid=rid)
+
     key = KB_RESOURCE_SECURITY.format(kbid=kbid, uuid=rid)
     return await get_kv_pb(txn, key, resources_pb2.Security)
 
@@ -186,6 +226,8 @@ async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb
 async def set_security(txn: Transaction, *, kbid: str, rid: str, security: resources_pb2.Security):
     key = KB_RESOURCE_SECURITY.format(kbid=kbid, uuid=rid)
     await txn.set(key, security.SerializeToString())
+
+    await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
 
 
 # KB resource ids (this functions use internal transactions, breaking the
@@ -200,6 +242,11 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncGenerator[str, None]:
 
     For this reason, it is not using the `txn` argument passed in.
     """
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        async for rid in resources_v2.iter_resource_ids(kbid=kbid):
+            yield rid
+        return
+
     batch = []
     async for slug in _iter_resource_slugs(kbid=kbid):
         batch.append(slug)
@@ -244,6 +291,9 @@ async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
     it is not the source of truth for the value so it is not ideal
     to move it to the node.
     """
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await resources_v2.count(txn, kbid=kbid)
+
     return await txn.count(KB_RESOURCE_SLUG_BASE.format(kbid=kbid))
 
 
@@ -267,6 +317,9 @@ async def set_number_of_resources(txn: Transaction, kbid: str, value: int) -> No
 async def get_all_field_ids(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> resources_pb2.AllFieldIDs | None:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await fields_v2.get_all_field_ids(txn, kbid=kbid, rid=rid)
+
     key = KB_RESOURCE_ALL_FIELDS.format(kbid=kbid, uuid=rid)
     return await get_kv_pb(txn, key, resources_pb2.AllFieldIDs, for_update=for_update)
 
@@ -279,6 +332,15 @@ async def set_all_field_ids(
 
 
 async def has_field(txn: Transaction, *, kbid: str, rid: str, field_id: resources_pb2.FieldID) -> bool:
+    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+        return await fields_v2.exists(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_id=field_id.field,
+            field_type=from_proto.field_type_name(field_id.field_type).abbreviation(),
+        )
+
     fields = await get_all_field_ids(txn, kbid=kbid, rid=rid)
     if fields is None:
         return False

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -22,7 +22,7 @@ from collections.abc import AsyncGenerator
 import backoff
 
 from nucliadb.common.datamanagers import fields_v2, resources_v2
-from nucliadb.common.datamanagers.utils import datamanagers_v2_migrating, datamanagers_v2_read, get_kv_pb
+from nucliadb.common.datamanagers.utils import datamanagers_v2_read, datamanagers_v2_write, get_kv_pb
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 
@@ -80,22 +80,14 @@ async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
 
 
 async def set_slug(txn: Transaction, *, kbid: str, rid: str, slug: str) -> None:
-    if datamanagers_v2_read(kbid):
-        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=slug)
-        return
-
     key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug)
     await txn.set(key, rid.encode())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=slug)
 
 
 async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -> str:
-    if datamanagers_v2_read(kbid):
-        old_slug = await resources_v2.modify_slug(txn, kbid=kbid, rid=rid, new_slug=new_slug)
-        return old_slug
-
     basic = await get_basic(txn, kbid=kbid, rid=rid)
     if basic is None:
         raise NotFoundError()
@@ -116,7 +108,7 @@ async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -
     basic.slug = new_slug
     await set_basic(txn, kbid=kbid, rid=rid, basic=basic)
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.modify_slug(txn, kbid=kbid, rid=rid, new_slug=new_slug)
 
     return old_slug
@@ -142,13 +134,9 @@ async def get_resource_shard_id(
 
 
 async def set_resource_shard_id(txn: Transaction, *, kbid: str, rid: str, shard: str):
-    if datamanagers_v2_read(kbid):
-        await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
-        return
-
     await txn.set(KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid), shard.encode())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
 
 
@@ -176,10 +164,6 @@ async def get_basic_raw(txn: Transaction, *, kbid: str, rid: str) -> bytes | Non
 
 
 async def set_basic(txn: Transaction, *, kbid: str, rid: str, basic: resources_pb2.Basic):
-    if datamanagers_v2_read(kbid):
-        await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
-        return
-
     if ingest_settings.driver == "local":
         await txn.set(
             KB_RESOURCE_BASIC_FS.format(kbid=kbid, uuid=rid),
@@ -190,7 +174,7 @@ async def set_basic(txn: Transaction, *, kbid: str, rid: str, basic: resources_p
             KB_RESOURCE_BASIC.format(kbid=kbid, uuid=rid),
             basic.SerializeToString(),
         )
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
 
 
@@ -206,14 +190,10 @@ async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.
 
 
 async def set_origin(txn: Transaction, *, kbid: str, rid: str, origin: resources_pb2.Origin):
-    if datamanagers_v2_read(kbid):
-        await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
-        return
-
     key = KB_RESOURCE_ORIGIN.format(kbid=kbid, uuid=rid)
     await txn.set(key, origin.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
 
 
@@ -229,14 +209,10 @@ async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.E
 
 
 async def set_extra(txn: Transaction, *, kbid: str, rid: str, extra: resources_pb2.Extra):
-    if datamanagers_v2_read(kbid):
-        await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
-        return
-
     key = KB_RESOURCE_EXTRA.format(kbid=kbid, uuid=rid)
     await txn.set(key, extra.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
 
 
@@ -252,14 +228,10 @@ async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb
 
 
 async def set_security(txn: Transaction, *, kbid: str, rid: str, security: resources_pb2.Security):
-    if datamanagers_v2_read(kbid):
-        await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
-        return
-
     key = KB_RESOURCE_SECURITY.format(kbid=kbid, uuid=rid)
     await txn.set(key, security.SerializeToString())
 
-    if datamanagers_v2_migrating(kbid):
+    if datamanagers_v2_write(kbid):
         await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
 
 

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -80,17 +80,20 @@ async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
 
 
 async def set_slug(txn: Transaction, *, kbid: str, rid: str, slug: str) -> None:
-    """Write the slug → resource-uuid mapping for a resource."""
+    if datamanagers_v2_read(kbid):
+        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=slug)
+        return
+
     key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug)
     await txn.set(key, rid.encode())
+
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=slug)
 
 
 async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -> str:
     if datamanagers_v2_read(kbid):
-        old_slug = await resources_v2.get_slug(txn, kbid=kbid, rid=rid)
-        if old_slug is None:
-            raise NotFoundError()
-        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=new_slug)
+        old_slug = await resources_v2.modify_slug(txn, kbid=kbid, rid=rid, new_slug=new_slug)
         return old_slug
 
     basic = await get_basic(txn, kbid=kbid, rid=rid)
@@ -105,6 +108,7 @@ async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -
             return old_slug
         else:
             raise ConflictError(f"Slug {new_slug} already exists")
+
     key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=old_slug)
     await txn.delete(key)
     key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=new_slug)
@@ -113,7 +117,7 @@ async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -
     await set_basic(txn, kbid=kbid, rid=rid, basic=basic)
 
     if datamanagers_v2_migrating(kbid):
-        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=new_slug)
+        await resources_v2.modify_slug(txn, kbid=kbid, rid=rid, new_slug=new_slug)
 
     return old_slug
 

--- a/nucliadb/src/nucliadb/common/datamanagers/resources.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources.py
@@ -22,16 +22,13 @@ from collections.abc import AsyncGenerator
 import backoff
 
 from nucliadb.common.datamanagers import fields_v2, resources_v2
-from nucliadb.common.datamanagers.utils import get_kv_pb
+from nucliadb.common.datamanagers.utils import datamanagers_v2_migrating, datamanagers_v2_read, get_kv_pb
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 
 # These should be refactored
-from nucliadb.common.models_utils import from_proto
 from nucliadb.ingest.settings import settings as ingest_settings
 from nucliadb_protos import resources_pb2
-from nucliadb_utils import const
-from nucliadb_utils.utilities import has_feature
 
 from .utils import with_ro_transaction
 
@@ -53,7 +50,7 @@ KB_RESOURCE_SHARD = "/kbs/{kbid}/r/{uuid}/shard"
 
 
 async def resource_exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.exists(txn, kbid=kbid, rid=rid)
 
     basic = await get_basic_raw(txn, kbid=kbid, rid=rid)
@@ -64,7 +61,7 @@ async def resource_exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
 
 
 async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str) -> str | None:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.get_resource_uuid_from_slug(txn, kbid=kbid, slug=slug)
 
     encoded_uuid = await txn.get(KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug, for_update=False))
@@ -74,7 +71,7 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
 
 
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.slug_exists(txn, kbid=kbid, slug=slug)
 
     key = KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug)
@@ -89,6 +86,13 @@ async def set_slug(txn: Transaction, *, kbid: str, rid: str, slug: str) -> None:
 
 
 async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -> str:
+    if datamanagers_v2_read(kbid):
+        old_slug = await resources_v2.get_slug(txn, kbid=kbid, rid=rid)
+        if old_slug is None:
+            raise NotFoundError()
+        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=new_slug)
+        return old_slug
+
     basic = await get_basic(txn, kbid=kbid, rid=rid)
     if basic is None:
         raise NotFoundError()
@@ -108,7 +112,8 @@ async def modify_slug(txn: Transaction, *, kbid: str, rid: str, new_slug: str) -
     basic.slug = new_slug
     await set_basic(txn, kbid=kbid, rid=rid, basic=basic)
 
-    await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=new_slug)
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=new_slug)
 
     return old_slug
 
@@ -121,7 +126,7 @@ async def get_resource_shard_id(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> str | None:
 
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.get_resource_shard_id(txn, kbid=kbid, rid=rid, for_update=for_update)
 
     key = KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid)
@@ -133,16 +138,21 @@ async def get_resource_shard_id(
 
 
 async def set_resource_shard_id(txn: Transaction, *, kbid: str, rid: str, shard: str):
+    if datamanagers_v2_read(kbid):
+        await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
+        return
+
     await txn.set(KB_RESOURCE_SHARD.format(kbid=kbid, uuid=rid), shard.encode())
 
-    await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard=shard)
 
 
 # Basic
 
 
 async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.get_basic(txn, kbid=kbid, rid=rid)
 
     raw = await get_basic_raw(txn, kbid=kbid, rid=rid)
@@ -162,6 +172,10 @@ async def get_basic_raw(txn: Transaction, *, kbid: str, rid: str) -> bytes | Non
 
 
 async def set_basic(txn: Transaction, *, kbid: str, rid: str, basic: resources_pb2.Basic):
+    if datamanagers_v2_read(kbid):
+        await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+        return
+
     if ingest_settings.driver == "local":
         await txn.set(
             KB_RESOURCE_BASIC_FS.format(kbid=kbid, uuid=rid),
@@ -172,15 +186,15 @@ async def set_basic(txn: Transaction, *, kbid: str, rid: str, basic: resources_p
             KB_RESOURCE_BASIC.format(kbid=kbid, uuid=rid),
             basic.SerializeToString(),
         )
-
-    await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
 
 
 # Origin
 
 
 async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Origin | None:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.get_origin(txn, kbid=kbid, rid=rid)
 
     key = KB_RESOURCE_ORIGIN.format(kbid=kbid, uuid=rid)
@@ -188,17 +202,22 @@ async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.
 
 
 async def set_origin(txn: Transaction, *, kbid: str, rid: str, origin: resources_pb2.Origin):
+    if datamanagers_v2_read(kbid):
+        await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
+        return
+
     key = KB_RESOURCE_ORIGIN.format(kbid=kbid, uuid=rid)
     await txn.set(key, origin.SerializeToString())
 
-    await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_origin(txn, kbid=kbid, rid=rid, origin=origin)
 
 
 # Extra
 
 
 async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Extra | None:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.get_extra(txn, kbid=kbid, rid=rid)
 
     key = KB_RESOURCE_EXTRA.format(kbid=kbid, uuid=rid)
@@ -206,17 +225,22 @@ async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.E
 
 
 async def set_extra(txn: Transaction, *, kbid: str, rid: str, extra: resources_pb2.Extra):
+    if datamanagers_v2_read(kbid):
+        await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
+        return
+
     key = KB_RESOURCE_EXTRA.format(kbid=kbid, uuid=rid)
     await txn.set(key, extra.SerializeToString())
 
-    await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
 
 
 # Security
 
 
 async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Security | None:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await resources_v2.get_security(txn, kbid=kbid, rid=rid)
 
     key = KB_RESOURCE_SECURITY.format(kbid=kbid, uuid=rid)
@@ -224,10 +248,15 @@ async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb
 
 
 async def set_security(txn: Transaction, *, kbid: str, rid: str, security: resources_pb2.Security):
+    if datamanagers_v2_read(kbid):
+        await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
+        return
+
     key = KB_RESOURCE_SECURITY.format(kbid=kbid, uuid=rid)
     await txn.set(key, security.SerializeToString())
 
-    await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
+    if datamanagers_v2_migrating(kbid):
+        await resources_v2.set_security(txn, kbid=kbid, rid=rid, security=security)
 
 
 # KB resource ids (this functions use internal transactions, breaking the
@@ -242,8 +271,8 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncGenerator[str, None]:
 
     For this reason, it is not using the `txn` argument passed in.
     """
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
-        async for rid in resources_v2.iter_resource_ids(kbid=kbid):
+    if datamanagers_v2_read(kbid):
+        async for rid in resources_v2.iterate_resource_ids(kbid=kbid):
             yield rid
         return
 
@@ -291,8 +320,8 @@ async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
     it is not the source of truth for the value so it is not ideal
     to move it to the node.
     """
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
-        return await resources_v2.count(txn, kbid=kbid)
+    if datamanagers_v2_read(kbid):
+        return await resources_v2.calculate_number_of_resources(txn, kbid=kbid)
 
     return await txn.count(KB_RESOURCE_SLUG_BASE.format(kbid=kbid))
 
@@ -317,7 +346,7 @@ async def set_number_of_resources(txn: Transaction, kbid: str, value: int) -> No
 async def get_all_field_ids(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> resources_pb2.AllFieldIDs | None:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
+    if datamanagers_v2_read(kbid):
         return await fields_v2.get_all_field_ids(txn, kbid=kbid, rid=rid)
 
     key = KB_RESOURCE_ALL_FIELDS.format(kbid=kbid, uuid=rid)
@@ -332,14 +361,8 @@ async def set_all_field_ids(
 
 
 async def has_field(txn: Transaction, *, kbid: str, rid: str, field_id: resources_pb2.FieldID) -> bool:
-    if has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid}):
-        return await fields_v2.exists(
-            txn,
-            kbid=kbid,
-            rid=rid,
-            field_id=field_id.field,
-            field_type=from_proto.field_type_name(field_id.field_type).abbreviation(),
-        )
+    if datamanagers_v2_read(kbid):
+        return await fields_v2.has_field(txn, kbid=kbid, rid=rid, field_id=field_id)
 
     fields = await get_all_field_ids(txn, kbid=kbid, rid=rid)
     if fields is None:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -36,8 +36,11 @@ import dataclasses
 from collections.abc import AsyncIterator
 from typing import cast
 
+import psycopg.errors
+
 from nucliadb.common.datamanagers.utils import with_ro_transaction
 from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.exceptions import ConflictError
 from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos import resources_pb2
 
@@ -225,22 +228,43 @@ async def set_user_relations(
         )
 
 
+async def get_slug(txn: Transaction, kbid: str, rid: str) -> str | None:
+    """Get the slug of a resource."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT slug FROM kb_resources
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        return str(row[0]) if row is not None else None
+
+
 async def set_slug(
     txn: Transaction,
     *,
     kbid: str,
     rid: str,
-    slug: str | None,
+    slug: str,
 ) -> None:
-    """Update only the slug column of an existing resource row."""
+    """Update only the slug column of an existing resource row.
+
+    Raises ConflictError if the slug already belongs to another resource in
+    the same knowledge box.
+    """
     async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            UPDATE kb_resources SET slug = %(slug)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-            """,
-            {"kbid": kbid, "rid": rid, "slug": slug},
-        )
+        try:
+            await cur.execute(
+                """
+                UPDATE kb_resources SET slug = %(slug)s
+                WHERE kbid = %(kbid)s AND rid = %(rid)s
+                """,
+                {"kbid": kbid, "rid": rid, "slug": slug},
+            )
+        except psycopg.errors.UniqueViolation:
+            raise ConflictError(f"Slug '{slug}' already exists")
 
 
 async def set_shard(
@@ -426,7 +450,7 @@ async def get_user_relations(txn: Transaction, *, kbid: str, rid: str) -> resour
         return pb
 
 
-async def iter_resource_ids(*, kbid: str) -> AsyncIterator[str]:
+async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
     """Iterate over all resource UUIDs in a knowledge box."""
     async with with_ro_transaction() as txn:
         async with _pg(txn).connection.cursor() as cur:
@@ -438,7 +462,7 @@ async def iter_resource_ids(*, kbid: str) -> AsyncIterator[str]:
                 yield str(rid)
 
 
-async def count(txn: Transaction, *, kbid: str) -> int:
+async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
     """Return the total number of resources in a knowledge box."""
     async with _pg(txn).connection.cursor() as cur:
         await cur.execute(
@@ -454,11 +478,10 @@ async def get_resource_shard_id(
 ) -> str | None:
     """Return the shard ID for a resource, or None."""
     async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            "SELECT shard FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
-            {"kbid": kbid, "rid": rid},
-            for_update=for_update,
-        )
+        sql = "SELECT shard FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s"
+        if for_update:
+            sql += " FOR UPDATE"
+        await cur.execute(sql, {"kbid": kbid, "rid": rid})
         row = await cur.fetchone()
         return row[0] if row is not None else None
 

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -1,0 +1,472 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Datamanager for the `kb_resources` PostgreSQL table (migration 0016).
+
+Each row represents one resource in a knowledge box and stores:
+  - kbid           - FK → kbs.kbid (ON DELETE CASCADE)
+  - rid            - resource UUID
+  - slug           - optional human-readable identifier
+  - shard          - shard ID the resource belongs to
+  - basic          - serialised resources_pb2.Basic
+  - origin         - serialised resources_pb2.Origin
+  - security       - serialised resources_pb2.Security
+  - extra          - serialised resources_pb2.Extra
+  - user_relations - serialised resources_pb2.Relations
+"""
+
+import dataclasses
+from collections.abc import AsyncIterator
+from typing import cast
+
+from nucliadb.common.datamanagers.utils import with_ro_transaction
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction
+from nucliadb_protos import resources_pb2
+
+# ---------------------------------------------------------------------------
+# Row model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ResourceRow:
+    kbid: str
+    rid: str
+    slug: str | None
+    shard: str | None
+    basic: bytes | None
+    origin: bytes | None
+    security: bytes | None
+    extra: bytes | None
+    user_relations: bytes | None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _pg(txn: Transaction) -> PGTransaction:
+    return cast(PGTransaction, txn)
+
+
+def _row_to_resource(row: tuple) -> ResourceRow:
+    kbid, rid, slug, shard, basic, origin, security, extra, user_relations = row
+    return ResourceRow(
+        kbid=str(kbid),
+        rid=str(rid),
+        slug=slug,
+        shard=shard,
+        basic=bytes(basic) if basic is not None else None,
+        origin=bytes(origin) if origin is not None else None,
+        security=bytes(security) if security is not None else None,
+        extra=bytes(extra) if extra is not None else None,
+        user_relations=bytes(user_relations) if user_relations is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write operations
+# ---------------------------------------------------------------------------
+
+
+async def upsert(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    slug: str | None = None,
+    shard: str | None = None,
+    basic: resources_pb2.Basic | None = None,
+    origin: resources_pb2.Origin | None = None,
+    security: resources_pb2.Security | None = None,
+    extra: resources_pb2.Extra | None = None,
+    user_relations: resources_pb2.Relations | None = None,
+) -> None:
+    """Insert or fully replace a resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO kb_resources
+                (kbid, rid, slug, shard, basic, origin, security, extra, user_relations)
+            VALUES
+                (%(kbid)s, %(rid)s, %(slug)s, %(shard)s, %(basic)s, %(origin)s,
+                 %(security)s, %(extra)s, %(user_relations)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                slug           = EXCLUDED.slug,
+                shard          = EXCLUDED.shard,
+                basic          = EXCLUDED.basic,
+                origin         = EXCLUDED.origin,
+                security       = EXCLUDED.security,
+                extra          = EXCLUDED.extra,
+                user_relations = EXCLUDED.user_relations
+            """,
+            {
+                "kbid": kbid,
+                "rid": rid,
+                "slug": slug,
+                "shard": shard,
+                "basic": basic.SerializeToString() if basic is not None else None,
+                "origin": origin.SerializeToString() if origin is not None else None,
+                "security": security.SerializeToString() if security is not None else None,
+                "extra": extra.SerializeToString() if extra is not None else None,
+                "user_relations": user_relations.SerializeToString()
+                if user_relations is not None
+                else None,
+            },
+        )
+
+
+async def set_basic(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    basic: resources_pb2.Basic,
+) -> None:
+    """Update only the basic column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET basic = %(basic)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "basic": basic.SerializeToString()},
+        )
+
+
+async def set_origin(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    origin: resources_pb2.Origin,
+) -> None:
+    """Update only the origin column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET origin = %(origin)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "origin": origin.SerializeToString()},
+        )
+
+
+async def set_security(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    security: resources_pb2.Security,
+) -> None:
+    """Update only the security column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET security = %(security)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "security": security.SerializeToString()},
+        )
+
+
+async def set_extra(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    extra: resources_pb2.Extra,
+) -> None:
+    """Update only the extra column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET extra = %(extra)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "extra": extra.SerializeToString()},
+        )
+
+
+async def set_user_relations(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    user_relations: resources_pb2.Relations,
+) -> None:
+    """Update only the user_relations column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET user_relations = %(user_relations)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "user_relations": user_relations.SerializeToString()},
+        )
+
+
+async def set_slug(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    slug: str | None,
+) -> None:
+    """Update only the slug column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET slug = %(slug)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "slug": slug},
+        )
+
+
+async def set_shard(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    shard: str,
+) -> None:
+    """Update only the shard column of an existing resource row."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE kb_resources SET shard = %(shard)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid, "shard": shard},
+        )
+
+
+async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
+    """Delete a resource row (cascades to fields)."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "DELETE FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Read operations
+# ---------------------------------------------------------------------------
+
+_SELECT_COLUMNS = "kbid, rid, slug, shard, basic, origin, security, extra, user_relations"
+
+
+async def get(txn: Transaction, *, kbid: str, rid: str) -> ResourceRow | None:
+    """Return the row for a single resource, or None if it does not exist."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM kb_resources
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            """,
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        return _row_to_resource(row) if row is not None else None
+
+
+async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
+    """Return True if the resource exists."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT 1 FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        return await cur.fetchone() is not None
+
+
+async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str) -> str | None:
+    """Return the resource UUID for the given slug within a KB, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT rid FROM kb_resources WHERE kbid = %(kbid)s AND slug = %(slug)s",
+            {"kbid": kbid, "slug": slug},
+        )
+        row = await cur.fetchone()
+        return str(row[0]) if row is not None else None
+
+
+async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
+    """Return True if a resource with the given slug exists within a KB."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT 1 FROM kb_resources WHERE kbid = %(kbid)s AND slug = %(slug)s",
+            {"kbid": kbid, "slug": slug},
+        )
+        return await cur.fetchone() is not None
+
+
+async def get_by_slug(txn: Transaction, *, kbid: str, slug: str) -> ResourceRow | None:
+    """Return the resource row matching the given slug within a KB, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM kb_resources
+            WHERE kbid = %(kbid)s AND slug = %(slug)s
+            """,
+            {"kbid": kbid, "slug": slug},
+        )
+        row = await cur.fetchone()
+        return _row_to_resource(row) if row is not None else None
+
+
+async def get_shard(txn: Transaction, *, kbid: str, rid: str) -> str | None:
+    """Return the shard ID for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT shard FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        return row[0] if row is not None else None
+
+
+async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:
+    """Return the deserialised Basic for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT slug, basic FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        if row is None or row[1] is None:
+            return None
+        slug = row[0]
+        pb = resources_pb2.Basic()
+        pb.ParseFromString(bytes(row[1]))
+        pb.slug = slug
+        return pb
+
+
+async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Origin | None:
+    """Return the deserialised Origin for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT origin FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = resources_pb2.Origin()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Security | None:
+    """Return the deserialised Security for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT security FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = resources_pb2.Security()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Extra | None:
+    """Return the deserialised Extra for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT extra FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = resources_pb2.Extra()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def get_user_relations(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Relations | None:
+    """Return the deserialised Relations for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT user_relations FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        pb = resources_pb2.Relations()
+        pb.ParseFromString(bytes(row[0]))
+        return pb
+
+
+async def iter_resource_ids(*, kbid: str) -> AsyncIterator[str]:
+    """Iterate over all resource UUIDs in a knowledge box."""
+    async with with_ro_transaction() as txn:
+        async with _pg(txn).connection.cursor() as cur:
+            await cur.execute(
+                "SELECT rid FROM kb_resources WHERE kbid = %(kbid)s ORDER BY rid",
+                {"kbid": kbid},
+            )
+            async for (rid,) in cur:
+                yield str(rid)
+
+
+async def count(txn: Transaction, *, kbid: str) -> int:
+    """Return the total number of resources in a knowledge box."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT COUNT(*) FROM kb_resources WHERE kbid = %(kbid)s",
+            {"kbid": kbid},
+        )
+        row = await cur.fetchone()
+        return row[0] if row else 0
+
+
+async def get_resource_shard_id(
+    txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
+) -> str | None:
+    """Return the shard ID for a resource, or None."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT shard FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+            for_update=for_update,
+        )
+        row = await cur.fetchone()
+        return row[0] if row is not None else None
+
+
+async def set_resource_shard_id(txn: Transaction, *, kbid: str, rid: str, shard: str) -> None:
+    """Set the shard ID for a resource."""
+    async with _pg(txn).connection.cursor() as cur:
+        await cur.execute(
+            "UPDATE kb_resources SET shard = %(shard)s WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid, "shard": shard},
+        )

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -29,7 +29,6 @@ Each row represents one resource in a knowledge box and stores:
   - origin         - serialised resources_pb2.Origin
   - security       - serialised resources_pb2.Security
   - extra          - serialised resources_pb2.Extra
-  - user_relations - serialised resources_pb2.Relations
 """
 
 import uuid
@@ -130,26 +129,6 @@ async def set_extra(
                 extra = EXCLUDED.extra
             """,
             {"kbid": kbid, "rid": rid, "extra": extra.SerializeToString()},
-        )
-
-
-async def set_user_relations(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-    user_relations: resources_pb2.Relations,
-) -> None:
-    """Upsert the user_relations column, creating the row if it does not exist."""
-    async with _pg_cursor(txn) as cur:
-        await cur.execute(
-            """
-            INSERT INTO kb_resources (kbid, rid, user_relations)
-            VALUES (%(kbid)s, %(rid)s, %(user_relations)s)
-            ON CONFLICT (kbid, rid) DO UPDATE SET
-                user_relations = EXCLUDED.user_relations
-            """,
-            {"kbid": kbid, "rid": rid, "user_relations": user_relations.SerializeToString()},
         )
 
 
@@ -348,21 +327,6 @@ async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.E
         if row is None or row[0] is None:
             return None
         pb = resources_pb2.Extra()
-        pb.ParseFromString(bytes(row[0]))
-        return pb
-
-
-async def get_user_relations(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Relations | None:
-    """Return the deserialised Relations for a resource, or None."""
-    async with _pg_cursor(txn) as cur:
-        await cur.execute(
-            "SELECT user_relations FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
-            {"kbid": kbid, "rid": rid},
-        )
-        row = await cur.fetchone()
-        if row is None or row[0] is None:
-            return None
-        pb = resources_pb2.Relations()
         pb.ParseFromString(bytes(row[0]))
         return pb
 

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -231,7 +231,6 @@ async def set_resource_shard_id(
         )
 
 
-@logs_foreign_key_error
 async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
     """Delete a resource row (cascades to fields)."""
     async with _pg_cursor(txn) as cur:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -32,7 +32,6 @@ Each row represents one resource in a knowledge box and stores:
   - user_relations - serialised resources_pb2.Relations
 """
 
-import dataclasses
 from collections.abc import AsyncIterator
 from typing import cast
 
@@ -44,98 +43,14 @@ from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos import resources_pb2
 
-# ---------------------------------------------------------------------------
-# Row model
-# ---------------------------------------------------------------------------
-
-
-@dataclasses.dataclass
-class ResourceRow:
-    kbid: str
-    rid: str
-    slug: str | None
-    shard: str | None
-    basic: bytes | None
-    origin: bytes | None
-    security: bytes | None
-    extra: bytes | None
-    user_relations: bytes | None
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
 
 def _pg(txn: Transaction) -> PGTransaction:
     return cast(PGTransaction, txn)
 
 
-def _row_to_resource(row: tuple) -> ResourceRow:
-    kbid, rid, slug, shard, basic, origin, security, extra, user_relations = row
-    return ResourceRow(
-        kbid=str(kbid),
-        rid=str(rid),
-        slug=slug,
-        shard=shard,
-        basic=bytes(basic) if basic is not None else None,
-        origin=bytes(origin) if origin is not None else None,
-        security=bytes(security) if security is not None else None,
-        extra=bytes(extra) if extra is not None else None,
-        user_relations=bytes(user_relations) if user_relations is not None else None,
-    )
-
-
 # ---------------------------------------------------------------------------
 # Write operations
 # ---------------------------------------------------------------------------
-
-
-async def upsert(
-    txn: Transaction,
-    *,
-    kbid: str,
-    rid: str,
-    slug: str | None = None,
-    shard: str | None = None,
-    basic: resources_pb2.Basic | None = None,
-    origin: resources_pb2.Origin | None = None,
-    security: resources_pb2.Security | None = None,
-    extra: resources_pb2.Extra | None = None,
-    user_relations: resources_pb2.Relations | None = None,
-) -> None:
-    """Insert or fully replace a resource row."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            """
-            INSERT INTO kb_resources
-                (kbid, rid, slug, shard, basic, origin, security, extra, user_relations)
-            VALUES
-                (%(kbid)s, %(rid)s, %(slug)s, %(shard)s, %(basic)s, %(origin)s,
-                 %(security)s, %(extra)s, %(user_relations)s)
-            ON CONFLICT (kbid, rid) DO UPDATE SET
-                slug           = EXCLUDED.slug,
-                shard          = EXCLUDED.shard,
-                basic          = EXCLUDED.basic,
-                origin         = EXCLUDED.origin,
-                security       = EXCLUDED.security,
-                extra          = EXCLUDED.extra,
-                user_relations = EXCLUDED.user_relations
-            """,
-            {
-                "kbid": kbid,
-                "rid": rid,
-                "slug": slug,
-                "shard": shard,
-                "basic": basic.SerializeToString() if basic is not None else None,
-                "origin": origin.SerializeToString() if origin is not None else None,
-                "security": security.SerializeToString() if security is not None else None,
-                "extra": extra.SerializeToString() if extra is not None else None,
-                "user_relations": user_relations.SerializeToString()
-                if user_relations is not None
-                else None,
-            },
-        )
 
 
 async def set_basic(
@@ -145,12 +60,14 @@ async def set_basic(
     rid: str,
     basic: resources_pb2.Basic,
 ) -> None:
-    """Update only the basic column of an existing resource row."""
+    """Upsert the basic column of a resource row, creating the row if it does not exist."""
     async with _pg(txn).connection.cursor() as cur:
         await cur.execute(
             """
-            UPDATE kb_resources SET basic = %(basic)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            INSERT INTO kb_resources (kbid, rid, basic)
+            VALUES (%(kbid)s, %(rid)s, %(basic)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                basic = EXCLUDED.basic
             """,
             {"kbid": kbid, "rid": rid, "basic": basic.SerializeToString()},
         )
@@ -329,23 +246,6 @@ async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
 # Read operations
 # ---------------------------------------------------------------------------
 
-_SELECT_COLUMNS = "kbid, rid, slug, shard, basic, origin, security, extra, user_relations"
-
-
-async def get(txn: Transaction, *, kbid: str, rid: str) -> ResourceRow | None:
-    """Return the row for a single resource, or None if it does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"""
-            SELECT {_SELECT_COLUMNS}
-            FROM kb_resources
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-            """,
-            {"kbid": kbid, "rid": rid},
-        )
-        row = await cur.fetchone()
-        return _row_to_resource(row) if row is not None else None
-
 
 async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
     """Return True if the resource exists."""
@@ -376,32 +276,6 @@ async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
             {"kbid": kbid, "slug": slug},
         )
         return await cur.fetchone() is not None
-
-
-async def get_by_slug(txn: Transaction, *, kbid: str, slug: str) -> ResourceRow | None:
-    """Return the resource row matching the given slug within a KB, or None."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            f"""
-            SELECT {_SELECT_COLUMNS}
-            FROM kb_resources
-            WHERE kbid = %(kbid)s AND slug = %(slug)s
-            """,
-            {"kbid": kbid, "slug": slug},
-        )
-        row = await cur.fetchone()
-        return _row_to_resource(row) if row is not None else None
-
-
-async def get_shard(txn: Transaction, *, kbid: str, rid: str) -> str | None:
-    """Return the shard ID for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
-        await cur.execute(
-            "SELECT shard FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
-            {"kbid": kbid, "rid": rid},
-        )
-        row = await cur.fetchone()
-        return row[0] if row is not None else None
 
 
 async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -36,7 +36,7 @@ from collections.abc import AsyncIterator
 
 import psycopg.errors
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, with_ro_transaction
+from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error, with_ro_transaction
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb_protos import resources_pb2
@@ -52,6 +52,7 @@ def _to_rid(value: uuid.UUID) -> str:
 # ---------------------------------------------------------------------------
 
 
+@logs_foreign_key_error
 async def set_basic(
     txn: Transaction,
     *,
@@ -72,6 +73,7 @@ async def set_basic(
         )
 
 
+@logs_foreign_key_error
 async def set_origin(
     txn: Transaction,
     *,
@@ -92,6 +94,7 @@ async def set_origin(
         )
 
 
+@logs_foreign_key_error
 async def set_security(
     txn: Transaction,
     *,
@@ -112,6 +115,7 @@ async def set_security(
         )
 
 
+@logs_foreign_key_error
 async def set_extra(
     txn: Transaction,
     *,
@@ -146,6 +150,7 @@ async def get_slug(txn: Transaction, kbid: str, rid: str) -> str | None:
         return str(row[0]) if row is not None else None
 
 
+@logs_foreign_key_error
 async def set_slug(
     txn: Transaction,
     *,
@@ -173,6 +178,7 @@ async def set_slug(
             raise ConflictError(f"Slug '{slug}' already exists")
 
 
+@logs_foreign_key_error
 async def modify_slug(
     txn: Transaction,
     *,
@@ -204,6 +210,7 @@ async def modify_slug(
             raise ConflictError(f"Slug '{new_slug}' already exists")
 
 
+@logs_foreign_key_error
 async def set_resource_shard_id(
     txn: Transaction,
     *,
@@ -224,6 +231,7 @@ async def set_resource_shard_id(
         )
 
 
+@logs_foreign_key_error
 async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
     """Delete a resource row (cascades to fields)."""
     async with _pg_cursor(txn) as cur:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -174,8 +174,10 @@ async def set_slug(
         try:
             await cur.execute(
                 """
-                UPDATE kb_resources SET slug = %(slug)s
-                WHERE kbid = %(kbid)s AND rid = %(rid)s
+                INSERT INTO kb_resources (kbid, rid, slug)
+                VALUES (%(kbid)s, %(rid)s, %(slug)s)
+                ON CONFLICT (kbid, rid) DO UPDATE SET
+                    slug = EXCLUDED.slug
                 """,
                 {"kbid": kbid, "rid": rid, "slug": slug},
             )

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -79,12 +79,14 @@ async def set_origin(
     rid: str,
     origin: resources_pb2.Origin,
 ) -> None:
-    """Update only the origin column of an existing resource row."""
+    """Upsert the origin column, creating the row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_resources SET origin = %(origin)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            INSERT INTO kb_resources (kbid, rid, origin)
+            VALUES (%(kbid)s, %(rid)s, %(origin)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                origin = EXCLUDED.origin
             """,
             {"kbid": kbid, "rid": rid, "origin": origin.SerializeToString()},
         )
@@ -97,12 +99,14 @@ async def set_security(
     rid: str,
     security: resources_pb2.Security,
 ) -> None:
-    """Update only the security column of an existing resource row."""
+    """Upsert the security column, creating the row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_resources SET security = %(security)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            INSERT INTO kb_resources (kbid, rid, security)
+            VALUES (%(kbid)s, %(rid)s, %(security)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                security = EXCLUDED.security
             """,
             {"kbid": kbid, "rid": rid, "security": security.SerializeToString()},
         )
@@ -115,12 +119,14 @@ async def set_extra(
     rid: str,
     extra: resources_pb2.Extra,
 ) -> None:
-    """Update only the extra column of an existing resource row."""
+    """Upsert the extra column, creating the row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_resources SET extra = %(extra)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            INSERT INTO kb_resources (kbid, rid, extra)
+            VALUES (%(kbid)s, %(rid)s, %(extra)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                extra = EXCLUDED.extra
             """,
             {"kbid": kbid, "rid": rid, "extra": extra.SerializeToString()},
         )
@@ -133,12 +139,14 @@ async def set_user_relations(
     rid: str,
     user_relations: resources_pb2.Relations,
 ) -> None:
-    """Update only the user_relations column of an existing resource row."""
+    """Upsert the user_relations column, creating the row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_resources SET user_relations = %(user_relations)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            INSERT INTO kb_resources (kbid, rid, user_relations)
+            VALUES (%(kbid)s, %(rid)s, %(user_relations)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                user_relations = EXCLUDED.user_relations
             """,
             {"kbid": kbid, "rid": rid, "user_relations": user_relations.SerializeToString()},
         )
@@ -216,19 +224,21 @@ async def modify_slug(
             raise ConflictError(f"Slug '{new_slug}' already exists")
 
 
-async def set_shard(
+async def set_resource_shard_id(
     txn: Transaction,
     *,
     kbid: str,
     rid: str,
     shard: str,
 ) -> None:
-    """Update only the shard column of an existing resource row."""
+    """Upsert the shard column, creating the row if it does not exist."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_resources SET shard = %(shard)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
+            INSERT INTO kb_resources (kbid, rid, shard)
+            VALUES (%(kbid)s, %(rid)s, %(shard)s)
+            ON CONFLICT (kbid, rid) DO UPDATE SET
+                shard = EXCLUDED.shard
             """,
             {"kbid": kbid, "rid": rid, "shard": shard},
         )
@@ -390,12 +400,3 @@ async def get_resource_shard_id(
         await cur.execute(sql, {"kbid": kbid, "rid": rid})
         row = await cur.fetchone()
         return row[0] if row is not None else None
-
-
-async def set_resource_shard_id(txn: Transaction, *, kbid: str, rid: str, shard: str) -> None:
-    """Set the shard ID for a resource."""
-    async with _pg_cursor(txn) as cur:
-        await cur.execute(
-            "UPDATE kb_resources SET shard = %(shard)s WHERE kbid = %(kbid)s AND rid = %(rid)s",
-            {"kbid": kbid, "rid": rid, "shard": shard},
-        )

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -33,20 +33,13 @@ Each row represents one resource in a knowledge box and stores:
 """
 
 from collections.abc import AsyncIterator
-from typing import cast
 
 import psycopg.errors
 
-from nucliadb.common.datamanagers.utils import with_ro_transaction
+from nucliadb.common.datamanagers.utils import _pg_cursor, with_ro_transaction
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
-from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos import resources_pb2
-
-
-def _pg(txn: Transaction) -> PGTransaction:
-    return cast(PGTransaction, txn)
-
 
 # ---------------------------------------------------------------------------
 # Write operations
@@ -61,7 +54,7 @@ async def set_basic(
     basic: resources_pb2.Basic,
 ) -> None:
     """Upsert the basic column of a resource row, creating the row if it does not exist."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             INSERT INTO kb_resources (kbid, rid, basic)
@@ -81,7 +74,7 @@ async def set_origin(
     origin: resources_pb2.Origin,
 ) -> None:
     """Update only the origin column of an existing resource row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kb_resources SET origin = %(origin)s
@@ -99,7 +92,7 @@ async def set_security(
     security: resources_pb2.Security,
 ) -> None:
     """Update only the security column of an existing resource row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kb_resources SET security = %(security)s
@@ -117,7 +110,7 @@ async def set_extra(
     extra: resources_pb2.Extra,
 ) -> None:
     """Update only the extra column of an existing resource row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kb_resources SET extra = %(extra)s
@@ -135,7 +128,7 @@ async def set_user_relations(
     user_relations: resources_pb2.Relations,
 ) -> None:
     """Update only the user_relations column of an existing resource row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kb_resources SET user_relations = %(user_relations)s
@@ -147,7 +140,7 @@ async def set_user_relations(
 
 async def get_slug(txn: Transaction, kbid: str, rid: str) -> str | None:
     """Get the slug of a resource."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             SELECT slug FROM kb_resources
@@ -171,7 +164,7 @@ async def set_slug(
     Raises ConflictError if the slug already belongs to another resource in
     the same knowledge box.
     """
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         try:
             await cur.execute(
                 """
@@ -201,7 +194,7 @@ async def modify_slug(
     old_slug = await get_slug(txn, kbid=kbid, rid=rid)
     if old_slug is None:
         raise NotFoundError()
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         try:
             await cur.execute(
                 """
@@ -223,7 +216,7 @@ async def set_shard(
     shard: str,
 ) -> None:
     """Update only the shard column of an existing resource row."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
             UPDATE kb_resources SET shard = %(shard)s
@@ -235,7 +228,7 @@ async def set_shard(
 
 async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
     """Delete a resource row (cascades to fields)."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "DELETE FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -249,7 +242,7 @@ async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
 
 async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
     """Return True if the resource exists."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT 1 FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -259,7 +252,7 @@ async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
 
 async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str) -> str | None:
     """Return the resource UUID for the given slug within a KB, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT rid FROM kb_resources WHERE kbid = %(kbid)s AND slug = %(slug)s",
             {"kbid": kbid, "slug": slug},
@@ -270,7 +263,7 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
 
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
     """Return True if a resource with the given slug exists within a KB."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT 1 FROM kb_resources WHERE kbid = %(kbid)s AND slug = %(slug)s",
             {"kbid": kbid, "slug": slug},
@@ -280,7 +273,7 @@ async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
 
 async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:
     """Return the deserialised Basic for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT slug, basic FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -297,7 +290,7 @@ async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.B
 
 async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Origin | None:
     """Return the deserialised Origin for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT origin FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -312,7 +305,7 @@ async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.
 
 async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Security | None:
     """Return the deserialised Security for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT security FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -327,7 +320,7 @@ async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb
 
 async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Extra | None:
     """Return the deserialised Extra for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT extra FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -342,7 +335,7 @@ async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.E
 
 async def get_user_relations(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Relations | None:
     """Return the deserialised Relations for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT user_relations FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid},
@@ -358,7 +351,7 @@ async def get_user_relations(txn: Transaction, *, kbid: str, rid: str) -> resour
 async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
     """Iterate over all resource UUIDs in a knowledge box."""
     async with with_ro_transaction() as txn:
-        async with _pg(txn).connection.cursor() as cur:
+        async with _pg_cursor(txn) as cur:
             await cur.execute(
                 "SELECT rid FROM kb_resources WHERE kbid = %(kbid)s ORDER BY rid",
                 {"kbid": kbid},
@@ -369,7 +362,7 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
 
 async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
     """Return the total number of resources in a knowledge box."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "SELECT COUNT(*) FROM kb_resources WHERE kbid = %(kbid)s",
             {"kbid": kbid},
@@ -382,7 +375,7 @@ async def get_resource_shard_id(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> str | None:
     """Return the shard ID for a resource, or None."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         sql = "SELECT shard FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s"
         if for_update:
             sql += " FOR UPDATE"
@@ -393,7 +386,7 @@ async def get_resource_shard_id(
 
 async def set_resource_shard_id(txn: Transaction, *, kbid: str, rid: str, shard: str) -> None:
     """Set the shard ID for a resource."""
-    async with _pg(txn).connection.cursor() as cur:
+    async with _pg_cursor(txn) as cur:
         await cur.execute(
             "UPDATE kb_resources SET shard = %(shard)s WHERE kbid = %(kbid)s AND rid = %(rid)s",
             {"kbid": kbid, "rid": rid, "shard": shard},

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -21,7 +21,7 @@
 Datamanager for the `kb_resources` PostgreSQL table (migration 0016).
 
 Each row represents one resource in a knowledge box and stores:
-  - kbid           - FK → kbs.kbid (ON DELETE CASCADE)
+  - kbid           - FK → kbs.kbid (ON DELETE RESTRICT)
   - rid            - resource UUID
   - slug           - optional human-readable identifier
   - shard          - shard ID the resource belongs to
@@ -32,6 +32,7 @@ Each row represents one resource in a knowledge box and stores:
   - user_relations - serialised resources_pb2.Relations
 """
 
+import uuid
 from collections.abc import AsyncIterator
 
 import psycopg.errors
@@ -42,9 +43,9 @@ from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb_protos import resources_pb2
 
 
-def _uuid(value) -> str:
-    """Convert a UUID returned by psycopg to the 32-char hex form (no hyphens)."""
-    return str(value).replace("-", "")
+def _to_rid(value: uuid.UUID) -> str:
+    """Return the 32-char hex form (no hyphens) of a UUID column value."""
+    return value.hex
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +277,7 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
             {"kbid": kbid, "slug": slug},
         )
         row = await cur.fetchone()
-        return _uuid(row[0]) if row is not None else None
+        return _to_rid(row[0]) if row is not None else None
 
 
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
@@ -375,7 +376,7 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
                 {"kbid": kbid},
             )
             async for (rid,) in cur:
-                yield _uuid(rid)
+                yield _to_rid(rid)
 
 
 async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -41,6 +41,12 @@ from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb_protos import resources_pb2
 
+
+def _uuid(value) -> str:
+    """Convert a UUID returned by psycopg to the 32-char hex form (no hyphens)."""
+    return str(value).replace("-", "")
+
+
 # ---------------------------------------------------------------------------
 # Write operations
 # ---------------------------------------------------------------------------
@@ -258,7 +264,7 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
             {"kbid": kbid, "slug": slug},
         )
         row = await cur.fetchone()
-        return str(row[0]) if row is not None else None
+        return _uuid(row[0]) if row is not None else None
 
 
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
@@ -357,7 +363,7 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
                 {"kbid": kbid},
             )
             async for (rid,) in cur:
-                yield str(rid)
+                yield _uuid(rid)
 
 
 async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -40,7 +40,7 @@ import psycopg.errors
 
 from nucliadb.common.datamanagers.utils import with_ro_transaction
 from nucliadb.common.maindb.driver import Transaction
-from nucliadb.common.maindb.exceptions import ConflictError
+from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb.common.maindb.pg import PGTransaction
 from nucliadb_protos import resources_pb2
 
@@ -265,6 +265,37 @@ async def set_slug(
             )
         except psycopg.errors.UniqueViolation:
             raise ConflictError(f"Slug '{slug}' already exists")
+
+
+async def modify_slug(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str,
+    new_slug: str,
+) -> str:
+    """Update only the slug column of an existing resource row.
+
+    Returns the old slug value.
+    Raises NotFoundError if the resource does not exist.
+    Raises ConflictError if the slug already belongs to another resource in
+    the same knowledge box.
+    """
+    old_slug = await get_slug(txn, kbid=kbid, rid=rid)
+    if old_slug is None:
+        raise NotFoundError()
+    async with _pg(txn).connection.cursor() as cur:
+        try:
+            await cur.execute(
+                """
+                UPDATE kb_resources SET slug = %(slug)s
+                WHERE kbid = %(kbid)s AND rid = %(rid)s
+                """,
+                {"kbid": kbid, "rid": rid, "slug": new_slug},
+            )
+            return old_slug
+        except psycopg.errors.UniqueViolation:
+            raise ConflictError(f"Slug '{new_slug}' already exists")
 
 
 async def set_shard(

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -59,11 +59,11 @@ async def with_ro_transaction():
         yield ro_txn
 
 
-def datamanagers_v2_migrating(kbid: str) -> bool:
+def datamanagers_v2_write(kbid: str) -> bool:
     """
     Check if the knowledge box is currently being migrated to the v2 datamanagers.
     """
-    return has_feature(const.Features.DATAMANAGERS_V2_MIGRATING, context={"kbid": kbid})
+    return has_feature(const.Features.DATAMANAGERS_V2_WRITE, context={"kbid": kbid})
 
 
 def datamanagers_v2_read(kbid: str) -> bool:

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -24,6 +24,8 @@ from google.protobuf.message import Message
 
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.utils import get_driver
+from nucliadb_utils import const
+from nucliadb_utils.utilities import has_feature
 
 PB_TYPE = TypeVar("PB_TYPE", bound=Message)
 
@@ -55,3 +57,17 @@ async def with_ro_transaction():
     driver = get_driver()
     async with driver.ro_transaction() as ro_txn:
         yield ro_txn
+
+
+def datamanagers_v2_migrating(kbid: str) -> bool:
+    """
+    Check if the knowledge box is currently being migrated to the v2 datamanagers.
+    """
+    return has_feature(const.Features.DATAMANAGERS_V2_MIGRATING, context={"kbid": kbid})
+
+
+def datamanagers_v2_read(kbid: str) -> bool:
+    """
+    Check if the knowledge box has already been migrated and has datamanagers v2 reads enabled.
+    """
+    return has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid})

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -18,8 +18,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import contextlib
+import functools
+import logging
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator, TypeVar, cast
+from typing import AsyncGenerator, Callable, Coroutine, TypeVar, cast
 
 import psycopg
 from google.protobuf.message import Message
@@ -30,7 +32,41 @@ from nucliadb.common.maindb.utils import get_driver
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
 
+logger = logging.getLogger(__name__)
+
 PB_TYPE = TypeVar("PB_TYPE", bound=Message)
+
+
+def logs_foreign_key_error(
+    func: Callable[..., Coroutine],
+) -> Callable[..., Coroutine]:
+    """Decorator for dual-write datamanager functions during the ORM backfill migration.
+
+    During the backfill migration, writes are sent to both the legacy KV store and
+    the new ORM (PostgreSQL) tables.  A write to an ORM table can fail with a
+    ForeignKeyViolation when the parent row (e.g. the kb_resources row for a field,
+    or the kbs row for a resource) has not been backfilled yet.
+
+    This decorator catches that specific error and logs a warning instead of
+    propagating the exception, so that the dual-write path does not break normal
+    operation for resources and fields that are still pending migration.
+
+    Example::
+
+        @logs_foreign_key_error
+        async def set_basic(txn, *, kbid, rid, basic): ...
+    """
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except psycopg.errors.ForeignKeyViolation as exc:
+            logger.warning(
+                f"Foreign key violation in {wrapper.__qualname__} (parent row not yet migrated to ORM tables): {exc}"
+            )
+
+    return wrapper
 
 
 async def get_kv_pb(

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -18,11 +18,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import contextlib
-from typing import TypeVar
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, TypeVar, cast
 
+import psycopg
 from google.protobuf.message import Message
 
 from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGTransaction, ReadOnlyPGTransaction
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb_utils import const
 from nucliadb_utils.utilities import has_feature
@@ -71,3 +74,19 @@ def datamanagers_v2_read(kbid: str) -> bool:
     Check if the knowledge box has already been migrated and has datamanagers v2 reads enabled.
     """
     return has_feature(const.Features.DATAMANAGERS_V2_READ, context={"kbid": kbid})
+
+
+def _pg(txn: Transaction) -> PGTransaction:
+    return cast(PGTransaction, txn)
+
+
+@asynccontextmanager
+async def _pg_cursor(txn: Transaction) -> AsyncGenerator[psycopg.AsyncCursor]:
+    if isinstance(txn, PGTransaction):
+        async with _pg(txn).connection.cursor() as cur:
+            yield cur
+    elif isinstance(txn, ReadOnlyPGTransaction):
+        async with txn.driver._get_connection() as conn, conn.cursor() as cur:
+            yield cur
+    else:
+        raise TypeError(f"Unsupported transaction type: {type(txn)}")

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -21,7 +21,7 @@ import contextlib
 import functools
 import logging
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator, Callable, Coroutine, TypeVar, cast
+from typing import Any, AsyncGenerator, Callable, Coroutine, ParamSpec, TypeVar, cast
 
 import psycopg
 from google.protobuf.message import Message
@@ -35,11 +35,13 @@ from nucliadb_utils.utilities import has_feature
 logger = logging.getLogger(__name__)
 
 PB_TYPE = TypeVar("PB_TYPE", bound=Message)
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 def logs_foreign_key_error(
-    func: Callable[..., Coroutine],
-) -> Callable[..., Coroutine]:
+    func: Callable[_P, Coroutine[Any, Any, _R]],
+) -> Callable[_P, Coroutine[Any, Any, _R | None]]:
     """Decorator for dual-write datamanager functions during the ORM backfill migration.
 
     During the backfill migration, writes are sent to both the legacy KV store and
@@ -58,13 +60,14 @@ def logs_foreign_key_error(
     """
 
     @functools.wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R | None:
         try:
             return await func(*args, **kwargs)
         except psycopg.errors.ForeignKeyViolation as exc:
             logger.warning(
                 f"Foreign key violation in {wrapper.__qualname__} (parent row not yet migrated to ORM tables): {exc}"
             )
+        return None
 
     return wrapper
 

--- a/nucliadb/src/nucliadb/common/file_md5.py
+++ b/nucliadb/src/nucliadb/common/file_md5.py
@@ -74,6 +74,20 @@ async def set(txn: Transaction, *, kbid: str, md5: str, rid: str, field_id: str)
         await file_md5_v2.set(txn, kbid=kbid, md5=md5, rid=rid, field_id=field_id)
 
 
+@observer.wrap({"op": "get"})
+async def get(txn: Transaction, *, kbid: str, rid: str, field_id: str) -> str | None:
+    """Get the MD5 hash for a resource field, or None if not found."""
+    async with _pg_transaction(txn).connection.cursor() as cur:
+        await cur.execute(
+            "SELECT md5 FROM file_md5 WHERE kbid = %(kbid)s AND rid = %(rid)s AND field_id = %(field_id)s",
+            {"kbid": kbid, "rid": rid, "field_id": f"f/{field_id}"},
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return row[0]
+
+
 @overload
 async def delete(txn: Transaction, *, kbid: str) -> None: ...
 

--- a/nucliadb/src/nucliadb/common/file_md5.py
+++ b/nucliadb/src/nucliadb/common/file_md5.py
@@ -21,6 +21,8 @@
 import logging
 from typing import cast, overload
 
+from nucliadb.common import file_md5_v2
+from nucliadb.common.datamanagers.utils import datamanagers_v2_read, datamanagers_v2_write
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.pg import PGDriver, PGTransaction
 from nucliadb.common.maindb.utils import get_driver
@@ -42,6 +44,9 @@ def _pg_transaction(txn: Transaction) -> PGTransaction:
 @observer.wrap({"op": "check"})
 async def exists(*, kbid: str, md5: str) -> bool:
     """Check if a file with the given MD5 hash already exists in the KB."""
+    if datamanagers_v2_read(kbid):
+        return await file_md5_v2.exists(kbid=kbid, md5=md5)
+
     pg = _pg_driver()
     async with pg._get_connection() as conn, conn.cursor() as cur:
         await cur.execute(
@@ -64,6 +69,9 @@ async def set(txn: Transaction, *, kbid: str, md5: str, rid: str, field_id: str)
             """,
             {"kbid": kbid, "md5": md5, "rid": rid, "field_id": f"f/{field_id}"},
         )
+
+    if datamanagers_v2_write(kbid):
+        await file_md5_v2.set(txn, kbid=kbid, md5=md5, rid=rid, field_id=field_id)
 
 
 @overload

--- a/nucliadb/src/nucliadb/common/file_md5.py
+++ b/nucliadb/src/nucliadb/common/file_md5.py
@@ -107,12 +107,18 @@ async def delete(
                 "DELETE FROM file_md5 WHERE kbid = %(kbid)s",
                 {"kbid": kbid},
             )
+        if datamanagers_v2_write(kbid):
+            await file_md5_v2.delete(txn, kbid=kbid)
+
     elif field_id is None:
         async with pg_txn.connection.cursor() as cur:
             await cur.execute(
                 "DELETE FROM file_md5 WHERE kbid = %(kbid)s AND rid = %(rid)s",
                 {"kbid": kbid, "rid": rid},
             )
+        if datamanagers_v2_write(kbid):
+            await file_md5_v2.delete(txn, kbid=kbid, rid=rid)
+
     else:
         async with pg_txn.connection.cursor() as cur:
             await cur.execute(
@@ -123,3 +129,5 @@ async def delete(
                     "field_id": f"f/{field_id}",
                 },
             )
+        if datamanagers_v2_write(kbid):
+            await file_md5_v2.delete(txn, kbid=kbid, rid=rid, field_id=field_id)

--- a/nucliadb/src/nucliadb/common/file_md5_v2.py
+++ b/nucliadb/src/nucliadb/common/file_md5_v2.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+V2 implementation of file MD5 tracking using the kb_fields.md5 column
+(migration 0016).
+
+Instead of the dedicated `file_md5` table, the MD5 hash is stored directly
+in the `kb_fields` row for the corresponding file field (field_type = 'f').
+This avoids a separate table and keeps the hash co-located with the field data,
+relying on the existing index on (kbid, md5) in kb_fields for efficient lookups.
+"""
+
+from typing import cast
+
+from nucliadb.common.datamanagers.utils import _pg_cursor
+from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.pg import PGDriver
+from nucliadb.common.maindb.utils import get_driver
+
+
+def _pg_driver() -> PGDriver:
+    return cast(PGDriver, get_driver())
+
+
+async def exists(*, kbid: str, md5: str) -> bool:
+    """Check if a file with the given MD5 hash already exists in the KB."""
+    pg = _pg_driver()
+    async with pg._get_connection() as conn, conn.cursor() as cur:
+        await cur.execute(
+            "SELECT 1 FROM kb_fields WHERE kbid = %(kbid)s AND md5 = %(md5)s LIMIT 1",
+            {"kbid": kbid, "md5": md5},
+        )
+        return cur.rowcount > 0
+
+
+async def set(txn: Transaction, *, kbid: str, md5: str, rid: str, field_id: str) -> None:
+    """Set the MD5 hash on the kb_fields row for the given file field.
+
+    The field row is expected to already exist (created by fields_v2.set in the
+    same transaction). If it does not exist for any reason the UPDATE is a no-op.
+    """
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            UPDATE kb_fields SET md5 = %(md5)s
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = 'f' AND field_id = %(field_id)s
+            """,
+            {"kbid": kbid, "md5": md5, "rid": rid, "field_id": field_id},
+        )

--- a/nucliadb/src/nucliadb/common/file_md5_v2.py
+++ b/nucliadb/src/nucliadb/common/file_md5_v2.py
@@ -27,7 +27,7 @@ This avoids a separate table and keeps the hash co-located with the field data,
 relying on the existing index on (kbid, md5) in kb_fields for efficient lookups.
 """
 
-from typing import cast
+from typing import cast, overload
 
 from nucliadb.common.datamanagers.utils import _pg_cursor
 from nucliadb.common.maindb.driver import Transaction
@@ -50,18 +50,60 @@ async def exists(*, kbid: str, md5: str) -> bool:
         return cur.rowcount > 0
 
 
-async def set(txn: Transaction, *, kbid: str, md5: str, rid: str, field_id: str) -> None:
-    """Set the MD5 hash on the kb_fields row for the given file field.
-
-    The field row is expected to already exist (created by fields_v2.set in the
-    same transaction). If it does not exist for any reason the UPDATE is a no-op.
-    """
+async def set(
+    txn: Transaction, *, kbid: str, md5: str, rid: str, field_id: str, field_type: str = "f"
+) -> None:
+    """Set the MD5 hash on the kb_fields row for the given file field."""
     async with _pg_cursor(txn) as cur:
         await cur.execute(
             """
-            UPDATE kb_fields SET md5 = %(md5)s
-            WHERE kbid = %(kbid)s AND rid = %(rid)s
-              AND field_type = 'f' AND field_id = %(field_id)s
+            INSERT INTO kb_fields (kbid, rid, field_type, field_id, md5)
+            VALUES (%(kbid)s, %(rid)s, %(field_type)s, %(field_id)s, %(md5)s)
+            ON CONFLICT (kbid, rid, field_type, field_id) DO UPDATE SET
+                md5 = EXCLUDED.md5
             """,
-            {"kbid": kbid, "md5": md5, "rid": rid, "field_id": field_id},
+            {"kbid": kbid, "md5": md5, "rid": rid, "field_id": field_id, "field_type": field_type},
+        )
+
+
+@overload
+async def delete(txn: Transaction, *, kbid: str) -> None: ...
+
+
+@overload
+async def delete(txn: Transaction, *, kbid: str, rid: str) -> None: ...
+
+
+@overload
+async def delete(txn: Transaction, *, kbid: str, rid: str, field_id: str) -> None: ...
+
+
+async def delete(
+    txn: Transaction,
+    *,
+    kbid: str,
+    rid: str | None = None,
+    field_id: str | None = None,
+    field_type: str = "f",
+) -> None:
+    """Clear the MD5 hash for a specific file field.
+
+    - kbid + rid + field_id: nulls out the md5 column for that field row.
+    - kbid only / kbid + rid: no-op — when a KB or resource is being deleted,
+      the kb_fields rows are removed by ON DELETE CASCADE, so there is no need
+      to UPDATE them first (doing so would write a new MVCC row version for
+      every matching field only for it to be immediately dead-tupled away).
+    """
+    if field_id is None:
+        # Rows will be removed by CASCADE; nothing to do.
+        return
+
+    async with _pg_cursor(txn) as cur:
+        await cur.execute(
+            """
+            UPDATE kb_fields SET md5 = NULL
+            WHERE kbid = %(kbid)s AND rid = %(rid)s
+              AND field_type = %(field_type)s AND field_id = %(field_id)s
+            """,
+            {"kbid": kbid, "rid": rid, "field_id": field_id, "field_type": field_type},
         )

--- a/nucliadb/src/nucliadb/common/maindb/exceptions.py
+++ b/nucliadb/src/nucliadb/common/maindb/exceptions.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+
+
 class ConflictError(Exception): ...
 
 

--- a/nucliadb/src/nucliadb/common/models_utils/to_proto.py
+++ b/nucliadb/src/nucliadb/common/models_utils/to_proto.py
@@ -18,6 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+from typing import overload
+
 from nucliadb_models.common import FieldID, FieldTypeName
 from nucliadb_models.conversation import MessageFormat
 from nucliadb_models.search import FeedbackTasks, NucliaDBClientType
@@ -45,13 +47,28 @@ def field_type_name(obj: FieldTypeName) -> resources_pb2.FieldType.ValueType:
     }[obj]
 
 
-def field_type(obj: FieldID.FieldType) -> resources_pb2.FieldType.ValueType:
+@overload
+def field_type(obj: str) -> resources_pb2.FieldType.ValueType: ...
+
+
+@overload
+def field_type(obj: FieldID.FieldType) -> resources_pb2.FieldType.ValueType: ...
+
+
+def field_type(obj: FieldID.FieldType | str) -> resources_pb2.FieldType.ValueType:
     return {
+        FieldTypeName.LINK.abbreviation(): resources_pb2.FieldType.LINK,
+        FieldTypeName.FILE.abbreviation(): resources_pb2.FieldType.FILE,
+        FieldTypeName.TEXT.abbreviation(): resources_pb2.FieldType.TEXT,
+        FieldTypeName.GENERIC.abbreviation(): resources_pb2.FieldType.GENERIC,
+        FieldTypeName.CONVERSATION.abbreviation(): resources_pb2.FieldType.CONVERSATION,
+        FieldTypeName.KEY_VALUE.abbreviation(): resources_pb2.FieldType.KEY_VALUE,
         FieldID.FieldType.LINK: resources_pb2.FieldType.LINK,
         FieldID.FieldType.FILE: resources_pb2.FieldType.FILE,
         FieldID.FieldType.TEXT: resources_pb2.FieldType.TEXT,
         FieldID.FieldType.GENERIC: resources_pb2.FieldType.GENERIC,
         FieldID.FieldType.CONVERSATION: resources_pb2.FieldType.CONVERSATION,
+        FieldID.FieldType.KEY_VALUE: resources_pb2.FieldType.KEY_VALUE,
     }[obj]
 
 

--- a/nucliadb/src/nucliadb/common/models_utils/to_proto.py
+++ b/nucliadb/src/nucliadb/common/models_utils/to_proto.py
@@ -48,14 +48,14 @@ def field_type_name(obj: FieldTypeName) -> resources_pb2.FieldType.ValueType:
 
 
 @overload
-def field_type(obj: str) -> resources_pb2.FieldType.ValueType: ...
+def field_type(enum: FieldID.FieldType, /) -> resources_pb2.FieldType.ValueType: ...
 
 
 @overload
-def field_type(obj: FieldID.FieldType) -> resources_pb2.FieldType.ValueType: ...
+def field_type(abbr: str, /) -> resources_pb2.FieldType.ValueType: ...
 
 
-def field_type(obj: FieldID.FieldType | str) -> resources_pb2.FieldType.ValueType:
+def field_type(abbr_or_enum: str | FieldID.FieldType, /) -> resources_pb2.FieldType.ValueType:
     return {
         FieldTypeName.LINK.abbreviation(): resources_pb2.FieldType.LINK,
         FieldTypeName.FILE.abbreviation(): resources_pb2.FieldType.FILE,
@@ -69,7 +69,7 @@ def field_type(obj: FieldID.FieldType | str) -> resources_pb2.FieldType.ValueTyp
         FieldID.FieldType.GENERIC: resources_pb2.FieldType.GENERIC,
         FieldID.FieldType.CONVERSATION: resources_pb2.FieldType.CONVERSATION,
         FieldID.FieldType.KEY_VALUE: resources_pb2.FieldType.KEY_VALUE,
-    }[obj]
+    }[abbr_or_enum]
 
 
 def kb_synonyms(obj: KnowledgeBoxSynonyms) -> knowledgebox_pb2.Synonyms:

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -31,6 +31,7 @@ from google.protobuf.message import DecodeError, Message
 from nucliadb.common import datamanagers
 from nucliadb.common.ids import FieldId
 from nucliadb.ingest.fields.exceptions import InvalidFieldClass
+from nucliadb_models.common import FieldTypeName
 from nucliadb_protos.knowledgebox_pb2 import VectorSetConfig
 from nucliadb_protos.resources_pb2 import (
     CloudFile,
@@ -188,6 +189,14 @@ class Field(Generic[PbType]):
             field_type=self.type,
             field_id=self.id,
         )
+        if self.type == FieldTypeName.CONVERSATION.abbreviation():
+            await datamanagers.conversations.delete_field(
+                self.resource.txn,
+                kbid=self.kbid,
+                rid=self.rid,
+                field_type=self.type,
+                field_id=self.id,
+            )
         await self.delete_extracted_text()
         async for vectorset_id, vs in datamanagers.vectorsets.iter(self.resource.txn, kbid=self.kbid):
             await self.delete_vectors(vectorset_id, vs.storage_key_kind)

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -54,7 +54,7 @@ from nucliadb_protos.utils_pb2 import (
     RelationNodeVectors,
     VectorObject,
 )
-from nucliadb_protos.writer_pb2 import Error, FieldStatus
+from nucliadb_protos.writer_pb2 import FieldStatus
 from nucliadb_utils.storages.exceptions import CouldNotCopyNotFound
 from nucliadb_utils.storages.storage import Storage, StorageField
 
@@ -265,25 +265,6 @@ class Field(Generic[PbType]):
             await self.storage.delete_upload(sf.key, sf.bucket)
         except KeyError:
             pass
-
-    async def get_error(self) -> Error | None:
-        return await datamanagers.fields.get_error(
-            self.resource.txn,
-            kbid=self.kbid,
-            rid=self.rid,
-            field_type=self.type,
-            field_id=self.id,
-        )
-
-    async def set_error(self, error: Error) -> None:
-        await datamanagers.fields.set_error(
-            self.resource.txn,
-            kbid=self.kbid,
-            rid=self.rid,
-            field_type=self.type,
-            field_id=self.id,
-            error=error,
-        )
 
     async def get_status(self) -> FieldStatus | None:
         return await datamanagers.fields.get_status(

--- a/nucliadb/src/nucliadb/ingest/fields/base.py
+++ b/nucliadb/src/nucliadb/ingest/fields/base.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from nucliadb.ingest.orm.resource import Resource
 
 
+# These are the field types that support splits (a.k.a. subfields).
 SUBFIELDFIELDS = ("c",)
 
 
@@ -182,6 +183,7 @@ class Field(Generic[PbType]):
         self.resource.modified = True
 
     async def delete(self):
+        # Delete from maindb
         await datamanagers.fields.delete(
             self.resource.txn,
             kbid=self.kbid,
@@ -197,17 +199,22 @@ class Field(Generic[PbType]):
                 field_type=self.type,
                 field_id=self.id,
             )
-        await self.delete_extracted_text()
+        # Delete from storage
+        tasks = [
+            self.delete_extracted_text(),
+            self.delete_question_answers(),
+            self.delete_metadata(),
+            self.delete_field_metadata(),
+            self.delete_large_computed_metadata(),
+            self.delete_thumbnail(),
+        ]
         async for vectorset_id, vs in datamanagers.vectorsets.iter(self.resource.txn, kbid=self.kbid):
-            await self.delete_vectors(vectorset_id, vs.storage_key_kind)
-
+            tasks.append(self.delete_vectors(vectorset_id, vs.storage_key_kind))
         for model in await datamanagers.graph_vectorsets.node.get_all(self.resource.txn, kbid=self.kbid):
-            await self.delete_relation_node_vectors(model.vectorset_id)
+            tasks.append(self.delete_relation_node_vectors(model.vectorset_id))
         for model in await datamanagers.graph_vectorsets.edge.get_all(self.resource.txn, kbid=self.kbid):
-            await self.delete_relation_edge_vectors(model.vectorset_id)
-
-        await self.delete_metadata()
-        await self.delete_question_answers()
+            tasks.append(self.delete_relation_edge_vectors(model.vectorset_id))
+        await asyncio.gather(*tasks)
 
     async def delete_question_answers(self) -> None:
         sf = self.get_storage_field(FieldTypes.QUESTION_ANSWERS)
@@ -261,6 +268,27 @@ class Field(Generic[PbType]):
 
     async def delete_metadata(self) -> None:
         sf = self.get_storage_field(FieldTypes.FIELD_METADATA)
+        try:
+            await self.storage.delete_upload(sf.key, sf.bucket)
+        except KeyError:
+            pass
+
+    async def delete_thumbnail(self) -> None:
+        sf = self.get_storage_field(FieldTypes.THUMBNAIL)
+        try:
+            await self.storage.delete_upload(sf.key, sf.bucket)
+        except KeyError:
+            pass
+
+    async def delete_field_metadata(self) -> None:
+        sf = self.get_storage_field(FieldTypes.FIELD_METADATA)
+        try:
+            await self.storage.delete_upload(sf.key, sf.bucket)
+        except KeyError:
+            pass
+
+    async def delete_large_computed_metadata(self) -> None:
+        sf = self.get_storage_field(FieldTypes.FIELD_LARGE_METADATA)
         try:
             await self.storage.delete_upload(sf.key, sf.bucket)
         except KeyError:
@@ -656,10 +684,6 @@ class Field(Generic[PbType]):
         author = FieldAuthor()
         author.user.SetInParent()
         return author
-
-    def serialize(self) -> str:
-        assert self.value
-        return self.value.SerializeToString()
 
     async def set_value(self, payload: Any):
         raise NotImplementedError()

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -44,8 +44,6 @@ class Conversation(Field[PBConversation]):
     value: dict[int, PBConversation]
     metadata: FieldConversation | None
 
-    _created: bool = False
-
     def __init__(self, id: str, resource: Any):
         super().__init__(id, resource)
         self.value = {}
@@ -69,14 +67,23 @@ class Conversation(Field[PBConversation]):
             # As we need to overwrite the value of the conversation, first delete any previous data.
             await self.delete_value()
 
+        created = False
         metadata = await self.get_metadata()
+        if metadata is None:
+            metadata = FieldConversation()
+            metadata.size = PAGE_SIZE
+            metadata.pages = 0
+            metadata.total = 0
+            await self.db_set_metadata(metadata)
+            created = True
+
         metadata.extract_strategy = payload.extract_strategy
         metadata.split_strategy = payload.split_strategy
         metadata.generated_by.CopyFrom(payload.generated_by)
 
         # Get the last page if it exists
         last_page: PBConversation | None = None
-        if self._created is False and metadata.pages > 0:
+        if not created and metadata.pages > 0:
             try:
                 last_page = await self.db_get_value(page=metadata.pages)
             except PageNotFound:
@@ -174,7 +181,7 @@ class Conversation(Field[PBConversation]):
             n_page += 1
         return full_conv
 
-    async def get_metadata(self) -> FieldConversation:
+    async def get_metadata(self) -> FieldConversation | None:
         if self.metadata is None:
             self.metadata = await datamanagers.conversations.get_metadata(
                 self.resource.txn,
@@ -183,12 +190,6 @@ class Conversation(Field[PBConversation]):
                 field_type=self.type,
                 field_id=self.id,
             )
-            if self.metadata is None:
-                self.metadata = FieldConversation()
-                self.metadata.size = PAGE_SIZE
-                self.metadata.pages = 0
-                self.metadata.total = 0
-                self._created = True
         return self.metadata
 
     async def db_get_value(self, page: int = 1):
@@ -233,7 +234,6 @@ class Conversation(Field[PBConversation]):
         )
         self.metadata = payload
         self.resource.modified = True
-        self._created = False
 
     async def get_splits_metadata(self) -> SplitsMetadata:
         if self._splits_metadata is None:

--- a/nucliadb/src/nucliadb/ingest/orm/index_message.py
+++ b/nucliadb/src/nucliadb/ingest/orm/index_message.py
@@ -274,9 +274,6 @@ class IndexMessageBuilder:
         await self._apply_resource_index_data(self.brain)
         basic = await self.get_basic()
         fields_to_index = get_bm_modified_fields(message)
-        fields_to_index.extend(
-            [x for x in self.resource._modified_extracted_text if x not in fields_to_index]
-        )
         vectorsets_configs = await self.get_vectorsets_configs()
         for fieldid in fields_to_index:
             if fieldid in message.delete_fields:
@@ -299,14 +296,8 @@ class IndexMessageBuilder:
                 self.brain,
                 fieldid,
                 basic,
-                texts=(
-                    needs_texts_update(fieldid, message)
-                    or fieldid in self.resource._modified_extracted_text
-                ),
-                paragraphs=(
-                    needs_paragraphs_update(fieldid, message)
-                    or fieldid in self.resource._modified_extracted_text
-                ),
+                texts=(needs_texts_update(fieldid, message)),
+                paragraphs=(needs_paragraphs_update(fieldid, message)),
                 relations=needs_relations_update(fieldid, message),
                 vectors=needs_vectors_update(fieldid, message),
                 replace=replace_field,

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -287,11 +287,7 @@ class KnowledgeBox:
                 raise datamanagers.exceptions.KnowledgeBoxNotFound()
 
             if slug:
-                await txn.delete(datamanagers.kb.KB_SLUGS.format(slug=stored.slug))
-                await txn.set(
-                    datamanagers.kb.KB_SLUGS.format(slug=slug),
-                    kbid.encode(),
-                )
+                await datamanagers.kb.modify_slug(txn, kbid=kbid, old_slug=stored.slug, new_slug=slug)
                 stored.slug = slug
 
             if title is not None:

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -372,6 +372,9 @@ class KnowledgeBox:
             if not exists:
                 return
 
+            # Delete from kbs table
+            await datamanagers.kb.kb_v2.delete(txn, kbid=kbid)
+
             # Delete main anchor
             kb_config = await datamanagers.kb.get_config(txn, kbid=kbid)
             if kb_config is not None:

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from collections.abc import AsyncGenerator, Callable, Coroutine, Sequence
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from datetime import datetime
 from functools import partial
 from typing import Any
@@ -602,10 +602,6 @@ class KnowledgeBox:
         stored: StoredExternalIndexProviderMetadata,
     ) -> None:
         return
-
-
-def chunker(seq: Sequence, size: int):
-    return (seq[pos : pos + size] for pos in range(0, len(seq), size))
 
 
 def fix_paragraph_annotation_keys(uuid: str, basic: Basic) -> None:

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -495,6 +495,8 @@ class KnowledgeBox:
             except Exception:
                 logger.exception("Error deleting slug")
 
+        await datamanagers.resources.resources_v2.delete(self.txn, kbid=self.kbid, rid=uuid)
+
     async def storage_delete_resource(self, uuid: str):
         if is_onprem_nucliadb():
             await self.storage.delete_resource(self.kbid, uuid)

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -27,12 +27,6 @@ from nidx_protos import nidx_pb2, noderesources_pb2
 
 from nucliadb.common import datamanagers, file_md5
 from nucliadb.common.cluster.utils import get_shard_manager
-
-# XXX: this keys shouldn't be exposed outside datamanagers
-from nucliadb.common.datamanagers.resources import (
-    KB_RESOURCE_SLUG,
-    KB_RESOURCE_SLUG_BASE,
-)
 from nucliadb.common.external_index_providers.base import VectorsetExternalIndex
 from nucliadb.common.maindb.driver import Driver, Transaction
 from nucliadb.common.maindb.pg import PGTransaction
@@ -64,9 +58,6 @@ from nucliadb_utils.utilities import (
     get_storage,
     has_feature,
 )
-
-# XXX Eventually all these keys should be moved to datamanagers.kb
-KB_RESOURCE = "/kbs/{kbid}/r/{uuid}"
 
 KB_KEYS = "/kbs/{kbid}/"
 
@@ -363,13 +354,40 @@ class KnowledgeBox:
             await nidx_api.ConfigureShards(nidx_pb2.ShardsConfig(configs=configs))
 
     @classmethod
+    async def mark_for_purge(cls, txn: Transaction, kbid: str):
+        """
+        Mark KB to purge. Purge command will eventually delete all KB keys and objects in storage.
+        """
+        key = KB_TO_DELETE.format(kbid=kbid)
+        value = datetime.now().isoformat().encode()
+        await txn.set(key, value)
+
+    @classmethod
+    async def unmark_for_purge(cls, txn: Transaction, kbid: str):
+        """
+        Unmark KB to purge. To be called after purge is completed, to remove the KB from the list of KBs to purge.
+        """
+        key = KB_TO_DELETE.format(kbid=kbid)
+        await txn.delete(key)
+
+    @classmethod
     async def delete(cls, driver: Driver, kbid: str):
+        """
+        Delete a knowledge base (KB) and all its associated data.
+
+        In the current transaction, the KB is marked for and we only delete:
+        - The KB config
+        - The KB slug
+        - Mark shards to be deleted from nidx
+        - Mark the KB for purge, which will eventually delete all KB keys in Postgresql and objects in storage.
+        """
+
         async with driver.rw_transaction() as txn:
             exists = await datamanagers.kb.exists_kb(txn, kbid=kbid)
             if not exists:
+                # Already deleted, or never existed.
                 return
 
-            # Delete main anchor
             kb_config = await datamanagers.kb.get_config(txn, kbid=kbid)
             if kb_config is not None:
                 slug = kb_config.slug
@@ -377,10 +395,7 @@ class KnowledgeBox:
 
             await datamanagers.kb.delete_config(txn, kbid=kbid)
 
-            # Mark KB to purge. This will eventually delete all KB keys, storage
-            # and index data (for the old index nodes)
-            when = datetime.now().isoformat()
-            await txn.set(KB_TO_DELETE.format(kbid=kbid), when.encode())
+            await cls.mark_for_purge(txn, kbid=kbid)
 
             shards_obj = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
 
@@ -413,10 +428,6 @@ class KnowledgeBox:
         """
         Deletes all kb parts
 
-        It takes care of signaling the nodes related to this kb that they
-        need to delete the kb shards and also deletes the related storage
-        buckets.
-
         Removes all catalog entries related to the kb.
 
         As non-empty buckets cannot be deleted, they are scheduled to be
@@ -429,9 +440,12 @@ class KnowledgeBox:
         exists = await storage.schedule_delete_kb(kbid)
         if exists is False:
             logger.error(f"{kbid} KB does not exists on Storage")
+
         async with driver.rw_transaction() as txn:
+            # Mark storage to be deleted. This will
             storage_to_delete = KB_TO_DELETE_STORAGE.format(kbid=kbid)
             await txn.set(storage_to_delete, b"")
+
             await catalog_delete_kb(txn, kbid)
             await file_md5.delete(txn, kbid=kbid)
             await txn.commit()
@@ -462,22 +476,14 @@ class KnowledgeBox:
         return await Resource.get(self.txn, self.kbid, uuid)
 
     async def maindb_delete_resource(self, uuid: str):
-        basic = await datamanagers.resources.get_basic(self.txn, kbid=self.kbid, rid=uuid)
-        await self.txn.delete_by_prefix(KB_RESOURCE.format(kbid=self.kbid, uuid=uuid))
-        if basic and basic.slug:
-            try:
-                await self.txn.delete(KB_RESOURCE_SLUG.format(kbid=self.kbid, slug=basic.slug))
-            except Exception:
-                logger.exception("Error deleting slug")
-
-        await datamanagers.resources.resources_v2.delete(self.txn, kbid=self.kbid, rid=uuid)
+        await datamanagers.resources.delete(self.txn, kbid=self.kbid, rid=uuid)
 
     async def storage_delete_resource(self, uuid: str):
         if is_onprem_nucliadb():
             await self.storage.delete_resource(self.kbid, uuid)
         else:
             # Deleting from storage can be slow, so we schedule its deletion and the purge cronjob
-            # will take care of it
+            # will take care of it. This is OK as resource uuids are unique and not reused.
             await self.schedule_delete_resource(self.kbid, uuid)
 
     async def schedule_delete_resource(self, kbid: str, uuid: str):
@@ -495,24 +501,11 @@ class KnowledgeBox:
             self.txn, kbid=self.kbid, slug=slug
         )
 
-    async def get_unique_slug(self, uuid: str, slug: str) -> str:
-        key = KB_RESOURCE_SLUG.format(kbid=self.kbid, slug=slug)
-        key_ok = False
-        while key_ok is False:
-            found = await self.txn.get(key, for_update=False)
-            if found and found.decode() != uuid:
-                slug += ".c"
-                key = KB_RESOURCE_SLUG.format(kbid=self.kbid, slug=slug)
-            else:
-                key_ok = True
-        return slug
-
     async def add_resource(self, uuid: str, slug: str, basic: Basic | None = None) -> Resource:
         if basic is None:
             basic = Basic()
         if slug == "":
             slug = uuid
-        slug = await self.get_unique_slug(uuid, slug)
         basic.slug = slug
         fix_paragraph_annotation_keys(uuid, basic)
         await datamanagers.resources.set_basic(self.txn, kbid=self.kbid, rid=uuid, basic=basic)
@@ -526,18 +519,15 @@ class KnowledgeBox:
         )
 
     async def iterate_resources(self) -> AsyncGenerator[Resource, None]:
-        base = KB_RESOURCE_SLUG_BASE.format(kbid=self.kbid)
-        async for key in self.txn.keys(match=base):
-            slug = key.split("/")[-1]
-            uuid = await self.get_resource_uuid_by_slug(slug)
-            if uuid is not None:
-                yield Resource(
-                    self.txn,
-                    self.storage,
-                    self.kbid,
-                    uuid,
-                    disable_vectors=False,
-                )
+        # This uses a separate transaction for iterating resource ids
+        async for uuid in datamanagers.resources.iterate_resource_ids(kbid=self.kbid):
+            yield Resource(
+                self.txn,
+                self.storage,
+                self.kbid,
+                uuid,
+                disable_vectors=False,
+            )
 
     async def create_vectorset(self, config: knowledgebox_pb2.VectorSetConfig):
         if await datamanagers.vectorsets.exists(

--- a/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
+++ b/nucliadb/src/nucliadb/ingest/orm/knowledgebox.py
@@ -23,12 +23,9 @@ from functools import partial
 from typing import Any
 from uuid import uuid4
 
-from grpc import StatusCode
-from grpc.aio import AioRpcError
 from nidx_protos import nidx_pb2, noderesources_pb2
 
 from nucliadb.common import datamanagers, file_md5
-from nucliadb.common.cluster.exceptions import ShardNotFound
 from nucliadb.common.cluster.utils import get_shard_manager
 
 # XXX: this keys shouldn't be exposed outside datamanagers
@@ -372,9 +369,6 @@ class KnowledgeBox:
             if not exists:
                 return
 
-            # Delete from kbs table
-            await datamanagers.kb.kb_v2.delete(txn, kbid=kbid)
-
             # Delete main anchor
             kb_config = await datamanagers.kb.get_config(txn, kbid=kbid)
             if kb_config is not None:
@@ -389,6 +383,8 @@ class KnowledgeBox:
             await txn.set(KB_TO_DELETE.format(kbid=kbid), when.encode())
 
             shards_obj = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
+
+            await datamanagers.kb.kb_v2.soft_delete(txn, kbid=kbid)
 
             await txn.commit()
 
@@ -433,44 +429,23 @@ class KnowledgeBox:
         exists = await storage.schedule_delete_kb(kbid)
         if exists is False:
             logger.error(f"{kbid} KB does not exists on Storage")
-
-        nidx_api = get_nidx_api_client()
-
         async with driver.rw_transaction() as txn:
             storage_to_delete = KB_TO_DELETE_STORAGE.format(kbid=kbid)
             await txn.set(storage_to_delete, b"")
-
             await catalog_delete_kb(txn, kbid)
-
             await file_md5.delete(txn, kbid=kbid)
-
-            # Delete KB Shards
-            shards_obj = await datamanagers.cluster.get_kb_shards(txn, kbid=kbid)
-            if shards_obj is None:
-                logger.warning(f"Shards not found for KB while purging it", extra={"kbid": kbid})
-            else:
-                for shard in shards_obj.shards:
-                    if shard.nidx_shard_id:
-                        try:
-                            await nidx_api.DeleteShard(noderesources_pb2.ShardId(id=shard.nidx_shard_id))
-                            logger.debug(
-                                f"Succeded deleting shard",
-                                extra={"kbid": kbid, "shard_id": shard.nidx_shard_id},
-                            )
-                        except AioRpcError as exc:
-                            if exc.code() == StatusCode.NOT_FOUND:
-                                continue
-                            raise ShardNotFound(f"{exc.details()} @ shard {shard.nidx_shard_id}")
-
             await txn.commit()
-        await cls.delete_all_kb_keys(driver, kbid)
+
+        # Delete by prefix in another transaction, as it can be slow and we don't want to block the previous one
+        async with driver.rw_transaction() as txn:
+            await cls.delete_all_kb_keys(txn, kbid)
+            await txn.commit()
 
     @classmethod
-    async def delete_all_kb_keys(cls, driver: Driver, kbid: str, chunk_size: int = 1_000):
+    async def delete_all_kb_keys(cls, txn: Transaction, kbid: str):
         prefix = KB_KEYS.format(kbid=kbid)
-        async with driver.rw_transaction() as txn:
-            await txn.delete_by_prefix(prefix)
-            await txn.commit()
+        await txn.delete_by_prefix(prefix)
+        await datamanagers.kb.kb_v2.delete(txn, kbid=kbid)
 
     async def get_resource_shard(self, shard_id: str) -> writer_pb2.ShardObject | None:
         async with datamanagers.with_ro_transaction() as txn:

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -945,13 +945,19 @@ async def compute_resource_status(
     field_ids = await datamanagers.resources.get_all_field_ids(
         txn, kbid=kbid, rid=uuid, for_update=False
     )
-    if field_ids is None or not has_some_processed_fields(field_ids):
+    if field_ids is None:
         # No fields, it is processed
         basic.metadata.status = resources_pb2.Metadata.Status.PROCESSED
         return
 
+    processed_fields = [f for f in field_ids.fields if is_processed_field(f)]
+    if not processed_fields:
+        # No processed fields, it is pending
+        basic.metadata.status = resources_pb2.Metadata.Status.PROCESSED
+        return
+
     field_statuses = await datamanagers.fields.get_statuses(
-        txn, kbid=kbid, rid=uuid, fields=field_ids.fields
+        txn, kbid=kbid, rid=uuid, fields=processed_fields
     )
 
     # If any field is processing -> PENDING
@@ -973,17 +979,13 @@ async def compute_resource_status(
         basic.metadata.status = resources_pb2.Metadata.Status.PROCESSED
 
 
-def has_some_processed_fields(field_ids: resources_pb2.AllFieldIDs) -> bool:
+def is_processed_field(field: resources_pb2.FieldID) -> bool:
     """
-    Returns True if the resource has at least one field. Title and summary fields are not considered fields for this purpose.
+    Title and summary fields are not considered processed fields
     """
-    return any(
-        f
-        not in (
-            resources_pb2.FieldID(field="title", field_type=resources_pb2.FieldType.GENERIC),
-            resources_pb2.FieldID(field="summary", field_type=resources_pb2.FieldType.GENERIC),
-        )
-        for f in field_ids.fields
+    return field not in (
+        resources_pb2.FieldID(field="title", field_type=resources_pb2.FieldType.GENERIC),
+        resources_pb2.FieldID(field="summary", field_type=resources_pb2.FieldType.GENERIC),
     )
 
 

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -599,20 +599,6 @@ class Processor:
     async def deadletter(self, message: writer_pb2.BrokerMessage, partition: str, seqid: int) -> None:
         await self.storage.deadletter(message, 0, seqid, partition)
 
-    async def _get_resource_filenames(self, resource: Resource) -> list[str]:
-        """
-        Get all resource filenames from the resource file fields.
-        """
-        fields = await resource.get_fields(force=True, load_values=False)
-        filenames = set()
-        for (field_type, _), field_obj in fields.items():
-            if field_type == writer_pb2.FieldType.FILE:
-                field_value: resources_pb2.FieldFile | None = await field_obj.get_value()
-                if field_value is not None:
-                    if field_value.file.filename not in ("", None):
-                        filenames.add(field_value.file.filename)
-        return list(filenames)
-
     @processor_observer.wrap({"type": "apply_resource"})
     async def apply_resource(
         self,

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -945,7 +945,7 @@ async def compute_resource_status(
     field_ids = await datamanagers.resources.get_all_field_ids(
         txn, kbid=kbid, rid=uuid, for_update=False
     )
-    if field_ids is None:
+    if field_ids is None or not has_some_processed_fields(field_ids):
         # No fields, it is processed
         basic.metadata.status = resources_pb2.Metadata.Status.PROCESSED
         return
@@ -971,6 +971,20 @@ async def compute_resource_status(
     # Otherwise (everything processed or we only have DA errors) -> PROCESSED
     else:
         basic.metadata.status = resources_pb2.Metadata.Status.PROCESSED
+
+
+def has_some_processed_fields(field_ids: resources_pb2.AllFieldIDs) -> bool:
+    """
+    Returns True if the resource has at least one field. Title and summary fields are not considered fields for this purpose.
+    """
+    return any(
+        f
+        not in (
+            resources_pb2.FieldID(field="title", field_type=resources_pb2.FieldType.GENERIC),
+            resources_pb2.FieldID(field="summary", field_type=resources_pb2.FieldType.GENERIC),
+        )
+        for f in field_ids.fields
+    )
 
 
 def delete_basic_computedmetadata_classifications(basic: PBBasic, deleted_fields: list[FieldID]) -> bool:

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -599,6 +599,20 @@ class Processor:
     async def deadletter(self, message: writer_pb2.BrokerMessage, partition: str, seqid: int) -> None:
         await self.storage.deadletter(message, 0, seqid, partition)
 
+    async def _get_resource_filenames(self, resource: Resource) -> list[str]:
+        """
+        Get all resource filenames from the resource file fields.
+        """
+        fields = await resource.get_fields(force=True)
+        filenames = set()
+        for (field_type, _), field_obj in fields.items():
+            if field_type == writer_pb2.FieldType.FILE:
+                field_value: resources_pb2.FieldFile | None = await field_obj.get_value()
+                if field_value is not None:
+                    if field_value.file.filename not in ("", None):
+                        filenames.add(field_value.file.filename)
+        return list(filenames)
+
     @processor_observer.wrap({"type": "apply_resource"})
     async def apply_resource(
         self,

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -603,7 +603,7 @@ class Processor:
         """
         Get all resource filenames from the resource file fields.
         """
-        fields = await resource.get_fields(force=True)
+        fields = await resource.get_fields(force=True, load_values=False)
         filenames = set()
         for (field_type, _), field_obj in fields.items():
             if field_type == writer_pb2.FieldType.FILE:

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -656,6 +656,7 @@ class Processor:
         """
         with processor_observer({"type": "apply_field_values"}):
             await resource.apply_field_values(message)
+
         with processor_observer({"type": "apply_field_extracted_data"}):
             await resource.apply_field_extracted_data(message)
 

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -44,7 +44,6 @@ from nucliadb_protos.resources_pb2 import (
     ExtractedTextWrapper,
     ExtractedVectorsWrapper,
     FieldComputedMetadataWrapper,
-    FieldFile,
     FieldID,
     FieldQuestionAnswerWrapper,
     FieldType,
@@ -74,6 +73,20 @@ KB_FIELDS: dict[int, type] = {
     FieldType.KEY_VALUE: KeyValue,
 }
 
+<<<<<<< HEAD
+=======
+PB_TEXT_FORMAT_TO_MIMETYPE = {
+    FieldText.Format.PLAIN: "text/plain",
+    FieldText.Format.HTML: "text/html",
+    FieldText.Format.RST: "text/x-rst",
+    FieldText.Format.MARKDOWN: "text/markdown",
+    FieldText.Format.JSON: "application/json",
+    FieldText.Format.KEEP_MARKDOWN: "text/markdown",
+    FieldText.Format.JSONL: "application/x-ndjson",
+    FieldText.Format.PLAIN_BLANKLINE_SPLIT: "text/plain+blankline",
+}
+
+>>>>>>> c9d070a3e (refactor resource and fields processing)
 
 class Resource:
     def __init__(

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any, cast
@@ -104,6 +105,10 @@ class Resource:
         self._previous_status: Metadata.Status.ValueType | None = None
         self.user_relations: PBRelations | None = None
         self.locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    @staticmethod
+    def new_unique_rid() -> str:
+        return uuid.uuid4().hex
 
     @classmethod
     async def get(cls, txn: Transaction, kbid: str, rid: str) -> Resource | None:

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -44,6 +44,7 @@ from nucliadb_protos.resources_pb2 import (
     ExtractedTextWrapper,
     ExtractedVectorsWrapper,
     FieldComputedMetadataWrapper,
+    FieldFile,
     FieldID,
     FieldQuestionAnswerWrapper,
     FieldType,

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -94,7 +94,6 @@ class Resource:
         self.extra: PBExtra | None = None
         self.security: utils_pb2.Security | None = None
         self.modified: bool = False
-        self._modified_extracted_text: list[FieldID] = []
 
         self.txn: Transaction = txn
         self.storage = storage
@@ -385,6 +384,8 @@ class Resource:
             )
             self.modified = True
 
+        await self.apply_fields_status(message)
+
     async def set_file_field_md5(self, field_id: str, file: CloudFile):
         """
         Record file MD5 hashes for deduplication checks.
@@ -402,7 +403,10 @@ class Resource:
         """
         await file_md5.delete(self.txn, kbid=self.kbid, rid=self.uuid, field_id=field_id)
 
-    async def apply_fields_status(self, message: BrokerMessage, updated_fields: list[FieldID]):
+    async def apply_fields_status(self, message: BrokerMessage):
+        # Update the status for fields for which the extracted text has been updated.
+        updated_fields = [et.field for et in message.extracted_text]
+
         # Dictionary of all errors per field (we may have several due to DA tasks)
         errors_by_field: dict[tuple[FieldType.ValueType, str], list[writer_pb2.Error]] = defaultdict(
             list
@@ -413,7 +417,6 @@ class Resource:
             errors_by_field[(field_id.field_type, field_id.field)] = []
         for fs in message.field_statuses:
             errors_by_field[(fs.id.field_type, fs.id.field)] = []
-
         for error in message.errors:
             errors_by_field[(error.field_type, error.field)].append(error)
 
@@ -521,9 +524,6 @@ class Resource:
         await asyncio.gather(*tasks)
         tasks.clear()
 
-        # Update field statuses depending on processing results. This depends on the extracted text being applied first
-        await self.apply_fields_status(message, self._modified_extracted_text)
-
     async def _apply_question_answers_ops(self, message: BrokerMessage):
         tasks = []
         updated = [qa.field for qa in message.question_answers]
@@ -540,9 +540,6 @@ class Resource:
             extracted_text.field.field, extracted_text.field.field_type, load=False
         )
         await field_obj.set_extracted_text(extracted_text)
-        self._modified_extracted_text.append(
-            extracted_text.field,
-        )
         self.modified = True
 
     async def _apply_question_answers(self, question_answers: FieldQuestionAnswerWrapper):

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -73,20 +73,6 @@ KB_FIELDS: dict[int, type] = {
     FieldType.KEY_VALUE: KeyValue,
 }
 
-<<<<<<< HEAD
-=======
-PB_TEXT_FORMAT_TO_MIMETYPE = {
-    FieldText.Format.PLAIN: "text/plain",
-    FieldText.Format.HTML: "text/html",
-    FieldText.Format.RST: "text/x-rst",
-    FieldText.Format.MARKDOWN: "text/markdown",
-    FieldText.Format.JSON: "application/json",
-    FieldText.Format.KEEP_MARKDOWN: "text/markdown",
-    FieldText.Format.JSONL: "application/x-ndjson",
-    FieldText.Format.PLAIN_BLANKLINE_SPLIT: "text/plain+blankline",
-}
-
->>>>>>> c9d070a3e (refactor resource and fields processing)
 
 class Resource:
     def __init__(

--- a/nucliadb/src/nucliadb/ingest/orm/resource.py
+++ b/nucliadb/src/nucliadb/ingest/orm/resource.py
@@ -411,7 +411,6 @@ class Resource:
         errors_by_field: dict[tuple[FieldType.ValueType, str], list[writer_pb2.Error]] = defaultdict(
             list
         )
-
         # Make sure if a file is updated without errors, it ends up in errors_by_field
         for field_id in updated_fields:
             errors_by_field[(field_id.field_type, field_id.field)] = []

--- a/nucliadb/src/nucliadb/ingest/serialize.py
+++ b/nucliadb/src/nucliadb/ingest/serialize.py
@@ -278,7 +278,10 @@ async def serialize_resource(
                     await serialize_field_errors(field, resource.data.conversations[field.id])
                 if include_value and isinstance(field, Conversation):
                     value = await field.get_metadata()
-                    resource.data.conversations[field.id].value = from_proto.field_conversation(value)
+                    if value is not None:
+                        resource.data.conversations[field.id].value = from_proto.field_conversation(
+                            value
+                        )
                 if include_extracted_data:
                     resource.data.conversations[field.id].extracted = ConversationFieldExtractedData()
                     await set_resource_field_extracted_data(

--- a/nucliadb/src/nucliadb/purge/__init__.py
+++ b/nucliadb/src/nucliadb/purge/__init__.py
@@ -31,7 +31,6 @@ from nucliadb.common.nidx import start_nidx_utility, stop_nidx_utility
 from nucliadb.ingest import SERVICE_NAME, logger
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.orm.knowledgebox import (
-    KB_TO_DELETE,
     KB_TO_DELETE_BASE,
     KB_TO_DELETE_STORAGE_BASE,
     KB_VECTORSET_TO_DELETE,
@@ -85,13 +84,12 @@ async def purge_kb(driver: Driver):
         # Now delete the delete mark
         try:
             async with driver.rw_transaction() as txn:
-                key_to_purge = KB_TO_DELETE.format(kbid=kbid)
-                await txn.delete(key_to_purge)
+                await KnowledgeBox.unmark_for_purge(txn, kbid)
                 await txn.commit()
-            logger.info(f"  √ Deleted {key_to_purge}")
+            logger.info(f"  √ Deleted {kbid}")
         except Exception as exc:
             errors.capture_exception(exc)
-            logger.error(f"  X Error while deleting key {key_to_purge}")
+            logger.error(f"  X Error while deleting key {kbid}")
             await txn.abort()
     logger.info("END PURGING KB")
 

--- a/nucliadb/src/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/download.py
@@ -97,6 +97,7 @@ async def _download_extract_file(
     rslug: str | None = None,
     range_request: str | None = None,
 ) -> Response:
+
     rid = await _get_resource_uuid_from_params(kbid, rid, rslug)
 
     storage = await get_storage(service_name=SERVICE_NAME)

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -140,6 +140,14 @@ async def list_resources(
             first_wanted_item_index = (page * size) + 1  # 1-based index
             current_key_index = 0
 
+            async def rids_generator(count: int):
+                iterated = 0
+                async for rid in datamanagers.resources.iterate_resource_ids(kbid=kbid):
+                    if iterated >= count:
+                        break
+                    yield rid
+                    iterated += 1
+
             # ask for one item more than we need, in order to know if it's the last page
             async def _rids_generator(count: int):
                 iterated = 0

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -140,14 +140,6 @@ async def list_resources(
             first_wanted_item_index = (page * size) + 1  # 1-based index
             current_key_index = 0
 
-            async def rids_generator(count: int):
-                iterated = 0
-                async for rid in datamanagers.resources.iterate_resource_ids(kbid=kbid):
-                    if iterated >= count:
-                        break
-                    yield rid
-                    iterated += 1
-
             # ask for one item more than we need, in order to know if it's the last page
             async def _rids_generator(count: int):
                 iterated = 0

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -431,30 +431,30 @@ async def _get_resource_field(
 
             if isinstance(field, Conversation):
                 conversation_metadata = await field.get_metadata()
-                if page == "first":
-                    page_to_fetch = 1
-                elif page == "last":
-                    page_to_fetch = conversation_metadata.pages
-                else:
-                    page_to_fetch = int(page)
+                if conversation_metadata is not None:
+                    if page == "first":
+                        page_to_fetch = 1
+                    elif page == "last":
+                        page_to_fetch = conversation_metadata.pages
+                    else:
+                        page_to_fetch = int(page)
 
-                page_value = await field.get_value(page=page_to_fetch)
-                if page_value is not None:
-                    splits_metadata = await field.get_splits_metadata()
-                    deleted_messages = set(splits_metadata.deleted_splits)
-                    resource_field.value = from_proto.conversation_page(
-                        page_value,
-                        total=conversation_metadata.total,
-                        pages=conversation_metadata.pages,
-                        page=page_to_fetch,
-                    )
-                    # Skip deleted messages
-                    resource_field.value.messages = [
-                        msg
-                        for msg in (resource_field.value.messages or [])
-                        if msg.ident not in deleted_messages
-                    ]
-
+                    page_value = await field.get_value(page=page_to_fetch)
+                    if page_value is not None:
+                        splits_metadata = await field.get_splits_metadata()
+                        deleted_messages = set(splits_metadata.deleted_splits)
+                        resource_field.value = from_proto.conversation_page(
+                            page_value,
+                            total=conversation_metadata.total,
+                            pages=conversation_metadata.pages,
+                            page=page_to_fetch,
+                        )
+                        # Skip deleted messages
+                        resource_field.value.messages = [
+                            msg
+                            for msg in (resource_field.value.messages or [])
+                            if msg.ident not in deleted_messages
+                        ]
         if (
             ResourceFieldProperties.EXTRACTED in show
             and extracted

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -310,6 +310,8 @@ async def db_augment_conversation_field(
 
         elif isinstance(prop, FieldValue):
             db_value = await field.get_metadata()
+            if db_value is None:
+                continue
             augmented.value = from_proto.field_conversation(db_value)
 
         elif isinstance(prop, FieldClassificationLabels):
@@ -482,6 +484,8 @@ async def find_conversation_message(
 ) -> tuple[int, int, resources_pb2.Message] | None:
     """Find a message in the conversation identified by `ident`."""
     conversation_metadata = await field.get_metadata()
+    if conversation_metadata is None:
+        return None
     splits_metadata = await field.get_splits_metadata()
     deleted_splits = set(splits_metadata.deleted_splits)
     if ident in deleted_splits:
@@ -515,6 +519,8 @@ async def iter_conversation_messages(
     """
     start_page, start_index = start_from
     conversation_metadata = await field.get_metadata()
+    if conversation_metadata is None:
+        return
     splits_metadata = await field.get_splits_metadata()
     deleted_splits = set(splits_metadata.deleted_splits)
     for page in range(start_page, conversation_metadata.pages + 1):
@@ -655,6 +661,8 @@ async def conversation_selector(
         # the window won't be centered
         messages: Deque[tuple[int, int, resources_pb2.Message]] = deque(maxlen=selector.size)
         metadata = await field.get_metadata()
+        if metadata is None:
+            return
         pending = -1
         for page in range(1, metadata.pages + 1):
             conversation_page = await field.db_get_value(page)

--- a/nucliadb/src/nucliadb/search/search/chat/prompt.py
+++ b/nucliadb/src/nucliadb/search/search/chat/prompt.py
@@ -171,6 +171,8 @@ async def get_next_conversation_messages(
 ) -> list[resources_pb2.Message]:
     output = []
     cmetadata = await field_obj.get_metadata()
+    if cmetadata is None:
+        return []
     for current_page in range(page, cmetadata.pages + 1):
         conv = await field_obj.db_get_value(current_page)
         for message in conv.messages[start_idx:]:
@@ -190,6 +192,8 @@ async def find_conversation_message(
     field_obj: Conversation, mident: str
 ) -> tuple[resources_pb2.Message | None, int, int]:
     cmetadata = await field_obj.get_metadata()
+    if cmetadata is None:
+        return None, -1, -1
     for page in range(1, cmetadata.pages + 1):
         conv = await field_obj.db_get_value(page)
         for idx, message in enumerate(conv.messages):
@@ -834,6 +838,8 @@ async def conversation_prompt_context(
                     field_id, FIELD_TYPE_STR_TO_PB["c"], load=True
                 )
                 cmetadata = await field_obj.get_metadata()
+                if cmetadata is None:
+                    continue
 
                 attachments: list[resources_pb2.FieldRef] = []
                 if strategy.full:

--- a/nucliadb/src/nucliadb/search/search/summarize.py
+++ b/nucliadb/src/nucliadb/search/search/summarize.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
+from uuid import UUID
 
 from nucliadb.common import datamanagers
 from nucliadb.common.maindb.utils import get_driver
@@ -126,14 +127,11 @@ async def get_resource_uuid(kbobj: KnowledgeBox, uuid_or_slug: str) -> str | Non
     Return the uuid of the resource with the given uuid_or_slug.
     """
     # Try with uuid first
-    resource = await kbobj.get(uuid_or_slug)
-    if resource is not None:
-        return uuid_or_slug
-
-    # Try with slug
-    uuid = await kbobj.get_resource_uuid_by_slug(uuid_or_slug)
-    if uuid is not None:
-        return uuid
-
-    # Resource not found
+    try:
+        ruuid = UUID(uuid_or_slug).hex
+        if await datamanagers.resources.resource_exists(kbobj.txn, kbid=kbobj.kbid, rid=ruuid):
+            return ruuid
+    except ValueError:
+        # Not a valid uuid, try with slug
+        return await kbobj.get_resource_uuid_by_slug(uuid_or_slug)
     return None

--- a/nucliadb/src/nucliadb/train/nodes.py
+++ b/nucliadb/src/nucliadb/train/nodes.py
@@ -23,7 +23,6 @@ from nucliadb.common import datamanagers
 from nucliadb.common.cluster import manager
 
 # XXX: this keys shouldn't be exposed outside datamanagers
-from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG_BASE
 from nucliadb.common.maindb.driver import Driver, Transaction
 from nucliadb.ingest.orm.entities import EntitiesManager
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
@@ -125,11 +124,7 @@ class TrainShardManager(manager.KBShardManager):
     async def kb_resources(self, request: GetResourcesRequest) -> AsyncIterator[TrainResource]:
         async with self.driver.ro_transaction() as txn:
             kb = KnowledgeBox(txn, self.storage, request.kb.uuid)
-            base = KB_RESOURCE_SLUG_BASE.format(kbid=request.kb.uuid)
-            async for key in txn.keys(match=base):
-                # Fetch and Add wanted item
-                rid = await txn.get(key, for_update=False)
-                if rid is not None:
-                    resource = await kb.get(rid.decode())
-                    if resource is not None:
-                        yield await generate_train_resource(resource, request.metadata)
+            async for rid in datamanagers.resources.iterate_resource_ids(kbid=request.kb.uuid):
+                resource = await kb.get(rid)
+                if resource is not None:
+                    yield await generate_train_resource(resource, request.metadata)

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -109,6 +109,7 @@ async def create_resource(
     partitioning = get_partitioning()
 
     # Create resource message
+    # resource ids are always UUIDs in hex format (32 chars, no hyphens)
     uuid = uuid4().hex
     partition = partitioning.generate_partition(kbid, uuid)
 

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -33,6 +33,7 @@ from starlette.requests import Request as StarletteRequest
 
 from nucliadb.common import datamanagers, file_md5
 from nucliadb.common.back_pressure import maybe_back_pressure
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.ingest.orm.utils import set_title
 from nucliadb.models.internal.processing import PushPayload, Source
 from nucliadb.models.responses import HTTPClientError
@@ -867,7 +868,7 @@ async def validate_field_upload(
             raise HTTPConflict("File already exists in the Knowledge Box")
 
         # We are creating a new resource. Assign a new resource id
-        rid = uuid.uuid4().hex
+        rid = Resource.new_unique_rid()
     else:
         # Adding a field to an existing resource, the resource must exist.
         if not await datamanagers.atomic.resources.resource_exists(kbid=kbid, rid=rid):

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -192,7 +192,7 @@ async def _to_push_conversationfield(
     Returns None if the conversation has no messages.
     """
     metadata = await field.get_metadata()
-    if metadata.pages == 0:
+    if metadata is None or metadata.pages == 0:
         return None
 
     full_conversation = PushConversation(
@@ -711,7 +711,11 @@ async def _conversation_append_checks(
         )
 
         # Make sure that the max number of messages is not exceeded
-        current_message_count = (await conv.get_metadata()).total
+        cmetadata = await conv.get_metadata()
+        if cmetadata is None:
+            current_message_count = 0
+        else:
+            current_message_count = cmetadata.total
         if (
             MAX_CONVERSATION_MESSAGES is not None
             and (len(input.messages) + current_message_count) > MAX_CONVERSATION_MESSAGES

--- a/nucliadb/tests/ingest/integration/consumer/test_materializer.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_materializer.py
@@ -43,11 +43,12 @@ async def test_materialize_kb_data(
     audit_storage = stream_audit
 
     count = 10
-    for _ in range(count):
+    for i in range(count):
         await create_resource(
             storage=storage,
             driver=maindb_driver,
             knowledgebox=knowledgebox,
+            slug=f"materializer-test-{i}",
         )
 
     mz = materializer.MaterializerHandler(

--- a/nucliadb/tests/ingest/integration/consumer/test_pull.py
+++ b/nucliadb/tests/ingest/integration/consumer/test_pull.py
@@ -20,7 +20,6 @@
 import asyncio
 import base64
 import time
-import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, patch
@@ -42,6 +41,7 @@ from nucliadb.common.http_clients.processing import (
 )
 from nucliadb.common.nidx import NidxUtility
 from nucliadb.ingest.consumer.pull import PullV2Worker
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_utils.fastapi.run import start_server
 from nucliadb_utils.nats import NatsConnectionManager
@@ -50,7 +50,7 @@ from nucliadb_utils.tests import free_port
 
 def create_broker_message(kbid: str) -> BrokerMessage:
     bm = BrokerMessage()
-    bm.uuid = uuid.uuid4().hex
+    bm.uuid = Resource.new_unique_rid()
     bm.kbid = kbid
     bm.texts["text1"].body = "My text1"
     bm.basic.title = "My Title"

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -19,7 +19,6 @@
 #
 import asyncio
 import base64
-import uuid
 from datetime import datetime
 from os.path import dirname, getsize
 from unittest import mock
@@ -115,7 +114,7 @@ def kbid(
 
 
 async def test_ingest_messages_autocommit(kbid: str, processor, dummy_nidx_utility):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     message1: BrokerMessage = BrokerMessage(
         kbid=kbid,
         uuid=rid,
@@ -381,7 +380,7 @@ async def test_ingest_audit_stream_files_only(
     await jetstream.add_stream(name=audit_settings.audit_stream, subjects=[subject])
     psub = await jetstream.pull_subscribe(subject, "psub")
 
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
 
     # We use the same file multiple times, so the size will be the same
     test_png_size = getsize(f"{dirname(__file__)}/assets/file.png")
@@ -653,7 +652,7 @@ async def test_ingest_processor_handles_missing_kb(
 async def test_ingest_autocommit_deadletter_marks_resource(
     kbid: str, processor: Processor, storage, maindb_driver: Driver
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     message = make_message(kbid, rid)
 
     with (
@@ -742,7 +741,7 @@ async def test_ingest_delete_field(
         mock.side_effect = extract_brain
         return new_mock
 
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
 
     message = make_message(knowledgebox, rid)
     await processor.process(message=message, seqid=0)
@@ -796,7 +795,7 @@ async def test_ingest_update_labels(
         mock.side_effect = extract_brain
         return new_mock
 
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
 
     message = make_message(knowledgebox, rid)
     await processor.process(message=message, seqid=0)

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -642,9 +642,9 @@ async def test_ingest_processor_handles_missing_kb(
     processor,
     test_resource: Resource,
 ):
-    kbid = str(uuid4())
-    rid = str(uuid4())
-    message = make_message(kbid, rid)
+    unexisting_kbid = KnowledgeBox.new_unique_kbid()
+    unexisting_rid = str(uuid4())
+    message = make_message(unexisting_kbid, unexisting_rid)
     message.account_seq = 1
     await processor.process(message=message, seqid=1)
 

--- a/nucliadb/tests/ingest/integration/ingest/test_ingest.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_ingest.py
@@ -115,7 +115,7 @@ def kbid(
 
 
 async def test_ingest_messages_autocommit(kbid: str, processor, dummy_nidx_utility):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     message1: BrokerMessage = BrokerMessage(
         kbid=kbid,
         uuid=rid,
@@ -381,7 +381,7 @@ async def test_ingest_audit_stream_files_only(
     await jetstream.add_stream(name=audit_settings.audit_stream, subjects=[subject])
     psub = await jetstream.pull_subscribe(subject, "psub")
 
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
 
     # We use the same file multiple times, so the size will be the same
     test_png_size = getsize(f"{dirname(__file__)}/assets/file.png")
@@ -653,7 +653,7 @@ async def test_ingest_processor_handles_missing_kb(
 async def test_ingest_autocommit_deadletter_marks_resource(
     kbid: str, processor: Processor, storage, maindb_driver: Driver
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     message = make_message(kbid, rid)
 
     with (
@@ -742,7 +742,7 @@ async def test_ingest_delete_field(
         mock.side_effect = extract_brain
         return new_mock
 
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
 
     message = make_message(knowledgebox, rid)
     await processor.process(message=message, seqid=0)
@@ -796,7 +796,7 @@ async def test_ingest_update_labels(
         mock.side_effect = extract_brain
         return new_mock
 
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
 
     message = make_message(knowledgebox, rid)
     await processor.process(message=message, seqid=0)

--- a/nucliadb/tests/ingest/integration/ingest/test_relations.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_relations.py
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import uuid
 
 from nucliadb.ingest import SERVICE_NAME
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos.resources_pb2 import (
     Classification,
     FieldComputedMetadataWrapper,
@@ -36,7 +36,7 @@ from nucliadb_utils.utilities import get_storage
 async def test_ingest_relations_indexing(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bm = BrokerMessage(kbid=knowledgebox, uuid=rid, slug="slug-1", type=BrokerMessage.AUTOCOMMIT)
 
     e0 = RelationNode(value="E0", ntype=RelationNode.NodeType.ENTITY, subtype="")
@@ -63,7 +63,7 @@ async def test_ingest_relations_indexing(
 async def test_ingest_label_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bm = BrokerMessage(kbid=knowledgebox, uuid=rid, slug="slug-1", type=BrokerMessage.AUTOCOMMIT)
 
     labels = [
@@ -92,7 +92,7 @@ async def test_ingest_label_relation_extraction(
 async def test_ingest_colab_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bm = BrokerMessage(kbid=knowledgebox, uuid=rid, slug="slug-1", type=BrokerMessage.AUTOCOMMIT)
 
     collaborators = ["Alice", "Bob", "Trudy"]
@@ -114,7 +114,7 @@ async def test_ingest_colab_relation_extraction(
 async def test_ingest_field_metadata_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bm_writer = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,
@@ -210,7 +210,7 @@ async def test_ingest_field_metadata_relation_extraction(
 async def test_ingest_field_relations_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bm = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,

--- a/nucliadb/tests/ingest/integration/ingest/test_relations.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_relations.py
@@ -36,7 +36,7 @@ from nucliadb_utils.utilities import get_storage
 async def test_ingest_relations_indexing(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bm = BrokerMessage(kbid=knowledgebox, uuid=rid, slug="slug-1", type=BrokerMessage.AUTOCOMMIT)
 
     e0 = RelationNode(value="E0", ntype=RelationNode.NodeType.ENTITY, subtype="")
@@ -63,7 +63,7 @@ async def test_ingest_relations_indexing(
 async def test_ingest_label_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bm = BrokerMessage(kbid=knowledgebox, uuid=rid, slug="slug-1", type=BrokerMessage.AUTOCOMMIT)
 
     labels = [
@@ -92,7 +92,7 @@ async def test_ingest_label_relation_extraction(
 async def test_ingest_colab_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bm = BrokerMessage(kbid=knowledgebox, uuid=rid, slug="slug-1", type=BrokerMessage.AUTOCOMMIT)
 
     collaborators = ["Alice", "Bob", "Trudy"]
@@ -114,7 +114,7 @@ async def test_ingest_colab_relation_extraction(
 async def test_ingest_field_metadata_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bm_writer = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,
@@ -210,7 +210,7 @@ async def test_ingest_field_metadata_relation_extraction(
 async def test_ingest_field_relations_relation_extraction(
     dummy_nidx_utility, local_files, storage, knowledgebox, processor
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bm = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,

--- a/nucliadb/tests/ingest/integration/ingest/test_vectorsets.py
+++ b/nucliadb/tests/ingest/integration/ingest/test_vectorsets.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import random
-import uuid
 from datetime import datetime
 
 from nidx_protos import noderesources_pb2
@@ -28,6 +27,7 @@ from nucliadb.common.maindb.driver import Driver
 from nucliadb.export_import.utils import get_processor_bm, get_writer_bm
 from nucliadb.ingest import SERVICE_NAME
 from nucliadb.ingest.orm.processor import Processor
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos import (
     knowledgebox_pb2,
     resources_pb2,
@@ -50,7 +50,7 @@ async def test_ingest_broker_message_with_vectorsets(
 
     """
     kbid = knowledgebox
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = "my-text-field"
     default_vectorset_id = "my-semantic-model"
     vectorset_id = "fancy-multilang"

--- a/nucliadb/tests/ingest/integration/orm/assets/largemetadata.pb
+++ b/nucliadb/tests/ingest/integration/orm/assets/largemetadata.pb
@@ -3,6 +3,6 @@
 
 tok1tokNAME
 
-tok2tok2NAME
-tok
-adeu
+tok2tok2NAME
+adeu
+tok

--- a/nucliadb/tests/ingest/integration/orm/test_orm_extracted.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_extracted.py
@@ -20,6 +20,7 @@
 from os.path import dirname, getsize
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -33,7 +34,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_extracted(
-    storage: Storage, txn, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -52,11 +53,13 @@ async def test_create_resource_orm_extracted(
     assert ex2 is not None
     assert ex2.text == ex1.body.text
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_extracted_file(
     local_files,
     storage: Storage,
-    txn,
+    txn: Transaction,
     dummy_nidx_utility,
     knowledgebox: str,
 ):
@@ -91,9 +94,11 @@ async def test_create_resource_orm_extracted_file(
     ex3.ParseFromString(data2)
     assert ex3.text == ex2.text
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_extracted_delta(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -123,3 +128,5 @@ async def test_create_resource_orm_extracted_delta(
     assert ex2 is not None
     assert ex2.text == ex1.body.text
     assert len(ex2.split_text) == 2
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_conversation.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_conversation.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from os.path import dirname, getsize
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.conversation import PAGE_SIZE, Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import CloudFile, FieldType, Message, MessageContent
@@ -29,7 +30,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_field_conversation(
-    storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -67,9 +68,11 @@ async def test_create_resource_orm_field_conversation(
     assert convfield.value[1].messages[-1].content.text == "198 hello"
     assert convfield.value[2].messages[-1].content.text == "299 hello"
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_field_conversation_file(
-    local_files, storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    local_files, storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -110,3 +113,5 @@ async def test_create_resource_orm_field_conversation_file(
     with open(filename, "rb") as testfile:
         data2 = testfile.read()
     assert data.read() == data2
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_file.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_file.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from os.path import dirname, getsize
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import CloudFile, FieldType
@@ -29,7 +30,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_field_file(
-    local_files, storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    local_files, storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -62,3 +63,5 @@ async def test_create_resource_orm_field_file(
     with open(filename, "rb") as testfile:
         data2 = testfile.read()
     assert data.read() == data2
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_link.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_link.py
@@ -20,6 +20,7 @@
 from datetime import datetime
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.fields.link import Link
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import FieldLink as PBFieldLink
@@ -28,7 +29,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_field_link(
-    storage: Storage, cache, dummy_nidx_utility, knowledgebox: str, maindb_driver
+    storage: Storage, cache, dummy_nidx_utility, knowledgebox: str, maindb_driver: Driver
 ):
     async with maindb_driver.rw_transaction() as txn:
         uuid = str(uuid4())

--- a/nucliadb/tests/ingest/integration/orm/test_orm_field_text.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_field_text.py
@@ -19,6 +19,7 @@
 #
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import FieldText as PBFieldText
@@ -27,7 +28,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_field_text(
-    storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -39,10 +40,12 @@ async def test_create_resource_orm_field_text(
 
     textfield: Text = await r.get_field("text1", FieldType.TEXT, load=True)
     assert textfield.value.body == t2.body
+
+    await txn.abort()
 
 
 async def test_create_resource_orm_field_text_file(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -55,3 +58,5 @@ async def test_create_resource_orm_field_text_file(
 
     textfield: Text = await r.get_field("text1", FieldType.TEXT, load=True)
     assert textfield.value.body == t2.body
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_file_extracted.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_file_extracted.py
@@ -20,6 +20,7 @@
 from os.path import dirname, getsize
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.file import File
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -32,7 +33,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_file_extracted(
-    local_files, storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    local_files, storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -75,3 +76,5 @@ async def test_create_resource_orm_file_extracted(
     with open(filename, "rb") as testfile:
         data2 = testfile.read()
     assert data.read() == data2
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_knowledgebox.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_knowledgebox.py
@@ -233,7 +233,7 @@ async def test_knowledgebox_delete_all_kb_keys(
     storage,
     cache,
     dummy_nidx_utility,
-    maindb_driver,
+    maindb_driver: Driver,
     knowledgebox: str,
 ):
     async with maindb_driver.rw_transaction() as txn:
@@ -262,7 +262,9 @@ async def test_knowledgebox_delete_all_kb_keys(
         await txn.abort()
 
     # Now delete all kb keys
-    await KnowledgeBox.delete_all_kb_keys(maindb_driver, kbid, chunk_size=10)
+    async with maindb_driver.rw_transaction() as txn:
+        await KnowledgeBox.delete_all_kb_keys(txn, kbid)
+        await txn.commit()
 
     # Check that all of them were deleted
     async with maindb_driver.ro_transaction() as txn:

--- a/nucliadb/tests/ingest/integration/orm/test_orm_knowledgebox.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_knowledgebox.py
@@ -26,7 +26,7 @@ from nucliadb.common import datamanagers
 from nucliadb.common.cluster import manager as cluster_manager
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.orm.exceptions import KnowledgeBoxConflict, KnowledgeBoxCreationError
-from nucliadb.ingest.orm.knowledgebox import KnowledgeBox, chunker
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos import knowledgebox_pb2, utils_pb2
 from nucliadb_protos.knowledgebox_pb2 import SemanticModelMetadata
 from nucliadb_utils.storages.storage import Storage
@@ -272,20 +272,3 @@ async def test_knowledgebox_delete_all_kb_keys(
         for rid, slug in rids_and_slugs:
             assert await kb_obj.get_resource_uuid_by_slug(slug) is None
         await txn.abort()
-
-
-def test_chunker():
-    total_items = 100
-    chunk_size = 10
-    iterations = 0
-    for chunk in chunker(list(range(total_items)), chunk_size):
-        assert len(chunk) == chunk_size
-        assert chunk == list(range(iterations * chunk_size, (iterations * chunk_size) + chunk_size))
-        iterations += 1
-
-    assert iterations == total_items / chunk_size
-
-    iterations = 0
-    for chunk in chunker([], 2):
-        iterations += 1
-    assert iterations == 0

--- a/nucliadb/tests/ingest/integration/orm/test_orm_large_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_large_metadata.py
@@ -20,6 +20,7 @@
 from os.path import dirname, getsize
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -34,7 +35,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_large_metadata(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -56,9 +57,11 @@ async def test_create_resource_orm_large_metadata(
     assert ex2 is not None
     assert ex2.metadata.tokens["tok"] == ex1.real.metadata.tokens["tok"]
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_large_metadata_file(
-    local_files, storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    local_files, storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -99,3 +102,5 @@ async def test_create_resource_orm_large_metadata_file(
         data2 = testfile.read()
     ex3.ParseFromString(data2)
     assert ex3.metadata.tokens["tok"] == ex2.metadata.tokens["tok"]
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_link_extracted.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_link_extracted.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from os.path import dirname, getsize
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.link import Link
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import CloudFile, FieldType, LinkExtractedData
@@ -28,7 +29,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_link_extracted(
-    local_files, storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    local_files, storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -68,3 +69,5 @@ async def test_create_resource_orm_link_extracted(
 
     data = await storage.downloadbytescf(ex2.file_generated["asd"])
     assert data.read() == data2
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_metadata.py
@@ -20,6 +20,7 @@
 from datetime import datetime
 from uuid import uuid4
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.text import Text
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import (
@@ -37,7 +38,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_metadata(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -78,9 +79,11 @@ async def test_create_resource_orm_metadata(
     assert ex2.metadata.links[0] == ex1.metadata.metadata.links[0]
     assert ex2.metadata.mime_type == ex1.metadata.metadata.mime_type
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_metadata_split(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -136,3 +139,5 @@ async def test_create_resource_orm_metadata_split(
     assert ex3 is not None
     assert ex1.metadata.split_metadata["ff1"].links[0] == ex3.split_metadata["ff1"].links[0]
     assert len(ex3.split_metadata) == 2
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_resource.py
@@ -23,6 +23,7 @@ from uuid import uuid4
 from nidx_protos.noderesources_pb2 import Resource
 
 from nucliadb.common import datamanagers
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.orm.broker_message import generate_broker_message
 from nucliadb.ingest.orm.index_message import get_resource_index_message
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
@@ -48,7 +49,7 @@ from tests.ndbfixtures.ingest import create_resource
 
 
 async def test_create_resource_orm_with_basic(
-    storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     basic = PBBasic(
         icon="text/plain",
@@ -93,9 +94,11 @@ async def test_create_resource_orm_with_basic(
     assert o2 is not None
     assert o2.source_id == "My Source"
 
+    await txn.abort()
+
 
 async def test_paragraphs_with_page(
-    maindb_driver, storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    maindb_driver, storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     # Create a resource
     basic = PBBasic(
@@ -156,9 +159,11 @@ async def test_paragraphs_with_page(
             assert metadata.metadata.representation.is_a_table is True
             assert metadata.metadata.representation.file == "myfile"
 
+    await txn.abort()
+
 
 async def test_vector_duplicate_fields(
-    maindb_driver, storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    maindb_driver, storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     basic = PBBasic(title="My title", summary="My summary")
     basic.metadata.status = PBMetadata.Status.PROCESSED
@@ -242,6 +247,8 @@ async def test_vector_duplicate_fields(
                     )
 
     assert count == 1
+
+    await txn.abort()
 
 
 async def test_generate_broker_message(

--- a/nucliadb/tests/ingest/integration/orm/test_orm_vectors.py
+++ b/nucliadb/tests/ingest/integration/orm/test_orm_vectors.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 
 import pytest
 
+from nucliadb.common.maindb.driver import Transaction
 from nucliadb.ingest.fields.base import Field
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.fields.text import Text
@@ -47,7 +48,7 @@ from nucliadb_utils.storages.storage import Storage
 
 
 async def test_create_resource_orm_vector(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -69,9 +70,11 @@ async def test_create_resource_orm_vector(
     assert ex2 is not None
     assert ex2.vectors.vectors[0].vector == ex1.vectors.vectors.vectors[0].vector
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_vector_file(
-    local_files, storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    local_files, storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -107,9 +110,11 @@ async def test_create_resource_orm_vector_file(
 
     assert ex3.vectors.vectors[0].vector == ex2.vectors.vectors[0].vector
 
+    await txn.abort()
+
 
 async def test_create_resource_orm_vector_split(
-    storage: Storage, txn, cache, dummy_nidx_utility, knowledgebox: str
+    storage: Storage, txn: Transaction, cache, dummy_nidx_utility, knowledgebox: str
 ):
     uuid = str(uuid4())
     kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
@@ -145,6 +150,8 @@ async def test_create_resource_orm_vector_split(
     ex2: VectorObject | None = await field_obj2.get_vectors(vectorset_id, storage_key_kind)
     assert ex2 is not None
     assert len(ex2.split_vectors) == 3
+
+    await txn.abort()
 
 
 @pytest.mark.parametrize(
@@ -182,7 +189,7 @@ async def test_create_resource_with_cloud_file_vectors(
     storage_key_kind: VectorSetConfig.StorageKeyKind.ValueType,
     destination_path: str,
     storage: Storage,
-    txn,
+    txn: Transaction,
     dummy_nidx_utility,
     knowledgebox: str,
 ):
@@ -219,12 +226,14 @@ async def test_create_resource_with_cloud_file_vectors(
         assert cf.uri == cf_uri
         assert sf.key == destination_path
 
+    await txn.abort()
+
 
 @pytest.mark.parametrize("found_in_storage", [True, False])
 async def test_create_resource_with_cloud_file_vectors_already_moved(
     found_in_storage: bool,
     storage: Storage,
-    txn,
+    txn: Transaction,
     dummy_nidx_utility,
     knowledgebox: str,
 ):
@@ -289,3 +298,5 @@ async def test_create_resource_with_cloud_file_vectors_already_moved(
             sf.exists.return_value = False
             with pytest.raises(CouldNotCopyNotFound):
                 await field_obj.set_vectors(evw, vectorset_id, storage_key_kind)
+
+    await txn.abort()

--- a/nucliadb/tests/ingest/integration/servicer/test_shards_management.py
+++ b/nucliadb/tests/ingest/integration/servicer/test_shards_management.py
@@ -32,10 +32,11 @@ async def test_create_cleansup_on_error(
 ):
     # Create a KB
     kbid = str(uuid4())
+    slug = f"slug-{kbid}"
     result = await nucliadb_ingest_grpc.NewKnowledgeBoxV2(  # type: ignore
         writer_pb2.NewKnowledgeBoxV2Request(
             kbid=kbid,
-            slug="test",
+            slug=slug,
             title="My Title",
             vectorsets=[
                 writer_pb2.NewKnowledgeBoxV2Request.VectorSet(

--- a/nucliadb/tests/ingest/unit/fields/test_conversation.py
+++ b/nucliadb/tests/ingest/unit/fields/test_conversation.py
@@ -21,28 +21,30 @@ from unittest import mock
 
 import pytest
 
+from nucliadb.common import datamanagers
+from nucliadb.common.maindb.driver import Driver, Transaction
 from nucliadb.ingest.fields.conversation import Conversation
-from nucliadb_protos.resources_pb2 import CloudFile
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb_protos.resources_pb2 import CloudFile, FieldConversation
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_protos.resources_pb2 import Message as PBMessage
 from nucliadb_protos.resources_pb2 import MessageContent as PBMessageContent
 
 
-class MockTransaction:
-    def __init__(self, *args, **kwargs):
-        self.data = {}
-
-    async def set(self, key, value):
-        self.data[key] = value
-
-    async def get(self, key):
-        return self.data.get(key, None)
+@pytest.fixture(scope="function")
+async def txn(maindb_driver: Driver):
+    async with maindb_driver.rw_transaction() as txn:
+        yield txn
 
 
 @pytest.fixture(scope="function")
-def txn():
-    txn = MockTransaction()
-    yield txn
+async def kbid(maindb_driver: Driver):
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await datamanagers.kb.kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
 
 
 @pytest.fixture(scope="function")
@@ -53,11 +55,18 @@ def storage():
 
 
 @pytest.fixture(scope="function")
-def resource(txn, storage):
+async def resource(maindb_driver: Driver, txn: Transaction, storage, kbid: str):
+    rid = Resource.new_unique_rid()
+    async with maindb_driver.rw_transaction() as txn:
+        await datamanagers.resources.resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=f"slug-{rid}")
+        await txn.commit()
+
     resource = mock.AsyncMock()
     resource.modified = False
     resource.txn = txn
     resource.storage = storage
+    resource.kbid = kbid
+    resource.uuid = rid
     yield resource
 
 
@@ -65,21 +74,18 @@ async def test_get_metadata(resource):
     conv = Conversation("faq", resource)
     assert conv.value == {}
     assert conv.metadata is None
-    assert conv._created is False
 
     metadata = await conv.get_metadata()
-    assert conv._created is True
-    assert metadata.size == 200
-    assert metadata.pages == 0
-    assert metadata.total == 0
+    assert metadata is None
 
+    metadata = FieldConversation()
+    metadata.size == 200
     metadata.pages = 1
     metadata.total = 10
 
     await conv.db_set_metadata(metadata)
     assert conv.metadata == metadata
     assert conv.resource.modified is True
-    assert conv._created is False
 
     # Check it is cached
     assert await conv.get_metadata() == metadata
@@ -87,7 +93,6 @@ async def test_get_metadata(resource):
     # Force reload
     conv.metadata = None
     assert await conv.get_metadata() == metadata
-    assert conv._created is False
 
 
 def get_cf(uri):
@@ -128,6 +133,7 @@ async def test_get_value(resource):
     await conv.set_value(payload)
 
     metadata = await conv.get_metadata()
+    assert metadata is not None
     assert metadata.size == 200
     assert metadata.pages == 1
     assert metadata.total == 2
@@ -141,6 +147,7 @@ async def test_get_value(resource):
 
     conv.metadata = None
     metadata = await conv.get_metadata()
+    assert metadata is not None
     assert metadata.size == 200
     assert metadata.pages == 2
     assert metadata.total == 302

--- a/nucliadb/tests/ingest/unit/orm/test_brain_vectors.py
+++ b/nucliadb/tests/ingest/unit/orm/test_brain_vectors.py
@@ -22,6 +22,7 @@ import uuid
 
 from nucliadb.common import ids
 from nucliadb.ingest.orm.brain_v2 import ResourceBrain
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos import utils_pb2
 
 
@@ -29,7 +30,7 @@ def test_apply_field_vectors_for_matryoshka_embeddings():
     STORED_VECTOR_DIMENSION = 100
     MATRYOSHKA_DIMENSION = 10
 
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = f"u/{uuid.uuid4().hex}"
     fid = ids.FieldId.from_string(f"{rid}/{field_id}")
     vectors = utils_pb2.VectorObject(
@@ -81,7 +82,7 @@ def test_apply_field_vectors_for_matryoshka_embeddings():
 
 
 def test_apply_field_vectors_append_splits():
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = f"u/{uuid.uuid4().hex}"
     split = "subfield"
     vectorset = "my-vectorset"

--- a/nucliadb/tests/ingest/unit/orm/test_resource.py
+++ b/nucliadb/tests/ingest/unit/orm/test_resource.py
@@ -296,7 +296,13 @@ async def test_update_all_fields_key(txn, storage, kb, rid):
 
     result = await resource.get_all_field_ids(for_update=False)
     assert result is not None
-    assert list(result.fields) == [*list(all_fields.fields), file_field]
+    assert len(result.fields) == 3
+    # Sort them by field_type and field to ensure consistent ordering for the assertion
+    obtained = list(result.fields)
+    obtained.sort(key=lambda x: (x.field_type, x.field))
+    expected = [*list(all_fields.fields), file_field]
+    expected.sort(key=lambda x: (x.field_type, x.field))
+    assert obtained == expected
 
     # Check deletes
     await datamanagers.fields.fields_v2.delete(txn, kbid=kb, rid=rid, field_type="f", field_id="file")

--- a/nucliadb/tests/ingest/unit/orm/test_resource.py
+++ b/nucliadb/tests/ingest/unit/orm/test_resource.py
@@ -23,7 +23,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from nucliadb.common import datamanagers
+from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.orm.brain_v2 import ResourceBrain
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.processor.processor import (
     get_text_field_mimetype,
     maybe_update_basic_icon,
@@ -166,20 +169,10 @@ def test_maybe_update_basic_icon(basic, icon, updated):
         assert basic.icon != icon
 
 
-class Transaction:
-    def __init__(self):
-        self.kv = {}
-
-    async def get(self, key, **kwargs):
-        return self.kv.get(key)
-
-    async def set(self, key, value):
-        self.kv[key] = value
-
-
 @pytest.fixture(scope="function")
-def txn():
-    return Transaction()
+async def txn(maindb_driver: Driver):
+    async with maindb_driver.rw_transaction() as txn:
+        yield txn
 
 
 @pytest.fixture(scope="function")
@@ -189,8 +182,21 @@ def storage():
 
 
 @pytest.fixture(scope="function")
-def kb():
-    return "mock-kbid"
+async def kb(maindb_driver: Driver):
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await datamanagers.kb.kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
+
+
+@pytest.fixture(scope="function")
+async def rid(maindb_driver: Driver, kb: str):
+    r_id = Resource.new_unique_rid()
+    async with maindb_driver.rw_transaction() as txn:
+        await datamanagers.resources.resources_v2.set_slug(txn, kbid=kb, rid=r_id, slug=f"slug-{r_id}")
+        await txn.commit()
+    return r_id
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -199,8 +205,8 @@ def file_md5_mock():
         yield mock
 
 
-async def test_get_fields_ids_caches_keys(txn, storage, kb):
-    resource = Resource(txn, storage, kb, "rid")
+async def test_get_fields_ids_caches_keys(txn, storage, kb: str, rid: str):
+    resource = Resource(txn, storage, kb, rid)
     cached_field_keys: list[tuple[FieldType.ValueType, str]] = [
         (FieldType.FILE, "foo"),
         (FieldType.TEXT, "bar"),
@@ -224,21 +230,33 @@ async def test_get_fields_ids_caches_keys(txn, storage, kb):
     resource._inner_get_fields_ids.assert_not_awaited()  # type: ignore[ty:unresolved-attribute]
 
 
-async def test_get_set_all_field_ids(txn, storage, kb):
-    resource = Resource(txn, storage, kb, "rid")
+async def test_get_set_all_field_ids(txn, storage, kb, rid):
+    resource = Resource(txn, storage, kb, rid)
 
-    assert await resource.get_all_field_ids(for_update=False) is None
+    all_field_ids = await resource.get_all_field_ids(for_update=False)
+    assert all_field_ids is None or all_field_ids.fields == []
 
     all_fields = AllFieldIDs()
     all_fields.fields.append(FieldID(field_type=FieldType.TEXT, field="text"))
 
+    await datamanagers.fields.fields_v2.set(
+        txn=txn,
+        kbid=kb,
+        rid=rid,
+        field_type="t",
+        field_id="text",
+        value=FieldText(body="text", format=FieldText.Format.PLAIN),
+    )
+
     await resource.set_all_field_ids(all_fields)
 
-    assert await resource.get_all_field_ids(for_update=False) == all_fields
+    final = await resource.get_all_field_ids(for_update=False)
+    assert final is not None
+    assert final == all_fields
 
 
-async def test_update_all_fields_key(txn, storage, kb):
-    resource = Resource(txn, storage, kb, "rid")
+async def test_update_all_fields_key(txn, storage, kb, rid):
+    resource = Resource(txn, storage, kb, rid)
 
     await resource.update_all_field_ids(updated=[], deleted=[])
 
@@ -248,6 +266,22 @@ async def test_update_all_fields_key(txn, storage, kb):
     all_fields = AllFieldIDs()
     all_fields.fields.append(FieldID(field_type=FieldType.TEXT, field="text1"))
     all_fields.fields.append(FieldID(field_type=FieldType.TEXT, field="text2"))
+    await datamanagers.fields.fields_v2.set(
+        txn=txn,
+        kbid=kb,
+        rid=rid,
+        field_type="t",
+        field_id="text1",
+        value=FieldText(body="text1", format=FieldText.Format.PLAIN),
+    )
+    await datamanagers.fields.fields_v2.set(
+        txn=txn,
+        kbid=kb,
+        rid=rid,
+        field_type="t",
+        field_id="text2",
+        value=FieldText(body="text2", format=FieldText.Format.PLAIN),
+    )
 
     await resource.update_all_field_ids(updated=list(all_fields.fields))
 
@@ -255,6 +289,9 @@ async def test_update_all_fields_key(txn, storage, kb):
     assert await resource.get_all_field_ids(for_update=False) == all_fields
 
     file_field = FieldID(field_type=FieldType.FILE, field="file")
+    await datamanagers.fields.fields_v2.set(
+        txn=txn, kbid=kb, rid=rid, field_type="f", field_id="file", value=FileExtractedData()
+    )
     await resource.update_all_field_ids(updated=[file_field])
 
     result = await resource.get_all_field_ids(for_update=False)
@@ -262,13 +299,14 @@ async def test_update_all_fields_key(txn, storage, kb):
     assert list(result.fields) == [*list(all_fields.fields), file_field]
 
     # Check deletes
+    await datamanagers.fields.fields_v2.delete(txn, kbid=kb, rid=rid, field_type="f", field_id="file")
     await resource.update_all_field_ids(deleted=[file_field])
 
     assert await resource.get_all_field_ids(for_update=False) == all_fields
 
 
-async def test_apply_fields_calls_update_all_field_ids(txn, storage, kb):
-    resource = Resource(txn, storage, kb, "rid")
+async def test_apply_fields_calls_update_all_field_ids(txn, storage, kb, rid):
+    resource = Resource(txn, storage, kb, rid)
     resource.update_all_field_ids = AsyncMock()  # type: ignore
     resource.set_field = AsyncMock()  # type: ignore
 
@@ -294,7 +332,7 @@ async def test_apply_fields_calls_update_all_field_ids(txn, storage, kb):
     ]
 
 
-async def test_apply_extracted_vectors_cut_by_dimension(txn, storage, kb):
+async def test_apply_extracted_vectors_cut_by_dimension(txn, storage, kb, rid):
     STORED_VECTOR_DIMENSION = 100
     MATRYOSHKA_DIMENSION = 10
 
@@ -312,7 +350,7 @@ async def test_apply_extracted_vectors_cut_by_dimension(txn, storage, kb):
         )
     )
 
-    brain = ResourceBrain("rid")
+    brain = ResourceBrain(rid)
     brain.generate_vectors(
         "t/text",
         vectors,
@@ -323,16 +361,16 @@ async def test_apply_extracted_vectors_cut_by_dimension(txn, storage, kb):
 
     sentences = (
         brain.brain.paragraphs["t/text"]
-        .paragraphs["rid/t/text/0-10"]
+        .paragraphs[f"{rid}/t/text/0-10"]
         .vectorsets_sentences["my-vectorset"]
         .sentences
     )
     assert len(sentences) == 1
-    assert sentences["rid/t/text/0/0-10"].metadata.position.start == 0
-    assert sentences["rid/t/text/0/0-10"].metadata.position.end == 10
-    assert len(sentences["rid/t/text/0/0-10"].vector) == STORED_VECTOR_DIMENSION
+    assert sentences[f"{rid}/t/text/0/0-10"].metadata.position.start == 0
+    assert sentences[f"{rid}/t/text/0/0-10"].metadata.position.end == 10
+    assert len(sentences[f"{rid}/t/text/0/0-10"].vector) == STORED_VECTOR_DIMENSION
 
-    brain = ResourceBrain("rid")
+    brain = ResourceBrain(rid)
     brain.generate_vectors(
         "t/text",
         vectors,
@@ -343,11 +381,11 @@ async def test_apply_extracted_vectors_cut_by_dimension(txn, storage, kb):
 
     sentences = (
         brain.brain.paragraphs["t/text"]
-        .paragraphs["rid/t/text/0-10"]
+        .paragraphs[f"{rid}/t/text/0-10"]
         .vectorsets_sentences["my-vectorset"]
         .sentences
     )
     assert len(sentences) == 1
-    assert sentences["rid/t/text/0/0-10"].metadata.position.start == 0
-    assert sentences["rid/t/text/0/0-10"].metadata.position.end == 10
-    assert len(sentences["rid/t/text/0/0-10"].vector) == MATRYOSHKA_DIMENSION
+    assert sentences[f"{rid}/t/text/0/0-10"].metadata.position.start == 0
+    assert sentences[f"{rid}/t/text/0/0-10"].metadata.position.end == 10
+    assert len(sentences[f"{rid}/t/text/0/0-10"].vector) == MATRYOSHKA_DIMENSION

--- a/nucliadb/tests/ndbfixtures/ingest.py
+++ b/nucliadb/tests/ndbfixtures/ingest.py
@@ -528,11 +528,13 @@ def broker_resource(knowledgebox: str, rid: str | None = None, slug: str | None 
     return message1
 
 
-async def create_resource(storage: Storage, driver: Driver, knowledgebox: str) -> Resource:
+async def create_resource(
+    storage: Storage, driver: Driver, knowledgebox: str, slug: str = "slug"
+) -> Resource:
     async with driver.rw_transaction() as txn:
         rid = Resource.new_unique_rid()
         kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
-        test_resource = await kb_obj.add_resource(uuid=rid, slug="slug")
+        test_resource = await kb_obj.add_resource(uuid=rid, slug=slug)
         await test_resource.set_slug()
 
         # 1.  ROOT ELEMENTS

--- a/nucliadb/tests/ndbfixtures/ingest.py
+++ b/nucliadb/tests/ndbfixtures/ingest.py
@@ -416,7 +416,7 @@ async def test_resource(storage: Storage, maindb_driver: Driver, knowledgebox: s
 
 def broker_resource(knowledgebox: str, rid: str | None = None, slug: str | None = None) -> BrokerMessage:
     if rid is None:
-        rid = str(uuid.uuid4())
+        rid = uuid.uuid4().hex
     if slug is None:
         slug = f"{rid}slug1"
 
@@ -530,7 +530,7 @@ def broker_resource(knowledgebox: str, rid: str | None = None, slug: str | None 
 
 async def create_resource(storage: Storage, driver: Driver, knowledgebox: str) -> Resource:
     async with driver.rw_transaction() as txn:
-        rid = str(uuid.uuid4())
+        rid = uuid.uuid4().hex
         kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
         test_resource = await kb_obj.add_resource(uuid=rid, slug="slug")
         await test_resource.set_slug()

--- a/nucliadb/tests/ndbfixtures/ingest.py
+++ b/nucliadb/tests/ndbfixtures/ingest.py
@@ -416,7 +416,7 @@ async def test_resource(storage: Storage, maindb_driver: Driver, knowledgebox: s
 
 def broker_resource(knowledgebox: str, rid: str | None = None, slug: str | None = None) -> BrokerMessage:
     if rid is None:
-        rid = uuid.uuid4().hex
+        rid = Resource.new_unique_rid()
     if slug is None:
         slug = f"{rid}slug1"
 
@@ -530,7 +530,7 @@ def broker_resource(knowledgebox: str, rid: str | None = None, slug: str | None 
 
 async def create_resource(storage: Storage, driver: Driver, knowledgebox: str) -> Resource:
     async with driver.rw_transaction() as txn:
-        rid = uuid.uuid4().hex
+        rid = Resource.new_unique_rid()
         kb_obj = KnowledgeBox(txn, storage, kbid=knowledgebox)
         test_resource = await kb_obj.add_resource(uuid=rid, slug="slug")
         await test_resource.set_slug()

--- a/nucliadb/tests/ndbfixtures/legacy.py
+++ b/nucliadb/tests/ndbfixtures/legacy.py
@@ -30,5 +30,7 @@ from nucliadb.common.maindb.driver import Driver, Transaction
 @pytest.fixture(scope="function")
 async def txn(maindb_driver: Driver) -> AsyncIterator[Transaction]:
     async with maindb_driver.rw_transaction() as txn:
-        yield txn
-        await txn.abort()
+        try:
+            yield txn
+        finally:
+            await txn.abort()

--- a/nucliadb/tests/ndbfixtures/maindb.py
+++ b/nucliadb/tests/ndbfixtures/maindb.py
@@ -89,6 +89,7 @@ async def cleanup_maindb(driver: Driver):
                 async with txn.connection.cursor() as cur:
                     await cur.execute("TRUNCATE kbs CASCADE")
         except Exception:
+            logger.exception("Could not truncate kbs table")
             pass
 
 

--- a/nucliadb/tests/ndbfixtures/maindb.py
+++ b/nucliadb/tests/ndbfixtures/maindb.py
@@ -84,6 +84,13 @@ async def cleanup_maindb(driver: Driver):
         except Exception:
             pass
 
+        try:
+            if isinstance(txn, PGTransaction):
+                async with txn.connection.cursor() as cur:
+                    await cur.execute("TRUNCATE kbs CASCADE")
+        except Exception:
+            pass
+
 
 async def create_test_database(base_url):
     async with (

--- a/nucliadb/tests/ndbfixtures/train.py
+++ b/nucliadb/tests/ndbfixtures/train.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
-import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -36,6 +35,7 @@ from nucliadb.common.maindb.driver import Driver
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.common.nidx import NidxUtility
 from nucliadb.ingest.orm.processor import Processor
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.standalone.settings import Settings
 from nucliadb.train.settings import settings as train_settings
 from nucliadb.train.utils import (
@@ -147,7 +147,7 @@ async def knowledgebox_with_labels(nucliadb_writer: AsyncClient, knowledgebox: s
 
 
 def broker_simple_resource(knowledgebox: str, number: int) -> BrokerMessage:
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     message1: BrokerMessage = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,

--- a/nucliadb/tests/ndbfixtures/train.py
+++ b/nucliadb/tests/ndbfixtures/train.py
@@ -30,7 +30,6 @@ from grpc import aio
 from httpx import AsyncClient
 
 from nucliadb.common import datamanagers
-from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG_BASE
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.common.nidx import NidxUtility
@@ -288,12 +287,9 @@ async def test_pagination_resources(processor: Processor, knowledgebox: str):
 
     while time() - t0 < 30:  # wait max 30 seconds for it
         async with driver.ro_transaction() as txn:
-            count = 0
-            async for key in txn.keys(match=KB_RESOURCE_SLUG_BASE.format(kbid=knowledgebox)):
-                count += 1
-
-        if count == amount:
-            break
+            count = await datamanagers.resources.calculate_number_of_resources(txn, kbid=knowledgebox)
+            if count == amount:
+                break
         print(f"got {count}, retrying")
         await asyncio.sleep(2)
 

--- a/nucliadb/tests/ndbfixtures/train.py
+++ b/nucliadb/tests/ndbfixtures/train.py
@@ -147,7 +147,7 @@ async def knowledgebox_with_labels(nucliadb_writer: AsyncClient, knowledgebox: s
 
 
 def broker_simple_resource(knowledgebox: str, number: int) -> BrokerMessage:
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     message1: BrokerMessage = BrokerMessage(
         kbid=knowledgebox,
         uuid=rid,

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_conversations_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_conversations_v2.py
@@ -1,0 +1,405 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Integration tests for nucliadb.common.datamanagers.conversations_v2.
+
+Covers: set_metadata, get_metadata, set_page, get_page,
+        set_splits_metadata, get_splits_metadata, delete_field.
+"""
+
+import logging
+
+import pytest
+
+from nucliadb.common.datamanagers import conversations_v2, fields_v2, kb_v2, resources_v2
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb_protos.resources_pb2 import (
+    Conversation,
+    FieldConversation,
+    Message,
+    SplitMetadata,
+    SplitsMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def kbid(maindb_driver: Driver) -> str:
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
+
+
+@pytest.fixture()
+async def rid(maindb_driver: Driver, kbid: str) -> str:
+    rid = Resource.new_unique_rid()
+    async with maindb_driver.rw_transaction() as txn:
+        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=f"slug-{rid}")
+        await txn.commit()
+    return rid
+
+
+@pytest.fixture()
+async def field_id(maindb_driver: Driver, kbid: str, rid: str) -> str:
+    """Create the parent kb_fields row ('c' type) so FK constraints are satisfied."""
+    fid = "chat"
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type="c", field_id=fid, value=b"")
+        await txn.commit()
+    return fid
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_conversation(*texts: str) -> Conversation:
+    conv = Conversation()
+    for text in texts:
+        msg = conv.messages.add()
+        msg.content.text = text
+        msg.type = Message.MessageType.QUESTION
+    return conv
+
+
+def make_metadata(pages: int = 1) -> FieldConversation:
+    meta = FieldConversation()
+    meta.pages = pages
+    meta.total = pages * 10
+    return meta
+
+
+def make_splits_metadata(*split_ids: str) -> SplitsMetadata:
+    meta = SplitsMetadata()
+    for sid in split_ids:
+        meta.metadata[sid].CopyFrom(SplitMetadata())
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# set_metadata / get_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_metadata(maindb_driver: Driver, kbid: str, rid: str, field_id: str) -> None:
+    meta = make_metadata(pages=3)
+
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_metadata(txn, kbid=kbid, rid=rid, field_id=field_id, metadata=meta)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+
+    assert result is not None
+    assert result.pages == 3
+
+
+@pytest.mark.asyncio
+async def test_set_metadata_overwrites(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, metadata=make_metadata(pages=1)
+        )
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, metadata=make_metadata(pages=5)
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+
+    assert result is not None
+    assert result.pages == 5
+
+
+@pytest.mark.asyncio
+async def test_get_metadata_returns_none_for_missing_field(
+    maindb_driver: Driver, kbid: str, rid: str
+) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_metadata(txn, kbid=kbid, rid=rid, field_id="no-such-field")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_page / get_page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_page(maindb_driver: Driver, kbid: str, rid: str, field_id: str) -> None:
+    conv = make_conversation("Hello", "World")
+
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=1, value=conv)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=1)
+
+    assert result is not None
+    assert len(result.messages) == 2
+    assert result.messages[0].content.text == "Hello"
+    assert result.messages[1].content.text == "World"
+
+
+@pytest.mark.asyncio
+async def test_set_page_overwrites(maindb_driver: Driver, kbid: str, rid: str, field_id: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=1, value=make_conversation("v1")
+        )
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=1, value=make_conversation("v2")
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=1)
+
+    assert result is not None
+    assert result.messages[0].content.text == "v2"
+
+
+@pytest.mark.asyncio
+async def test_multiple_pages_are_independent(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=1, value=make_conversation("page-one")
+        )
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=2, value=make_conversation("page-two")
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        p1 = await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=1)
+        p2 = await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=2)
+
+    assert p1 is not None and p1.messages[0].content.text == "page-one"
+    assert p2 is not None and p2.messages[0].content.text == "page-two"
+
+
+@pytest.mark.asyncio
+async def test_get_page_returns_none_for_missing_page(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=99)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_page_rejects_page_zero(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        with pytest.raises(ValueError, match="pages start at index 1"):
+            await conversations_v2.set_page(
+                txn, kbid=kbid, rid=rid, field_id=field_id, page=0, value=make_conversation("x")
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_page_rejects_page_zero(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        with pytest.raises(ValueError, match="pages start at index 1"):
+            await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=0)
+
+
+# ---------------------------------------------------------------------------
+# set_splits_metadata / get_splits_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_splits_metadata(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    splits = make_splits_metadata("split-a", "split-b")
+
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_splits_metadata(
+            txn, kbid=kbid, rid=rid, field_id=field_id, splits_metadata=splits
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_splits_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+
+    assert result is not None
+    assert "split-a" in result.metadata
+    assert "split-b" in result.metadata
+
+
+@pytest.mark.asyncio
+async def test_get_splits_metadata_returns_none_when_not_set(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await conversations_v2.get_splits_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_splits_metadata_does_not_clash_with_pages(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    """The sentinel page=0 must not conflict with real page data."""
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_splits_metadata(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_id=field_id,
+            splits_metadata=make_splits_metadata("s1"),
+        )
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=1, value=make_conversation("msg")
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        splits = await conversations_v2.get_splits_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+        page = await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=1)
+
+    assert splits is not None and "s1" in splits.metadata
+    assert page is not None and page.messages[0].content.text == "msg"
+
+
+# ---------------------------------------------------------------------------
+# delete_field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_field_removes_all_pages_and_metadata(
+    maindb_driver: Driver, kbid: str, rid: str, field_id: str
+) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=1, value=make_conversation("p1")
+        )
+        await conversations_v2.set_page(
+            txn, kbid=kbid, rid=rid, field_id=field_id, page=2, value=make_conversation("p2")
+        )
+        await conversations_v2.set_splits_metadata(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_id=field_id,
+            splits_metadata=make_splits_metadata("s"),
+        )
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.delete_field(txn, kbid=kbid, rid=rid, field_id=field_id)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert (
+            await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=1) is None
+        )
+        assert (
+            await conversations_v2.get_page(txn, kbid=kbid, rid=rid, field_id=field_id, page=2) is None
+        )
+        assert (
+            await conversations_v2.get_splits_metadata(txn, kbid=kbid, rid=rid, field_id=field_id)
+            is None
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_field_noop_when_no_rows_exist(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await conversations_v2.delete_field(txn, kbid=kbid, rid=rid, field_id="ghost")
+        await txn.commit()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# logs_foreign_key_error on set_metadata / set_page / set_splits_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_metadata_missing_parent_logs_warning(
+    maindb_driver: Driver,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    kbid = KnowledgeBox.new_unique_kbid()
+    rid = Resource.new_unique_rid()
+
+    with caplog.at_level(logging.WARNING, logger="nucliadb.common.datamanagers.utils"):
+        async with maindb_driver.rw_transaction() as txn:
+            await conversations_v2.set_metadata(
+                txn,
+                kbid=kbid,
+                rid=rid,
+                field_id="chat",
+                metadata=make_metadata(),
+            )
+            await txn.commit()
+
+    assert any("Foreign key violation" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_set_page_missing_parent_logs_warning(
+    maindb_driver: Driver,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    kbid = KnowledgeBox.new_unique_kbid()
+    rid = Resource.new_unique_rid()
+
+    with caplog.at_level(logging.WARNING, logger="nucliadb.common.datamanagers.utils"):
+        async with maindb_driver.rw_transaction() as txn:
+            await conversations_v2.set_page(
+                txn,
+                kbid=kbid,
+                rid=rid,
+                field_id="chat",
+                page=1,
+                value=make_conversation("hi"),
+            )
+            await txn.commit()
+
+    assert any("Foreign key violation" in r.message for r in caplog.records)

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_fields_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_fields_v2.py
@@ -1,0 +1,325 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Integration tests for nucliadb.common.datamanagers.fields_v2.
+
+Covers: set, set_status, get_raw, get_status, get_statuses, get_all_field_ids,
+        has_field, delete.
+"""
+
+import logging
+
+import pytest
+
+from nucliadb.common.datamanagers import fields_v2, kb_v2, resources_v2
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb_protos import resources_pb2 as rpb2
+from nucliadb_protos import writer_pb2 as wpb2
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TEXT = "t"
+FILE = "f"
+
+
+def make_status(
+    code: wpb2.FieldStatus.Status.ValueType = wpb2.FieldStatus.Status.PROCESSED,
+) -> wpb2.FieldStatus:
+    s = wpb2.FieldStatus()
+    s.status = code
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def kbid(maindb_driver: Driver) -> str:
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
+
+
+@pytest.fixture()
+async def rid(maindb_driver: Driver, kbid: str) -> str:
+    rid = Resource.new_unique_rid()
+    async with maindb_driver.rw_transaction() as txn:
+        await resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug=f"slug-{rid}")
+        await txn.commit()
+    return rid
+
+
+# ---------------------------------------------------------------------------
+# set / get_raw
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_raw(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    payload = b"raw-field-bytes"
+
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=payload)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_raw(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body")
+
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_set_overwrites_existing_value(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"v1")
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"v2")
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_raw(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body")
+
+    assert result == b"v2"
+
+
+@pytest.mark.asyncio
+async def test_get_raw_returns_none_for_missing_field(
+    maindb_driver: Driver, kbid: str, rid: str
+) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_raw(
+            txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="nonexistent"
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_set_with_protobuf_message(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    text_field = rpb2.FieldText(body="hello world", format=rpb2.FieldText.Format.PLAIN)
+
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=text_field)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        raw = await fields_v2.get_raw(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body")
+
+    assert raw is not None
+    recovered = rpb2.FieldText()
+    recovered.ParseFromString(raw)
+    assert recovered.body == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# set_status / get_status / get_statuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_status(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"data")
+        await fields_v2.set_status(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_type=TEXT,
+            field_id="body",
+            status=make_status(wpb2.FieldStatus.Status.PROCESSED),
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_status(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body")
+
+    assert result is not None
+    assert result.status == wpb2.FieldStatus.Status.PROCESSED
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_none_for_missing_row(
+    maindb_driver: Driver, kbid: str, rid: str
+) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_status(
+            txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="no-such-field"
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_statuses_returns_in_order(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        for fid in ("f1", "f2", "f3"):
+            await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id=fid, value=b"x")
+        await fields_v2.set_status(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_type=TEXT,
+            field_id="f1",
+            status=make_status(wpb2.FieldStatus.Status.PROCESSED),
+        )
+        await fields_v2.set_status(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_type=TEXT,
+            field_id="f3",
+            status=make_status(wpb2.FieldStatus.Status.ERROR),
+        )
+        await txn.commit()
+
+    field_ids = [
+        rpb2.FieldID(field_type=rpb2.FieldType.TEXT, field="f1"),
+        rpb2.FieldID(field_type=rpb2.FieldType.TEXT, field="f2"),
+        rpb2.FieldID(field_type=rpb2.FieldType.TEXT, field="f3"),
+    ]
+
+    async with maindb_driver.ro_transaction() as txn:
+        statuses = await fields_v2.get_statuses(txn, kbid=kbid, rid=rid, fields=field_ids)
+
+    assert len(statuses) == 3
+    assert statuses[0].status == wpb2.FieldStatus.Status.PROCESSED  # f1
+    assert statuses[1].status == wpb2.FieldStatus.Status.PENDING  # f2 - default empty
+    assert statuses[2].status == wpb2.FieldStatus.Status.ERROR  # f3
+
+
+@pytest.mark.asyncio
+async def test_get_statuses_empty_input(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_statuses(txn, kbid=kbid, rid=rid, fields=[])
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# has_field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_has_field_true_after_set(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"x")
+        await txn.commit()
+
+    fid = rpb2.FieldID(field_type=rpb2.FieldType.TEXT, field="body")
+    async with maindb_driver.ro_transaction() as txn:
+        assert await fields_v2.has_field(txn, kbid=kbid, rid=rid, field_id=fid) is True
+
+
+@pytest.mark.asyncio
+async def test_has_field_false_for_missing(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    fid = rpb2.FieldID(field_type=rpb2.FieldType.TEXT, field="ghost")
+    async with maindb_driver.ro_transaction() as txn:
+        assert await fields_v2.has_field(txn, kbid=kbid, rid=rid, field_id=fid) is False
+
+
+# ---------------------------------------------------------------------------
+# get_all_field_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_all_field_ids(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"x")
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=FILE, field_id="doc", value=b"y")
+        # These are the special title/summary generic fields that should be excluded
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type="a", field_id="title", value=b"t")
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type="a", field_id="summary", value=b"s")
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_all_field_ids(txn, kbid=kbid, rid=rid)
+
+    field_pairs = {(f.field_type, f.field) for f in result.fields}
+    assert (rpb2.FieldType.TEXT, "body") in field_pairs
+    assert (rpb2.FieldType.FILE, "doc") in field_pairs
+    # title and summary generics must be excluded
+    assert (rpb2.FieldType.GENERIC, "title") not in field_pairs
+    assert (rpb2.FieldType.GENERIC, "summary") not in field_pairs
+
+
+@pytest.mark.asyncio
+async def test_get_all_field_ids_empty(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await fields_v2.get_all_field_ids(txn, kbid=kbid, rid=rid)
+    assert list(result.fields) == []
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_field(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"x")
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.delete(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body")
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await fields_v2.get_raw(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body") is None
+        fid = rpb2.FieldID(field_type=rpb2.FieldType.TEXT, field="body")
+        assert await fields_v2.has_field(txn, kbid=kbid, rid=rid, field_id=fid) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_field_is_noop(maindb_driver: Driver, kbid: str, rid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await fields_v2.delete(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="ghost")
+        await txn.commit()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# logs_foreign_key_error on set / set_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_missing_parent_logs_warning_and_does_not_raise(
+    maindb_driver: Driver,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Writing to kb_fields whose parent kb_resources row does not exist must not raise."""
+    kbid = KnowledgeBox.new_unique_kbid()
+    rid = Resource.new_unique_rid()
+
+    with caplog.at_level(logging.WARNING, logger="nucliadb.common.datamanagers.utils"):
+        async with maindb_driver.rw_transaction() as txn:
+            await fields_v2.set(txn, kbid=kbid, rid=rid, field_type=TEXT, field_id="body", value=b"data")
+            await txn.commit()
+
+    assert any("Foreign key violation" in r.message for r in caplog.records)

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_kb_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_kb_v2.py
@@ -1,0 +1,348 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Integration tests for nucliadb.common.datamanagers.kb_v2.
+
+Covers every public function in the module:
+  set_config, delete, soft_delete, set_kbid_for_slug, update_kb_shards,
+  exists_kb, get_config, get_kb_uuid, get_kbs, get_kb_shards.
+"""
+
+import pytest
+
+from nucliadb.common.datamanagers import kb_v2
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb_protos import knowledgebox_pb2, writer_pb2
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def new_kbid() -> str:
+    return KnowledgeBox.new_unique_kbid()
+
+
+def make_config(title: str = "Test KB") -> knowledgebox_pb2.KnowledgeBoxConfig:
+    cfg = knowledgebox_pb2.KnowledgeBoxConfig()
+    cfg.title = title
+    return cfg
+
+
+def make_shards(kbid: str) -> writer_pb2.Shards:
+    shards = writer_pb2.Shards()
+    shards.kbid = kbid
+    return shards
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def kbid(maindb_driver: Driver) -> str:
+    """Create a minimal KB row (with a slug) and return its kbid."""
+    kbid = new_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
+
+
+# ---------------------------------------------------------------------------
+# set_config / get_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_config_creates_row_and_is_readable(maindb_driver: Driver) -> None:
+    kbid = new_kbid()
+    cfg = make_config("My KB")
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_config(txn, kbid=kbid, config=cfg)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_config(txn, kbid=kbid)
+
+    assert result is not None
+    assert result.title == "My KB"
+
+
+@pytest.mark.asyncio
+async def test_set_config_overwrites_existing(maindb_driver: Driver) -> None:
+    kbid = new_kbid()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_config(txn, kbid=kbid, config=make_config("First"))
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_config(txn, kbid=kbid, config=make_config("Second"))
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_config(txn, kbid=kbid)
+
+    assert result is not None
+    assert result.title == "Second"
+
+
+@pytest.mark.asyncio
+async def test_get_config_returns_none_for_missing_kb(maindb_driver: Driver) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_config(txn, kbid=new_kbid())
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_kbid_for_slug / get_kb_uuid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_kbid_for_slug_and_get_kb_uuid(maindb_driver: Driver) -> None:
+    kbid = new_kbid()
+    slug = f"my-slug-{kbid}"
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=slug)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_kb_uuid(txn, slug=slug)
+
+    assert result == kbid
+
+
+@pytest.mark.asyncio
+async def test_set_kbid_for_slug_overwrites_slug(maindb_driver: Driver) -> None:
+    kbid = new_kbid()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug="old-slug")
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug="new-slug")
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await kb_v2.get_kb_uuid(txn, slug="new-slug") == kbid
+        assert await kb_v2.get_kb_uuid(txn, slug="old-slug") is None
+
+
+@pytest.mark.asyncio
+async def test_get_kb_uuid_returns_none_for_unknown_slug(maindb_driver: Driver) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_kb_uuid(txn, slug="no-such-slug")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# exists_kb
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exists_kb_true_for_active_kb(maindb_driver: Driver, kbid: str) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        assert await kb_v2.exists_kb(txn, kbid=kbid) is True
+
+
+@pytest.mark.asyncio
+async def test_exists_kb_false_for_missing_kb(maindb_driver: Driver) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        assert await kb_v2.exists_kb(txn, kbid=new_kbid()) is False
+
+
+@pytest.mark.asyncio
+async def test_exists_kb_false_after_soft_delete(maindb_driver: Driver, kbid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.soft_delete(txn, kbid=kbid)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await kb_v2.exists_kb(txn, kbid=kbid) is False
+
+
+@pytest.mark.asyncio
+async def test_exists_kb_false_after_hard_delete(maindb_driver: Driver, kbid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.delete(txn, kbid=kbid)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await kb_v2.exists_kb(txn, kbid=kbid) is False
+
+
+# ---------------------------------------------------------------------------
+# soft_delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_clears_slug(maindb_driver: Driver, kbid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.soft_delete(txn, kbid=kbid)
+        await txn.commit()
+
+    # The row still exists but slug is NULL, so get_kb_uuid returns None for the old slug
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_kb_uuid(txn, slug=f"slug-{kbid}")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_on_nonexistent_kb_is_noop(maindb_driver: Driver) -> None:
+    """soft_delete must not raise when the KB does not exist."""
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.soft_delete(txn, kbid=new_kbid())  # must not raise
+        await txn.commit()
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_kb_row(maindb_driver: Driver, kbid: str) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.delete(txn, kbid=kbid)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await kb_v2.get_config(txn, kbid=kbid) is None
+        assert await kb_v2.exists_kb(txn, kbid=kbid) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_on_nonexistent_kb_is_noop(maindb_driver: Driver) -> None:
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.delete(txn, kbid=new_kbid())  # must not raise
+        await txn.commit()
+
+
+# ---------------------------------------------------------------------------
+# update_kb_shards / get_kb_shards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_and_get_kb_shards(maindb_driver: Driver, kbid: str) -> None:
+    shards = make_shards(kbid)
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.update_kb_shards(txn, kbid=kbid, shards=shards)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_kb_shards(txn, kbid=kbid)
+
+    assert result is not None
+    assert result.kbid == kbid
+
+
+@pytest.mark.asyncio
+async def test_get_kb_shards_returns_none_for_missing_kb(maindb_driver: Driver) -> None:
+    async with maindb_driver.ro_transaction() as txn:
+        result = await kb_v2.get_kb_shards(txn, kbid=new_kbid())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_kb_shards_for_update(maindb_driver: Driver, kbid: str) -> None:
+    shards = make_shards(kbid)
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.update_kb_shards(txn, kbid=kbid, shards=shards)
+        await txn.commit()
+
+    # for_update=True is a SELECT … FOR UPDATE; verify it returns the same data
+    async with maindb_driver.rw_transaction() as txn:
+        result = await kb_v2.get_kb_shards(txn, kbid=kbid, for_update=True)
+
+    assert result is not None
+    assert result.kbid == kbid
+
+
+# ---------------------------------------------------------------------------
+# get_kbs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_kbs_yields_active_kbs(maindb_driver: Driver) -> None:
+    kbid_a = new_kbid()
+    kbid_b = new_kbid()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid_a, slug="prefix-alpha")
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid_b, slug="prefix-beta")
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        all_kbs = {kbid async for kbid, _ in kb_v2.get_kbs(txn)}
+
+    assert kbid_a in all_kbs
+    assert kbid_b in all_kbs
+
+
+@pytest.mark.asyncio
+async def test_get_kbs_with_slug_prefix(maindb_driver: Driver) -> None:
+    kbid_a = new_kbid()
+    kbid_b = new_kbid()
+    kbid_c = new_kbid()
+    prefix = f"pfx-{kbid_a[:8]}-"
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid_a, slug=f"{prefix}one")
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid_b, slug=f"{prefix}two")
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid_c, slug="other-slug")
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        filtered = {kbid async for kbid, _ in kb_v2.get_kbs(txn, slug_prefix=prefix)}
+
+    assert kbid_a in filtered
+    assert kbid_b in filtered
+    assert kbid_c not in filtered
+
+
+@pytest.mark.asyncio
+async def test_get_kbs_does_not_yield_soft_deleted(maindb_driver: Driver) -> None:
+    kbid = new_kbid()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.soft_delete(txn, kbid=kbid)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        all_kbs = {kbid async for kbid, _ in kb_v2.get_kbs(txn)}
+
+    assert kbid not in all_kbs

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resource_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resource_v2.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Integration tests for the `logs_foreign_key_error` decorator behaviour on
+resources_v2 write operations.
+
+These tests verify that writing to an ORM table whose parent row does not yet
+exist (simulating a resource that has not been backfilled yet) does not raise an
+exception but does emit a warning log, so that the dual-write migration path
+cannot break normal operation.
+"""
+
+import logging
+
+import pytest
+
+from nucliadb.common.datamanagers import resources_v2
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
+from nucliadb_protos import resources_pb2
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_basic_missing_parent_logs_warning_and_does_not_raise(
+    maindb_driver: Driver,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Writing a kb_resources row whose kbid has no parent kbs row must not raise;
+    instead a WARNING is logged by logs_foreign_key_error.
+    """
+    kbid = KnowledgeBox.new_unique_kbid()
+    rid = Resource.new_unique_rid()
+
+    with caplog.at_level(logging.WARNING, logger="nucliadb.common.datamanagers.utils"):
+        async with maindb_driver.rw_transaction() as txn:
+            # No kbs row exists for kbid — FK violation expected to be swallowed
+            await resources_v2.set_basic(
+                txn,
+                kbid=kbid,
+                rid=rid,
+                basic=resources_pb2.Basic(slug="test-slug"),
+            )
+            await txn.commit()
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Foreign key violation" in r.message for r in warning_records), (
+        f"Expected a FK warning log, got: {[r.message for r in warning_records]}"
+    )

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resource_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resource_v2.py
@@ -31,8 +31,9 @@ import logging
 
 import pytest
 
-from nucliadb.common.datamanagers import resources_v2
+from nucliadb.common.datamanagers import kb_v2, resources_v2
 from nucliadb.common.maindb.driver import Driver
+from nucliadb.common.maindb.exceptions import ConflictError
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos import resources_pb2
@@ -40,6 +41,16 @@ from nucliadb_protos import resources_pb2
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+async def kbid(maindb_driver: Driver) -> str:
+    """Create a new knowledge box and return its kbid."""
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, slug=kbid, kbid=kbid)
+        await txn.commit()
+    return kbid
 
 
 @pytest.mark.asyncio
@@ -69,3 +80,158 @@ async def test_set_basic_missing_parent_logs_warning_and_does_not_raise(
     assert any("Foreign key violation" in r.message for r in warning_records), (
         f"Expected a FK warning log, got: {[r.message for r in warning_records]}"
     )
+
+
+@pytest.mark.asyncio
+async def test_set_slug_raises_conflict_error(
+    maindb_driver: Driver,
+    kbid: str,
+) -> None:
+    """
+    Writing a kb_resources row whose kbid has no parent kbs row must not raise;
+    instead a WARNING is logged by logs_foreign_key_error.
+    """
+    rid = Resource.new_unique_rid()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await resources_v2.set_slug(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            slug="test-slug",
+        )
+        await txn.commit()
+
+    # Now try to set the same slug again for another resource, which should raise a conflict error
+    with pytest.raises(ConflictError):
+        async with maindb_driver.rw_transaction() as txn:
+            rid2 = Resource.new_unique_rid()
+            await resources_v2.set_slug(
+                txn,
+                kbid=kbid,
+                rid=rid2,
+                slug="test-slug",
+            )
+            await txn.commit()
+
+    # But setting it for the previous resource should succeed, as it is idempotent
+    async with maindb_driver.rw_transaction() as txn:
+        await resources_v2.set_slug(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            slug="another-slug",
+        )
+        await txn.commit()
+
+
+async def test_modify_slug(
+    maindb_driver: Driver,
+    kbid: str,
+) -> None:
+    """
+    Test that modifying a slug for a resource works correctly.
+    """
+    rid = Resource.new_unique_rid()
+
+    async with maindb_driver.rw_transaction() as txn:
+        await resources_v2.set_slug(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            slug="initial-slug",
+        )
+        await txn.commit()
+
+    # Now modify the slug
+    async with maindb_driver.rw_transaction() as txn:
+        old_slug = await resources_v2.modify_slug(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            new_slug="modified-slug",
+        )
+        await txn.commit()
+
+    assert old_slug == "initial-slug", f"Expected old slug to be 'initial-slug', got {old_slug}"
+
+
+async def test_resource_set_get(
+    maindb_driver: Driver,
+    kbid: str,
+) -> None:
+    """
+    Test that resource metadata can be set and retrieved correctly.
+    """
+    rid = Resource.new_unique_rid()
+    assert {rid async for rid in resources_v2.iterate_resource_ids(kbid=kbid)} == set()
+
+    async with maindb_driver.rw_transaction() as txn:
+        assert await resources_v2.exists(txn, kbid=kbid, rid=rid) is False
+        assert await resources_v2.calculate_number_of_resources(txn, kbid=kbid) == 0
+
+        await resources_v2.set_slug(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            slug="test-slug",
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await resources_v2.calculate_number_of_resources(txn, kbid=kbid) == 1
+        assert [rid async for rid in resources_v2.iterate_resource_ids(kbid=kbid)] == [rid]
+        assert await resources_v2.exists(txn, kbid=kbid, rid=rid) is True
+        assert await resources_v2.get_basic(txn, kbid=kbid, rid=rid) is None
+        assert await resources_v2.get_origin(txn, kbid=kbid, rid=rid) is None
+        assert await resources_v2.get_security(txn, kbid=kbid, rid=rid) is None
+        assert await resources_v2.get_extra(txn, kbid=kbid, rid=rid) is None
+        assert await resources_v2.get_resource_shard_id(txn, kbid=kbid, rid=rid) is None
+        assert await resources_v2.get_resource_uuid_from_slug(txn, kbid=kbid, slug="test-slug") == rid
+
+    async with maindb_driver.rw_transaction() as txn:
+        extra = resources_pb2.Extra()
+        extra.metadata.update({"key": "value"})
+        await resources_v2.set_extra(txn, kbid=kbid, rid=rid, extra=extra)
+        await resources_v2.set_origin(
+            txn, kbid=kbid, rid=rid, origin=resources_pb2.Origin(source_id="test-source")
+        )
+        await resources_v2.set_security(
+            txn, kbid=kbid, rid=rid, security=resources_pb2.Security(access_groups=["group1", "group2"])
+        )
+        await resources_v2.set_resource_shard_id(txn, kbid=kbid, rid=rid, shard="shard-1")
+        await resources_v2.set_basic(
+            txn, kbid=kbid, rid=rid, basic=resources_pb2.Basic(slug="test-slug", title="Test Title")
+        )
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        basic = await resources_v2.get_basic(txn, kbid=kbid, rid=rid)
+        assert basic is not None
+        assert basic.slug == "test-slug"
+        assert basic.title == "Test Title"
+
+        origin = await resources_v2.get_origin(txn, kbid=kbid, rid=rid)
+        assert origin is not None
+        assert origin.source_id == "test-source"
+
+        security = await resources_v2.get_security(txn, kbid=kbid, rid=rid)
+        assert security is not None
+        assert security.access_groups == ["group1", "group2"]
+
+        extra_ = await resources_v2.get_extra(txn, kbid=kbid, rid=rid)
+        assert extra_ is not None
+        assert extra_.metadata["key"] == "value"
+
+        shard_id = await resources_v2.get_resource_shard_id(txn, kbid=kbid, rid=rid)
+        assert shard_id == "shard-1"
+
+    async with maindb_driver.rw_transaction() as txn:
+        await resources_v2.delete(txn, kbid=kbid, rid=rid)
+        await txn.commit()
+
+    async with maindb_driver.ro_transaction() as txn:
+        assert await resources_v2.exists(txn, kbid=kbid, rid=rid) is False
+        assert await resources_v2.calculate_number_of_resources(txn, kbid=kbid) == 0
+        assert [rid async for rid in resources_v2.iterate_resource_ids(kbid=kbid)] == []
+        assert await resources_v2.get_basic(txn, kbid=kbid, rid=rid) is None

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
@@ -67,7 +67,7 @@ async def test_modify_slug(resource_with_slug, maindb_driver: Driver):
 
 async def test_all_fields(maindb_driver: Driver):
     kbid = str(uuid.uuid4())
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     field = resources_pb2.FieldID(field="myfield", field_type=resources_pb2.FieldType.LINK)
 
     async with maindb_driver.ro_transaction() as txn:

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
@@ -88,9 +88,7 @@ async def test_all_fields(maindb_driver: Driver, resource_with_slug: tuple[str, 
 
     async with maindb_driver.ro_transaction() as txn:
         all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
-        assert all_fields is not None
-        assert len(all_fields.fields) == 0
-
+        assert all_fields is None or len(all_fields.fields) == 0
         assert (await datamanagers.resources.has_field(txn, kbid=kbid, rid=rid, field_id=field)) is False
 
     # set a field for a resource

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import uuid
+
 import pytest
 
 from nucliadb.common import datamanagers
@@ -64,8 +66,8 @@ async def test_modify_slug(resource_with_slug, maindb_driver: Driver):
 
 
 async def test_all_fields(maindb_driver: Driver):
-    kbid = "mykb"
-    rid = "myresource"
+    kbid = str(uuid.uuid4())
+    rid = str(uuid.uuid4())
     field = resources_pb2.FieldID(field="myfield", field_type=resources_pb2.FieldType.LINK)
 
     async with maindb_driver.ro_transaction() as txn:

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
@@ -17,17 +17,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import uuid
+from typing import AsyncIterator
 
 import pytest
 
 from nucliadb.common import datamanagers
-from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG
 from nucliadb.common.maindb.driver import Driver
+from nucliadb.common.models_utils import from_proto
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos import resources_pb2
-from nucliadb_protos.resources_pb2 import Basic
+from nucliadb_protos.resources_pb2 import Basic, FieldLink
 
 
 async def check_slug(driver: Driver, kbid, rid, slug):
@@ -40,15 +40,28 @@ async def check_slug(driver: Driver, kbid, rid, slug):
 
 
 @pytest.fixture(scope="function")
-async def resource_with_slug(maindb_driver: Driver):
+async def kbid(maindb_driver: Driver) -> AsyncIterator[str]:
     kbid = KnowledgeBox.new_unique_kbid()
+    slug = kbid
+    async with maindb_driver.rw_transaction() as txn:
+        await datamanagers.kb.kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=slug)
+        await txn.commit()
+    try:
+        yield kbid
+    finally:
+        async with maindb_driver.rw_transaction() as txn:
+            await datamanagers.kb.kb_v2.delete(txn, kbid=kbid)
+            await txn.commit()
+
+
+@pytest.fixture(scope="function")
+async def resource_with_slug(maindb_driver: Driver, kbid: str):
     rid = Resource.new_unique_rid()
     slug = "slug"
 
     async with maindb_driver.rw_transaction() as txn:
-        await txn.set(KB_RESOURCE_SLUG.format(kbid=kbid, slug=slug), rid.encode())
-        basic = Basic(slug=slug)
-        await datamanagers.resources.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+        await datamanagers.resources.set_basic(txn, kbid=kbid, rid=rid, basic=Basic(slug=slug))
+        await datamanagers.resources.set_slug(txn, kbid=kbid, rid=rid, slug=slug)
         await txn.commit()
 
     await check_slug(maindb_driver, kbid, rid, slug)
@@ -67,14 +80,16 @@ async def test_modify_slug(resource_with_slug, maindb_driver: Driver):
     await check_slug(maindb_driver, kbid, rid, new_slug)
 
 
-async def test_all_fields(maindb_driver: Driver):
-    kbid = str(uuid.uuid4())
-    rid = Resource.new_unique_rid()
+async def test_all_fields(maindb_driver: Driver, resource_with_slug: tuple[str, str, str]):
+    kbid, rid, _ = resource_with_slug
+
     field = resources_pb2.FieldID(field="myfield", field_type=resources_pb2.FieldType.LINK)
+    field_type_abbr = from_proto.field_type_name(field.field_type).abbreviation()
 
     async with maindb_driver.ro_transaction() as txn:
         all_fields = await datamanagers.resources.get_all_field_ids(txn, kbid=kbid, rid=rid)
-        assert all_fields is None
+        assert all_fields is not None
+        assert len(all_fields.fields) == 0
 
         assert (await datamanagers.resources.has_field(txn, kbid=kbid, rid=rid, field_id=field)) is False
 
@@ -83,6 +98,14 @@ async def test_all_fields(maindb_driver: Driver):
     async with maindb_driver.rw_transaction() as txn:
         pb = resources_pb2.AllFieldIDs()
         pb.fields.append(field)
+        await datamanagers.fields.fields_v2.set(
+            txn,
+            kbid=kbid,
+            rid=rid,
+            field_type=field_type_abbr,
+            field_id=field.field,
+            value=FieldLink(uri="http://example.com"),
+        )
         await datamanagers.resources.set_all_field_ids(txn, kbid=kbid, rid=rid, allfields=pb)
         await txn.commit()
 
@@ -98,6 +121,9 @@ async def test_all_fields(maindb_driver: Driver):
     async with maindb_driver.rw_transaction() as txn:
         await datamanagers.resources.set_all_field_ids(
             txn, kbid=kbid, rid=rid, allfields=resources_pb2.AllFieldIDs()
+        )
+        await datamanagers.fields.fields_v2.delete(
+            txn, kbid=kbid, rid=rid, field_type=field_type_abbr, field_id=field.field
         )
         await txn.commit()
 

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resources.py
@@ -24,6 +24,8 @@ import pytest
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.resources import KB_RESOURCE_SLUG
 from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos import resources_pb2
 from nucliadb_protos.resources_pb2 import Basic
 
@@ -39,8 +41,8 @@ async def check_slug(driver: Driver, kbid, rid, slug):
 
 @pytest.fixture(scope="function")
 async def resource_with_slug(maindb_driver: Driver):
-    kbid = "kbid"
-    rid = "rid"
+    kbid = KnowledgeBox.new_unique_kbid()
+    rid = Resource.new_unique_rid()
     slug = "slug"
 
     async with maindb_driver.rw_transaction() as txn:
@@ -67,7 +69,7 @@ async def test_modify_slug(resource_with_slug, maindb_driver: Driver):
 
 async def test_all_fields(maindb_driver: Driver):
     kbid = str(uuid.uuid4())
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field = resources_pb2.FieldID(field="myfield", field_type=resources_pb2.FieldType.LINK)
 
     async with maindb_driver.ro_transaction() as txn:

--- a/nucliadb/tests/nucliadb/integration/common/test_file_md5.py
+++ b/nucliadb/tests/nucliadb/integration/common/test_file_md5.py
@@ -18,14 +18,13 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
-import time
-import uuid
 
 import pytest
 
 from nucliadb.common import file_md5
+from nucliadb.common.datamanagers import fields_v2, kb_v2, resources_v2
 from nucliadb.common.maindb.pg import PGDriver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.resource import Resource
 from nucliadb_utils.utilities import Utility
 from tests.ndbfixtures.utils import global_utility
@@ -37,255 +36,121 @@ async def driver(pg_maindb_driver: PGDriver):
         yield pg_maindb_driver
 
 
-def kbid() -> str:
-    return str(uuid.uuid4())
+@pytest.fixture(scope="function")
+async def kbid(driver: PGDriver) -> str:
+    kb_id = KnowledgeBox.new_unique_kbid()
+    async with driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kb_id, slug=f"slug-{kb_id}")
+        await txn.commit()
+    return kb_id
 
 
-def rid() -> str:
-    return uuid.uuid4().hex
+@pytest.fixture(scope="function")
+async def rid(driver: PGDriver, kbid: str) -> str:
+    r_id = Resource.new_unique_rid()
+    async with driver.rw_transaction() as txn:
+        await resources_v2.set_slug(txn, kbid=kbid, rid=r_id, slug=f"slug-{r_id}")
+        await txn.commit()
+    return r_id
 
 
-async def test_set_and_exists(driver: PGDriver):
-    kb = kbid()
-    r1 = rid()
-
-    assert await file_md5.exists(kbid=kb, md5="aaa") is False
+async def test_set_and_exists(driver: PGDriver, kbid: str, rid: str):
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is False
 
     async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
         await txn.commit()
 
-    assert await file_md5.exists(kbid=kb, md5="aaa") is True
-    assert await file_md5.exists(kbid=kbid(), md5="aaa") is False
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is True
+
+    non_existing_kbid = KnowledgeBox.new_unique_kbid()
+    assert await file_md5.exists(kbid=non_existing_kbid, md5="aaa") is False
 
 
-async def test_set_is_idempotent(driver: PGDriver):
-    kb = kbid()
-    r1 = rid()
-
+async def test_set_is_idempotent(driver: PGDriver, kbid: str, rid: str):
     async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
-        await txn.commit()
-
-    async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
-        await txn.commit()
-
-    assert await file_md5.exists(kbid=kb, md5="aaa") is True
-
-
-async def test_same_md5_different_fields(driver: PGDriver):
-    kb = kbid()
-    r1 = rid()
-
-    async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file2")
-        await txn.commit()
-
-    assert await file_md5.exists(kbid=kb, md5="aaa") is True
-
-    async with driver.rw_transaction() as txn:
-        await file_md5.delete(txn, kbid=kb, rid=r1, field_id="file1")
-        await txn.commit()
-
-    assert await file_md5.exists(kbid=kb, md5="aaa") is True
-
-
-async def test_delete_by_field(driver: PGDriver):
-    kb = kbid()
-    r1 = rid()
-
-    async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
-        await file_md5.set(txn, kbid=kb, md5="bbb", rid=r1, field_id="file2")
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
         await txn.commit()
 
     async with driver.rw_transaction() as txn:
-        await file_md5.delete(txn, kbid=kb, rid=r1, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
         await txn.commit()
 
-    assert await file_md5.exists(kbid=kb, md5="aaa") is False
-    assert await file_md5.exists(kbid=kb, md5="bbb") is True
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is True
 
 
-async def test_delete_by_resource(driver: PGDriver):
-    kb = kbid()
-    r1 = rid()
-    r2 = rid()
-
+async def test_same_md5_different_fields(driver: PGDriver, kbid: str, rid: str):
     async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
-        await file_md5.set(txn, kbid=kb, md5="bbb", rid=r1, field_id="file2")
-        await file_md5.set(txn, kbid=kb, md5="ccc", rid=r2, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file2")
         await txn.commit()
 
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is True
+
     async with driver.rw_transaction() as txn:
-        await file_md5.delete(txn, kbid=kb, rid=r1)
+        await file_md5.delete(txn, kbid=kbid, rid=rid, field_id="file1")
         await txn.commit()
 
-    assert await file_md5.exists(kbid=kb, md5="aaa") is False
-    assert await file_md5.exists(kbid=kb, md5="bbb") is False
-    assert await file_md5.exists(kbid=kb, md5="ccc") is True
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is True
 
 
-async def test_delete_by_kb(driver: PGDriver):
-    kb = kbid()
-    other_kb = kbid()
-    r1 = rid()
-    r2 = rid()
-
+async def test_delete_by_field(driver: PGDriver, kbid: str, rid: str):
     async with driver.rw_transaction() as txn:
-        await file_md5.set(txn, kbid=kb, md5="aaa", rid=r1, field_id="file1")
-        await file_md5.set(txn, kbid=kb, md5="bbb", rid=r2, field_id="file1")
-        await file_md5.set(txn, kbid=other_kb, md5="ccc", rid=r1, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="bbb", rid=rid, field_id="file2")
         await txn.commit()
 
     async with driver.rw_transaction() as txn:
-        await file_md5.delete(txn, kbid=kb)
+        await file_md5.delete(txn, kbid=kbid, rid=rid, field_id="file1")
+        await fields_v2.delete(txn, kbid=kbid, rid=rid, field_id="file1", field_type="f")
         await txn.commit()
 
-    assert await file_md5.exists(kbid=kb, md5="aaa") is False
-    assert await file_md5.exists(kbid=kb, md5="bbb") is False
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is False
+    assert await file_md5.exists(kbid=kbid, md5="bbb") is True
+
+
+async def test_delete_by_resource(driver: PGDriver, kbid: str, rid: str):
+    r2 = Resource.new_unique_rid()
+    async with driver.rw_transaction() as txn:
+        await resources_v2.set_slug(txn, kbid=kbid, rid=r2, slug=f"slug-{r2}")
+        await txn.commit()
+
+    async with driver.rw_transaction() as txn:
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="bbb", rid=rid, field_id="file2")
+        await file_md5.set(txn, kbid=kbid, md5="ccc", rid=r2, field_id="file1")
+        await txn.commit()
+
+    async with driver.rw_transaction() as txn:
+        await file_md5.delete(txn, kbid=kbid, rid=rid)
+        await resources_v2.delete(txn, kbid=kbid, rid=rid)
+        await txn.commit()
+
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is False
+    assert await file_md5.exists(kbid=kbid, md5="bbb") is False
+    assert await file_md5.exists(kbid=kbid, md5="ccc") is True
+
+
+async def test_delete_by_kb(driver: PGDriver, kbid: str, rid: str):
+    other_kb = KnowledgeBox.new_unique_kbid()
+    r2 = Resource.new_unique_rid()
+    async with driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=other_kb, slug=f"slug-{other_kb}")
+        await resources_v2.set_slug(txn, kbid=kbid, rid=r2, slug=f"slug-{r2}")
+        await resources_v2.set_slug(txn, kbid=other_kb, rid=rid, slug=f"slug-{rid}")
+        await txn.commit()
+
+    async with driver.rw_transaction() as txn:
+        await file_md5.set(txn, kbid=kbid, md5="aaa", rid=rid, field_id="file1")
+        await file_md5.set(txn, kbid=kbid, md5="bbb", rid=r2, field_id="file1")
+        await file_md5.set(txn, kbid=other_kb, md5="ccc", rid=rid, field_id="file1")
+        await txn.commit()
+
+    async with driver.rw_transaction() as txn:
+        await file_md5.delete(txn, kbid=kbid)
+        await kb_v2.delete(txn, kbid=kbid)
+        await txn.commit()
+
+    assert await file_md5.exists(kbid=kbid, md5="aaa") is False
+    assert await file_md5.exists(kbid=kbid, md5="bbb") is False
     assert await file_md5.exists(kbid=other_kb, md5="ccc") is True
-
-
-@pytest.mark.skipif(
-    not os.environ.get("LOCAL_TEST"),
-    reason="Performance tests are skipped by default. Set LOCAL_TEST=1 to enable.",
-)
-async def test_performance(driver: PGDriver):
-    """Insert 2M rows across 300 KBs (5 large KBs hold ~70% of rows), then benchmark operations."""
-    total_rows = 2_000_000
-    num_large_kbs = 5
-    num_small_kbs = 295
-    large_kb_rows = int(total_rows * 0.70)
-    small_kb_rows = total_rows - large_kb_rows
-
-    rows_per_large_kb = large_kb_rows // num_large_kbs
-    rows_per_small_kb = small_kb_rows // num_small_kbs
-
-    large_kbs = [kbid() for _ in range(num_large_kbs)]
-    small_kbs = [kbid() for _ in range(num_small_kbs)]
-
-    batch_size = 10_000
-
-    # Bulk insert rows
-    pg_driver: PGDriver = driver
-    async with pg_driver._get_connection() as conn:
-        async with conn.cursor() as cur:
-            row_idx = 0
-            for kb, count in [(kb, rows_per_large_kb) for kb in large_kbs] + [
-                (kb, rows_per_small_kb) for kb in small_kbs
-            ]:
-                for batch_start in range(0, count, batch_size):
-                    batch_end = min(batch_start + batch_size, count)
-                    rows = [
-                        (kb, f"md5_{row_idx + i}", Resource.new_unique_rid(), f"f/field_{i % 10}")
-                        for i in range(batch_end - batch_start)
-                    ]
-                    await cur.executemany(
-                        "INSERT INTO file_md5 (kbid, md5, rid, field_id) VALUES (%s, %s, %s, %s)",
-                        rows,
-                    )
-                    row_idx += batch_end - batch_start
-
-    target_kb = large_kbs[0]
-
-    # Benchmark exists (hit)
-    start = time.monotonic()
-    result = await file_md5.exists(kbid=target_kb, md5="md5_0")
-    exists_hit_ms = (time.monotonic() - start) * 1000
-    assert result is True
-
-    # Benchmark exists (miss)
-    start = time.monotonic()
-    result = await file_md5.exists(kbid=target_kb, md5="nonexistent_md5")
-    exists_miss_ms = (time.monotonic() - start) * 1000
-    assert result is False
-
-    # Benchmark exists on a small KB
-    small_target = small_kbs[0]
-    start = time.monotonic()
-    result = await file_md5.exists(kbid=small_target, md5="nonexistent_md5")
-    exists_small_kb_ms = (time.monotonic() - start) * 1000
-    assert result is False
-
-    # Benchmark set (insert new)
-    new_rid = rid()
-    async with driver.rw_transaction() as txn:
-        start = time.monotonic()
-        await file_md5.set(txn, kbid=target_kb, md5="new_md5", rid=new_rid, field_id="f/new")
-        set_new_ms = (time.monotonic() - start) * 1000
-        await txn.commit()
-
-    # Benchmark set (upsert existing)
-    async with driver.rw_transaction() as txn:
-        start = time.monotonic()
-        await file_md5.set(txn, kbid=target_kb, md5="new_md5", rid=new_rid, field_id="f/new")
-        set_upsert_ms = (time.monotonic() - start) * 1000
-        await txn.commit()
-
-    # Benchmark delete by field
-    async with driver.rw_transaction() as txn:
-        start = time.monotonic()
-        await file_md5.delete(txn, kbid=target_kb, rid=new_rid, field_id="f/new")
-        delete_field_ms = (time.monotonic() - start) * 1000
-        await txn.commit()
-
-    # Insert a resource with multiple fields for resource-level delete benchmark
-    resource_rid = rid()
-    num_fields = 50
-    async with driver.rw_transaction() as txn:
-        for i in range(num_fields):
-            await file_md5.set(
-                txn, kbid=target_kb, md5=f"res_md5_{i}", rid=resource_rid, field_id=f"field_{i}"
-            )
-        await txn.commit()
-
-    # Benchmark delete by resource
-    async with driver.rw_transaction() as txn:
-        start = time.monotonic()
-        await file_md5.delete(txn, kbid=target_kb, rid=resource_rid)
-        delete_resource_ms = (time.monotonic() - start) * 1000
-        await txn.commit()
-
-    assert await file_md5.exists(kbid=target_kb, md5="res_md5_0") is False
-
-    # Benchmark delete by KB (large KB, ~280k rows)
-    async with driver.rw_transaction() as txn:
-        start = time.monotonic()
-        await file_md5.delete(txn, kbid=target_kb)
-        delete_large_kb_ms = (time.monotonic() - start) * 1000
-        await txn.commit()
-
-    assert await file_md5.exists(kbid=target_kb, md5="md5_0") is False
-
-    # Benchmark delete by KB (small KB)
-    async with driver.rw_transaction() as txn:
-        start = time.monotonic()
-        await file_md5.delete(txn, kbid=small_target)
-        delete_small_kb_ms = (time.monotonic() - start) * 1000
-        await txn.commit()
-
-    print(
-        f"\n--- file_md5 performance with {total_rows:,} rows across 300 KBs ---\n"
-        f"  exists (hit, large KB):     {exists_hit_ms:>8.2f} ms\n"
-        f"  exists (miss, large KB):    {exists_miss_ms:>8.2f} ms\n"
-        f"  exists (miss, small KB):    {exists_small_kb_ms:>8.2f} ms\n"
-        f"  set (new):                  {set_new_ms:>8.2f} ms\n"
-        f"  set (upsert):               {set_upsert_ms:>8.2f} ms\n"
-        f"  delete (field):             {delete_field_ms:>8.2f} ms\n"
-        f"  delete (resource, {num_fields} fields): {delete_resource_ms:>8.2f} ms\n"
-        f"  delete (large KB, ~{rows_per_large_kb:,}):  {delete_large_kb_ms:>8.2f} ms\n"
-        f"  delete (small KB, ~{rows_per_small_kb:,}):   {delete_small_kb_ms:>8.2f} ms\n"
-    )
-
-    # Sanity thresholds — single-row operations should be well under 100ms
-    assert exists_hit_ms < 100, f"exists (hit) too slow: {exists_hit_ms:.2f}ms"
-    assert exists_miss_ms < 100, f"exists (miss) too slow: {exists_miss_ms:.2f}ms"
-    assert exists_small_kb_ms < 100, f"exists (small KB) too slow: {exists_small_kb_ms:.2f}ms"
-    assert set_new_ms < 100, f"set (new) too slow: {set_new_ms:.2f}ms"
-    assert set_upsert_ms < 100, f"set (upsert) too slow: {set_upsert_ms:.2f}ms"
-    assert delete_field_ms < 100, f"delete (field) too slow: {delete_field_ms:.2f}ms"
-    assert delete_resource_ms < 100, f"delete (resource) too slow: {delete_resource_ms:.2f}ms"

--- a/nucliadb/tests/nucliadb/integration/common/test_file_md5.py
+++ b/nucliadb/tests/nucliadb/integration/common/test_file_md5.py
@@ -41,7 +41,7 @@ def kbid() -> str:
 
 
 def rid() -> str:
-    return str(uuid.uuid4())
+    return uuid.uuid4().hex
 
 
 async def test_set_and_exists(driver: PGDriver):
@@ -180,7 +180,7 @@ async def test_performance(driver: PGDriver):
                 for batch_start in range(0, count, batch_size):
                     batch_end = min(batch_start + batch_size, count)
                     rows = [
-                        (kb, f"md5_{row_idx + i}", str(uuid.uuid4()), f"f/field_{i % 10}")
+                        (kb, f"md5_{row_idx + i}", uuid.uuid4().hex, f"f/field_{i % 10}")
                         for i in range(batch_end - batch_start)
                     ]
                     await cur.executemany(

--- a/nucliadb/tests/nucliadb/integration/common/test_file_md5.py
+++ b/nucliadb/tests/nucliadb/integration/common/test_file_md5.py
@@ -26,6 +26,7 @@ import pytest
 
 from nucliadb.common import file_md5
 from nucliadb.common.maindb.pg import PGDriver
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_utils.utilities import Utility
 from tests.ndbfixtures.utils import global_utility
 
@@ -180,7 +181,7 @@ async def test_performance(driver: PGDriver):
                 for batch_start in range(0, count, batch_size):
                     batch_end = min(batch_start + batch_size, count)
                     rows = [
-                        (kb, f"md5_{row_idx + i}", uuid.uuid4().hex, f"f/field_{i % 10}")
+                        (kb, f"md5_{row_idx + i}", Resource.new_unique_rid(), f"f/field_{i % 10}")
                         for i in range(batch_end - batch_start)
                     ]
                     await cur.executemany(

--- a/nucliadb/tests/nucliadb/integration/search/test_search.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search.py
@@ -36,6 +36,7 @@ from nucliadb.common.cluster.settings import settings as cluster_settings
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.export_import.utils import get_processor_bm, get_writer_bm
 from nucliadb.ingest.consumer import shard_creator
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.search.predict import SendToPredictError
 from nucliadb.tests.vectors import V1
 from nucliadb_models.search import FindOptions
@@ -1288,8 +1289,9 @@ async def test_search_by_path_filter(
 
 @pytest.mark.deploy_modes("standalone")
 async def test_search_kb_not_found(nucliadb_reader: AsyncClient):
+    nonexistent_kbid = KnowledgeBox.new_unique_kbid()
     resp = await nucliadb_reader.get(
-        "/kb/00000000000000/search?query=own+text",
+        f"/kb/{nonexistent_kbid}/search?query=own+text",
     )
     assert resp.status_code == 404
 

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -76,7 +76,7 @@ from tests.utils.dirty_index import mark_dirty, wait_for_sync
 async def resource_with_conversation(
     nucliadb_ingest_grpc, nucliadb_writer: AsyncClient, standalone_knowledgebox
 ):
-    messages = []
+    messages: list[InputMessage] = []
     for i in range(1, 301):
         messages.append(
             InputMessage(
@@ -94,13 +94,22 @@ async def resource_with_conversation(
         content=CreateResourcePayload(
             slug="myresource",
             conversations={
-                "faq": InputConversationField(messages=messages),
+                "faq": InputConversationField(messages=[messages[0]]),
             },
         ).model_dump_json(by_alias=True),
     )
 
     assert resp.status_code == 201
     rid = resp.json()["uuid"]
+
+    # Put in buckets of 30 messages
+    remaining = messages[1:]
+    for i in range(0, len(remaining), 30):
+        resp = await nucliadb_writer.put(
+            f"/kb/{standalone_knowledgebox}/resource/{rid}/conversation/faq/messages",
+            json=[m.model_dump(mode="json", by_alias=True) for m in remaining[i : i + 30]],
+        )
+        assert resp.status_code == 200
 
     # add another message using the api to add single message
     resp = await nucliadb_writer.put(

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -26,6 +26,7 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 
+from nucliadb.ingest.orm.resource import Resource as ORMResource
 from nucliadb.ingest.processing import DummyProcessingEngine
 from nucliadb.models.internal.processing import PushMessageFormat, PushPayload
 from nucliadb.reader.api.models import ResourceField
@@ -1156,8 +1157,9 @@ async def test_delete_conversation_message_lambs_resource(
     # Verify error cases
 
     # Non-existent resource
+    nonexistent_rid = ORMResource.new_unique_rid()
     resp = await nucliadb_writer.delete(
-        f"/kb/{kbid}/resource/nonexistent-rid/conversation/lambs/messages/6",
+        f"/kb/{kbid}/resource/{nonexistent_rid}/conversation/lambs/messages/6",
     )
     assert resp.status_code == 404
 

--- a/nucliadb/tests/nucliadb/integration/test_data_augmentation_field_generation.py
+++ b/nucliadb/tests/nucliadb/integration/test_data_augmentation_field_generation.py
@@ -20,7 +20,6 @@
 import datetime
 import hashlib
 import json
-import uuid
 from collections.abc import AsyncIterator, Iterable
 from unittest.mock import patch
 
@@ -33,6 +32,7 @@ from pytest_mock import MockerFixture
 from nucliadb.common import datamanagers
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.ingest.orm.processor import Processor
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.ingest.processing import (
     DummyProcessingEngine,
     ProcessingEngine,
@@ -100,7 +100,7 @@ async def test_send_to_process_generated_fields(
     mocker: MockerFixture,
 ):
     kbid = knowledgebox
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
 
     # Resource creation (from writer)
     bm = BrokerMessage()
@@ -366,7 +366,7 @@ async def test_send_to_process_generated_conversation_field(
     This emulates the generation of a conversation field in the context of the memory feature.
     """
     kbid = knowledgebox
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     slug = "my-resource"
 
     # Resource creation (from writer)

--- a/nucliadb/tests/nucliadb/integration/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/test_labels.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import uuid
 from datetime import datetime
 
 import pytest
@@ -27,6 +26,7 @@ from nucliadb.ingest.orm.processor.processor import (
     delete_basic_computedmetadata_classifications,
     update_basic_computedmetadata_classifications,
 )
+from nucliadb.ingest.orm.resource import Resource as ORMResource
 from nucliadb.tests.vectors import V1, V2, V3
 from nucliadb_models.common import UserClassification
 from nucliadb_models.extracted import Classification
@@ -48,7 +48,7 @@ from tests.utils import inject_message
 
 
 def broker_resource(standalone_knowledgebox: str) -> BrokerMessage:
-    rid = uuid.uuid4().hex
+    rid = ORMResource.new_unique_rid()
     slug = f"{rid}slug1"
 
     bm: BrokerMessage = BrokerMessage(

--- a/nucliadb/tests/nucliadb/integration/test_labels.py
+++ b/nucliadb/tests/nucliadb/integration/test_labels.py
@@ -48,7 +48,7 @@ from tests.utils import inject_message
 
 
 def broker_resource(standalone_knowledgebox: str) -> BrokerMessage:
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     slug = f"{rid}slug1"
 
     bm: BrokerMessage = BrokerMessage(

--- a/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
+++ b/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
@@ -19,10 +19,10 @@
 #
 
 
-import uuid
-
 import pytest
 from httpx import AsyncClient
+
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 
 
 @pytest.mark.parametrize(
@@ -89,7 +89,7 @@ async def test_predict_proxy_not_proxied_returns_422(
 async def test_predict_proxy_returns_404_on_non_existing_kb(
     nucliadb_reader: AsyncClient,
 ):
-    idonotexist_kb = uuid.uuid4().hex
+    idonotexist_kb = KnowledgeBox.new_unique_kbid()
     resp = await nucliadb_reader.post(
         f"/kb/{idonotexist_kb}/predict/chat",
         json={"question": "foo", "query_context": ["foobar"], "user_id": "foo"},

--- a/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
+++ b/nucliadb/tests/nucliadb/integration/test_predict_proxy.py
@@ -19,6 +19,8 @@
 #
 
 
+import uuid
+
 import pytest
 from httpx import AsyncClient
 
@@ -87,8 +89,9 @@ async def test_predict_proxy_not_proxied_returns_422(
 async def test_predict_proxy_returns_404_on_non_existing_kb(
     nucliadb_reader: AsyncClient,
 ):
+    idonotexist_kb = uuid.uuid4().hex
     resp = await nucliadb_reader.post(
-        f"/kb/idonotexist-kb/predict/chat",
+        f"/kb/{idonotexist_kb}/predict/chat",
         json={"question": "foo", "query_context": ["foobar"], "user_id": "foo"},
     )
     assert resp.status_code == 404

--- a/nucliadb/tests/nucliadb/integration/test_processing_status.py
+++ b/nucliadb/tests/nucliadb/integration/test_processing_status.py
@@ -60,6 +60,14 @@ async def test_endpoint_set_resource_status_to_pending(
     )
     await inject_message(nucliadb_ingest_grpc, br)
 
+    async def _get_status():
+        resp = await nucliadb_reader.get(f"/kb/{standalone_knowledgebox}/resource/{br.uuid}")
+        assert resp.status_code == 200
+        resp_json = resp.json()
+        return resp_json["metadata"]["status"]
+
+    assert await _get_status() == "PENDING"
+
     # Receive message from processor
     br.source = BrokerMessage.MessageSource.PROCESSOR
     etw = rpb.ExtractedTextWrapper()
@@ -67,12 +75,10 @@ async def test_endpoint_set_resource_status_to_pending(
     etw.field.field = "text"
     etw.field.field_type = rpb.FieldType.TEXT
     br.extracted_text.append(etw)
+
     await inject_message(nucliadb_ingest_grpc, br)
 
-    resp = await nucliadb_reader.get(f"/kb/{standalone_knowledgebox}/resource/{br.uuid}")
-    assert resp.status_code == 200
-    resp_json = resp.json()
-    assert resp_json["metadata"]["status"] == "PROCESSED"
+    assert await _get_status() == "PROCESSED"
 
     kwargs = payload or {}
     resp = await nucliadb_writer.post(
@@ -81,10 +87,7 @@ async def test_endpoint_set_resource_status_to_pending(
     )
     assert resp.status_code == expected_status
 
-    resp = await nucliadb_reader.get(f"/kb/{standalone_knowledgebox}/resource/{br.uuid}")
-    assert resp.status_code == 200
-    resp_json = resp.json()
-    assert resp_json["metadata"]["status"] == "PENDING"
+    assert await _get_status() == "PENDING"
 
 
 @pytest.mark.deploy_modes("standalone")

--- a/nucliadb/tests/nucliadb/integration/test_purge_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_purge_vectorsets.py
@@ -19,7 +19,6 @@
 #
 
 import random
-import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -30,6 +29,7 @@ from nucliadb.ingest.orm.knowledgebox import (
     KB_VECTORSET_TO_DELETE,
     KnowledgeBox,
 )
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.purge import purge_kb_vectorsets
 from nucliadb_protos import resources_pb2, utils_pb2, writer_pb2
 from nucliadb_protos.knowledgebox_pb2 import VectorSetConfig, VectorSetPurge
@@ -85,7 +85,7 @@ async def create_broker_message_with_vectorset(
     kbid: str,
     driver: Driver,
 ):
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = f"{rid}-text-field"
     bm = writer_pb2.BrokerMessage(kbid=kbid, uuid=rid, type=writer_pb2.BrokerMessage.AUTOCOMMIT)
 

--- a/nucliadb/tests/nucliadb/integration/test_purge_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_purge_vectorsets.py
@@ -85,7 +85,7 @@ async def create_broker_message_with_vectorset(
     kbid: str,
     driver: Driver,
 ):
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     field_id = f"{rid}-text-field"
     bm = writer_pb2.BrokerMessage(kbid=kbid, uuid=rid, type=writer_pb2.BrokerMessage.AUTOCOMMIT)
 

--- a/nucliadb/tests/nucliadb/integration/test_resources.py
+++ b/nucliadb/tests/nucliadb/integration/test_resources.py
@@ -26,6 +26,7 @@ from httpx import AsyncClient
 
 from nucliadb.common.maindb.pg import PGDriver
 from nucliadb.common.maindb.utils import get_driver
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.writer.api.v1.router import KB_PREFIX, RESOURCES_PREFIX
 
 
@@ -321,8 +322,9 @@ async def test_resource_slug_modification_handles_unknown_resources(
     nucliadb_writer: AsyncClient,
     standalone_knowledgebox,
 ):
+    non_existing_resource = Resource.new_unique_rid()
     resp = await nucliadb_writer.patch(
-        f"/{KB_PREFIX}/{standalone_knowledgebox}/resource/foobar",
+        f"/{KB_PREFIX}/{standalone_knowledgebox}/resource/{non_existing_resource}",
         json={
             "slug": "foo",
         },

--- a/nucliadb/tests/nucliadb/integration/test_suggest.py
+++ b/nucliadb/tests/nucliadb/integration/test_suggest.py
@@ -25,6 +25,7 @@ import pytest
 from httpx import AsyncClient, Response
 from typing_extensions import assert_never
 
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos.resources_pb2 import LinkExtractedData
 from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_protos.writer_pb2_grpc import WriterStub
@@ -506,8 +507,9 @@ async def test_suggest_features(
 
 @pytest.mark.deploy_modes("standalone")
 async def test_search_kb_not_found(nucliadb_reader: AsyncClient) -> None:
+    nonexistent_kbid = KnowledgeBox.new_unique_kbid()
     resp = await nucliadb_reader.get(
-        f"/kb/00000000000000/suggest?query=own+text",
+        f"/kb/{nonexistent_kbid}/suggest?query=own+text",
     )
     assert resp.status_code == 404
 

--- a/nucliadb/tests/nucliadb/integration/test_summarize.py
+++ b/nucliadb/tests/nucliadb/integration/test_summarize.py
@@ -21,6 +21,7 @@ import pytest
 from httpx import AsyncClient
 
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_models.search import SummarizedResponse
 
 
@@ -54,8 +55,9 @@ async def test_summarize(
     resources = resource_uuids[0:9] + resource_slugs[10:]
 
     # Summarize all of them
+    non_existent = Resource.new_unique_rid()
     resp = await nucliadb_reader.post(
-        f"/kb/{kbid}/summarize", json={"resources": [*resources, "non-existent"]}
+        f"/kb/{kbid}/summarize", json={"resources": [*resources, non_existent]}
     )
     assert resp.status_code == 200, resp.text
 

--- a/nucliadb/tests/nucliadb/integration/test_summarize.py
+++ b/nucliadb/tests/nucliadb/integration/test_summarize.py
@@ -20,6 +20,7 @@
 import pytest
 from httpx import AsyncClient
 
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_models.search import SummarizedResponse
 
 
@@ -67,5 +68,8 @@ async def test_summarize(
 async def test_summarize_unexisting_kb(
     nucliadb_reader: AsyncClient,
 ):
-    resp = await nucliadb_reader.post(f"/kb/foobar/summarize", json={"resources": ["1", "2", "3"]})
+    unexisting_kb = KnowledgeBox.new_unique_kbid()
+    resp = await nucliadb_reader.post(
+        f"/kb/{unexisting_kb}/summarize", json={"resources": ["1", "2", "3"]}
+    )
     assert resp.status_code == 404

--- a/nucliadb/tests/nucliadb/integration/test_vectorsets.py
+++ b/nucliadb/tests/nucliadb/integration/test_vectorsets.py
@@ -20,7 +20,6 @@
 
 import functools
 import random
-import uuid
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -33,6 +32,7 @@ from nucliadb.common.cluster import manager
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.common.nidx import get_nidx_searcher_client
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.search.predict import DummyPredictEngine
 from nucliadb.search.requesters import utils
 from nucliadb_models.internal.predict import (
@@ -285,7 +285,7 @@ async def test_querying_kb_with_vectorsets(
             ),
         },
     )
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = "my-field"
     bm = create_broker_message_with_vectorsets(kbid, rid, field_id, [("model", 768)])
     await inject_message(nucliadb_ingest_grpc, bm)
@@ -351,7 +351,7 @@ async def test_querying_kb_with_vectorsets(
             ),
         },
     )
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = "my-field"
     bm = create_broker_message_with_vectorsets(
         kbid, rid, field_id, [("model-A", 768), ("model-B", 1024)]

--- a/nucliadb/tests/nucliadb/knowledgeboxes/vectorsets.py
+++ b/nucliadb/tests/nucliadb/knowledgeboxes/vectorsets.py
@@ -26,6 +26,7 @@ import pytest
 from httpx import AsyncClient
 
 from nucliadb.export_import.utils import get_processor_bm, get_writer_bm
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from tests.utils import inject_message
 
@@ -77,7 +78,7 @@ async def inject_broker_message_with_vectorset_data(
 
     bm = create_broker_message_with_vectorset(
         kbid,
-        rid=uuid.uuid4().hex,
+        rid=Resource.new_unique_rid(),
         field_id=uuid.uuid4().hex,
         vectorset_id=vectorset_id,
         default_vectorset_dimension=default_vector_dimension,

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0018.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0018.py
@@ -44,7 +44,7 @@ async def test_migration_0018_global(maindb_driver: Driver):
         # setup some orphan /kbslugs keys and some real ones
         async with maindb_driver.rw_transaction() as txn:
             fake_kb_slug = "fake-kb-slug"
-            fake_kb_id = "fake-kb-id"
+            fake_kb_id = KnowledgeBox.new_unique_kbid()
             key = KB_SLUGS.format(slug=fake_kb_slug)
             await txn.set(key, fake_kb_id.encode())
             assert not await datamanagers.kb.exists_kb(txn, kbid=fake_kb_id)

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0018.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0018.py
@@ -19,6 +19,8 @@
 #
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
+
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.kb import KB_SLUGS
 from nucliadb.common.maindb.driver import Driver
@@ -30,6 +32,7 @@ from tests.nucliadb.migrations import get_migration
 migration: Migration = get_migration(18)
 
 
+@pytest.mark.skip(reason="This migration is not needed anymore")
 async def test_migration_0018_global(maindb_driver: Driver):
     execution_context = Mock()
     execution_context.kv_driver = maindb_driver

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
@@ -20,6 +20,7 @@
 import uuid
 from unittest.mock import Mock, patch
 
+from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.conversations import KB_CONVERSATION_SPLITS_METADATA
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.fields.conversation import Conversation
@@ -45,7 +46,10 @@ async def test_migration_0039(maindb_driver: Driver):
     with patch("nucliadb.ingest.orm.resource.get_storage"):
         # Create a fake conversation field with only one message
         async with maindb_driver.rw_transaction() as txn:
+            await datamanagers.kb.kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug="slug")
+
             kb_obj = KnowledgeBox(txn, storage, kbid)
+            await datamanagers.resources.resources_v2.set_slug(txn, kbid=kbid, rid=rid, slug="slug")
             r_obj = await kb_obj.add_resource(rid, "slug")
             conv_pb = resources_pb2.Conversation()
             conv_pb.messages.append(resources_pb2.Message(ident="foo"))

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
@@ -24,6 +24,7 @@ from nucliadb.common.datamanagers.conversations import KB_CONVERSATION_SPLITS_ME
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.migrator.models import Migration
 from nucliadb_protos import resources_pb2
 from tests.nucliadb.migrations import get_migration
@@ -38,7 +39,7 @@ async def test_migration_0039(maindb_driver: Driver):
     execution_context.blob_storage = storage
 
     kbid = str(uuid.uuid4())
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     field_id = "faq"
 
     with patch("nucliadb.ingest.orm.resource.get_storage"):

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0039.py
@@ -38,7 +38,7 @@ async def test_migration_0039(maindb_driver: Driver):
     execution_context.blob_storage = storage
 
     kbid = str(uuid.uuid4())
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     field_id = "faq"
 
     with patch("nucliadb.ingest.orm.resource.get_storage"):

--- a/nucliadb/tests/nucliadb/unit/common/cluster/test_kb_shard_manager.py
+++ b/nucliadb/tests/nucliadb/unit/common/cluster/test_kb_shard_manager.py
@@ -17,13 +17,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from typing import Any
 
 import pytest
 
 from nucliadb.common import datamanagers
 from nucliadb.common.cluster import manager
-from nucliadb.common.maindb.driver import Transaction
+from nucliadb.common.maindb.driver import Driver, Transaction
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb_protos import writer_pb2
 
 
@@ -34,7 +34,7 @@ async def test_shard_creation(dummy_nidx_utility, txn: Transaction):
     update the information about writable shards.
 
     """
-    kbid = f"kbid:{test_shard_creation.__name__}"
+    kbid = KnowledgeBox.new_unique_kbid()
     sm = manager.KBShardManager()
 
     # Fake KB shards instead of creating a KB to generate it
@@ -82,15 +82,6 @@ async def test_shard_creation(dummy_nidx_utility, txn: Transaction):
 
 
 @pytest.fixture
-def txn():
-    class MockTransaction:
-        def __init__(self):
-            self.store = {}
-
-        async def get(self, key: str, for_update=False) -> Any | None:
-            return self.store.get(key, None)
-
-        async def set(self, key: str, value: Any):
-            self.store[key] = value
-
-    yield MockTransaction()
+async def txn(maindb_driver: Driver):
+    async with maindb_driver.rw_transaction() as txn:
+        yield txn

--- a/nucliadb/tests/reader/integration/api/v1/test_export_import.py
+++ b/nucliadb/tests/reader/integration/api/v1/test_export_import.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import uuid
+
 import pytest
 from httpx import AsyncClient
 
@@ -35,10 +37,11 @@ async def test_api(nucliadb_reader: AsyncClient, knowledgebox: str):
     assert resp.status_code < 500
 
     # Check that for non-existing kbs, endpoints return a 404
+    idonotexist = uuid.uuid4().hex
     for endpoint in (
-        "/kb/idonotexist/export/foo",
-        "/kb/idonotexist/export/foo/status",
-        "/kb/idonotexist/import/foo/status",
+        f"/kb/{idonotexist}/export/foo",
+        f"/kb/{idonotexist}/export/foo/status",
+        f"/kb/{idonotexist}/import/foo/status",
     ):
         resp = await nucliadb_reader.get(endpoint)
         assert resp.status_code == 404

--- a/nucliadb/tests/reader/integration/api/v1/test_reader_resource.py
+++ b/nucliadb/tests/reader/integration/api/v1/test_reader_resource.py
@@ -18,6 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import uuid
+
 import pytest
 from httpx import AsyncClient
 
@@ -52,10 +54,10 @@ EXTRACTED = ("extracted",)
 @pytest.mark.deploy_modes("component")
 async def test_get_resource_inexistent(nucliadb_reader: AsyncClient, knowledgebox: str) -> None:
     kbid = knowledgebox
-    rid = "000000000000001"
+    inexistent = uuid.uuid4().hex
 
     resp = await nucliadb_reader.get(
-        f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}",
+        f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{inexistent}",
     )
     assert resp.status_code == 404
 
@@ -329,15 +331,17 @@ async def test_get_resource_extracted_metadata(nucliadb_reader: AsyncClient, tes
 async def test_head_resource(nucliadb_reader: AsyncClient, test_resource: Resource):
     kbid = test_resource.kbid
     slug = test_resource.basic.slug  # type: ignore
-    uuid = test_resource.uuid
+    ruuid = test_resource.uuid
 
     # By UUID
     resp = await nucliadb_reader.head(
-        f"/kb/{kbid}/resource/{uuid}",
+        f"/kb/{kbid}/resource/{ruuid}",
     )
     assert resp.status_code == 200
+
+    non_existent_ruuid = uuid.uuid4().hex
     resp = await nucliadb_reader.head(
-        f"/kb/{kbid}/resource/non-existent-uuid",
+        f"/kb/{kbid}/resource/{non_existent_ruuid}",
     )
     assert resp.status_code == 404
 

--- a/nucliadb/tests/reader/integration/api/v1/test_services.py
+++ b/nucliadb/tests/reader/integration/api/v1/test_services.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
+import uuid
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from unittest import mock
@@ -145,7 +146,8 @@ async def test_activity(kb_notifications, nucliadb_reader: AsyncClient, knowledg
 async def test_activity_kb_not_found(
     nucliadb_reader: AsyncClient,
 ):
-    resp = await nucliadb_reader.get(f"/{KB_PREFIX}/foobar/notifications")
+    foobar = uuid.uuid4().hex
+    resp = await nucliadb_reader.get(f"/{KB_PREFIX}/{foobar}/notifications")
     assert resp.status_code == 404
 
 

--- a/nucliadb/tests/reader/integration/reader/test_notifications.py
+++ b/nucliadb/tests/reader/integration/reader/test_notifications.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import asyncio
+import uuid
 from unittest import mock
 
 import pytest
@@ -48,7 +49,8 @@ async def pubsub(natsd):
 
 
 async def test_kb_notifications(pubsub):
-    kbid = "testkb"
+    kbid = uuid.uuid4().hex
+    other_kb = uuid.uuid4().hex
     activity = []
 
     async def read_activity(kbid):
@@ -63,10 +65,12 @@ async def test_kb_notifications(pubsub):
     await asyncio.sleep(0.1)
 
     # Publish some notifications
-    await resource_notification(pubsub, kbid, uuid="resource1", seqid=1)
-    await resource_notification(pubsub, kbid, uuid="resource2", seqid=2)
+    resource_1 = uuid.uuid4().hex
+    await resource_notification(pubsub, kbid, uuid=resource_1, seqid=1)
+    resource_2 = uuid.uuid4().hex
+    await resource_notification(pubsub, kbid, uuid=resource_2, seqid=2)
     # This notification should not be read as it is for a different kbid
-    await resource_notification(pubsub, "other-kb")
+    await resource_notification(pubsub, other_kb)
 
     # Wait for the reader task to process the notifications
     await asyncio.sleep(1)
@@ -77,9 +81,9 @@ async def test_kb_notifications(pubsub):
 
     # Check that the activity was read
     assert len(activity) == 2
-    assert activity[0].uuid == "resource1"
+    assert activity[0].uuid == resource_1
     assert activity[0].seqid == 1
-    assert activity[1].uuid == "resource2"
+    assert activity[1].uuid == resource_2
     assert activity[1].seqid == 2
 
 

--- a/nucliadb/tests/search/integration/search/test_paragraphs.py
+++ b/nucliadb/tests/search/integration/search/test_paragraphs.py
@@ -34,6 +34,7 @@ async def test_get_paragraph_text(storage, cache, txn, dummy_nidx_utility, proce
     rid = Resource.new_unique_rid()
     basic = Basic(slug="slug", uuid=rid)
     await datamanagers.resources.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
+    await datamanagers.resources.set_slug(txn, kbid=kbid, rid=rid, slug="slug")
     kb = KnowledgeBox(txn, storage, kbid)
     orm_resource = await kb.get(rid)
     assert orm_resource

--- a/nucliadb/tests/search/integration/search/test_paragraphs.py
+++ b/nucliadb/tests/search/integration/search/test_paragraphs.py
@@ -17,13 +17,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import uuid
 
 import pytest
 
 from nucliadb.common import datamanagers
 from nucliadb.common.ids import ParagraphId
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.search.search import paragraphs
 from nucliadb_protos.resources_pb2 import Basic, ExtractedTextWrapper, FieldType
 from nucliadb_protos.utils_pb2 import ExtractedText
@@ -31,7 +31,7 @@ from nucliadb_protos.utils_pb2 import ExtractedText
 
 async def test_get_paragraph_text(storage, cache, txn, dummy_nidx_utility, processor, knowledgebox):
     kbid = knowledgebox
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     basic = Basic(slug="slug", uuid=rid)
     await datamanagers.resources.set_basic(txn, kbid=kbid, rid=rid, basic=basic)
     kb = KnowledgeBox(txn, storage, kbid)

--- a/nucliadb/tests/search/unit/search/test_query_parsing.py
+++ b/nucliadb/tests/search/unit/search/test_query_parsing.py
@@ -23,7 +23,9 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
+from nucliadb.common.datamanagers import kb_v2
 from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.search.predict import DummyPredictEngine
 from nucliadb.search.search.query_parser import models as parser_models
 from nucliadb.search.search.query_parser.parsers import parse_find
@@ -41,14 +43,24 @@ def disable_hidden_resources_check():
         yield
 
 
+@pytest.fixture(scope="function", autouse=True)
+async def kbid(maindb_driver: Driver):
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
+
+
 async def test_find_query_parsing__top_k(
     maindb_driver: Driver,
     dummy_predict: PredictEngine,
+    kbid: str,
 ):
     find = FindRequest(
         top_k=20,
     )
-    parsed = await parse_find("kbid", find)
+    parsed = await parse_find(kbid, find)
     assert parsed.retrieval.top_k == find.top_k
 
 
@@ -76,13 +88,14 @@ async def test_find_query_parsing__rank_fusion(
     expected: parser_models.RankFusion,
     maindb_driver: Driver,
     dummy_predict: PredictEngine,
+    kbid: str,
 ):
     find = FindRequest(
         top_k=20,
         rank_fusion=rank_fusion,
         reranker=search_models.RerankerName.NOOP,
     )
-    parsed = await parse_find("kbid", find)
+    parsed = await parse_find(kbid, find)
     assert parsed.retrieval.rank_fusion is not None
     assert parsed.retrieval.rank_fusion == expected
 
@@ -90,7 +103,7 @@ async def test_find_query_parsing__rank_fusion(
 # ATENTION: if you're changing this test, make sure public models, private
 # models and parsing are change accordingly!
 async def test_find_query_parsing__rank_fusion_limits(
-    maindb_driver: Driver, dummy_predict: PredictEngine
+    maindb_driver: Driver, dummy_predict: PredictEngine, kbid: str
 ):
     FindRequest.model_validate(
         {
@@ -102,7 +115,7 @@ async def test_find_query_parsing__rank_fusion_limits(
     )
 
     await parse_find(
-        "kbid", FindRequest(rank_fusion=search_models.ReciprocalRankFusion.model_construct(window=500))
+        kbid, FindRequest(rank_fusion=search_models.ReciprocalRankFusion.model_construct(window=500))
     )
 
     with pytest.raises(ValidationError):
@@ -116,7 +129,7 @@ async def test_find_query_parsing__rank_fusion_limits(
         )
 
     parsed = await parse_find(
-        "kbid", FindRequest(rank_fusion=search_models.ReciprocalRankFusion.model_construct(window=501))
+        kbid, FindRequest(rank_fusion=search_models.ReciprocalRankFusion.model_construct(window=501))
     )
     assert parsed.retrieval.rank_fusion is not None and parsed.retrieval.rank_fusion.window == 500
 
@@ -132,6 +145,7 @@ async def test_find_query_parsing__rank_fusion_limits(
 async def test_find_query_parsing__reranker(
     maindb_driver: Driver,
     dummy_predict: PredictEngine,
+    kbid: str,
     reranker: search_models.RerankerName | search_models.Reranker,
     expected: parser_models.Reranker,
 ):
@@ -139,14 +153,16 @@ async def test_find_query_parsing__reranker(
         top_k=20,
         reranker=reranker,
     )
-    parsed = await parse_find("kbid", find)
+    parsed = await parse_find(kbid, find)
     assert parsed.retrieval.reranker is not None
     assert parsed.retrieval.reranker == expected
 
 
 # ATENTION: if you're changing this test, make sure public models, private
 # models and parsing are change accordingly!
-async def test_find_query_parsing__reranker_limits(maindb_driver: Driver, dummy_predict: PredictEngine):
+async def test_find_query_parsing__reranker_limits(
+    maindb_driver: Driver, dummy_predict: PredictEngine, kbid: str
+):
     FindRequest.model_validate(
         {
             "reranker": {
@@ -156,13 +172,13 @@ async def test_find_query_parsing__reranker_limits(maindb_driver: Driver, dummy_
         }
     )
 
-    await parse_find("kbid", FindRequest(reranker=search_models.PredictReranker(window=200)))
+    await parse_find(kbid, FindRequest(reranker=search_models.PredictReranker(window=200)))
 
     with pytest.raises(ValidationError):
         FindRequest.model_validate({"reranker": {"name": "predict", "window": 201}})
 
     parsed = await parse_find(
-        "kbid", FindRequest(reranker=search_models.PredictReranker.model_construct(window=201))
+        kbid, FindRequest(reranker=search_models.PredictReranker.model_construct(window=201))
     )
     assert (
         isinstance(parsed.retrieval.reranker, parser_models.PredictReranker)
@@ -170,7 +186,9 @@ async def test_find_query_parsing__reranker_limits(maindb_driver: Driver, dummy_
     )
 
 
-async def test_find_query_parsing__query_image(maindb_driver: Driver, dummy_predict: PredictEngine):
+async def test_find_query_parsing__query_image(
+    maindb_driver: Driver, dummy_predict: PredictEngine, kbid: str
+):
     """We want to check that the rephrased query is used for keyword search if an image is provided."""
     predict = get_predict()
     assert isinstance(predict, DummyPredictEngine)
@@ -183,15 +201,15 @@ async def test_find_query_parsing__query_image(maindb_driver: Driver, dummy_pred
         ),
     )
 
-    fetcher = fetcher_for_find("kbid", find)
-    parsed = await parse_find("kbid", find, fetcher=fetcher)
+    fetcher = fetcher_for_find(kbid, find)
+    parsed = await parse_find(kbid, find, fetcher=fetcher)
     assert parsed.retrieval.query.keyword is not None
     assert parsed.retrieval.query.keyword.query == "<REPHRASED-QUERY>"
 
     # If rephrase is on but there is no query image, we should use the original query
     find.rephrase = True
     find.query_image = None
-    fetcher = fetcher_for_find("kbid", find)
-    parsed = await parse_find("kbid", find, fetcher=fetcher)
+    fetcher = fetcher_for_find(kbid, find)
+    parsed = await parse_find(kbid, find, fetcher=fetcher)
     assert parsed.retrieval.query.keyword is not None
     assert parsed.retrieval.query.keyword.query == find.query

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -57,6 +57,7 @@ def disable_hidden_resources_check():
         yield
 
 
+@pytest.fixture(scope="function")
 async def kbid(maindb_driver: Driver) -> str:
     kbid = KnowledgeBox.new_unique_kbid()
     async with maindb_driver.rw_transaction() as txn:

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -31,9 +31,11 @@ import pytest
 from nidx_protos.nodereader_pb2 import DocumentScored, GraphSearchResponse, ParagraphResult
 
 import nucliadb_models.search as search_models
+from nucliadb.common import datamanagers
 from nucliadb.common.external_index_providers.base import TextBlockMatch
 from nucliadb.common.ids import ParagraphId, VectorId
 from nucliadb.common.maindb.driver import Driver
+from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.search.predict import PredictEngine
 from nucliadb.search.search.query_parser.parsers import parse_find
 from nucliadb.search.search.rank_fusion import ReciprocalRankFusion, WeightedCombSum, get_rank_fusion
@@ -55,6 +57,14 @@ def disable_hidden_resources_check():
         yield
 
 
+async def kbid(maindb_driver: Driver) -> str:
+    kbid = KnowledgeBox.new_unique_kbid()
+    async with maindb_driver.rw_transaction() as txn:
+        await datamanagers.kb.kb_v2.set_kbid_for_slug(txn, kbid=kbid, slug=f"slug-{kbid}")
+        await txn.commit()
+    return kbid
+
+
 @pytest.mark.parametrize(
     "rank_fusion,expected_type",
     [
@@ -63,10 +73,10 @@ def disable_hidden_resources_check():
     ],
 )
 async def test_get_rank_fusion(
-    maindb_driver: Driver, dummy_predict: PredictEngine, rank_fusion, expected_type: type
+    maindb_driver: Driver, dummy_predict: PredictEngine, kbid: str, rank_fusion, expected_type: type
 ):
     item = FindRequest(rank_fusion=rank_fusion)
-    parsed = await parse_find("kbid", item)
+    parsed = await parse_find(kbid, item)
     assert parsed.retrieval.rank_fusion is not None
     algorithm = get_rank_fusion(parsed.retrieval.rank_fusion)
     assert isinstance(algorithm, expected_type)

--- a/nucliadb/tests/train/test_paragraph_classification.py
+++ b/nucliadb/tests/train/test_paragraph_classification.py
@@ -18,11 +18,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import uuid
 
 import aiohttp
 import pytest
 
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
 from nucliadb_protos import resources_pb2 as rpb
@@ -79,7 +79,7 @@ async def inject_resource_with_paragraph_classification(knowledgebox, writer):
 
 
 def broker_resource(knowledgebox: str) -> BrokerMessage:
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bmb = BrokerMessageBuilder(kbid=knowledgebox, rid=rid)
     bmb.with_title("Title Resource")
     bmb.with_summary("Summary of document")

--- a/nucliadb/tests/train/test_paragraph_classification.py
+++ b/nucliadb/tests/train/test_paragraph_classification.py
@@ -79,7 +79,7 @@ async def inject_resource_with_paragraph_classification(knowledgebox, writer):
 
 
 def broker_resource(knowledgebox: str) -> BrokerMessage:
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bmb = BrokerMessageBuilder(kbid=knowledgebox, rid=rid)
     bmb.with_title("Title Resource")
     bmb.with_summary("Summary of document")

--- a/nucliadb/tests/train/test_sentence_classification.py
+++ b/nucliadb/tests/train/test_sentence_classification.py
@@ -18,11 +18,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-import uuid
 
 import aiohttp
 import pytest
 
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.train import API_PREFIX
 from nucliadb.train.api.v1.router import KB_PREFIX
 from nucliadb_protos import resources_pb2 as rpb
@@ -77,7 +77,7 @@ async def inject_resource_with_sentence_classification(knowledgebox, writer):
 
 
 def broker_resource(knowledgebox: str) -> BrokerMessage:
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     bmb = BrokerMessageBuilder(kbid=knowledgebox, rid=rid)
     bmb.with_title("Title Resource")
     bmb.with_summary("Summary of document")

--- a/nucliadb/tests/train/test_sentence_classification.py
+++ b/nucliadb/tests/train/test_sentence_classification.py
@@ -77,7 +77,7 @@ async def inject_resource_with_sentence_classification(knowledgebox, writer):
 
 
 def broker_resource(knowledgebox: str) -> BrokerMessage:
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     bmb = BrokerMessageBuilder(kbid=knowledgebox, rid=rid)
     bmb.with_title("Title Resource")
     bmb.with_summary("Summary of document")

--- a/nucliadb/tests/utils/__init__.py
+++ b/nucliadb/tests/utils/__init__.py
@@ -35,7 +35,7 @@ def broker_resource(
     """
     Returns a broker resource with barebones metadata.
     """
-    rid = rid or str(uuid.uuid4()).replace("-", "")
+    rid = rid or uuid.uuid4().hex
     slug = slug or f"{rid}slug1"
 
     bmb = BrokerMessageBuilder(kbid=kbid, rid=rid, slug=slug, source=source)

--- a/nucliadb/tests/utils/__init__.py
+++ b/nucliadb/tests/utils/__init__.py
@@ -19,6 +19,7 @@
 #
 import uuid
 
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_protos import resources_pb2 as rpb
 from nucliadb_protos.writer_pb2 import BrokerMessage, OpStatusWriter
 from nucliadb_protos.writer_pb2_grpc import WriterStub
@@ -35,7 +36,7 @@ def broker_resource(
     """
     Returns a broker resource with barebones metadata.
     """
-    rid = rid or uuid.uuid4().hex
+    rid = rid or Resource.new_unique_rid()
     slug = slug or f"{rid}slug1"
 
     bmb = BrokerMessageBuilder(kbid=kbid, rid=rid, slug=slug, source=source)

--- a/nucliadb/tests/writer/integration/api/v1/test_export_import.py
+++ b/nucliadb/tests/writer/integration/api/v1/test_export_import.py
@@ -18,6 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import uuid
+
 import pytest
 from httpx import AsyncClient
 
@@ -50,7 +52,8 @@ async def test_api(nucliadb_writer: AsyncClient, knowledgebox: str, export_impor
     assert resp.status_code < 500
 
     # Check that for non-existing kbs, endpoints return a 404
-    for endpoint in ("/kb/idonotexist/import", "/kb/idonotexist/export"):
+    idonotexist = uuid.uuid4().hex
+    for endpoint in (f"/kb/{idonotexist}/import", f"/kb/{idonotexist}/export"):
         resp = await nucliadb_writer.post(endpoint)
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Knowledge Box not found"

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -21,6 +21,7 @@ import asyncio
 import base64
 import io
 import os
+import uuid
 from typing import cast
 
 import pytest
@@ -533,8 +534,9 @@ async def test_file_tus_upload_urls_field_by_resource_id(
         "upload-defer-length": "1",
     }
 
+    idonotexist = uuid.uuid4().hex
     resp = await nucliadb_writer.post(
-        f"/{KB_PREFIX}/{kbid}/resource/idonotexist/file/field1/{TUSUPLOAD}",
+        f"/{KB_PREFIX}/{kbid}/resource/{idonotexist}/file/field1/{TUSUPLOAD}",
         headers=headers,
     )
     assert resp.status_code == 404

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -269,8 +269,9 @@ async def test_knowledgebox_file_tus_upload_field(
     filename = base64.b64encode(b"image.jpg").decode()
     md5 = base64.b64encode(b"7af0916dba8b70e29d99e72941923529").decode()
 
+    invalid_resource = uuid.uuid4().hex
     resp = await nucliadb_writer.post(
-        f"/{KB_PREFIX}/{kbid}/resource/invalidresource/file/field1/{TUSUPLOAD}",
+        f"/{KB_PREFIX}/{kbid}/resource/{invalid_resource}/file/field1/{TUSUPLOAD}",
         headers={
             "tus-resumable": "1.0.0",
             "upload-metadata": f"filename {filename},language {language},md5 {md5}",

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -28,6 +28,7 @@ import pytest
 from httpx import AsyncClient
 
 from nucliadb.common import datamanagers
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.writer.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX
 from nucliadb.writer.api.v1.upload import maybe_b64decode
 from nucliadb.writer.tus import TUSUPLOAD, UPLOAD, get_storage_manager
@@ -269,7 +270,7 @@ async def test_knowledgebox_file_tus_upload_field(
     filename = base64.b64encode(b"image.jpg").decode()
     md5 = base64.b64encode(b"7af0916dba8b70e29d99e72941923529").decode()
 
-    invalid_resource = uuid.uuid4().hex
+    invalid_resource = Resource.new_unique_rid()
     resp = await nucliadb_writer.post(
         f"/{KB_PREFIX}/{kbid}/resource/{invalid_resource}/file/field1/{TUSUPLOAD}",
         headers={

--- a/nucliadb/tests/writer/test_resources.py
+++ b/nucliadb/tests/writer/test_resources.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock
@@ -201,9 +202,9 @@ async def test_resource_crud_sync(nucliadb_writer: AsyncClient, knowledgebox: st
     assert resp.status_code == 200
 
     # Test delete resource
-
+    non_existing_rid = uuid.uuid4().hex
     resp = await nucliadb_writer.delete(
-        f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/resource1",
+        f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{non_existing_rid}",
     )
 
     assert resp.status_code == 404

--- a/nucliadb/tests/writer/test_resources.py
+++ b/nucliadb/tests/writer/test_resources.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import uuid
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock
@@ -202,7 +201,7 @@ async def test_resource_crud_sync(nucliadb_writer: AsyncClient, knowledgebox: st
     assert resp.status_code == 200
 
     # Test delete resource
-    non_existing_rid = uuid.uuid4().hex
+    non_existing_rid = Resource.new_unique_rid()
     resp = await nucliadb_writer.delete(
         f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{non_existing_rid}",
     )

--- a/nucliadb/tests/writer/test_tus.py
+++ b/nucliadb/tests/writer/test_tus.py
@@ -119,7 +119,7 @@ async def test_local_driver(local_storage_tus: LocalBlobStore):
 async def storage_test(storage: BlobStore, file_storage_manager: FileStorageManager):
     example = b"mytestinfo"
     field = "myfield"
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     kbid = str(uuid.uuid4())
 
     metadata: dict[str, str] = {"filename": "non-ascii is problematic - Ôñ"}

--- a/nucliadb/tests/writer/test_tus.py
+++ b/nucliadb/tests/writer/test_tus.py
@@ -119,16 +119,16 @@ async def test_local_driver(local_storage_tus: LocalBlobStore):
 async def storage_test(storage: BlobStore, file_storage_manager: FileStorageManager):
     example = b"mytestinfo"
     field = "myfield"
-    rid = "myrid"
-    kbid = "mykb_tus_test"
+    rid = str(uuid.uuid4())
+    kbid = str(uuid.uuid4())
 
     metadata: dict[str, str] = {"filename": "non-ascii is problematic - Ôñ"}
     bucket_name = storage.get_bucket_name(kbid)
     assert bucket_name in [
-        "test_mykb_tus_test",
-        "test-mykb-tus-test",
-        "ndb_mykb_tus_test",
-        "mykb_tus_test",
+        f"test_{kbid}",
+        f"test-{kbid}",
+        f"ndb_{kbid}",
+        kbid,
     ]
 
     assert await storage.check_exists(bucket_name) is False

--- a/nucliadb/tests/writer/test_tus.py
+++ b/nucliadb/tests/writer/test_tus.py
@@ -22,6 +22,7 @@ import uuid
 
 import pytest
 
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb.writer.settings import settings
 from nucliadb.writer.tus import get_dm
 from nucliadb.writer.tus.gcs import GCloudBlobStore, GCloudFileStorageManager
@@ -119,7 +120,7 @@ async def test_local_driver(local_storage_tus: LocalBlobStore):
 async def storage_test(storage: BlobStore, file_storage_manager: FileStorageManager):
     example = b"mytestinfo"
     field = "myfield"
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     kbid = str(uuid.uuid4())
 
     metadata: dict[str, str] = {"filename": "non-ascii is problematic - Ôñ"}

--- a/nucliadb/tests/writer/unit/api/v1/test_upload.py
+++ b/nucliadb/tests/writer/unit/api/v1/test_upload.py
@@ -137,6 +137,7 @@ async def test_validate_field_upload(rid, field, md5, resource_exists: bool, md5
     mock_uuid.uuid4 = Mock(return_value=mock_uuid4)
 
     with (
+        patch("nucliadb.writer.api.v1.upload.Resource.new_unique_rid", return_value="uuid4"),
         patch("nucliadb.writer.api.v1.upload.uuid", mock_uuid),
         patch(
             "nucliadb.writer.api.v1.upload.datamanagers.atomic.resources.resource_exists",

--- a/nucliadb_dataset/tests/integration/test_question_answer_streaming.py
+++ b/nucliadb_dataset/tests/integration/test_question_answer_streaming.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import time
-import uuid
 from datetime import datetime
 
 import pytest
 
 from integration.utils import export_dataset
+from nucliadb.ingest.orm.resource import Resource
 from nucliadb_models.resource import KnowledgeBoxObj
 from nucliadb_protos.dataset_pb2 import TaskType, TrainSet
 from nucliadb_protos.resources_pb2 import (
@@ -79,7 +79,7 @@ def qa_kb(sdk: NucliaDB, kb: KnowledgeBoxObj, ingest_stub_sync: WriterStub) -> K
 
 
 def smb_wonder_bm(kbid: str) -> BrokerMessage:
-    rid = uuid.uuid4().hex
+    rid = Resource.new_unique_rid()
     now = datetime.now()
 
     bm = BrokerMessage()

--- a/nucliadb_dataset/tests/integration/test_question_answer_streaming.py
+++ b/nucliadb_dataset/tests/integration/test_question_answer_streaming.py
@@ -79,7 +79,7 @@ def qa_kb(sdk: NucliaDB, kb: KnowledgeBoxObj, ingest_stub_sync: WriterStub) -> K
 
 
 def smb_wonder_bm(kbid: str) -> BrokerMessage:
-    rid = str(uuid.uuid4())
+    rid = uuid.uuid4().hex
     now = datetime.now()
 
     bm = BrokerMessage()

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -80,6 +80,7 @@ class FieldID(BaseModel):
         TEXT = "text"
         GENERIC = "generic"
         CONVERSATION = "conversation"
+        KEY_VALUE = "key_value"
 
     field_type: FieldType
     field: str

--- a/nucliadb_sdk/tests/test_sdk.py
+++ b/nucliadb_sdk/tests/test_sdk.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import uuid
 from typing import cast
 
 import httpx
@@ -65,7 +66,8 @@ def test_kb_services(sdk: nucliadb_sdk.NucliaDB, kb):
 
 def test_resource_endpoints(sdk: nucliadb_sdk.NucliaDB, kb):
     # Create, Get, List, Update
-    assert not sdk.exists_resource(kbid=kb.uuid, rid="nonexistent")
+    nonexistent = uuid.uuid4().hex
+    assert not sdk.exists_resource(kbid=kb.uuid, rid=nonexistent)
     assert not sdk.exists_resource_by_slug(kbid=kb.uuid, slug="nonexistent")
     sdk.create_resource(kbid=kb.uuid, title="Resource", slug="resource")
     resource = sdk.get_resource_by_slug(kbid=kb.uuid, slug="resource")
@@ -145,7 +147,8 @@ def test_search_endpoints(sdk: nucliadb_sdk.NucliaDB, kb):
     sdk.ask_on_resource_by_slug(kbid=kb.uuid, slug="resource", query="foo")
     sdk.feedback(kbid=kb.uuid, ident="bar", good=True, feedback="baz", task="CHAT")
     with pytest.raises(nucliadb_sdk.exceptions.PreconditionFailed) as err:
-        sdk.summarize(kbid=kb.uuid, resources=["foobar"])
+        foobar = uuid.uuid4().hex
+        sdk.summarize(kbid=kb.uuid, resources=[foobar])
     assert "Could not summarize" in str(err.value)
 
 

--- a/nucliadb_sdk/tests/test_sdk_async.py
+++ b/nucliadb_sdk/tests/test_sdk_async.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import uuid
+
 import pytest
 
 import nucliadb_sdk
@@ -47,8 +49,9 @@ async def test_kb_services(sdk_async: nucliadb_sdk.NucliaDBAsync, kb):
 
 async def test_resource_endpoints(sdk_async: nucliadb_sdk.NucliaDBAsync, kb):
     # Create, Get, List, Update
-    assert not await sdk_async.exists_resource(kbid=kb.uuid, rid="nonexistent")
-    assert not await sdk_async.exists_resource_by_slug(kbid=kb.uuid, slug="nonexistent")
+    idonotexist = uuid.uuid4().hex
+    assert not await sdk_async.exists_resource(kbid=kb.uuid, rid=idonotexist)
+    assert not await sdk_async.exists_resource_by_slug(kbid=kb.uuid, slug=idonotexist)
     await sdk_async.create_resource(kbid=kb.uuid, title="Resource", slug="resource")
     resource = await sdk_async.get_resource_by_slug(kbid=kb.uuid, slug="resource")
     await sdk_async.get_resource_by_id(kbid=kb.uuid, rid=resource.id)
@@ -86,7 +89,8 @@ async def test_search_endpoints(sdk_async: nucliadb_sdk.NucliaDBAsync, kb):
         kbid=kb.uuid, ident="bar", good=True, feedback="baz", task=FeedbackTasks.CHAT
     )
     with pytest.raises(nucliadb_sdk.exceptions.PreconditionFailed) as err:
-        await sdk_async.summarize(kbid=kb.uuid, resources=["foobar"])
+        foobar = uuid.uuid4().hex
+        await sdk_async.summarize(kbid=kb.uuid, resources=[foobar])
     assert "Could not summarize" in str(err.value)
 
 

--- a/nucliadb_utils/src/nucliadb_utils/const.py
+++ b/nucliadb_utils/src/nucliadb_utils/const.py
@@ -46,5 +46,7 @@ class Features:
 _FliptFeatures = set(
     [
         Features.KEY_VALUE_FIELDS,
+        Features.DATAMANAGERS_V2_READ,
+        Features.DATAMANAGERS_V2_WRITE,
     ]
 )

--- a/nucliadb_utils/src/nucliadb_utils/const.py
+++ b/nucliadb_utils/src/nucliadb_utils/const.py
@@ -40,6 +40,7 @@ class Features:
     # Flipt features
     KEY_VALUE_FIELDS = "nucliadb_key_value_fields"
     DATAMANAGERS_V2_READ = "nucliadb_datamanagers_v2_read"
+    DATAMANAGERS_V2_MIGRATING = "nucliadb_datamanagers_v2_migrating"
 
 
 _FliptFeatures = set(

--- a/nucliadb_utils/src/nucliadb_utils/const.py
+++ b/nucliadb_utils/src/nucliadb_utils/const.py
@@ -40,7 +40,7 @@ class Features:
     # Flipt features
     KEY_VALUE_FIELDS = "nucliadb_key_value_fields"
     DATAMANAGERS_V2_READ = "nucliadb_datamanagers_v2_read"
-    DATAMANAGERS_V2_MIGRATING = "nucliadb_datamanagers_v2_migrating"
+    DATAMANAGERS_V2_WRITE = "nucliadb_datamanagers_v2_write"
 
 
 _FliptFeatures = set(

--- a/nucliadb_utils/src/nucliadb_utils/const.py
+++ b/nucliadb_utils/src/nucliadb_utils/const.py
@@ -39,6 +39,7 @@ class Features:
     AUDIT_RETRIEVE_AND_AUGMENT = "nucliadb_audit_retrieve_and_augment"
     # Flipt features
     KEY_VALUE_FIELDS = "nucliadb_key_value_fields"
+    DATAMANAGERS_V2_READ = "nucliadb_datamanagers_v2_read"
 
 
 _FliptFeatures = set(

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -66,11 +66,11 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
     },
     const.Features.DATAMANAGERS_V2_WRITE: {
         "rollout": 0,
-        "variants": {"environment": ["none"]},
+        "variants": {"environment": ["local"]},
     },
     const.Features.DATAMANAGERS_V2_READ: {
         "rollout": 0,
-        "variants": {"environment": ["none"]},
+        "variants": {"environment": ["local"]},
     },
 }
 

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -65,21 +65,15 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "variants": {"environment": ["local"]},
     },
     const.Features.DATAMANAGERS_V2_WRITE: {
-        "rollout": 100,
+        "rollout": 0,
         "variants": {
-            "environment": ["none"],
-            "kbid": [
-                "458c57f3-d207-4843-b8f2-17cb8cbf3ece",
-            ],
+            "environment": ["local"],
         },
     },
     const.Features.DATAMANAGERS_V2_READ: {
-        "rollout": 100,
+        "rollout": 0,
         "variants": {
-            "environment": ["none"],
-            "kbid": [
-                "458c57f3-d207-4843-b8f2-17cb8cbf3ece",
-            ],
+            "environment": ["local"],
         },
     },
 }

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -64,6 +64,10 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },
+    const.Features.DATAMANAGERS_V2_READ: {
+        "rollout": 0,
+        "variants": {"environment": ["local"]},
+    },
 }
 
 

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -64,6 +64,10 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },
+    const.Features.DATAMANAGERS_V2_MIGRATING: {
+        "rollout": 0,
+        "variants": {"environment": ["local"]},
+    },
     const.Features.DATAMANAGERS_V2_READ: {
         "rollout": 0,
         "variants": {"environment": ["local"]},

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -66,11 +66,11 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
     },
     const.Features.DATAMANAGERS_V2_WRITE: {
         "rollout": 0,
-        "variants": {"environment": ["local"]},
+        "variants": {"environment": ["none"]},
     },
     const.Features.DATAMANAGERS_V2_READ: {
         "rollout": 0,
-        "variants": {"environment": ["local"]},
+        "variants": {"environment": ["none"]},
     },
 }
 

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -64,7 +64,7 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },
-    const.Features.DATAMANAGERS_V2_MIGRATING: {
+    const.Features.DATAMANAGERS_V2_WRITE: {
         "rollout": 0,
         "variants": {"environment": ["local"]},
     },

--- a/nucliadb_utils/src/nucliadb_utils/featureflagging.py
+++ b/nucliadb_utils/src/nucliadb_utils/featureflagging.py
@@ -65,12 +65,22 @@ DEFAULT_FLAG_DATA: dict[str, Any] = {
         "variants": {"environment": ["local"]},
     },
     const.Features.DATAMANAGERS_V2_WRITE: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
+        "rollout": 100,
+        "variants": {
+            "environment": ["none"],
+            "kbid": [
+                "458c57f3-d207-4843-b8f2-17cb8cbf3ece",
+            ],
+        },
     },
     const.Features.DATAMANAGERS_V2_READ: {
-        "rollout": 0,
-        "variants": {"environment": ["local"]},
+        "rollout": 100,
+        "variants": {
+            "environment": ["none"],
+            "kbid": [
+                "458c57f3-d207-4843-b8f2-17cb8cbf3ece",
+            ],
+        },
     },
 }
 

--- a/nucliadb_utils/tests/unit/storages/test_s3_onefs.py
+++ b/nucliadb_utils/tests/unit/storages/test_s3_onefs.py
@@ -19,6 +19,7 @@ applying to NucliaDB.
 
 """
 
+import uuid
 from unittest.mock import AsyncMock
 
 import botocore.exceptions
@@ -90,7 +91,8 @@ async def test_delete_bucket_conflict_string_code():
     )
     storage._s3aioclient.delete_bucket.side_effect = make_client_error("BucketNotEmpty", 409)
 
-    deleted, conflict = await storage.delete_kb("mykb")
+    mykb = str(uuid.uuid4())
+    deleted, conflict = await storage.delete_kb(mykb)
 
     assert deleted is False
     assert conflict is True
@@ -103,7 +105,8 @@ async def test_delete_bucket_conflict_numeric_string_code():
     )
     storage._s3aioclient.delete_bucket.side_effect = make_client_error("409", 409)
 
-    deleted, conflict = await storage.delete_kb("mykb")
+    mykb = str(uuid.uuid4())
+    deleted, conflict = await storage.delete_kb(mykb)
 
     assert deleted is False
     assert conflict is True
@@ -116,7 +119,8 @@ async def test_delete_bucket_nosuchbucket():
     )
     storage._s3aioclient.delete_bucket.side_effect = make_client_error("NoSuchBucket", 404)
 
-    deleted, conflict = await storage.delete_kb("mykb")
+    mykb = str(uuid.uuid4())
+    deleted, conflict = await storage.delete_kb(mykb)
 
     assert deleted is False
     assert conflict is False


### PR DESCRIPTION
### Description

PR to move from the key-value to specialized tables for each of the ORM types: kbs, resources and fields. Conversations have a dedicated table as they implement pagination

Writing and reading from/to the new tables is controlled via a feature flag.

### How was this PR tested?
Existing tests, changes should be totally transparent to the upper layers of ndb

### Migration plan

- Take biggest kbs and:
  1. Activate the write flag for kb
  2. Run backfill migration for kb.
  3. Activate the read flag for kb.

- Once we're verified that all is working OK:
  1. Activate the write flag for all kbs.
  2. Run the backfill migration to the remaining kbs.
  3. Activate the read flag for all kbs.

- Activate flag that only writes to orm tables, no longer writing to resources KV table.
- Finally, remove the old code and all the featureflag logic: only write to new tables.
