### PR TITLE
Validate resource and kb ids.

### DIFF
--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -39,7 +39,7 @@ Deleting a single conversation field requires an explicit DELETE by (kbid, rid, 
 because there is no FK from kb_conversations to kb_fields.
 """
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, handle_invalid_uuid, logs_foreign_key_error
+from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_protos.resources_pb2 import FieldConversation, SplitsMetadata
@@ -53,7 +53,6 @@ _SPLITS_METADATA_PAGE = 0
 # ---------------------------------------------------------------------------
 
 
-@handle_invalid_uuid(default=None)
 async def get_metadata(
     txn: Transaction,
     *,
@@ -111,7 +110,6 @@ async def set_metadata(
 # ---------------------------------------------------------------------------
 
 
-@handle_invalid_uuid(default=None)
 async def get_page(
     txn: Transaction,
     *,
@@ -176,7 +174,6 @@ async def set_page(
 # ---------------------------------------------------------------------------
 
 
-@handle_invalid_uuid(default=None)
 async def get_splits_metadata(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations_v2.py
@@ -39,7 +39,7 @@ Deleting a single conversation field requires an explicit DELETE by (kbid, rid, 
 because there is no FK from kb_conversations to kb_fields.
 """
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error
+from nucliadb.common.datamanagers.utils import _pg_cursor, handle_invalid_uuid, logs_foreign_key_error
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos.resources_pb2 import Conversation as PBConversation
 from nucliadb_protos.resources_pb2 import FieldConversation, SplitsMetadata
@@ -53,6 +53,7 @@ _SPLITS_METADATA_PAGE = 0
 # ---------------------------------------------------------------------------
 
 
+@handle_invalid_uuid(default=None)
 async def get_metadata(
     txn: Transaction,
     *,
@@ -110,6 +111,7 @@ async def set_metadata(
 # ---------------------------------------------------------------------------
 
 
+@handle_invalid_uuid(default=None)
 async def get_page(
     txn: Transaction,
     *,
@@ -174,6 +176,7 @@ async def set_page(
 # ---------------------------------------------------------------------------
 
 
+@handle_invalid_uuid(default=None)
 async def get_splits_metadata(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -41,7 +41,7 @@ from typing import Sequence
 
 from google.protobuf.message import Message
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error
+from nucliadb.common.datamanagers.utils import _pg_cursor, handle_invalid_uuid, logs_foreign_key_error
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.models_utils import from_proto, to_proto
 from nucliadb_protos import resources_pb2 as rpb2
@@ -142,6 +142,7 @@ async def delete(
 # ---------------------------------------------------------------------------
 
 
+@handle_invalid_uuid(default=None)
 async def get_raw(
     txn: Transaction,
     *,
@@ -171,6 +172,7 @@ async def get_raw(
         return bytes(row[0])
 
 
+@handle_invalid_uuid(default=None)
 async def get_status(
     txn: Transaction,
     *,
@@ -202,6 +204,10 @@ async def get_status(
         return pb
 
 
+default_statuses: list[wpb2.FieldStatus] = []
+
+
+@handle_invalid_uuid(default=default_statuses)
 async def get_statuses(
     txn: Transaction,
     *,
@@ -248,6 +254,7 @@ def _to_abbr(field_type: rpb2.FieldType.ValueType) -> str:
     return from_proto.field_type_name(field_type).abbreviation()
 
 
+@handle_invalid_uuid(default=rpb2.AllFieldIDs())
 async def get_all_field_ids(
     txn: Transaction,
     *,
@@ -273,6 +280,7 @@ async def get_all_field_ids(
         return pb
 
 
+@handle_invalid_uuid(default=False)
 async def has_field(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/fields_v2.py
@@ -41,7 +41,7 @@ from typing import Sequence
 
 from google.protobuf.message import Message
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, handle_invalid_uuid, logs_foreign_key_error
+from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.models_utils import from_proto, to_proto
 from nucliadb_protos import resources_pb2 as rpb2
@@ -142,7 +142,6 @@ async def delete(
 # ---------------------------------------------------------------------------
 
 
-@handle_invalid_uuid(default=None)
 async def get_raw(
     txn: Transaction,
     *,
@@ -172,7 +171,6 @@ async def get_raw(
         return bytes(row[0])
 
 
-@handle_invalid_uuid(default=None)
 async def get_status(
     txn: Transaction,
     *,
@@ -204,10 +202,6 @@ async def get_status(
         return pb
 
 
-default_statuses: list[wpb2.FieldStatus] = []
-
-
-@handle_invalid_uuid(default=default_statuses)
 async def get_statuses(
     txn: Transaction,
     *,
@@ -254,7 +248,6 @@ def _to_abbr(field_type: rpb2.FieldType.ValueType) -> str:
     return from_proto.field_type_name(field_type).abbreviation()
 
 
-@handle_invalid_uuid(default=rpb2.AllFieldIDs())
 async def get_all_field_ids(
     txn: Transaction,
     *,
@@ -280,7 +273,6 @@ async def get_all_field_ids(
         return pb
 
 
-@handle_invalid_uuid(default=False)
 async def has_field(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -31,9 +31,7 @@ Each row represents one knowledge box and stores:
 import logging
 from collections.abc import AsyncIterator
 
-import psycopg.errors
-
-from nucliadb.common.datamanagers.utils import _pg_cursor
+from nucliadb.common.datamanagers.utils import _pg_cursor, handle_invalid_uuid
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import knowledgebox_pb2, writer_pb2
 
@@ -122,28 +120,23 @@ async def update_kb_shards(
 # ---------------------------------------------------------------------------
 
 
+@handle_invalid_uuid(default=False)
 async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
     """Return True if a KB with the given kbid exists, has a slug, and has not been soft-deleted."""
     async with _pg_cursor(txn) as cur:
-        try:
-            await cur.execute(
-                """
-                SELECT 1 FROM kbs
-                WHERE kbid = %(kbid)s
-                  AND slug IS NOT NULL
-                  AND deleted_at IS NULL
-                """,
-                {"kbid": kbid},
-            )
-        except psycopg.errors.InvalidTextRepresentation:
-            logger.warning(
-                "Invalid UUID format in exists_kb() check, returning False",
-                extra={"kbid": kbid},
-            )
-            return False
+        await cur.execute(
+            """
+            SELECT 1 FROM kbs
+            WHERE kbid = %(kbid)s
+                AND slug IS NOT NULL
+                AND deleted_at IS NULL
+            """,
+            {"kbid": kbid},
+        )
         return await cur.fetchone() is not None
 
 
+@handle_invalid_uuid(default=None)
 async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
     """Return the deserialised KnowledgeBoxConfig for a KB, or None."""
     async with _pg_cursor(txn) as cur:
@@ -159,6 +152,7 @@ async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.Knowled
         return pb
 
 
+@handle_invalid_uuid(default=None)
 async def get_kb_uuid(txn: Transaction, *, slug: str) -> str | None:
     """Return the kbid for a given slug, or None if it does not exist."""
     async with _pg_cursor(txn) as cur:
@@ -187,6 +181,7 @@ async def get_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[t
                 yield (str(row[0]), row[1])
 
 
+@handle_invalid_uuid(default=None)
 async def get_kb_shards(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/kb_v2.py
@@ -31,7 +31,7 @@ Each row represents one knowledge box and stores:
 import logging
 from collections.abc import AsyncIterator
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, handle_invalid_uuid
+from nucliadb.common.datamanagers.utils import _pg_cursor
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb_protos import knowledgebox_pb2, writer_pb2
 
@@ -120,7 +120,6 @@ async def update_kb_shards(
 # ---------------------------------------------------------------------------
 
 
-@handle_invalid_uuid(default=False)
 async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
     """Return True if a KB with the given kbid exists, has a slug, and has not been soft-deleted."""
     async with _pg_cursor(txn) as cur:
@@ -136,7 +135,6 @@ async def exists_kb(txn: Transaction, *, kbid: str) -> bool:
         return await cur.fetchone() is not None
 
 
-@handle_invalid_uuid(default=None)
 async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.KnowledgeBoxConfig | None:
     """Return the deserialised KnowledgeBoxConfig for a KB, or None."""
     async with _pg_cursor(txn) as cur:
@@ -152,7 +150,6 @@ async def get_config(txn: Transaction, *, kbid: str) -> knowledgebox_pb2.Knowled
         return pb
 
 
-@handle_invalid_uuid(default=None)
 async def get_kb_uuid(txn: Transaction, *, slug: str) -> str | None:
     """Return the kbid for a given slug, or None if it does not exist."""
     async with _pg_cursor(txn) as cur:
@@ -181,7 +178,6 @@ async def get_kbs(txn: Transaction, *, slug_prefix: str = "") -> AsyncIterator[t
                 yield (str(row[0]), row[1])
 
 
-@handle_invalid_uuid(default=None)
 async def get_kb_shards(
     txn: Transaction,
     *,

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -305,7 +305,6 @@ async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.B
         return pb
 
 
-@handle_invalid_uuid(default=None)
 async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Origin | None:
     """Return the deserialised Origin for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -321,7 +320,6 @@ async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.
         return pb
 
 
-@handle_invalid_uuid(default=None)
 async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Security | None:
     """Return the deserialised Security for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -337,7 +335,6 @@ async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb
         return pb
 
 
-@handle_invalid_uuid(default=None)
 async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Extra | None:
     """Return the deserialised Extra for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -365,7 +362,6 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
                 yield _to_rid(rid)
 
 
-@handle_invalid_uuid(default=0)
 async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
     """Return the total number of resources in a knowledge box."""
     async with _pg_cursor(txn) as cur:
@@ -377,7 +373,6 @@ async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
         return row[0] if row else 0
 
 
-@handle_invalid_uuid(default=None)
 async def get_resource_shard_id(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> str | None:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -37,7 +37,12 @@ from collections.abc import AsyncIterator
 
 import psycopg.errors
 
-from nucliadb.common.datamanagers.utils import _pg_cursor, logs_foreign_key_error, with_ro_transaction
+from nucliadb.common.datamanagers.utils import (
+    _pg_cursor,
+    handle_invalid_uuid,
+    logs_foreign_key_error,
+    with_ro_transaction,
+)
 from nucliadb.common.maindb.driver import Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb_protos import resources_pb2
@@ -248,23 +253,18 @@ async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+@handle_invalid_uuid(default=False)
 async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
     """Return True if the resource exists."""
     async with _pg_cursor(txn) as cur:
-        try:
-            await cur.execute(
-                "SELECT 1 FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
-                {"kbid": kbid, "rid": rid},
-            )
-        except psycopg.errors.InvalidTextRepresentation:
-            logger.warning(
-                "Invalid UUID format in exists() check, returning False",
-                extra={"kbid": kbid, "rid": rid},
-            )
-            return False
+        await cur.execute(
+            "SELECT 1 FROM kb_resources WHERE kbid = %(kbid)s AND rid = %(rid)s",
+            {"kbid": kbid, "rid": rid},
+        )
         return await cur.fetchone() is not None
 
 
+@handle_invalid_uuid(default=None)
 async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str) -> str | None:
     """Return the resource UUID for the given slug within a KB, or None."""
     async with _pg_cursor(txn) as cur:
@@ -276,6 +276,7 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
         return _to_rid(row[0]) if row is not None else None
 
 
+@handle_invalid_uuid(default=False)
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
     """Return True if a resource with the given slug exists within a KB."""
     async with _pg_cursor(txn) as cur:
@@ -286,6 +287,7 @@ async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
         return await cur.fetchone() is not None
 
 
+@handle_invalid_uuid(default=None)
 async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:
     """Return the deserialised Basic for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -303,6 +305,7 @@ async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.B
         return pb
 
 
+@handle_invalid_uuid(default=None)
 async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Origin | None:
     """Return the deserialised Origin for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -318,6 +321,7 @@ async def get_origin(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.
         return pb
 
 
+@handle_invalid_uuid(default=None)
 async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Security | None:
     """Return the deserialised Security for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -333,6 +337,7 @@ async def get_security(txn: Transaction, *, kbid: str, rid: str) -> resources_pb
         return pb
 
 
+@handle_invalid_uuid(default=None)
 async def get_extra(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Extra | None:
     """Return the deserialised Extra for a resource, or None."""
     async with _pg_cursor(txn) as cur:
@@ -360,6 +365,7 @@ async def iterate_resource_ids(*, kbid: str) -> AsyncIterator[str]:
                 yield _to_rid(rid)
 
 
+@handle_invalid_uuid(default=0)
 async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
     """Return the total number of resources in a knowledge box."""
     async with _pg_cursor(txn) as cur:
@@ -371,6 +377,7 @@ async def calculate_number_of_resources(txn: Transaction, *, kbid: str) -> int:
         return row[0] if row else 0
 
 
+@handle_invalid_uuid(default=None)
 async def get_resource_shard_id(
     txn: Transaction, *, kbid: str, rid: str, for_update: bool = False
 ) -> str | None:

--- a/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/resources_v2.py
@@ -39,7 +39,6 @@ import psycopg.errors
 
 from nucliadb.common.datamanagers.utils import (
     _pg_cursor,
-    handle_invalid_uuid,
     logs_foreign_key_error,
     with_ro_transaction,
 )
@@ -253,7 +252,6 @@ async def delete(txn: Transaction, *, kbid: str, rid: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@handle_invalid_uuid(default=False)
 async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
     """Return True if the resource exists."""
     async with _pg_cursor(txn) as cur:
@@ -264,7 +262,6 @@ async def exists(txn: Transaction, *, kbid: str, rid: str) -> bool:
         return await cur.fetchone() is not None
 
 
-@handle_invalid_uuid(default=None)
 async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str) -> str | None:
     """Return the resource UUID for the given slug within a KB, or None."""
     async with _pg_cursor(txn) as cur:
@@ -276,7 +273,6 @@ async def get_resource_uuid_from_slug(txn: Transaction, *, kbid: str, slug: str)
         return _to_rid(row[0]) if row is not None else None
 
 
-@handle_invalid_uuid(default=False)
 async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
     """Return True if a resource with the given slug exists within a KB."""
     async with _pg_cursor(txn) as cur:
@@ -287,7 +283,6 @@ async def slug_exists(txn: Transaction, *, kbid: str, slug: str) -> bool:
         return await cur.fetchone() is not None
 
 
-@handle_invalid_uuid(default=None)
 async def get_basic(txn: Transaction, *, kbid: str, rid: str) -> resources_pb2.Basic | None:
     """Return the deserialised Basic for a resource, or None."""
     async with _pg_cursor(txn) as cur:

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -77,6 +77,51 @@ def logs_foreign_key_error(
     return wrapper
 
 
+_D = TypeVar("_D")
+
+
+def handle_invalid_uuid(
+    default: _D,
+) -> Callable[
+    [Callable[_P, Coroutine[Any, Any, _R]]],
+    Callable[_P, Coroutine[Any, Any, _R | _D]],
+]:
+    """Decorator that catches ``psycopg.errors.InvalidTextRepresentation`` and
+    returns *default* instead of propagating the exception.
+
+    Use this on read functions that accept a ``kbid`` or ``rid`` parameter that
+    may arrive as a non-UUID string, so callers receive a safe fallback value
+    rather than an unhandled database error.
+
+    Example::
+
+        @handle_invalid_uuid(default=None)
+        async def get_basic(txn, *, kbid, rid): ...
+
+        @handle_invalid_uuid(default=False)
+        async def exists(txn, *, kbid, rid): ...
+    """
+
+    def decorator(
+        func: Callable[_P, Coroutine[Any, Any, _R]],
+    ) -> Callable[_P, Coroutine[Any, Any, _R | _D]]:
+        @functools.wraps(func)
+        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R | _D:
+            try:
+                return await func(*args, **kwargs)
+            except psycopg.errors.InvalidTextRepresentation:
+                logger.warning(
+                    "Invalid UUID format in %s(), returning default value %r",
+                    getattr(func, "__qualname__", repr(func)),
+                    default,
+                )
+                return default
+
+        return wrapper
+
+    return decorator
+
+
 async def get_kv_pb(
     txn: Transaction, key: str, pb_type: type[PB_TYPE], for_update: bool = True
 ) -> PB_TYPE | None:

--- a/nucliadb/src/nucliadb/common/datamanagers/utils.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/utils.py
@@ -24,7 +24,6 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Callable, Concatenate, Coroutine, ParamSpec, TypeVar, cast
 
 import psycopg
-import psycopg.sql
 from google.protobuf.message import Message
 
 from nucliadb.common.maindb.driver import Transaction
@@ -75,51 +74,6 @@ def logs_foreign_key_error(
         return None
 
     return wrapper
-
-
-_D = TypeVar("_D")
-
-
-def handle_invalid_uuid(
-    default: _D,
-) -> Callable[
-    [Callable[_P, Coroutine[Any, Any, _R]]],
-    Callable[_P, Coroutine[Any, Any, _R | _D]],
-]:
-    """Decorator that catches ``psycopg.errors.InvalidTextRepresentation`` and
-    returns *default* instead of propagating the exception.
-
-    Use this on read functions that accept a ``kbid`` or ``rid`` parameter that
-    may arrive as a non-UUID string, so callers receive a safe fallback value
-    rather than an unhandled database error.
-
-    Example::
-
-        @handle_invalid_uuid(default=None)
-        async def get_basic(txn, *, kbid, rid): ...
-
-        @handle_invalid_uuid(default=False)
-        async def exists(txn, *, kbid, rid): ...
-    """
-
-    def decorator(
-        func: Callable[_P, Coroutine[Any, Any, _R]],
-    ) -> Callable[_P, Coroutine[Any, Any, _R | _D]]:
-        @functools.wraps(func)
-        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R | _D:
-            try:
-                return await func(*args, **kwargs)
-            except psycopg.errors.InvalidTextRepresentation:
-                logger.warning(
-                    "Invalid UUID format in %s(), returning default value %r",
-                    getattr(func, "__qualname__", repr(func)),
-                    default,
-                )
-                return default
-
-        return wrapper
-
-    return decorator
 
 
 async def get_kv_pb(

--- a/nucliadb/src/nucliadb/common/fastapi.py
+++ b/nucliadb/src/nucliadb/common/fastapi.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import uuid
+from typing import Annotated, Any
+
+from fastapi import Depends, HTTPException, Path
+
+# ---------------------------------------------------------------------------
+# FastAPI path-parameter dependencies that return 404 for non-UUID values.
+#
+# Use these instead of plain ``str`` for ``kbid`` and ``rid`` path parameters
+# so that requests with syntactically invalid identifiers are rejected at the
+# API layer before reaching the database, while preserving the existing
+# behaviour of returning 404 (not 422) for bad input.
+#
+# Usage::
+#
+#     from nucliadb.common.fastapi import KbId, RId
+#
+#     @router.get("/kb/{kbid}/resource/{rid}")
+#     async def get_resource(kbid: KbId, rid: RId): ...
+# ---------------------------------------------------------------------------
+
+
+def _uuid_path_param(name: str, not_found_detail: str) -> Any:
+    """Return a FastAPI ``Depends`` callable that validates *name* as a UUID."""
+
+    def _validate(value: str = Path(alias=name)) -> str:
+
+        try:
+            uuid.UUID(value)
+        except ValueError:
+            raise HTTPException(status_code=404, detail=not_found_detail)
+        return value
+
+    _validate.__name__ = f"validate_{name}"
+    return Depends(_validate)
+
+
+KbId = Annotated[str, _uuid_path_param("kbid", "KnowledgeBox not found. UUID expected.")]
+RId = Annotated[str, _uuid_path_param("rid", "Resource not found. UUID expected.")]
+PathRId = Annotated[str, _uuid_path_param("path_rid", "Resource not found. UUID expected.")]

--- a/nucliadb/src/nucliadb/common/fastapi.py
+++ b/nucliadb/src/nucliadb/common/fastapi.py
@@ -18,10 +18,11 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import uuid
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable
 
 from fastapi import Depends, HTTPException, Path
+
+from nucliadb.common.ids import valid_kbid, valid_rid
 
 # ---------------------------------------------------------------------------
 # FastAPI path-parameter dependencies that return 404 for non-UUID values.
@@ -40,14 +41,11 @@ from fastapi import Depends, HTTPException, Path
 # ---------------------------------------------------------------------------
 
 
-def _uuid_path_param(name: str, not_found_detail: str) -> Any:
+def _uuid_path_param(name: str, not_found_detail: str, validator_func: Callable[[str], bool]) -> Any:
     """Return a FastAPI ``Depends`` callable that validates *name* as a UUID."""
 
     def _validate(value: str = Path(alias=name)) -> str:
-
-        try:
-            uuid.UUID(value)
-        except ValueError:
+        if not validator_func(value):
             raise HTTPException(status_code=404, detail=not_found_detail)
         return value
 
@@ -55,6 +53,6 @@ def _uuid_path_param(name: str, not_found_detail: str) -> Any:
     return Depends(_validate)
 
 
-KbId = Annotated[str, _uuid_path_param("kbid", "KnowledgeBox not found. UUID expected.")]
-RId = Annotated[str, _uuid_path_param("rid", "Resource not found. UUID expected.")]
-PathRId = Annotated[str, _uuid_path_param("path_rid", "Resource not found. UUID expected.")]
+KbId = Annotated[str, _uuid_path_param("kbid", "Knowledge box not found. UUID expected.", valid_kbid)]
+RId = Annotated[str, _uuid_path_param("rid", "Resource not found. UUID expected.", valid_rid)]
+PathRId = Annotated[str, _uuid_path_param("path_rid", "Resource not found. UUID expected.", valid_rid)]

--- a/nucliadb/src/nucliadb/common/ids.py
+++ b/nucliadb/src/nucliadb/common/ids.py
@@ -23,6 +23,7 @@ This module aims to centralize how we build ids for resources, fields,
 paragraphs... Avoiding spread of id construction and parsing everywhere
 """
 
+import uuid
 from dataclasses import dataclass
 
 from nucliadb_models.common import FieldTypeName
@@ -310,3 +311,31 @@ def extract_data_augmentation_id(generated_field_id: str) -> str | None:
         return None
 
     return parts[1] or None
+
+
+def is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
+
+
+def valid_kbid(kbid: str) -> bool:
+    # Must be a UUID in canonical dashed format.
+    if len(kbid) != 36 or kbid.count("-") != 4:
+        return False
+    try:
+        return str(uuid.UUID(kbid)) == kbid.lower()
+    except ValueError:
+        return False
+
+
+def valid_rid(rid: str) -> bool:
+    # Must be a UUID in hex format.
+    if len(rid) != 32 or "-" in rid:
+        return False
+    try:
+        return uuid.UUID(rid).hex == rid.lower()
+    except ValueError:
+        return False

--- a/nucliadb/src/nucliadb/common/ids.py
+++ b/nucliadb/src/nucliadb/common/ids.py
@@ -313,14 +313,6 @@ def extract_data_augmentation_id(generated_field_id: str) -> str | None:
     return parts[1] or None
 
 
-def is_uuid(value: str) -> bool:
-    try:
-        uuid.UUID(value)
-        return True
-    except ValueError:
-        return False
-
-
 def valid_kbid(kbid: str) -> bool:
     # Must be a UUID in canonical dashed format.
     if len(kbid) != 36 or kbid.count("-") != 4:

--- a/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
+++ b/nucliadb/src/nucliadb/ingest/orm/processor/processor.py
@@ -32,7 +32,7 @@ from nucliadb.common.cluster.settings import settings as cluster_settings
 from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.external_index_providers.base import ExternalIndexManager
 from nucliadb.common.external_index_providers.manager import get_external_index_manager
-from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
+from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR, valid_rid
 from nucliadb.common.maindb.driver import Driver, Transaction
 from nucliadb.common.maindb.exceptions import ConflictError, MaindbServerError
 from nucliadb.ingest.orm.exceptions import (
@@ -168,6 +168,12 @@ class Processor:
         partition: str | None = None,
         transaction_check: bool = True,
     ) -> None:
+
+        if message.uuid and not valid_rid(message.uuid):
+            raise InvalidBrokerMessage(
+                f"Invalid resource ID: {message.uuid}. UUID in hex format expected."
+            )
+
         partition = partition if self.partition is None else self.partition
         if partition is None:
             raise AttributeError("Can't process message from unknown partition")

--- a/nucliadb/src/nucliadb/ingest/service/writer.py
+++ b/nucliadb/src/nucliadb/ingest/service/writer.py
@@ -27,6 +27,7 @@ from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
 from nucliadb.common.external_index_providers.exceptions import ExternalIndexCreationError
 from nucliadb.common.external_index_providers.manager import get_external_index_manager
+from nucliadb.common.ids import valid_kbid
 from nucliadb.common.maindb.utils import setup_driver
 from nucliadb.ingest import SERVICE_NAME, logger
 from nucliadb.ingest.orm.entities import EntitiesManager
@@ -107,6 +108,11 @@ class WriterServicer(writer_pb2_grpc.WriterServicer):
         # model metadata in the request
 
         try:
+            if not valid_kbid(request.kbid):
+                return writer_pb2.NewKnowledgeBoxV2Response(
+                    status=KnowledgeBoxResponseStatus.ERROR,
+                    error_message=f"Invalid kbid: {request.kbid}. Should be a valid UUID4 string.",
+                )
             kbid, _ = await KnowledgeBoxORM.create(
                 self.driver,
                 kbid=request.kbid,

--- a/nucliadb/src/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/download.py
@@ -30,7 +30,7 @@ from nucliadb.common import datamanagers
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.common.models_utils import to_proto
 from nucliadb.reader import RANGE_HEADER, SERVICE_NAME, logger
-from nucliadb_models.common import FieldTypeName
+from nucliadb_models.common import FieldTypeName, KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 from nucliadb_utils.storages.storage import ObjectMetadata, Range, StorageField
@@ -49,7 +49,7 @@ from .router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX, api
 @version(1)
 async def download_extract_file_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_type: FieldTypeName,
     field_id: str,
@@ -76,8 +76,8 @@ async def download_extract_file_rslug_prefix(
 @version(1)
 async def download_extract_file_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_type: FieldTypeName,
     field_id: str,
     download_field: str,
@@ -120,7 +120,7 @@ async def _download_extract_file(
 @version(1)
 async def download_field_file_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: str,
     inline: bool = False,
@@ -139,8 +139,8 @@ async def download_field_file_rslug_prefix(
 @version(1)
 async def download_field_file_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: str,
     inline: bool = False,
     range: Annotated[str | None, RANGE_HEADER] = None,
@@ -175,7 +175,7 @@ async def _download_field_file(
 @version(1)
 async def download_field_conversation_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: str,
     message_id: str,
@@ -202,8 +202,8 @@ async def download_field_conversation_rslug_prefix(
 @version(1)
 async def download_field_conversation_attachment_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: str,
     message_id: str,
     file_num: int,

--- a/nucliadb/src/nucliadb/reader/api/v1/download.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/download.py
@@ -27,10 +27,11 @@ from fastapi_versioning import version
 from starlette.responses import StreamingResponse
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId, RId
 from nucliadb.common.ids import FIELD_TYPE_PB_TO_STR
 from nucliadb.common.models_utils import to_proto
 from nucliadb.reader import RANGE_HEADER, SERVICE_NAME, logger
-from nucliadb_models.common import FieldTypeName, KbId, RId
+from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 from nucliadb_utils.storages.storage import ObjectMetadata, Range, StorageField

--- a/nucliadb/src/nucliadb/reader/api/v1/export_import.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/export_import.py
@@ -27,13 +27,13 @@ from nucliadb.common import datamanagers
 from nucliadb.common.cluster.settings import in_standalone_mode
 from nucliadb.common.context import ApplicationContext
 from nucliadb.common.context.fastapi import get_app_context
+from nucliadb.common.fastapi import KbId
 from nucliadb.export_import import exceptions as export_exceptions
 from nucliadb.export_import import exporter
 from nucliadb.export_import.datamanager import ExportImportDataManager
 from nucliadb.export_import.exceptions import MetadataNotFound
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.export_import import Status, StatusResponse
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one

--- a/nucliadb/src/nucliadb/reader/api/v1/export_import.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/export_import.py
@@ -33,6 +33,7 @@ from nucliadb.export_import.datamanager import ExportImportDataManager
 from nucliadb.export_import.exceptions import MetadataNotFound
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.export_import import Status, StatusResponse
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
@@ -47,7 +48,7 @@ from nucliadb_utils.authentication import requires_one
 )
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.READER])
 @version(1)
-async def download_export_kb_endpoint(request: Request, kbid: str, export_id: str):
+async def download_export_kb_endpoint(request: Request, kbid: KbId, export_id: str):
     context = get_app_context(request.app)
     if not await exists_kb(kbid):
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")
@@ -107,7 +108,7 @@ async def download_export_and_delete(
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.READER])
 @version(1)
 async def get_export_status_endpoint(
-    request: Request, kbid: str, export_id: str
+    request: Request, kbid: KbId, export_id: str
 ) -> StatusResponse | HTTPClientError:
     context = get_app_context(request.app)
     if not await exists_kb(kbid):
@@ -126,7 +127,7 @@ async def get_export_status_endpoint(
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.READER])
 @version(1)
 async def get_import_status_endpoint(
-    request: Request, kbid: str, import_id: str
+    request: Request, kbid: KbId, import_id: str
 ) -> StatusResponse | HTTPClientError:
     context = get_app_context(request.app)
     if not await exists_kb(kbid):

--- a/nucliadb/src/nucliadb/reader/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/knowledgebox.py
@@ -22,10 +22,10 @@ from fastapi_versioning import version
 from starlette.requests import Request
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.common.models_utils import from_proto
 from nucliadb.reader.api.v1.router import KB_PREFIX, KBS_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     KnowledgeBoxList,
     KnowledgeBoxObj,

--- a/nucliadb/src/nucliadb/reader/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/knowledgebox.py
@@ -25,6 +25,7 @@ from nucliadb.common import datamanagers
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.common.models_utils import from_proto
 from nucliadb.reader.api.v1.router import KB_PREFIX, KBS_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     KnowledgeBoxList,
     KnowledgeBoxObj,
@@ -71,7 +72,7 @@ async def get_kbs(
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.READER])
 @version(1)
 async def get_kb(
-    request: Request, kbid: str, x_nucliadb_account: str = Header(default="", include_in_schema=False)
+    request: Request, kbid: KbId, x_nucliadb_account: str = Header(default="", include_in_schema=False)
 ) -> KnowledgeBoxObj:
     driver = get_driver()
     async with driver.ro_transaction() as txn:

--- a/nucliadb/src/nucliadb/reader/api/v1/learning_config.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/learning_config.py
@@ -25,6 +25,7 @@ from nuclia_models.config.proto import ExtractConfig, SplitConfiguration
 from nucliadb.learning_proxy import learning_config_proxy
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 from nucliadb_utils.settings import is_onprem_nucliadb
@@ -42,7 +43,7 @@ from nucliadb_utils.settings import is_onprem_nucliadb
 @version(1)
 async def download_model(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     model_id: str,
     filename: str,
 ):
@@ -59,7 +60,7 @@ async def download_model(
 )
 @requires_one([NucliaDBRoles.READER, NucliaDBRoles.MANAGER])
 @version(1)
-async def get_configuration(request: Request, kbid: str):
+async def get_configuration(request: Request, kbid: KbId):
     return await learning_config_proxy(
         request,
         "GET",
@@ -79,7 +80,7 @@ async def get_configuration(request: Request, kbid: str):
 @version(1)
 async def get_models(
     request: Request,
-    kbid: str,
+    kbid: KbId,
 ):
     return await learning_config_proxy(request, "GET", f"/models/{kbid}")
 
@@ -96,7 +97,7 @@ async def get_models(
 @version(1)
 async def get_model(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     model_id: str,
 ):
     return await learning_config_proxy(
@@ -117,7 +118,7 @@ async def get_model(
 @requires_one([NucliaDBRoles.READER, NucliaDBRoles.MANAGER])
 @version(1)
 async def get_schema_for_configuration_updates(
-    request: Request, kbid: str, x_nucliadb_account: str = Header(default="", include_in_schema=False)
+    request: Request, kbid: KbId, x_nucliadb_account: str = Header(default="", include_in_schema=False)
 ):
     return await learning_config_proxy(
         request,
@@ -139,7 +140,7 @@ async def get_schema_for_configuration_updates(
 @version(1)
 async def get_models_group_by_providers(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     x_nucliadb_account: str = Header(default="", include_in_schema=False),
     x_nucliadb_account_type: str = Header(default="", include_in_schema=False),
     x_allow_access_non_enterprise_models: bool = Header(False, include_in_schema=False),
@@ -187,7 +188,7 @@ async def get_schema_for_configuration_creation(
 @version(1)
 async def get_extract_strategies(
     request: Request,
-    kbid: str,
+    kbid: KbId,
 ):
     return await learning_config_proxy(request, "GET", f"/extract_strategies/{kbid}")
 
@@ -204,7 +205,7 @@ async def get_extract_strategies(
 @version(1)
 async def get_extract_strategy_from_id(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     strategy_id: str,
 ):
     return await learning_config_proxy(
@@ -224,7 +225,7 @@ async def get_extract_strategy_from_id(
 @version(1)
 async def get_split_strategies(
     request: Request,
-    kbid: str,
+    kbid: KbId,
 ):
     return await learning_config_proxy(request, "GET", f"/split_strategies/{kbid}")
 
@@ -241,7 +242,7 @@ async def get_split_strategies(
 @version(1)
 async def get_split_strategy_from_id(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     strategy_id: str,
 ):
     return await learning_config_proxy(

--- a/nucliadb/src/nucliadb/reader/api/v1/learning_config.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/learning_config.py
@@ -22,10 +22,10 @@ from fastapi import Header, Request
 from fastapi_versioning import version
 from nuclia_models.config.proto import ExtractConfig, SplitConfiguration
 
+from nucliadb.common.fastapi import KbId
 from nucliadb.learning_proxy import learning_config_proxy
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 from nucliadb_utils.settings import is_onprem_nucliadb

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -40,7 +40,7 @@ from nucliadb.reader.api.models import (
     ResourceField,
 )
 from nucliadb.reader.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX, api
-from nucliadb_models.common import FieldTypeName
+from nucliadb_models.common import FieldTypeName, KbId, RId
 from nucliadb_models.resource import (
     Error,
     ExtractedDataTypeName,
@@ -69,8 +69,8 @@ from nucliadb_utils.utilities import get_audit, get_storage
 @version(1)
 async def head_resource_by_uuid(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
 ):
     return await head_resource(kbid=kbid, rid=rid)
 
@@ -86,7 +86,7 @@ async def head_resource_by_uuid(
 @version(1)
 async def head_resource_by_slug(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
 ):
     return await head_resource(kbid=kbid, rslug=rslug)
@@ -120,7 +120,7 @@ async def head_resource(
 async def list_resources(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     page: int = Query(0, description="Requested page number (0-based)"),
     size: int = Query(DEFAULT_RESOURCE_LIST_PAGE_SIZE, description="Page size"),
 ) -> ResourceList:
@@ -201,8 +201,8 @@ async def list_resources(
 @version(1)
 async def get_resource_by_uuid(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     show: list[ResourceProperties] = Query([ResourceProperties.BASIC]),
     field_type_filter: list[FieldTypeName] = Query(list(FieldTypeName), alias="field_type"),
     extracted: list[ExtractedDataTypeName] = Query(
@@ -239,7 +239,7 @@ async def get_resource_by_uuid(
 @version(1)
 async def get_resource_by_slug(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     show: list[ResourceProperties] = Query([ResourceProperties.BASIC]),
     field_type_filter: list[FieldTypeName] = Query(list(FieldTypeName), alias="field_type"),
@@ -310,7 +310,7 @@ async def _get_resource(
 @version(1)
 async def get_resource_field_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_type: FieldTypeName,
     field_id: str,
@@ -350,8 +350,8 @@ async def get_resource_field_rslug_prefix(
 @version(1)
 async def get_resource_field_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_type: FieldTypeName,
     field_id: str,
     show: list[ResourceFieldProperties] = Query([ResourceFieldProperties.VALUE]),

--- a/nucliadb/src/nucliadb/reader/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/resource.py
@@ -23,6 +23,7 @@ from fastapi import Header, HTTPException, Query, Request, Response
 from fastapi_versioning import version
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId, RId
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.common.models_utils import from_proto, to_proto
 from nucliadb.ingest.fields.conversation import Conversation
@@ -40,7 +41,7 @@ from nucliadb.reader.api.models import (
     ResourceField,
 )
 from nucliadb.reader.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RSLUG_PREFIX, api
-from nucliadb_models.common import FieldTypeName, KbId, RId
+from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import (
     Error,
     ExtractedDataTypeName,

--- a/nucliadb/src/nucliadb/reader/api/v1/services.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/services.py
@@ -29,6 +29,7 @@ from nucliadb.common import datamanagers
 from nucliadb.common.cluster.settings import in_standalone_mode
 from nucliadb.common.context.fastapi import get_app_context
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.http_clients import processing
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.common.models_utils import from_proto
@@ -37,7 +38,6 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.reader import SERVICE_NAME
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
 from nucliadb.reader.reader.notifications import kb_notifications_stream
-from nucliadb_models.common import KbId
 from nucliadb_models.configuration import SearchConfiguration
 from nucliadb_models.entities import (
     EntitiesGroup,

--- a/nucliadb/src/nucliadb/reader/api/v1/services.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/services.py
@@ -37,6 +37,7 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.reader import SERVICE_NAME
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
 from nucliadb.reader.reader.notifications import kb_notifications_stream
+from nucliadb_models.common import KbId
 from nucliadb_models.configuration import SearchConfiguration
 from nucliadb_models.entities import (
     EntitiesGroup,
@@ -68,7 +69,7 @@ from nucliadb_utils.utilities import get_ingest, get_storage
 @requires(NucliaDBRoles.READER)
 @version(1)
 async def get_entities(
-    request: Request, kbid: str, show_entities: bool = False
+    request: Request, kbid: KbId, show_entities: bool = False
 ) -> KnowledgeBoxEntities | HTTPClientError:
     if show_entities:
         return HTTPClientError(
@@ -107,7 +108,7 @@ async def list_entities_groups(kbid: str):
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def get_entity(request: Request, kbid: str, group: str) -> EntitiesGroup:
+async def get_entity(request: Request, kbid: KbId, group: str) -> EntitiesGroup:
     ingest = get_ingest()
     l_request: GetEntitiesGroupRequest = GetEntitiesGroupRequest()
     l_request.kb.uuid = kbid
@@ -134,7 +135,7 @@ async def get_entity(request: Request, kbid: str, group: str) -> EntitiesGroup:
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def get_labelsets_endoint(request: Request, kbid: str) -> KnowledgeBoxLabels:
+async def get_labelsets_endoint(request: Request, kbid: KbId) -> KnowledgeBoxLabels:
     try:
         return await get_labelsets(kbid)
     except KnowledgeBoxNotFound:
@@ -171,7 +172,7 @@ async def get_labelsets(kbid: str) -> KnowledgeBoxLabels:
 @version(1)
 async def get_labelset_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     labelset: str = Path(
         title="The ID of the labelset to get. This is a unique identifier that should be used at search time.",
         examples=["categories", "movie-genres", "document-types"],
@@ -218,7 +219,7 @@ async def get_labelset(kbid: str, labelset_id: str) -> LabelSet:
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def get_custom_synonyms(request: Request, kbid: str):
+async def get_custom_synonyms(request: Request, kbid: KbId):
     if not await datamanagers.atomic.kb.exists_kb(kbid=kbid):
         raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
     synonyms = await datamanagers.atomic.synonyms.get(kbid=kbid) or Synonyms()
@@ -237,7 +238,7 @@ async def get_custom_synonyms(request: Request, kbid: str):
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def notifications_endpoint(request: Request, kbid: str) -> StreamingResponse | HTTPClientError:
+async def notifications_endpoint(request: Request, kbid: KbId) -> StreamingResponse | HTTPClientError:
     if in_standalone_mode():
         return HTTPClientError(
             status_code=404,
@@ -278,7 +279,7 @@ async def exists_kb(kbid: str) -> bool:
 @version(1)
 async def processing_status(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     cursor: str | None = None,
     scheduled: bool | None = None,
     limit: int = 20,
@@ -332,7 +333,9 @@ async def processing_status(
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def get_search_configuration(request: Request, kbid: str, config_name: str) -> SearchConfiguration:
+async def get_search_configuration(
+    request: Request, kbid: KbId, config_name: str
+) -> SearchConfiguration:
     async with datamanagers.with_ro_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
@@ -353,7 +356,7 @@ async def get_search_configuration(request: Request, kbid: str, config_name: str
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def list_search_configurations(request: Request, kbid: str) -> dict[str, SearchConfiguration]:
+async def list_search_configurations(request: Request, kbid: KbId) -> dict[str, SearchConfiguration]:
     async with datamanagers.with_ro_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
@@ -370,7 +373,7 @@ async def list_search_configurations(request: Request, kbid: str) -> dict[str, S
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def list_kv_schemas(request: Request, kbid: str) -> KBKVSchemas:
+async def list_kv_schemas(request: Request, kbid: KbId) -> KBKVSchemas:
     async with datamanagers.with_ro_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
@@ -387,7 +390,7 @@ async def list_kv_schemas(request: Request, kbid: str) -> KBKVSchemas:
 )
 @requires(NucliaDBRoles.READER)
 @version(1)
-async def get_kv_schema(request: Request, kbid: str, schema_id: str) -> KVSchema:
+async def get_kv_schema(request: Request, kbid: KbId, schema_id: str) -> KVSchema:
     async with datamanagers.with_ro_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")

--- a/nucliadb/src/nucliadb/reader/api/v1/vectorsets.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/vectorsets.py
@@ -22,6 +22,7 @@ from starlette.requests import Request
 
 from nucliadb.common import datamanagers
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     NucliaDBRoles,
 )
@@ -40,7 +41,7 @@ from nucliadb_utils.authentication import requires_one
 )
 @requires_one([NucliaDBRoles.READER])
 @version(1)
-async def list_vectorsets(request: Request, kbid: str) -> VectorSetList:
+async def list_vectorsets(request: Request, kbid: KbId) -> VectorSetList:
     vectorsets = []
     async with datamanagers.with_ro_transaction() as txn:
         async for vid, _ in datamanagers.vectorsets.iter(txn, kbid=kbid):

--- a/nucliadb/src/nucliadb/reader/api/v1/vectorsets.py
+++ b/nucliadb/src/nucliadb/reader/api/v1/vectorsets.py
@@ -21,8 +21,8 @@ from fastapi_versioning import version
 from starlette.requests import Request
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId
 from nucliadb.reader.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     NucliaDBRoles,
 )

--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -31,6 +31,7 @@ from nucliadb.search.search import cache
 from nucliadb.search.search.chat.ask import AskResult, ask, handled_ask_exceptions
 from nucliadb.search.search.chat.exceptions import AnswerJsonSchemaTooLong
 from nucliadb.search.search.utils import maybe_log_request_payload
+from nucliadb_models.common import KbId
 from nucliadb_models.configuration import AskConfig
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (
@@ -55,7 +56,7 @@ from nucliadb_utils.authentication import NucliaUser, requires
 @version(1)
 async def ask_knowledgebox_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: AskRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_show_consumption: bool = Header(default=False),

--- a/nucliadb/src/nucliadb/search/api/v1/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/ask.py
@@ -25,13 +25,13 @@ from pydantic import ValidationError
 from starlette.responses import StreamingResponse
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.search import cache
 from nucliadb.search.search.chat.ask import AskResult, ask, handled_ask_exceptions
 from nucliadb.search.search.chat.exceptions import AnswerJsonSchemaTooLong
 from nucliadb.search.search.utils import maybe_log_request_payload
-from nucliadb_models.common import KbId
 from nucliadb_models.configuration import AskConfig
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (

--- a/nucliadb/src/nucliadb/search/api/v1/augment.py
+++ b/nucliadb/src/nucliadb/search/api/v1/augment.py
@@ -80,7 +80,7 @@ from nucliadb_models.augment import (
     AugmentResources,
     AugmentResponse,
 )
-from nucliadb_models.common import FieldTypeName
+from nucliadb_models.common import FieldTypeName, KbId
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import NucliaDBClientType, ResourceProperties
 from nucliadb_utils.authentication import requires
@@ -98,7 +98,7 @@ from nucliadb_utils.utilities import get_audit
 @version(1)
 async def _augment_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: AugmentRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/augment.py
+++ b/nucliadb/src/nucliadb/search/api/v1/augment.py
@@ -24,6 +24,7 @@ from typing import cast
 from fastapi import Header, Request
 from fastapi_versioning import version
 
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb.common.models_utils import to_proto
 from nucliadb.models.internal import augment as internal_augment
@@ -80,7 +81,7 @@ from nucliadb_models.augment import (
     AugmentResources,
     AugmentResponse,
 )
-from nucliadb_models.common import FieldTypeName, KbId
+from nucliadb_models.common import FieldTypeName
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import NucliaDBClientType, ResourceProperties
 from nucliadb_utils.authentication import requires

--- a/nucliadb/src/nucliadb/search/api/v1/catalog.py
+++ b/nucliadb/src/nucliadb/search/api/v1/catalog.py
@@ -27,6 +27,7 @@ from pydantic import ValidationError
 from nucliadb.common.catalog import catalog_facets, catalog_search
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
 from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import logger
 from nucliadb.search.api.v1.router import KB_PREFIX, api
@@ -38,7 +39,7 @@ from nucliadb.search.search.query_parser.parsers import parse_catalog
 from nucliadb.search.search.utils import (
     maybe_log_request_payload,
 )
-from nucliadb_models.common import FieldTypeName, KbId
+from nucliadb_models.common import FieldTypeName
 from nucliadb_models.filters import CatalogFilterExpression
 from nucliadb_models.metadata import ResourceProcessingStatus
 from nucliadb_models.resource import NucliaDBRoles

--- a/nucliadb/src/nucliadb/search/api/v1/catalog.py
+++ b/nucliadb/src/nucliadb/search/api/v1/catalog.py
@@ -38,7 +38,7 @@ from nucliadb.search.search.query_parser.parsers import parse_catalog
 from nucliadb.search.search.utils import (
     maybe_log_request_payload,
 )
-from nucliadb_models.common import FieldTypeName
+from nucliadb_models.common import FieldTypeName, KbId
 from nucliadb_models.filters import CatalogFilterExpression
 from nucliadb_models.metadata import ResourceProcessingStatus
 from nucliadb_models.resource import NucliaDBRoles
@@ -73,7 +73,7 @@ from nucliadb_utils.exceptions import LimitsExceededError
 async def catalog_get(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     query: str = fastapi_query(SearchParamDefaults.query),
     filter_expression: str | None = fastapi_query(SearchParamDefaults.catalog_filter_expression),
     filters: list[str] = fastapi_query(SearchParamDefaults.filters),
@@ -143,7 +143,7 @@ async def catalog_get(
 @version(1)
 async def catalog_post(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: CatalogRequest,
 ) -> CatalogResponse | HTTPClientError:
     return await catalog(kbid, item)
@@ -209,6 +209,6 @@ async def catalog(
 @requires(NucliaDBRoles.READER)
 @version(1)
 async def catalog_facets_endpoint(
-    request: Request, kbid: str, item: CatalogFacetsRequest
+    request: Request, kbid: KbId, item: CatalogFacetsRequest
 ) -> CatalogFacetsResponse:
     return CatalogFacetsResponse(facets=await catalog_facets(kbid, item))

--- a/nucliadb/src/nucliadb/search/api/v1/feedback.py
+++ b/nucliadb/src/nucliadb/search/api/v1/feedback.py
@@ -25,6 +25,7 @@ from nucliadb.common.models_utils import to_proto
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import logger
 from nucliadb.search.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import FeedbackRequest, NucliaDBClientType
 from nucliadb_telemetry import errors
@@ -44,7 +45,7 @@ from nucliadb_utils.utilities import get_audit
 async def send_feedback_endpoint(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: FeedbackRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/feedback.py
+++ b/nucliadb/src/nucliadb/search/api/v1/feedback.py
@@ -21,11 +21,11 @@
 from fastapi import Header, Request, Response
 from fastapi_versioning import version
 
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.models_utils import to_proto
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import logger
 from nucliadb.search.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import FeedbackRequest, NucliaDBClientType
 from nucliadb_telemetry import errors

--- a/nucliadb/src/nucliadb/search/api/v1/find.py
+++ b/nucliadb/src/nucliadb/search/api/v1/find.py
@@ -27,6 +27,7 @@ from pydantic import ValidationError
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
 from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.router import KB_PREFIX, api
@@ -35,7 +36,7 @@ from nucliadb.search.search import cache
 from nucliadb.search.search.find import find
 from nucliadb.search.search.metrics import Metrics
 from nucliadb.search.search.utils import maybe_log_request_payload, min_score_from_query_params
-from nucliadb_models.common import FieldTypeName, KbId
+from nucliadb_models.common import FieldTypeName
 from nucliadb_models.configuration import FindConfig
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles

--- a/nucliadb/src/nucliadb/search/api/v1/find.py
+++ b/nucliadb/src/nucliadb/search/api/v1/find.py
@@ -35,7 +35,7 @@ from nucliadb.search.search import cache
 from nucliadb.search.search.find import find
 from nucliadb.search.search.metrics import Metrics
 from nucliadb.search.search.utils import maybe_log_request_payload, min_score_from_query_params
-from nucliadb_models.common import FieldTypeName
+from nucliadb_models.common import FieldTypeName, KbId
 from nucliadb_models.configuration import FindConfig
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
@@ -80,7 +80,7 @@ FIND_EXAMPLES = {
 async def find_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     query: str = fastapi_query(SearchParamDefaults.query),
     filter_expression: str | None = fastapi_query(SearchParamDefaults.filter_expression),
     fields: list[str] = fastapi_query(SearchParamDefaults.fields),
@@ -188,7 +188,7 @@ async def find_knowledgebox(
 async def find_post_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: FindRequest = Body(openapi_examples=FIND_EXAMPLES),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/graph.py
+++ b/nucliadb/src/nucliadb/search/api/v1/graph.py
@@ -32,6 +32,7 @@ from nucliadb.search.search.query_parser.parsers import (
     parse_graph_relation_search,
     parse_graph_search,
 )
+from nucliadb_models.common import KbId
 from nucliadb_models.graph.requests import (
     GraphNodesSearchRequest,
     GraphRelationsSearchRequest,
@@ -62,7 +63,7 @@ from nucliadb_utils.authentication import requires
 async def graph_search_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: GraphSearchRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),
@@ -93,7 +94,7 @@ async def graph_path_search(kbid: str, item: GraphSearchRequest) -> GraphSearchR
 async def graph_nodes_search_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: GraphNodesSearchRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),
@@ -124,7 +125,7 @@ async def graph_nodes_search(kbid: str, item: GraphNodesSearchRequest) -> GraphN
 async def graph_relations_search_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: GraphRelationsSearchRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/graph.py
+++ b/nucliadb/src/nucliadb/search/api/v1/graph.py
@@ -20,6 +20,7 @@
 from fastapi import Header, Request, Response
 from fastapi_versioning import version
 
+from nucliadb.common.fastapi import KbId
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.requesters.utils import Method, nidx_query
 from nucliadb.search.search.graph_merge import (
@@ -32,7 +33,6 @@ from nucliadb.search.search.query_parser.parsers import (
     parse_graph_relation_search,
     parse_graph_search,
 )
-from nucliadb_models.common import KbId
 from nucliadb_models.graph.requests import (
     GraphNodesSearchRequest,
     GraphRelationsSearchRequest,

--- a/nucliadb/src/nucliadb/search/api/v1/hydrate.py
+++ b/nucliadb/src/nucliadb/search/api/v1/hydrate.py
@@ -35,6 +35,7 @@ from nucliadb.search.search.hydrator.images import (
 )
 from nucliadb.search.search.hydrator.paragraphs import ParagraphIndex, hydrate_paragraph
 from nucliadb.search.search.hydrator.resources import hydrate_resource
+from nucliadb_models.common import KbId
 from nucliadb_models.hydration import (
     Hydrated,
     HydratedConversationField,
@@ -67,7 +68,7 @@ from nucliadb_utils.authentication import requires
 async def hydrate_endpoint(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: HydrateRequest,
 ) -> Hydrated:
     with request_caches():

--- a/nucliadb/src/nucliadb/search/api/v1/hydrate.py
+++ b/nucliadb/src/nucliadb/search/api/v1/hydrate.py
@@ -24,6 +24,7 @@ from async_lru import alru_cache
 from fastapi import Request, Response
 from fastapi_versioning import version
 
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.ids import FIELD_TYPE_STR_TO_PB, FieldId, ParagraphId
 from nucliadb.ingest.fields.base import Field
 from nucliadb.search.api.v1.router import KB_PREFIX, api
@@ -35,7 +36,6 @@ from nucliadb.search.search.hydrator.images import (
 )
 from nucliadb.search.search.hydrator.paragraphs import ParagraphIndex, hydrate_paragraph
 from nucliadb.search.search.hydrator.resources import hydrate_resource
-from nucliadb_models.common import KbId
 from nucliadb_models.hydration import (
     Hydrated,
     HydratedConversationField,

--- a/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
@@ -32,13 +32,13 @@ from nucliadb.common.cluster.utils import get_shard_manager
 from nucliadb.common.constants import AVG_PARAGRAPH_SIZE_BYTES
 from nucliadb.common.counters import IndexCounts
 from nucliadb.common.external_index_providers.manager import get_external_index_manager
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.models_utils import from_proto
 from nucliadb.search import logger
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.search.shards import get_shard
 from nucliadb.search.settings import settings
-from nucliadb_models.common import KbId
 from nucliadb_models.internal.shards import KnowledgeboxShards
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (

--- a/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/search/api/v1/knowledgebox.py
@@ -38,6 +38,7 @@ from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
 from nucliadb.search.search.shards import get_shard
 from nucliadb.search.settings import settings
+from nucliadb_models.common import KbId
 from nucliadb_models.internal.shards import KnowledgeboxShards
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (
@@ -62,7 +63,7 @@ MAX_PARAGRAPHS_FOR_SMALL_KB = 250_000
 )
 @requires(NucliaDBRoles.MANAGER)
 @version(1)
-async def knowledgebox_shards(request: Request, kbid: str) -> KnowledgeboxShards:
+async def knowledgebox_shards(request: Request, kbid: KbId) -> KnowledgeboxShards:
     shard_manager = get_shard_manager()
     try:
         shards: Shards = await shard_manager.get_shards_by_kbid_inner(kbid)
@@ -86,7 +87,7 @@ async def knowledgebox_shards(request: Request, kbid: str) -> KnowledgeboxShards
 @version(1)
 async def knowledgebox_counters(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     debug: bool = fastapi_query(SearchParamDefaults.debug),
 ) -> KnowledgeboxCounters:
     try:

--- a/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
@@ -28,6 +28,7 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.search.predict_proxy import PredictProxiedEndpoints, predict_proxy
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import NucliaDBClientType
 from nucliadb_utils.authentication import requires
@@ -62,7 +63,7 @@ DESCRIPTION = (
 @version(1)
 async def predict_proxy_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     endpoint: PredictProxiedEndpoints,
     x_nucliadb_user: str = Header(""),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),

--- a/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
+++ b/nucliadb/src/nucliadb/search/api/v1/predict_proxy.py
@@ -24,11 +24,11 @@ from fastapi.responses import Response, StreamingResponse
 from fastapi_versioning import version
 
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.search.predict_proxy import PredictProxiedEndpoints, predict_proxy
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import NucliaDBClientType
 from nucliadb_utils.authentication import requires

--- a/nucliadb/src/nucliadb/search/api/v1/resource/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/ask.py
@@ -24,9 +24,9 @@ from fastapi_versioning import version
 from starlette.responses import StreamingResponse
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, RESOURCE_SLUG_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import AskRequest, NucliaDBClientType, SyncAskResponse
 from nucliadb_models.security import RequestSecurity

--- a/nucliadb/src/nucliadb/search/api/v1/resource/ask.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/ask.py
@@ -26,6 +26,7 @@ from starlette.responses import StreamingResponse
 from nucliadb.common import datamanagers
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, RESOURCE_SLUG_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import AskRequest, NucliaDBClientType, SyncAskResponse
 from nucliadb_models.security import RequestSecurity
@@ -46,7 +47,7 @@ from ..ask import create_ask_response
 @version(1)
 async def resource_ask_endpoint_by_uuid(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rid: UUID,
     item: AskRequest,
     x_show_consumption: bool = Header(default=False),
@@ -92,7 +93,7 @@ async def resource_ask_endpoint_by_uuid(
 @version(1)
 async def resource_ask_endpoint_by_slug(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     slug: str,
     item: AskRequest,
     x_show_consumption: bool = Header(default=False),

--- a/nucliadb/src/nucliadb/search/api/v1/resource/ingestion_agents.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/ingestion_agents.py
@@ -22,6 +22,7 @@ from fastapi import Header, Request, Response
 from fastapi_versioning import version
 
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId, RId
 from nucliadb.common.models_utils import from_proto
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, RESOURCE_SLUG_PREFIX, api
@@ -35,7 +36,6 @@ from nucliadb_models.agents.ingestion import (
     ResourceAgentsResponse,
 )
 from nucliadb_models.agents.ingestion import AugmentedField as PublicAugmentedField
-from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 

--- a/nucliadb/src/nucliadb/search/api/v1/resource/ingestion_agents.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/ingestion_agents.py
@@ -35,6 +35,7 @@ from nucliadb_models.agents.ingestion import (
     ResourceAgentsResponse,
 )
 from nucliadb_models.agents.ingestion import AugmentedField as PublicAugmentedField
+from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 
@@ -53,8 +54,8 @@ from nucliadb_utils.authentication import requires_one
 async def run_agents_by_uuid(
     request: Request,
     response: Response,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     item: ResourceAgentsRequest,
     x_nucliadb_user: str = Header(""),
 ) -> ResourceAgentsResponse | HTTPClientError:
@@ -75,7 +76,7 @@ async def run_agents_by_uuid(
 async def run_agents_by_slug(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     slug: str,
     item: ResourceAgentsRequest,
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/resource/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/search.py
@@ -32,6 +32,7 @@ from nucliadb.search.requesters.utils import Method, nidx_query
 from nucliadb.search.search import cache
 from nucliadb.search.search.merge import merge_paragraphs_results
 from nucliadb.search.search.query import paragraph_query_to_pb
+from nucliadb_models.common import KbId, RId
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (
@@ -59,9 +60,9 @@ from nucliadb_utils.authentication import requires_one
 async def resource_search(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     query: str,
-    rid: str,
+    rid: RId,
     filter_expression: str | None = fastapi_query(SearchParamDefaults.filter_expression),
     fields: list[str] = fastapi_query(SearchParamDefaults.fields),
     filters: list[str] = fastapi_query(SearchParamDefaults.filters),

--- a/nucliadb/src/nucliadb/search/api/v1/resource/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/resource/search.py
@@ -25,6 +25,7 @@ from fastapi_versioning import version
 from pydantic import ValidationError
 
 from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.fastapi import KbId, RId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, RESOURCE_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
@@ -32,7 +33,6 @@ from nucliadb.search.requesters.utils import Method, nidx_query
 from nucliadb.search.search import cache
 from nucliadb.search.search.merge import merge_paragraphs_results
 from nucliadb.search.search.query import paragraph_query_to_pb
-from nucliadb_models.common import KbId, RId
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import (

--- a/nucliadb/src/nucliadb/search/api/v1/retrieve.py
+++ b/nucliadb/src/nucliadb/search/api/v1/retrieve.py
@@ -25,6 +25,7 @@ from fastapi_versioning import version
 
 from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.common.external_index_providers.base import TextBlockMatch
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.models_utils import to_proto
 from nucliadb.models.internal.augment import Paragraph, ParagraphText
 from nucliadb.search.api.v1.router import KB_PREFIX, api
@@ -34,7 +35,6 @@ from nucliadb.search.search.query_parser.parsers.retrieve import parse_retrieve
 from nucliadb.search.search.query_parser.parsers.unit_retrieval import get_rephrased_query
 from nucliadb.search.search.rerankers import RerankableItem, Reranker, RerankingOptions, get_reranker
 from nucliadb.search.search.retrieval import text_block_search
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.retrieval import (
     Metadata,

--- a/nucliadb/src/nucliadb/search/api/v1/retrieve.py
+++ b/nucliadb/src/nucliadb/search/api/v1/retrieve.py
@@ -34,6 +34,7 @@ from nucliadb.search.search.query_parser.parsers.retrieve import parse_retrieve
 from nucliadb.search.search.query_parser.parsers.unit_retrieval import get_rephrased_query
 from nucliadb.search.search.rerankers import RerankableItem, Reranker, RerankingOptions, get_reranker
 from nucliadb.search.search.retrieval import text_block_search
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.retrieval import (
     Metadata,
@@ -59,7 +60,7 @@ from nucliadb_utils.utilities import get_audit
 @version(1)
 async def _retrieve_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: RetrievalRequest,
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -43,7 +43,7 @@ from nucliadb.search.search.query_parser.parsers.unit_retrieval import (
 from nucliadb.search.search.utils import (
     min_score_from_query_params,
 )
-from nucliadb_models.common import FieldTypeName
+from nucliadb_models.common import FieldTypeName, KbId
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import (
@@ -99,7 +99,7 @@ SEARCH_EXAMPLES = {
 async def search_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     query: str = fastapi_query(SearchParamDefaults.query),
     filter_expression: str | None = fastapi_query(SearchParamDefaults.filter_expression),
     fields: list[str] = fastapi_query(SearchParamDefaults.fields),
@@ -205,7 +205,7 @@ async def search_knowledgebox(
 async def search_post_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: SearchRequest = Body(openapi_examples=SEARCH_EXAMPLES),
     x_ndb_client: NucliaDBClientType = Header(NucliaDBClientType.API),
     x_nucliadb_user: str = Header(""),

--- a/nucliadb/src/nucliadb/search/api/v1/search.py
+++ b/nucliadb/src/nucliadb/search/api/v1/search.py
@@ -27,6 +27,7 @@ from pydantic import ValidationError
 
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
 from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.models_utils import to_proto
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
@@ -43,7 +44,7 @@ from nucliadb.search.search.query_parser.parsers.unit_retrieval import (
 from nucliadb.search.search.utils import (
     min_score_from_query_params,
 )
-from nucliadb_models.common import FieldTypeName, KbId
+from nucliadb_models.common import FieldTypeName
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import ExtractedDataTypeName, NucliaDBRoles
 from nucliadb_models.search import (

--- a/nucliadb/src/nucliadb/search/api/v1/suggest.py
+++ b/nucliadb/src/nucliadb/search/api/v1/suggest.py
@@ -33,6 +33,7 @@ from nucliadb.search.search import cache
 from nucliadb.search.search.merge import merge_suggest_results
 from nucliadb.search.search.query_parser.parsers import parse_suggest
 from nucliadb_models import SuggestRequest
+from nucliadb_models.common import KbId
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import KnowledgeboxSuggestResults
@@ -55,7 +56,7 @@ from nucliadb_utils.authentication import requires
 async def suggest_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     query: str = fastapi_query(SuggestParamDefaults.suggest_query),
     filter_expression: str | None = fastapi_query(
         SuggestParamDefaults.filter_expression, include_in_schema=False
@@ -115,7 +116,7 @@ async def suggest_knowledgebox(
 async def suggest_post_knowledgebox(
     request: Request,
     response: Response,
-    kbid: str,
+    kbid: KbId,
     item: SuggestRequest,
 ) -> KnowledgeboxSuggestResults | HTTPClientError:
     try:

--- a/nucliadb/src/nucliadb/search/api/v1/suggest.py
+++ b/nucliadb/src/nucliadb/search/api/v1/suggest.py
@@ -25,6 +25,7 @@ from fastapi_versioning import version
 from pydantic import ValidationError
 
 from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.api.v1.utils import fastapi_query
@@ -33,7 +34,6 @@ from nucliadb.search.search import cache
 from nucliadb.search.search.merge import merge_suggest_results
 from nucliadb.search.search.query_parser.parsers import parse_suggest
 from nucliadb_models import SuggestRequest
-from nucliadb_models.common import KbId
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import KnowledgeboxSuggestResults

--- a/nucliadb/src/nucliadb/search/api/v1/summarize.py
+++ b/nucliadb/src/nucliadb/search/api/v1/summarize.py
@@ -22,11 +22,11 @@ from fastapi import Header, Request
 from fastapi_versioning import version
 
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
+from nucliadb.common.fastapi import KbId
 from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.search.summarize import NoResourcesToSummarize, summarize
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import SummarizedResponse, SummarizeRequest
 from nucliadb_utils.authentication import requires

--- a/nucliadb/src/nucliadb/search/api/v1/summarize.py
+++ b/nucliadb/src/nucliadb/search/api/v1/summarize.py
@@ -26,6 +26,7 @@ from nucliadb.models.responses import HTTPClientError
 from nucliadb.search import predict
 from nucliadb.search.api.v1.router import KB_PREFIX, api
 from nucliadb.search.search.summarize import NoResourcesToSummarize, summarize
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.search import SummarizedResponse, SummarizeRequest
 from nucliadb_utils.authentication import requires
@@ -44,7 +45,7 @@ from nucliadb_utils.exceptions import LimitsExceededError
 @version(1)
 async def summarize_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: SummarizeRequest,
     x_show_consumption: bool = Header(default=False),
 ) -> SummarizedResponse | HTTPClientError:

--- a/nucliadb/src/nucliadb/train/api/v1/shards.py
+++ b/nucliadb/src/nucliadb/train/api/v1/shards.py
@@ -26,6 +26,7 @@ from fastapi.responses import StreamingResponse
 from fastapi_versioning import version
 
 from nucliadb.common.cluster.exceptions import ShardNotFound
+from nucliadb.common.fastapi import KbId
 from nucliadb.train.api.utils import get_kb_partitions
 from nucliadb.train.api.v1.router import KB_PREFIX, api
 from nucliadb.train.generator import generate_train_data
@@ -46,7 +47,7 @@ from nucliadb_utils.authentication import requires_one
 @version(1)
 async def object_get_response(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     shard: str,
 ) -> StreamingResponse:
     try:

--- a/nucliadb/src/nucliadb/train/api/v1/trainset.py
+++ b/nucliadb/src/nucliadb/train/api/v1/trainset.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException, Request
 from fastapi_versioning import version
 
 from nucliadb.common.cluster.exceptions import ShardNotFound
+from nucliadb.common.fastapi import KbId
 from nucliadb.train.api.utils import get_kb_partitions
 from nucliadb.train.api.v1.router import KB_PREFIX, api
 from nucliadb_models.resource import NucliaDBRoles
@@ -39,7 +40,7 @@ from nucliadb_utils.authentication import requires_one
 )
 @requires_one([NucliaDBRoles.READER])
 @version(1)
-async def get_partitions_all(request: Request, kbid: str) -> TrainSetPartitions:
+async def get_partitions_all(request: Request, kbid: KbId) -> TrainSetPartitions:
     return await get_partitions(kbid)
 
 
@@ -52,11 +53,11 @@ async def get_partitions_all(request: Request, kbid: str) -> TrainSetPartitions:
 )
 @requires_one([NucliaDBRoles.READER])
 @version(1)
-async def get_partitions_prefix(request: Request, kbid: str, prefix: str) -> TrainSetPartitions:
+async def get_partitions_prefix(request: Request, kbid: KbId, prefix: str) -> TrainSetPartitions:
     return await get_partitions(kbid, prefix=prefix)
 
 
-async def get_partitions(kbid: str, prefix: str | None = None) -> TrainSetPartitions:
+async def get_partitions(kbid: KbId, prefix: str | None = None) -> TrainSetPartitions:
     try:
         all_keys = await get_kb_partitions(kbid, prefix)
     except ShardNotFound:

--- a/nucliadb/src/nucliadb/writer/api/v1/export_import.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/export_import.py
@@ -29,6 +29,7 @@ from nucliadb.common.back_pressure import maybe_back_pressure
 from nucliadb.common.cluster.settings import in_standalone_mode
 from nucliadb.common.context import ApplicationContext
 from nucliadb.common.context.fastapi import get_app_context
+from nucliadb.common.fastapi import KbId
 from nucliadb.export_import import importer
 from nucliadb.export_import.datamanager import ExportImportDataManager
 from nucliadb.export_import.exceptions import (
@@ -46,7 +47,6 @@ from nucliadb.writer import logger
 from nucliadb.writer.api.utils import only_for_onprem
 from nucliadb.writer.api.v1.knowledgebox import create_kb
 from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.export_import import (
     CreateExportResponse,
     CreateImportResponse,

--- a/nucliadb/src/nucliadb/writer/api/v1/export_import.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/export_import.py
@@ -46,6 +46,7 @@ from nucliadb.writer import logger
 from nucliadb.writer.api.utils import only_for_onprem
 from nucliadb.writer.api.v1.knowledgebox import create_kb
 from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.export_import import (
     CreateExportResponse,
     CreateImportResponse,
@@ -70,7 +71,7 @@ from nucliadb_utils.authentication import requires_one
 )
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.WRITER])
 @version(1)
-async def start_kb_export_endpoint(request: Request, kbid: str):
+async def start_kb_export_endpoint(request: Request, kbid: KbId):
     context = get_app_context(request.app)
     if not await datamanagers.atomic.kb.exists_kb(kbid=kbid):
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")
@@ -146,7 +147,7 @@ async def kb_create_and_import_endpoint(request: Request):
 )
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.WRITER])
 @version(1)
-async def start_kb_import_endpoint(request: Request, kbid: str):
+async def start_kb_import_endpoint(request: Request, kbid: KbId):
     context = get_app_context(request.app)
     if not await datamanagers.atomic.kb.exists_kb(kbid=kbid):
         return HTTPClientError(status_code=404, detail="Knowledge Box not found")

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -29,6 +29,7 @@ from starlette.requests import Request
 import nucliadb_models as models
 from nucliadb.common import datamanagers
 from nucliadb.common.back_pressure import maybe_back_pressure
+from nucliadb.common.fastapi import KbId, RId
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.fields.conversation import Conversation
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
@@ -59,7 +60,6 @@ from nucliadb.writer.resource.field import (
     parse_text_field,
 )
 from nucliadb.writer.utilities import get_processing
-from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.utils import FieldIdString
 from nucliadb_models.writer import KeyValueField, ResourceFieldAdded, ResourceUpdated

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -59,6 +59,7 @@ from nucliadb.writer.resource.field import (
     parse_text_field,
 )
 from nucliadb.writer.utilities import get_processing
+from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.utils import FieldIdString
 from nucliadb_models.writer import KeyValueField, ResourceFieldAdded, ResourceUpdated
@@ -322,7 +323,7 @@ FIELD_PARSERS_MAP: dict[type, Callable] = {
 @version(1)
 async def add_resource_field_key_value_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     item: KeyValueField,
@@ -341,8 +342,8 @@ async def add_resource_field_key_value_rslug_prefix(
 @version(1)
 async def add_resource_field_key_value_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     item: KeyValueField,
 ):
@@ -360,7 +361,7 @@ async def add_resource_field_key_value_rid_prefix(
 @version(1)
 async def add_resource_field_text_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     field_payload: models.TextField,
@@ -379,8 +380,8 @@ async def add_resource_field_text_rslug_prefix(
 @version(1)
 async def add_resource_field_text_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     field_payload: models.TextField,
 ) -> ResourceFieldAdded:
@@ -398,7 +399,7 @@ async def add_resource_field_text_rid_prefix(
 @version(1)
 async def add_resource_field_link_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     field_payload: models.LinkField,
@@ -417,8 +418,8 @@ async def add_resource_field_link_rslug_prefix(
 @version(1)
 async def add_resource_field_link_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     field_payload: models.LinkField,
 ) -> ResourceFieldAdded:
@@ -436,7 +437,7 @@ async def add_resource_field_link_rid_prefix(
 @version(1)
 async def add_resource_field_conversation_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     field_payload: models.InputConversationField,
@@ -457,8 +458,8 @@ async def add_resource_field_conversation_rslug_prefix(
 @version(1)
 async def add_resource_field_conversation_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     field_payload: models.InputConversationField,
 ) -> ResourceFieldAdded:
@@ -476,7 +477,7 @@ async def add_resource_field_conversation_rid_prefix(
 @version(1)
 async def add_resource_field_file_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     field_payload: models.FileField,
@@ -498,8 +499,8 @@ async def add_resource_field_file_rslug_prefix(
 @version(1)
 async def add_resource_field_file_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     field_payload: models.FileField,
     x_skip_store: Annotated[bool, X_SKIP_STORE] = False,
@@ -520,7 +521,7 @@ async def add_resource_field_file_rid_prefix(
 @version(1)
 async def append_messages_to_conversation_field_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     messages: list[models.InputMessage],
@@ -545,8 +546,8 @@ async def append_messages_to_conversation_field_rslug_prefix(
 @version(1)
 async def append_messages_to_conversation_field_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     messages: list[models.InputMessage],
 ) -> ResourceFieldAdded:
@@ -568,7 +569,7 @@ async def append_messages_to_conversation_field_rid_prefix(
 @version(1)
 async def delete_resource_field_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_type: models.FieldTypeName,
     field_id: FieldIdString,
@@ -587,8 +588,8 @@ async def delete_resource_field_rslug_prefix(
 @version(1)
 async def delete_resource_field_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_type: models.FieldTypeName,
     field_id: FieldIdString,
 ):
@@ -606,8 +607,8 @@ async def delete_resource_field_rid_prefix(
 @version(1)
 async def reprocess_file_field(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     x_nucliadb_user: Annotated[str, X_NUCLIADB_USER] = "",
     x_file_password: Annotated[str | None, X_FILE_PASSWORD] = None,
@@ -711,7 +712,7 @@ MessageIdent = Annotated[str, Path(max_length=128, description="The ident of the
 @version(1)
 async def delete_conversation_messages_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field_id: FieldIdString,
     message_ident: MessageIdent,
@@ -731,8 +732,8 @@ async def delete_conversation_messages_rslug_prefix(
 @version(1)
 async def delete_conversation_messages_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field_id: FieldIdString,
     message_ident: MessageIdent,
 ) -> Response:

--- a/nucliadb/src/nucliadb/writer/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/knowledgebox.py
@@ -35,6 +35,7 @@ from nucliadb.writer import logger
 from nucliadb.writer.api.utils import only_for_onprem
 from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX, api
 from nucliadb.writer.utilities import get_processing
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     KnowledgeBoxConfig,
     KnowledgeBoxObj,
@@ -151,7 +152,7 @@ async def create_kb(item: KnowledgeBoxConfig) -> tuple[str, str]:
 )
 @requires(NucliaDBRoles.MANAGER)
 @version(1)
-async def update_kb(request: Request, kbid: str, item: KnowledgeBoxConfig) -> KnowledgeBoxObjID:
+async def update_kb(request: Request, kbid: KbId, item: KnowledgeBoxConfig) -> KnowledgeBoxObjID:
     if (
         item.slug
         or item.title
@@ -191,7 +192,7 @@ async def update_kb(request: Request, kbid: str, item: KnowledgeBoxConfig) -> Kn
 )
 @requires(NucliaDBRoles.MANAGER)
 @version(1)
-async def delete_kb(request: Request, kbid: str, background: BackgroundTasks) -> KnowledgeBoxObj:
+async def delete_kb(request: Request, kbid: KbId, background: BackgroundTasks) -> KnowledgeBoxObj:
     driver = get_driver()
     try:
         await KnowledgeBox.delete(driver, kbid=kbid)

--- a/nucliadb/src/nucliadb/writer/api/v1/knowledgebox.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/knowledgebox.py
@@ -28,6 +28,7 @@ from nucliadb.common import datamanagers
 from nucliadb.common.external_index_providers.exceptions import (
     ExternalIndexCreationError,
 )
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.orm.exceptions import KnowledgeBoxConflict
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
@@ -35,7 +36,6 @@ from nucliadb.writer import logger
 from nucliadb.writer.api.utils import only_for_onprem
 from nucliadb.writer.api.v1.router import KB_PREFIX, KBS_PREFIX, api
 from nucliadb.writer.utilities import get_processing
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     KnowledgeBoxConfig,
     KnowledgeBoxObj,

--- a/nucliadb/src/nucliadb/writer/api/v1/learning_config.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/learning_config.py
@@ -21,9 +21,9 @@ from fastapi import Header, Request
 from fastapi_versioning import version
 from nuclia_models.config.proto import ExtractConfig, SplitConfiguration
 
+from nucliadb.common.fastapi import KbId
 from nucliadb.learning_proxy import learning_config_proxy
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 

--- a/nucliadb/src/nucliadb/writer/api/v1/learning_config.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/learning_config.py
@@ -23,6 +23,7 @@ from nuclia_models.config.proto import ExtractConfig, SplitConfiguration
 
 from nucliadb.learning_proxy import learning_config_proxy
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_utils.authentication import requires_one
 
@@ -39,7 +40,7 @@ from nucliadb_utils.authentication import requires_one
 @version(1)
 async def set_configuration(
     request: Request,
-    kbid: str,
+    kbid: KbId,
 ):
     return await learning_config_proxy(request, "POST", f"/config/{kbid}")
 
@@ -55,7 +56,7 @@ async def set_configuration(
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.OWNER])
 @version(1)
 async def patch_configuration(
-    request: Request, kbid: str, x_nucliadb_account: str = Header(default="", include_in_schema=False)
+    request: Request, kbid: KbId, x_nucliadb_account: str = Header(default="", include_in_schema=False)
 ):
     return await learning_config_proxy(
         request, "PATCH", f"/config/{kbid}", headers={"account-id": x_nucliadb_account}
@@ -74,7 +75,7 @@ async def patch_configuration(
 @version(1)
 async def add_strategy(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: ExtractConfig,
 ):
     return await learning_config_proxy(request, "POST", f"/extract_strategies/{kbid}")
@@ -92,7 +93,7 @@ async def add_strategy(
 @version(1)
 async def delete_strategy(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     strategy_id: str,
 ):
     return await learning_config_proxy(
@@ -112,7 +113,7 @@ async def delete_strategy(
 @version(1)
 async def add_split_strategy(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: SplitConfiguration,
 ):
     return await learning_config_proxy(request, "POST", f"/split_strategies/{kbid}")
@@ -130,7 +131,7 @@ async def add_split_strategy(
 @version(1)
 async def delete_split_strategy(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     strategy_id: str,
 ):
     return await learning_config_proxy(

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -29,6 +29,7 @@ from starlette.requests import Request
 from nucliadb.common import datamanagers
 from nucliadb.common.back_pressure import maybe_back_pressure
 from nucliadb.common.context.fastapi import get_app_context
+from nucliadb.common.fastapi import KbId, RId
 from nucliadb.common.maindb.driver import Driver
 from nucliadb.common.maindb.exceptions import ConflictError, NotFoundError
 from nucliadb.common.maindb.utils import get_driver
@@ -61,7 +62,6 @@ from nucliadb.writer.resource.field import (
 )
 from nucliadb.writer.resource.origin import parse_extra, parse_origin
 from nucliadb.writer.utilities import get_processing
-from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.writer import (
     CreateResourcePayload,

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -61,6 +61,7 @@ from nucliadb.writer.resource.field import (
 )
 from nucliadb.writer.resource.origin import parse_extra, parse_origin
 from nucliadb.writer.utilities import get_processing
+from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.writer import (
     CreateResourcePayload,
@@ -94,7 +95,7 @@ from nucliadb_utils.utilities import (
 async def create_resource(
     request: Request,
     item: CreateResourcePayload,
-    kbid: str,
+    kbid: KbId,
     x_skip_store: Annotated[bool, X_SKIP_STORE] = False,
     x_nucliadb_user: Annotated[str, X_NUCLIADB_USER] = "",
 ):
@@ -187,7 +188,7 @@ async def create_resource(
 @version(1)
 async def modify_resource_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     item: UpdateResourcePayload,
     x_skip_store: Annotated[bool, X_SKIP_STORE] = False,
@@ -215,8 +216,8 @@ async def modify_resource_rslug_prefix(
 @version(1)
 async def modify_resource_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     item: UpdateResourcePayload,
     x_nucliadb_user: Annotated[str, X_NUCLIADB_USER] = "",
     x_skip_store: Annotated[bool, X_SKIP_STORE] = False,
@@ -389,7 +390,7 @@ async def update_resource_slug(
 @version(1)
 async def reprocess_resource_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     x_nucliadb_user: Annotated[str, X_NUCLIADB_USER] = "",
     reset_title: bool = Query(
@@ -414,8 +415,8 @@ async def reprocess_resource_rslug_prefix(
 @version(1)
 async def reprocess_resource_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     x_nucliadb_user: Annotated[str, X_NUCLIADB_USER] = "",
     reset_title: bool = Query(
         default=False,
@@ -497,7 +498,7 @@ async def _reprocess_resource(
 @requires(NucliaDBRoles.WRITER)
 @version(1)
 async def delete_resource_rslug_prefix(
-    request: Request, kbid: str, rslug: str, background: BackgroundTasks
+    request: Request, kbid: KbId, rslug: str, background: BackgroundTasks
 ):
     rid = await get_rid_from_slug_or_raise_error(kbid, rslug)
     return await _delete_resource(request, kbid, rid, background)
@@ -511,7 +512,9 @@ async def delete_resource_rslug_prefix(
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def delete_resource_rid_prefix(request: Request, kbid: str, rid: str, background: BackgroundTasks):
+async def delete_resource_rid_prefix(
+    request: Request, kbid: KbId, rid: RId, background: BackgroundTasks
+):
     return await _delete_resource(request, kbid, rid, background)
 
 
@@ -545,7 +548,7 @@ async def _delete_resource(request: Request, kbid: str, rid: str, background: Ba
 @version(1)
 async def reindex_resource_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     reindex_vectors: bool = Query(False),
 ):
@@ -563,8 +566,8 @@ async def reindex_resource_rslug_prefix(
 @version(1)
 async def reindex_resource_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     reindex_vectors: bool = Query(False),
 ):
     return await _reindex_resource(request, kbid, rid, reindex_vectors=reindex_vectors)

--- a/nucliadb/src/nucliadb/writer/api/v1/services.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/services.py
@@ -23,9 +23,9 @@ from starlette.requests import Request
 
 from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
+from nucliadb.common.fastapi import KbId
 from nucliadb.common.models_utils import to_proto
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.configuration import SearchConfiguration
 from nucliadb_models.kv_schemas import MAX_KV_SCHEMAS, KVSchema, UpdateKVSchema
 from nucliadb_models.labels import LabelSet

--- a/nucliadb/src/nucliadb/writer/api/v1/services.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/services.py
@@ -25,6 +25,7 @@ from nucliadb.common import datamanagers
 from nucliadb.common.datamanagers.exceptions import KnowledgeBoxNotFound
 from nucliadb.common.models_utils import to_proto
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.configuration import SearchConfiguration
 from nucliadb_models.kv_schemas import MAX_KV_SCHEMAS, KVSchema, UpdateKVSchema
 from nucliadb_models.labels import LabelSet
@@ -47,7 +48,7 @@ from nucliadb_utils.authentication import requires
 @version(1)
 async def set_labelset_endpoint(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     labelset: str = Path(
         title="The ID of the labelset to create or update. This is a unique identifier that should be used at search time.",
         examples=["categories", "movie-genres", "document-types"],
@@ -109,7 +110,7 @@ async def set_labelset(kbid: str, labelset_id: str, item: LabelSet):
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def delete_labelset_endpoint(request: Request, kbid: str, labelset: str):
+async def delete_labelset_endpoint(request: Request, kbid: KbId, labelset: str):
     try:
         await delete_labelset(kbid, labelset)
     except KnowledgeBoxNotFound:
@@ -132,7 +133,7 @@ async def delete_labelset(kbid: str, labelset_id: str):
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def set_custom_synonyms(request: Request, kbid: str, item: KnowledgeBoxSynonyms):
+async def set_custom_synonyms(request: Request, kbid: KbId, item: KnowledgeBoxSynonyms):
     if not await datamanagers.atomic.kb.exists_kb(kbid=kbid):
         raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
     synonyms = to_proto.kb_synonyms(item)
@@ -149,7 +150,7 @@ async def set_custom_synonyms(request: Request, kbid: str, item: KnowledgeBoxSyn
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def delete_custom_synonyms(request: Request, kbid: str):
+async def delete_custom_synonyms(request: Request, kbid: KbId):
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
@@ -169,7 +170,7 @@ async def delete_custom_synonyms(request: Request, kbid: str):
 @requires(NucliaDBRoles.OWNER)
 @version(1)
 async def create_search_configuration(
-    request: Request, kbid: str, config_name: str, search_configuration: SearchConfiguration
+    request: Request, kbid: KbId, config_name: str, search_configuration: SearchConfiguration
 ):
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
@@ -195,7 +196,7 @@ async def create_search_configuration(
 @requires(NucliaDBRoles.OWNER)
 @version(1)
 async def update_search_configuration(
-    request: Request, kbid: str, config_name: str, search_configuration: SearchConfiguration
+    request: Request, kbid: KbId, config_name: str, search_configuration: SearchConfiguration
 ):
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
@@ -220,7 +221,7 @@ async def update_search_configuration(
 )
 @requires(NucliaDBRoles.OWNER)
 @version(1)
-async def delete_search_configuration(request: Request, kbid: str, config_name: str):
+async def delete_search_configuration(request: Request, kbid: KbId, config_name: str):
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
@@ -243,7 +244,7 @@ async def delete_search_configuration(request: Request, kbid: str, config_name: 
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def create_kv_schema(request: Request, kbid: str, item: KVSchema) -> KVSchema:
+async def create_kv_schema(request: Request, kbid: KbId, item: KVSchema) -> KVSchema:
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")
@@ -274,7 +275,7 @@ async def create_kv_schema(request: Request, kbid: str, item: KVSchema) -> KVSch
 @requires(NucliaDBRoles.WRITER)
 @version(1)
 async def update_kv_schema(
-    request: Request, kbid: str, schema_id: str, item: UpdateKVSchema
+    request: Request, kbid: KbId, schema_id: str, item: UpdateKVSchema
 ) -> KVSchema:
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
@@ -303,7 +304,7 @@ async def update_kv_schema(
 )
 @requires(NucliaDBRoles.WRITER)
 @version(1)
-async def delete_kv_schema(request: Request, kbid: str, schema_id: str) -> Response:
+async def delete_kv_schema(request: Request, kbid: KbId, schema_id: str) -> Response:
     async with datamanagers.with_transaction() as txn:
         if not await datamanagers.kb.exists_kb(txn, kbid=kbid):
             raise HTTPException(status_code=404, detail="Knowledge Box does not exist")

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -72,6 +72,7 @@ from nucliadb.writer.tus.storage import FileStorageManager
 from nucliadb.writer.tus.utils import parse_tus_metadata
 from nucliadb.writer.utilities import get_processing
 from nucliadb_models import content_types
+from nucliadb_models.common import KbId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.utils import FieldIdString
 from nucliadb_models.writer import CreateResourcePayload, ResourceFileUploaded
@@ -152,7 +153,7 @@ def _tus_options() -> Response:
 @version(1)
 async def tus_post_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field: FieldIdString,
     item: CreateResourcePayload | None = None,
@@ -181,8 +182,8 @@ async def tus_post_rslug_prefix(
 @version(1)
 async def tus_post_rid_prefix(
     request: Request,
-    kbid: str,
-    path_rid: str,
+    kbid: KbId,
+    path_rid: RId,
     field: FieldIdString,
     item: CreateResourcePayload | None = None,
     x_extract_strategy: Annotated[str | None, X_EXTRACT_STRATEGY] = None,
@@ -209,7 +210,7 @@ async def tus_post_rid_prefix(
 @version(1)
 async def tus_post(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     item: CreateResourcePayload | None = None,
     x_extract_strategy: Annotated[str | None, X_EXTRACT_STRATEGY] = None,
     x_split_strategy: Annotated[str | None, X_SPLIT_STRATEGY] = None,
@@ -361,7 +362,7 @@ async def _tus_post(
 @version(1)
 async def tus_head_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field: FieldIdString,
     upload_id: str,
@@ -381,8 +382,8 @@ async def tus_head_rslug_prefix(
 @version(1)
 async def tus_head_rid_prefix(
     request: Request,
-    kbid: str,
-    path_rid: str,
+    kbid: KbId,
+    path_rid: RId,
     field: FieldIdString,
     upload_id: str,
 ) -> Response:
@@ -401,7 +402,7 @@ async def tus_head_rid_prefix(
 @version(1)
 async def head(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     upload_id: str,
 ) -> Response:
     return await _tus_head(upload_id)
@@ -439,7 +440,7 @@ async def _tus_head(
 @version(1)
 async def tus_patch_rslug_prefix(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field: FieldIdString,
     upload_id: str,
@@ -459,8 +460,8 @@ async def tus_patch_rslug_prefix(
 @version(1)
 async def tus_patch_rid_prefix(
     request: Request,
-    kbid: str,
-    rid: str,
+    kbid: KbId,
+    rid: RId,
     field: FieldIdString,
     upload_id: str,
 ) -> Response:
@@ -478,7 +479,7 @@ async def tus_patch_rid_prefix(
 @version(1)
 async def patch(
     request: Request,
-    kbid: str,
+    kbid: KbId,
     upload_id: str,
 ) -> Response:
     return await tus_patch(request, kbid, upload_id)
@@ -645,7 +646,7 @@ def validate_intermediate_tus_chunk(read_bytes: int, storage_manager: FileStorag
 @version(1)
 async def upload_rslug_prefix(
     request: StarletteRequest,
-    kbid: str,
+    kbid: KbId,
     rslug: str,
     field: FieldIdString,
     x_filename: Annotated[str | None, X_FILENAME] = None,
@@ -681,8 +682,8 @@ async def upload_rslug_prefix(
 @version(1)
 async def upload_rid_prefix(
     request: StarletteRequest,
-    kbid: str,
-    path_rid: str,
+    kbid: KbId,
+    path_rid: RId,
     field: FieldIdString,
     x_filename: Annotated[str | None, X_FILENAME] = None,
     x_password: Annotated[str | None, X_PASSWORD] = None,
@@ -716,7 +717,7 @@ async def upload_rid_prefix(
 @version(1)
 async def upload(
     request: StarletteRequest,
-    kbid: str,
+    kbid: KbId,
     x_filename: Annotated[str | None, X_FILENAME] = None,
     x_password: Annotated[str | None, X_PASSWORD] = None,
     x_language: Annotated[str | None, X_LANGUAGE] = None,

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -33,6 +33,7 @@ from starlette.requests import Request as StarletteRequest
 
 from nucliadb.common import datamanagers, file_md5
 from nucliadb.common.back_pressure import maybe_back_pressure
+from nucliadb.common.fastapi import KbId, PathRId, RId
 from nucliadb.ingest.orm.resource import Resource
 from nucliadb.ingest.orm.utils import set_title
 from nucliadb.models.internal.processing import PushPayload, Source
@@ -72,7 +73,6 @@ from nucliadb.writer.tus.storage import FileStorageManager
 from nucliadb.writer.tus.utils import parse_tus_metadata
 from nucliadb.writer.utilities import get_processing
 from nucliadb_models import content_types
-from nucliadb_models.common import KbId, PathRId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.utils import FieldIdString
 from nucliadb_models.writer import CreateResourcePayload, ResourceFileUploaded

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -72,7 +72,7 @@ from nucliadb.writer.tus.storage import FileStorageManager
 from nucliadb.writer.tus.utils import parse_tus_metadata
 from nucliadb.writer.utilities import get_processing
 from nucliadb_models import content_types
-from nucliadb_models.common import KbId, RId
+from nucliadb_models.common import KbId, PathRId, RId
 from nucliadb_models.resource import NucliaDBRoles
 from nucliadb_models.utils import FieldIdString
 from nucliadb_models.writer import CreateResourcePayload, ResourceFileUploaded
@@ -126,8 +126,8 @@ TUS_HEADERS = {
 @version(1)
 def tus_options(
     request: Request,
-    kbid: str,
-    rid: str | None = None,
+    kbid: KbId,
+    rid: RId | None = None,
     rslug: str | None = None,
     upload_id: str | None = None,
     field: str | None = None,
@@ -183,7 +183,7 @@ async def tus_post_rslug_prefix(
 async def tus_post_rid_prefix(
     request: Request,
     kbid: KbId,
-    path_rid: RId,
+    path_rid: PathRId,
     field: FieldIdString,
     item: CreateResourcePayload | None = None,
     x_extract_strategy: Annotated[str | None, X_EXTRACT_STRATEGY] = None,
@@ -383,7 +383,7 @@ async def tus_head_rslug_prefix(
 async def tus_head_rid_prefix(
     request: Request,
     kbid: KbId,
-    path_rid: RId,
+    path_rid: PathRId,
     field: FieldIdString,
     upload_id: str,
 ) -> Response:
@@ -683,7 +683,7 @@ async def upload_rslug_prefix(
 async def upload_rid_prefix(
     request: StarletteRequest,
     kbid: KbId,
-    path_rid: RId,
+    path_rid: PathRId,
     field: FieldIdString,
     x_filename: Annotated[str | None, X_FILENAME] = None,
     x_password: Annotated[str | None, X_PASSWORD] = None,

--- a/nucliadb/src/nucliadb/writer/api/v1/vectorsets.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/vectorsets.py
@@ -28,6 +28,7 @@ from nucliadb.ingest.orm.exceptions import VectorSetConflict
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.writer import logger
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
+from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     NucliaDBRoles,
 )
@@ -48,7 +49,7 @@ from nucliadb_utils.utilities import get_storage
 )
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.OWNER])
 @version(1)
-async def add_vectorset(request: Request, kbid: str, vectorset_id: str) -> CreatedVectorSet:
+async def add_vectorset(request: Request, kbid: KbId, vectorset_id: str) -> CreatedVectorSet:
     try:
         await _add_vectorset(kbid, vectorset_id)
 
@@ -139,7 +140,7 @@ def get_vectorset_config(
 )
 @requires_one([NucliaDBRoles.MANAGER, NucliaDBRoles.OWNER])
 @version(1)
-async def delete_vectorset(request: Request, kbid: str, vectorset_id: str) -> Response:
+async def delete_vectorset(request: Request, kbid: KbId, vectorset_id: str) -> Response:
     try:
         await _delete_vectorset(kbid, vectorset_id)
 

--- a/nucliadb/src/nucliadb/writer/api/v1/vectorsets.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/vectorsets.py
@@ -24,11 +24,11 @@ from starlette.requests import Request
 
 from nucliadb import learning_proxy
 from nucliadb.common import datamanagers
+from nucliadb.common.fastapi import KbId
 from nucliadb.ingest.orm.exceptions import VectorSetConflict
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.writer import logger
 from nucliadb.writer.api.v1.router import KB_PREFIX, api
-from nucliadb_models.common import KbId
 from nucliadb_models.resource import (
     NucliaDBRoles,
 )

--- a/nucliadb/tests/ingest/unit/service/test_writer.py
+++ b/nucliadb/tests/ingest/unit/service/test_writer.py
@@ -33,6 +33,7 @@ from nucliadb_protos.utils_pb2 import VectorSimilarity
 from nucliadb_utils.utilities import Utility, clean_utility, set_utility
 
 WRITER_MODULE = "nucliadb.ingest.service.writer"
+VALID_KBID = "d6fcb6d1-4525-4a1d-84a5-35c7be5dbfbb"
 
 
 class TestWriterServicer:
@@ -77,7 +78,7 @@ class TestWriterServicer:
 
     async def test_NewKnowledgeBoxV2(self, writer: WriterServicer, hosted_nucliadb, knowledgebox_class):
         request = writer_pb2.NewKnowledgeBoxV2Request(
-            kbid="kbid",
+            kbid=VALID_KBID,
             slug="slug",
             title="Title",
             description="Description",
@@ -110,7 +111,7 @@ class TestWriterServicer:
         self, writer: WriterServicer, hosted_nucliadb, knowledgebox_class
     ):
         request = writer_pb2.NewKnowledgeBoxV2Request(
-            kbid="kbid",
+            kbid=VALID_KBID,
             slug="slug",
             title="Title",
             description="Description",
@@ -144,7 +145,7 @@ class TestWriterServicer:
         self, writer: WriterServicer, hosted_nucliadb, knowledgebox_class
     ):
         request = writer_pb2.NewKnowledgeBoxV2Request(
-            kbid="kbid",
+            kbid=VALID_KBID,
             slug="slug",
             title="Title",
             description="Description",
@@ -182,7 +183,7 @@ class TestWriterServicer:
     async def test_NewKnowledgeBoxV2_handle_conflict_error(
         self, writer: WriterServicer, knowledgebox_class
     ):
-        request = writer_pb2.NewKnowledgeBoxV2Request(kbid="kbid", slug="slug")
+        request = writer_pb2.NewKnowledgeBoxV2Request(kbid=VALID_KBID, slug="slug")
         knowledgebox_class.create.side_effect = KnowledgeBoxConflict()
 
         resp = await writer.NewKnowledgeBoxV2(request)
@@ -190,7 +191,7 @@ class TestWriterServicer:
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.CONFLICT
 
     async def test_NewKnowledgeBoxV2_handle_error(self, writer: WriterServicer, knowledgebox_class):
-        request = writer_pb2.NewKnowledgeBoxV2Request(kbid="kbid", slug="slug")
+        request = writer_pb2.NewKnowledgeBoxV2Request(kbid=VALID_KBID, slug="slug")
         knowledgebox_class.create.side_effect = Exception("error")
 
         resp = await writer.NewKnowledgeBoxV2(request)
@@ -200,13 +201,24 @@ class TestWriterServicer:
     async def test_NewKnowledgeBoxV2_handle_external_index_error(
         self, writer: WriterServicer, knowledgebox_class
     ):
-        request = writer_pb2.NewKnowledgeBoxV2Request(kbid="kbid", slug="slug")
+        request = writer_pb2.NewKnowledgeBoxV2Request(kbid=VALID_KBID, slug="slug")
         knowledgebox_class.create.side_effect = ExternalIndexCreationError("unset", "foo")
 
         resp = await writer.NewKnowledgeBoxV2(request)
 
         assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.EXTERNAL_INDEX_PROVIDER_ERROR
         assert resp.error_message == "foo"
+
+    async def test_NewKnowledgeBoxV2_rejects_invalid_kbid(
+        self, writer: WriterServicer, hosted_nucliadb, knowledgebox_class
+    ):
+        request = writer_pb2.NewKnowledgeBoxV2Request(kbid="not-a-uuid", slug="slug")
+
+        resp = await writer.NewKnowledgeBoxV2(request)
+
+        assert resp.status == writer_pb2.KnowledgeBoxResponseStatus.ERROR
+        assert resp.error_message == "Invalid kbid: not-a-uuid. Should be a valid UUID4 string."
+        knowledgebox_class.create.assert_not_called()
 
     async def test_UpdateKnowledgeBox(self, writer: WriterServicer, knowledgebox_class):
         request = writer_pb2.KnowledgeBoxUpdate(slug="slug", uuid="uuid")

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_fields_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_fields_v2.py
@@ -204,7 +204,9 @@ async def test_get_statuses_returns_in_order(maindb_driver: Driver, kbid: str, r
     ]
 
     async with maindb_driver.ro_transaction() as txn:
-        statuses = await fields_v2.get_statuses(txn, kbid=kbid, rid=rid, fields=field_ids)
+        statuses: list[wpb2.FieldStatus] = await fields_v2.get_statuses(
+            txn, kbid=kbid, rid=rid, fields=field_ids
+        )
 
     assert len(statuses) == 3
     assert statuses[0].status == wpb2.FieldStatus.Status.PROCESSED  # f1
@@ -215,7 +217,7 @@ async def test_get_statuses_returns_in_order(maindb_driver: Driver, kbid: str, r
 @pytest.mark.asyncio
 async def test_get_statuses_empty_input(maindb_driver: Driver, kbid: str, rid: str) -> None:
     async with maindb_driver.ro_transaction() as txn:
-        result = await fields_v2.get_statuses(txn, kbid=kbid, rid=rid, fields=[])
+        result: list[wpb2.FieldStatus] = await fields_v2.get_statuses(txn, kbid=kbid, rid=rid, fields=[])
     assert result == []
 
 

--- a/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resource_v2.py
+++ b/nucliadb/tests/nucliadb/integration/common/datamanagers/test_resource_v2.py
@@ -294,12 +294,3 @@ async def test_resource_set_get(
         assert await resources_v2.calculate_number_of_resources(txn, kbid=kbid) == 0
         assert [rid async for rid in resources_v2.iterate_resource_ids(kbid=kbid)] == []
         assert await resources_v2.get_basic(txn, kbid=kbid, rid=rid) is None
-
-
-@pytest.mark.asyncio
-async def test_exists_returns_false_for_invalid_uuid(
-    maindb_driver: Driver,
-) -> None:
-    async with maindb_driver.ro_transaction() as txn:
-        result = await resources_v2.exists(txn, kbid="not-a-valid-uuid", rid="also-not-valid")
-    assert result is False

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -254,6 +254,20 @@ async def test_can_create_standalone_knowledgebox_with_colon_in_slug(
 
 
 @pytest.mark.deploy_modes("standalone")
+async def test_invalid_non_uuid_kbid_and_rid_return_specific_404_details(
+    nucliadb_reader: AsyncClient,
+    standalone_knowledgebox: str,
+):
+    resp = await nucliadb_reader.get("/kb/not-a-uuid")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "KnowledgeBox not found. UUID expected."
+
+    resp = await nucliadb_reader.get(f"/kb/{standalone_knowledgebox}/resource/not-a-uuid")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Resource not found. UUID expected."
+
+
+@pytest.mark.deploy_modes("standalone")
 async def test_serialize_errors(
     nucliadb_writer: AsyncClient,
     nucliadb_reader: AsyncClient,

--- a/nucliadb/tests/nucliadb/unit/common/test_ids.py
+++ b/nucliadb/tests/nucliadb/unit/common/test_ids.py
@@ -27,6 +27,8 @@ from nucliadb.common.ids import (
     ParagraphId,
     VectorId,
     extract_data_augmentation_id,
+    valid_kbid,
+    valid_rid,
 )
 from nucliadb_protos.resources_pb2 import FieldType
 
@@ -179,3 +181,31 @@ def test_invalid_data_augmentation_id_extraction_2(
     gen_field_id: str,
 ):
     assert extract_data_augmentation_id(gen_field_id) is None
+
+
+@pytest.mark.parametrize(
+    "kbid,expected",
+    [
+        ("d6fcb6d1-4525-4a1d-84a5-35c7be5dbfbb", True),
+        ("D6FCB6D1-4525-4A1D-84A5-35C7BE5DBFBB", True),
+        ("d6fcb6d145254a1d84a535c7be5dbfbb", False),
+        ("d6fcb6d1-4525-4a1d84a5-35c7be5dbfbb", False),
+        ("not-a-uuid", False),
+    ],
+)
+def test_valid_kbid(kbid: str, expected: bool):
+    assert valid_kbid(kbid) is expected
+
+
+@pytest.mark.parametrize(
+    "rid,expected",
+    [
+        ("d6fcb6d145254a1d84a535c7be5dbfbb", True),
+        ("D6FCB6D145254A1D84A535C7BE5DBFBB", True),
+        ("d6fcb6d1-4525-4a1d-84a5-35c7be5dbfbb", False),
+        ("d6fcb6d145254a1d84a535c7be5dbfb", False),
+        ("not-a-uuid", False),
+    ],
+)
+def test_valid_rid(rid: str, expected: bool):
+    assert valid_rid(rid) is expected

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -322,19 +322,21 @@ class QuestionAnswers(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _uuid_path_param(name: str) -> Any:
+def _uuid_path_param(name: str, not_found_detail: str) -> Any:
     """Return a FastAPI ``Depends`` callable that validates *name* as a UUID."""
 
     def _validate(value: str = Path(alias=name)) -> str:
+
         try:
             uuid.UUID(value)
         except ValueError:
-            raise HTTPException(status_code=404, detail="Not found")
+            raise HTTPException(status_code=404, detail=not_found_detail)
         return value
 
     _validate.__name__ = f"validate_{name}"
     return Depends(_validate)
 
 
-KbId = Annotated[str, _uuid_path_param("kbid")]
-RId = Annotated[str, _uuid_path_param("rid")]
+KbId = Annotated[str, _uuid_path_param("kbid", "KnowledgeBox not found. UUID expected.")]
+RId = Annotated[str, _uuid_path_param("rid", "Resource not found. UUID expected.")]
+PathRId = Annotated[str, _uuid_path_param("path_rid", "Resource not found. UUID expected.")]

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -15,11 +15,9 @@
 import base64
 import hashlib
 import re
-import uuid
 from enum import Enum
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import Depends, HTTPException, Path
 from pydantic import (
     BaseModel,
     Field,
@@ -303,40 +301,3 @@ class QuestionAnswer(BaseModel):
 
 class QuestionAnswers(BaseModel):
     question_answer: list[QuestionAnswer]
-
-
-# ---------------------------------------------------------------------------
-# FastAPI path-parameter dependencies that return 404 for non-UUID values.
-#
-# Use these instead of plain ``str`` for ``kbid`` and ``rid`` path parameters
-# so that requests with syntactically invalid identifiers are rejected at the
-# API layer before reaching the database, while preserving the existing
-# behaviour of returning 404 (not 422) for bad input.
-#
-# Usage::
-#
-#     from nucliadb_models.common import KbId, RId
-#
-#     @router.get("/kb/{kbid}/resource/{rid}")
-#     async def get_resource(kbid: KbId, rid: RId): ...
-# ---------------------------------------------------------------------------
-
-
-def _uuid_path_param(name: str, not_found_detail: str) -> Any:
-    """Return a FastAPI ``Depends`` callable that validates *name* as a UUID."""
-
-    def _validate(value: str = Path(alias=name)) -> str:
-
-        try:
-            uuid.UUID(value)
-        except ValueError:
-            raise HTTPException(status_code=404, detail=not_found_detail)
-        return value
-
-    _validate.__name__ = f"validate_{name}"
-    return Depends(_validate)
-
-
-KbId = Annotated[str, _uuid_path_param("kbid", "KnowledgeBox not found. UUID expected.")]
-RId = Annotated[str, _uuid_path_param("rid", "Resource not found. UUID expected.")]
-PathRId = Annotated[str, _uuid_path_param("path_rid", "Resource not found. UUID expected.")]

--- a/nucliadb_models/src/nucliadb_models/common.py
+++ b/nucliadb_models/src/nucliadb_models/common.py
@@ -15,9 +15,11 @@
 import base64
 import hashlib
 import re
+import uuid
 from enum import Enum
-from typing import Any
+from typing import Annotated, Any
 
+from fastapi import Depends, HTTPException, Path
 from pydantic import (
     BaseModel,
     Field,
@@ -301,3 +303,38 @@ class QuestionAnswer(BaseModel):
 
 class QuestionAnswers(BaseModel):
     question_answer: list[QuestionAnswer]
+
+
+# ---------------------------------------------------------------------------
+# FastAPI path-parameter dependencies that return 404 for non-UUID values.
+#
+# Use these instead of plain ``str`` for ``kbid`` and ``rid`` path parameters
+# so that requests with syntactically invalid identifiers are rejected at the
+# API layer before reaching the database, while preserving the existing
+# behaviour of returning 404 (not 422) for bad input.
+#
+# Usage::
+#
+#     from nucliadb_models.common import KbId, RId
+#
+#     @router.get("/kb/{kbid}/resource/{rid}")
+#     async def get_resource(kbid: KbId, rid: RId): ...
+# ---------------------------------------------------------------------------
+
+
+def _uuid_path_param(name: str) -> Any:
+    """Return a FastAPI ``Depends`` callable that validates *name* as a UUID."""
+
+    def _validate(value: str = Path(alias=name)) -> str:
+        try:
+            uuid.UUID(value)
+        except ValueError:
+            raise HTTPException(status_code=404, detail="Not found")
+        return value
+
+    _validate.__name__ = f"validate_{name}"
+    return Depends(_validate)
+
+
+KbId = Annotated[str, _uuid_path_param("kbid")]
+RId = Annotated[str, _uuid_path_param("rid")]


### PR DESCRIPTION
### Description

This PR adds proper validation early on in the system, rather than in the datamanager layer.

If they are not uuids, return 404 to keep backward compatibility -- before, we were not validating and simply returning a kb or resource not found.

### How was this PR tested?
Existing tests and added new tests
