### PR TITLE
Stable booster

### DIFF
--- a/nidx/nidx_paragraph/src/search_response.rs
+++ b/nidx/nidx_paragraph/src/search_response.rs
@@ -191,6 +191,7 @@ impl From<SearchIntResponse<'_>> for ParagraphSearchResponse {
                         matches: terms,
                         sort_value,
                         metadata: schema.metadata(&doc),
+                        shard_id: vec![],
                     };
 
                     results.push(result);
@@ -224,7 +225,7 @@ impl From<SearchBm25Response<'_>> for ParagraphSearchResponse {
         let no_results = std::cmp::min(obtained, requested);
         let mut results: Vec<ParagraphResult> = Vec::with_capacity(no_results);
         let searcher = response.searcher;
-        for (i, (score, doc_address)) in response.top_docs.into_iter().take(no_results).enumerate() {
+        for (score, doc_address) in response.top_docs.into_iter().take(no_results) {
             if score < min_score {
                 break;
             }
@@ -232,7 +233,7 @@ impl From<SearchBm25Response<'_>> for ParagraphSearchResponse {
                 Ok(doc) => {
                     let score = ResultScore {
                         bm25: score,
-                        booster: (response.total - i) as f32,
+                        booster: (doc_address.segment_ord as u64) << 32 | doc_address.doc_id as u64,
                     };
                     let schema = &response.text_service.schema;
                     let uuid = doc
@@ -284,6 +285,7 @@ impl From<SearchBm25Response<'_>> for ParagraphSearchResponse {
                         end: end_pos,
                         matches: terms,
                         metadata: schema.metadata(&doc),
+                        shard_id: vec![],
                     };
 
                     results.push(result);

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -46,10 +46,10 @@ message FacetResults {
 }
 
 message ResultScore {
+    reserved 2;
+
     float bm25 = 1;
-    // In the case of two equal bm25 scores, booster
-    // decides
-    float booster = 2;
+    uint64 booster = 3;
 }
 
 message DocumentResult {
@@ -98,6 +98,8 @@ message ParagraphResult {
     noderesources.ParagraphMetadata metadata = 11;
 
     repeated string labels = 12;
+
+    bytes shard_id = 14;
 }
 
 message ParagraphSearchResponse {

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -60,6 +60,7 @@ message DocumentResult {
     }
     string field = 4;
     repeated string labels = 5;
+    bytes shard_id = 7;
 }
 
 message DocumentSearchResponse {

--- a/nidx/nidx_text/src/reader.rs
+++ b/nidx/nidx_text/src/reader.rs
@@ -268,6 +268,7 @@ impl TextReaderService {
                         field,
                         sort_value,
                         labels,
+                        shard_id: vec![],
                     };
                     results.push(result);
                 }
@@ -295,10 +296,10 @@ impl TextReaderService {
         let retrieved_results = response.results_per_page;
         let next_page = total > retrieved_results;
         let results_per_page = response.results_per_page as usize;
-        let result_stream = response.top_docs.into_iter().take(results_per_page).enumerate();
+        let result_stream = response.top_docs.into_iter().take(results_per_page);
 
         let mut results = Vec::with_capacity(results_per_page);
-        for (id, (score, doc_address)) in result_stream {
+        for (score, doc_address) in result_stream {
             if score < min_score {
                 continue;
             }
@@ -306,7 +307,7 @@ impl TextReaderService {
                 Ok(doc) => {
                     let score = ResultScore {
                         bm25: score,
-                        booster: id as u64,
+                        booster: (doc_address.segment_ord as u64) << 32 | doc_address.doc_id as u64,
                     };
                     let uuid = String::from_utf8(
                         doc.get_first(self.schema.uuid)
@@ -335,6 +336,7 @@ impl TextReaderService {
                         field,
                         sort_value: Some(SortValue::Score(score)),
                         labels,
+                        shard_id: vec![],
                     };
                     results.push(result);
                 }

--- a/nidx/nidx_text/src/reader.rs
+++ b/nidx/nidx_text/src/reader.rs
@@ -306,7 +306,7 @@ impl TextReaderService {
                 Ok(doc) => {
                     let score = ResultScore {
                         bm25: score,
-                        booster: id as f32,
+                        booster: id as u64,
                     };
                     let uuid = String::from_utf8(
                         doc.get_first(self.schema.uuid)

--- a/nidx/nidx_vector/tests/test_paragraph_merge.rs
+++ b/nidx/nidx_vector/tests/test_paragraph_merge.rs
@@ -65,14 +65,8 @@ fn build_resource(uuid: &str, vector0: Vec<f32>, vector1: Vec<f32>) -> Resource 
     }
 }
 
-/// Verifies that merging two paragraph segments—each carrying a self-referencing
-/// deletion for its own field—keeps both vectors alive in the merged output.
-///
-/// The deletion pattern (a deletion at the same seq as the segment) mirrors
-/// what happens during a resource update: the old version of a field is marked
-/// for deletion atomically with the new version being written.  When the two
-/// segments belong to *different* resources the deletions are disjoint and
-/// neither removes the other resource's vectors.
+/// Verifies that merging two segments that update a resource each are applied correctly.
+/// This requires that deletions are applied in the correct order during merging.
 #[test]
 fn test_paragraph_merge_with_deletions() -> anyhow::Result<()> {
     let config = VectorConfig::for_paragraphs(VectorType::DenseF32 { dimension: DIMENSION });

--- a/nidx/nidx_vector/tests/test_paragraph_merge.rs
+++ b/nidx/nidx_vector/tests/test_paragraph_merge.rs
@@ -1,0 +1,180 @@
+// Copyright 2021 Bosutech XXI S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+mod common;
+
+use nidx_protos::{IndexParagraph, IndexParagraphs, Resource, ResourceId, VectorSentence};
+use nidx_types::prefilter::PrefilterResult;
+use nidx_vector::{VectorIndexer, VectorSearchRequest, VectorSearcher, config::*};
+use tempfile::tempdir;
+
+use crate::common::TestOpener;
+
+const DIMENSION: usize = 4;
+
+fn make_vector(index: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; DIMENSION];
+    v[index] = 1.0;
+    v
+}
+
+/// Builds a minimal Resource with two fields (`a/title` and `t/body`), each
+/// containing a single paragraph sentence.
+fn make_field(uuid: &str, field_key: &str, vector: Vec<f32>) -> (String, IndexParagraphs) {
+    let para_key = format!("{uuid}/{field_key}/0-10");
+    (
+        format!("{uuid}/{field_key}"),
+        IndexParagraphs {
+            paragraphs: [(
+                para_key.clone(),
+                IndexParagraph {
+                    start: 0,
+                    end: 10,
+                    sentences: [(para_key, VectorSentence { vector, metadata: None })].into(),
+                    ..Default::default()
+                },
+            )]
+            .into(),
+        },
+    )
+}
+
+fn build_resource(uuid: &str, vector0: Vec<f32>, vector1: Vec<f32>) -> Resource {
+    Resource {
+        resource: Some(ResourceId {
+            shard_id: String::new(),
+            uuid: uuid.into(),
+        }),
+        paragraphs: [
+            make_field(uuid, "a/title", vector0),
+            make_field(uuid, "t/body", vector1),
+        ]
+        .into(),
+        ..Default::default()
+    }
+}
+
+/// Verifies that merging two paragraph segments—each carrying a self-referencing
+/// deletion for its own field—keeps both vectors alive in the merged output.
+///
+/// The deletion pattern (a deletion at the same seq as the segment) mirrors
+/// what happens during a resource update: the old version of a field is marked
+/// for deletion atomically with the new version being written.  When the two
+/// segments belong to *different* resources the deletions are disjoint and
+/// neither removes the other resource's vectors.
+#[test]
+fn test_paragraph_merge_with_deletions() -> anyhow::Result<()> {
+    let config = VectorConfig::for_paragraphs(VectorType::DenseF32 { dimension: DIMENSION });
+
+    let uuid1 = "00112233445566778899aabbccddeeff";
+    let uuid2 = "ffeeddccbbaa99887766554433221100";
+
+    // --- Segment 1 (seq 2): resource1 / a/title, vector pointing along axis 0 ---
+    // Deletion at seq 2 (same seq) for resource1/a/title simulates an atomic
+    // update: delete the old field version and write the new one together.
+    let resource1 = build_resource(uuid1, make_vector(0), make_vector(1));
+    let segment_dir1 = tempdir()?;
+    let segment_meta1 = VectorIndexer
+        .index_resource(segment_dir1.path(), &config, &resource1, "default", true)?
+        .unwrap();
+    assert_eq!(segment_meta1.records, 2, "segment 1 should have exactly two vectors");
+
+    // --- Segment 2 (seq 4): resource2 / a/title, vector pointing along axis 1 ---
+    // Deletion at seq 4 (same seq), same rationale.
+    let resource2 = build_resource(uuid2, make_vector(2), make_vector(3));
+    let segment_dir2 = tempdir()?;
+    let segment_meta2 = VectorIndexer
+        .index_resource(segment_dir2.path(), &config, &resource2, "default", true)?
+        .unwrap();
+    assert_eq!(segment_meta2.records, 2, "segment 2 should have exactly two vectors");
+
+    // --- Merge with deletions ---
+    // Segments are at seq 2 and 4.  Deletions share the same seq as their
+    // respective segments, so they remove any vectors for that field indexed
+    // *before* that seq—none exist here.  The merged result must retain both.
+    let segment_dir_merge = tempdir()?;
+    let merged_meta = VectorIndexer.merge(
+        segment_dir_merge.path(),
+        config.clone(),
+        TestOpener::new(
+            vec![
+                (segment_meta1.clone(), 2i64.into()),
+                (segment_meta2.clone(), 4i64.into()),
+            ],
+            vec![
+                (format!("{uuid1}/a/title"), 2u64.into()),
+                (format!("{uuid1}/t/body"), 2u64.into()),
+                (format!("{uuid2}/a/title"), 4u64.into()),
+                (format!("{uuid2}/t/body"), 4u64.into()),
+            ],
+        ),
+    )?;
+    assert_eq!(merged_meta.records, 4, "merged segment must contain all four vectors");
+
+    // --- Verify both vectors are searchable in the merged segment ---
+    let searcher = VectorSearcher::open(
+        config.clone(),
+        TestOpener::new(vec![(merged_meta, 5i64.into())], vec![]),
+    )?;
+
+    // Search near vector 0 (resource1) – should be the top hit.
+    let results = searcher.search(
+        &VectorSearchRequest {
+            vector: make_vector(0),
+            result_per_page: 10,
+            with_duplicates: true,
+            ..Default::default()
+        },
+        &PrefilterResult::All,
+    )?;
+    assert_eq!(results.documents.len(), 4, "all four vectors should be returned");
+    assert!(
+        results.documents[0].score > 0.9999,
+        "top result should be an exact match for vector 0"
+    );
+
+    // Search near vector 2 (resource2/a/title) – should be the top hit.
+    let results = searcher.search(
+        &VectorSearchRequest {
+            vector: make_vector(2),
+            result_per_page: 10,
+            with_duplicates: true,
+            ..Default::default()
+        },
+        &PrefilterResult::All,
+    )?;
+    assert_eq!(results.documents.len(), 4, "all four vectors should be returned");
+    assert!(
+        results.documents[0].score > 0.9999,
+        "top result should be an exact match for vector 2"
+    );
+
+    // Search near vector 3 (resource2/t/body) – should be the top hit.
+    let results = searcher.search(
+        &VectorSearchRequest {
+            vector: make_vector(3),
+            result_per_page: 10,
+            with_duplicates: true,
+            ..Default::default()
+        },
+        &PrefilterResult::All,
+    )?;
+    assert_eq!(results.documents.len(), 4, "all four vectors should be returned");
+    assert!(
+        results.documents[0].score > 0.9999,
+        "top result should be an exact match for vector 3"
+    );
+
+    Ok(())
+}

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -64,7 +64,10 @@ pub fn merge_search(shard_responses: Vec<SearchResponse>, order_by: OrderBy, lim
             .unwrap_or_default();
         shard_ids.extend(response.shard_ids);
 
-        if let Some(document) = response.document {
+        if let Some(mut document) = response.document {
+            for result in &mut document.results {
+                result.shard_id = shard_id.clone();
+            }
             document_responses.push(document);
         }
         if let Some(mut paragraph) = response.paragraph {
@@ -216,7 +219,11 @@ fn sort_documents_fn(order_by: OrderBy) -> Box<dyn Fn(&DocumentResult, &Document
                         bm25: b_bm25,
                         booster: b_booster,
                     })),
-                ) => a_bm25.total_cmp(&b_bm25).then(a_booster.cmp(&b_booster)).is_gt(),
+                ) => a_bm25
+                    .total_cmp(&b_bm25)
+                    .then(a.shard_id.cmp(&b.shard_id))
+                    .then(a_booster.cmp(&b_booster))
+                    .is_gt(),
                 _ => {
                     unreachable!("index always return values with the same order_by as we have")
                 }
@@ -471,6 +478,7 @@ mod tests {
         use nidx_protos::document_result;
         use nidx_protos::prost_types::Timestamp;
         use nidx_protos::{DocumentResult, DocumentSearchResponse, FacetResult, SearchResponse};
+        use uuid::Uuid;
 
         use crate::searcher::shard_merge::OrderBy;
         use crate::searcher::shard_merge::{Limit, SortExpr};
@@ -663,6 +671,87 @@ mod tests {
             assert_eq!(merged.results[1].uuid, "foo");
             assert_eq!(merged.results[2].uuid, "bar");
             assert_eq!(merged.results[3].uuid, "quux");
+        }
+
+        #[test]
+        fn test_merge_document_results_shard_tiebreak() {
+            const SHARD_A: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+            const SHARD_B: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+            let shard_bytes = |s: &str| Uuid::parse_str(s).unwrap().as_bytes().to_vec();
+
+            let document = |rid: &str, score: f32, booster: u64| DocumentResult {
+                uuid: rid.to_string(),
+                field: "a/title".to_string(),
+                sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore {
+                    bm25: score,
+                    booster,
+                })),
+                ..Default::default()
+            };
+            let response = |shard_id: &str, documents: Vec<DocumentResult>| SearchResponse {
+                shard_ids: vec![shard_id.to_string()],
+                document: Some(DocumentSearchResponse {
+                    total: 100,
+                    results: documents,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // Equal score and booster: SHARD_B bytes sort higher, so "foo" wins.
+            let merged = merge(
+                vec![
+                    response(SHARD_B, vec![document("foo", 2.0, 1)]),
+                    response(SHARD_A, vec![document("bar", 2.0, 1)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.results[0].uuid, "foo");
+            assert_eq!(merged.results[0].shard_id, shard_bytes(SHARD_B));
+            assert_eq!(merged.results[1].uuid, "bar");
+            assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
+
+            // Reversing shard assignment flips the order.
+            let merged = merge(
+                vec![
+                    response(SHARD_A, vec![document("foo", 2.0, 1)]),
+                    response(SHARD_B, vec![document("bar", 2.0, 1)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.results[0].uuid, "bar");
+            assert_eq!(merged.results[0].shard_id, shard_bytes(SHARD_B));
+            assert_eq!(merged.results[1].uuid, "foo");
+            assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
+
+            // When shard bytes are equal, booster is the final tiebreaker.
+            let merged = merge(
+                vec![
+                    response(SHARD_A, vec![document("foo", 2.0, 1)]),
+                    response(SHARD_A, vec![document("bar", 2.0, 2)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .document
+            .unwrap();
+            assert_eq!(merged.results[0].uuid, "bar");
+            assert_eq!(merged.results[1].uuid, "foo");
         }
 
         #[test]

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -23,7 +23,6 @@ use nidx_protos::{
 };
 use tracing::field::Empty;
 use tracing::{Span, instrument};
-use uuid::Uuid;
 
 #[derive(Clone, Copy)]
 pub struct OrderBy {
@@ -56,24 +55,12 @@ pub fn merge_search(shard_responses: Vec<SearchResponse>, order_by: OrderBy, lim
     let mut graph_responses = Vec::with_capacity(shard_responses.len());
 
     for response in shard_responses {
-        let shard_id = response
-            .shard_ids
-            .first()
-            .and_then(|s| Uuid::parse_str(s).ok())
-            .map(|u| u.as_bytes().to_vec())
-            .unwrap_or_default();
         shard_ids.extend(response.shard_ids);
 
-        if let Some(mut document) = response.document {
-            for result in &mut document.results {
-                result.shard_id = shard_id.clone();
-            }
+        if let Some(document) = response.document {
             document_responses.push(document);
         }
-        if let Some(mut paragraph) = response.paragraph {
-            for result in &mut paragraph.results {
-                result.shard_id = shard_id.clone();
-            }
+        if let Some(paragraph) = response.paragraph {
             paragraph_responses.push(paragraph);
         }
         if let Some(vector) = response.vector {
@@ -679,17 +666,18 @@ mod tests {
             const SHARD_B: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
             let shard_bytes = |s: &str| Uuid::parse_str(s).unwrap().as_bytes().to_vec();
 
-            let document = |rid: &str, score: f32, booster: u64| DocumentResult {
+            let document = |rid: &str, score: f32, booster: u64, shard_id: &str| DocumentResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                     bm25: score,
                     booster,
                 })),
+                shard_id: shard_bytes(shard_id),
                 ..Default::default()
             };
-            let response = |shard_id: &str, documents: Vec<DocumentResult>| SearchResponse {
-                shard_ids: vec![shard_id.to_string()],
+            // shard_id is stamped by shard_search before merge; simulate that here
+            let response = |documents: Vec<DocumentResult>| SearchResponse {
                 document: Some(DocumentSearchResponse {
                     total: 100,
                     results: documents,
@@ -701,8 +689,8 @@ mod tests {
             // Equal score and booster: SHARD_B bytes sort higher, so "foo" wins.
             let merged = merge(
                 vec![
-                    response(SHARD_B, vec![document("foo", 2.0, 1)]),
-                    response(SHARD_A, vec![document("bar", 2.0, 1)]),
+                    response(vec![document("foo", 2.0, 1, SHARD_B)]),
+                    response(vec![document("bar", 2.0, 1, SHARD_A)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -720,8 +708,8 @@ mod tests {
             // Reversing shard assignment flips the order.
             let merged = merge(
                 vec![
-                    response(SHARD_A, vec![document("foo", 2.0, 1)]),
-                    response(SHARD_B, vec![document("bar", 2.0, 1)]),
+                    response(vec![document("foo", 2.0, 1, SHARD_A)]),
+                    response(vec![document("bar", 2.0, 1, SHARD_B)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -739,8 +727,8 @@ mod tests {
             // When shard bytes are equal, booster is the final tiebreaker.
             let merged = merge(
                 vec![
-                    response(SHARD_A, vec![document("foo", 2.0, 1)]),
-                    response(SHARD_A, vec![document("bar", 2.0, 2)]),
+                    response(vec![document("foo", 2.0, 1, SHARD_A)]),
+                    response(vec![document("bar", 2.0, 2, SHARD_A)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -1050,18 +1038,17 @@ mod tests {
             const SHARD_B: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
             let shard_bytes = |s: &str| Uuid::parse_str(s).unwrap().as_bytes().to_vec();
 
-            let paragraph = |rid: &str, score: f32, booster: u64| ParagraphResult {
+            let paragraph = |rid: &str, score: f32, booster: u64, shard_id: &str| ParagraphResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                     bm25: score,
                     booster,
                 })),
+                shard_id: shard_bytes(shard_id),
                 ..Default::default()
             };
-            // Response with an explicit shard_id so merge() can tag the results
-            let response = |shard_id: &str, paragraphs: Vec<ParagraphResult>| SearchResponse {
-                shard_ids: vec![shard_id.to_string()],
+            let response = |paragraphs: Vec<ParagraphResult>| SearchResponse {
                 paragraph: Some(ParagraphSearchResponse {
                     total: 100,
                     results: paragraphs,
@@ -1074,8 +1061,8 @@ mod tests {
             // SHARD_B bytes sort higher than SHARD_A bytes, so "foo" (SHARD_B) wins.
             let merged = merge(
                 vec![
-                    response(SHARD_B, vec![paragraph("foo", 2.0, 1)]),
-                    response(SHARD_A, vec![paragraph("bar", 2.0, 1)]),
+                    response(vec![paragraph("foo", 2.0, 1, SHARD_B)]),
+                    response(vec![paragraph("bar", 2.0, 1, SHARD_A)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -1093,8 +1080,8 @@ mod tests {
             // Reversing shard assignment flips the order, confirming determinism.
             let merged = merge(
                 vec![
-                    response(SHARD_A, vec![paragraph("foo", 2.0, 1)]),
-                    response(SHARD_B, vec![paragraph("bar", 2.0, 1)]),
+                    response(vec![paragraph("foo", 2.0, 1, SHARD_A)]),
+                    response(vec![paragraph("bar", 2.0, 1, SHARD_B)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -1112,8 +1099,8 @@ mod tests {
             // When shard bytes are also equal, booster is the final tiebreaker.
             let merged = merge(
                 vec![
-                    response(SHARD_A, vec![paragraph("foo", 2.0, 1)]),
-                    response(SHARD_A, vec![paragraph("bar", 2.0, 2)]),
+                    response(vec![paragraph("foo", 2.0, 1, SHARD_A)]),
+                    response(vec![paragraph("bar", 2.0, 2, SHARD_A)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -23,6 +23,7 @@ use nidx_protos::{
 };
 use tracing::field::Empty;
 use tracing::{Span, instrument};
+use uuid::Uuid;
 
 #[derive(Clone, Copy)]
 pub struct OrderBy {
@@ -55,12 +56,21 @@ pub fn merge_search(shard_responses: Vec<SearchResponse>, order_by: OrderBy, lim
     let mut graph_responses = Vec::with_capacity(shard_responses.len());
 
     for response in shard_responses {
+        let shard_id = response
+            .shard_ids
+            .first()
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .map(|u| u.as_bytes().to_vec())
+            .unwrap_or_default();
         shard_ids.extend(response.shard_ids);
 
         if let Some(document) = response.document {
             document_responses.push(document);
         }
-        if let Some(paragraph) = response.paragraph {
+        if let Some(mut paragraph) = response.paragraph {
+            for result in &mut paragraph.results {
+                result.shard_id = shard_id.clone();
+            }
             paragraph_responses.push(paragraph);
         }
         if let Some(vector) = response.vector {
@@ -206,7 +216,7 @@ fn sort_documents_fn(order_by: OrderBy) -> Box<dyn Fn(&DocumentResult, &Document
                         bm25: b_bm25,
                         booster: b_booster,
                     })),
-                ) => a_bm25.total_cmp(&b_bm25).then(a_booster.total_cmp(&b_booster)).is_gt(),
+                ) => a_bm25.total_cmp(&b_bm25).then(a_booster.cmp(&b_booster)).is_gt(),
                 _ => {
                     unreachable!("index always return values with the same order_by as we have")
                 }
@@ -280,7 +290,11 @@ fn sort_paragraphs_fn(order_by: OrderBy) -> Box<dyn Fn(&ParagraphResult, &Paragr
                         bm25: b_bm25,
                         booster: b_booster,
                     })),
-                ) => a_bm25.total_cmp(&b_bm25).then(a_booster.total_cmp(&b_booster)).is_gt(),
+                ) => a_bm25
+                    .total_cmp(&b_bm25)
+                    .then(a.shard_id.cmp(&b.shard_id))
+                    .then(a_booster.cmp(&b_booster))
+                    .is_gt(),
                 _ => {
                     unreachable!("index always return values with the same order_by as we have")
                 }
@@ -613,7 +627,7 @@ mod tests {
 
         #[test]
         fn test_merge_document_results_by_score() {
-            let document = |rid: &str, score: f32, booster: f32| DocumentResult {
+            let document = |rid: &str, score: f32, booster: u64| DocumentResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore {
@@ -633,8 +647,8 @@ mod tests {
 
             let merged = merge_search(
                 vec![
-                    response(vec![document("foo", 3.0, 1.0), document("bar", 2.0, 2.0)]),
-                    response(vec![document("baz", 4.0, 1.0), document("quux", 2.0, 1.0)]),
+                    response(vec![document("foo", 3.0, 1), document("bar", 2.0, 2)]),
+                    response(vec![document("baz", 4.0, 1), document("quux", 2.0, 1)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -712,6 +726,7 @@ mod tests {
         use nidx_protos::prost_types::Timestamp;
         use nidx_protos::{FacetResult, ParagraphSearchResponse, SearchResponse};
         use nidx_protos::{ParagraphResult, paragraph_result};
+        use uuid::Uuid;
 
         use crate::searcher::shard_merge::OrderBy;
         use crate::searcher::shard_merge::{Limit, SortExpr};
@@ -901,7 +916,7 @@ mod tests {
 
         #[test]
         fn test_merge_paragraph_results_by_score() {
-            let paragraph = |rid: &str, score: f32, booster: f32| ParagraphResult {
+            let paragraph = |rid: &str, score: f32, booster: u64| ParagraphResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
@@ -921,8 +936,8 @@ mod tests {
 
             let merged = merge_search(
                 vec![
-                    response(vec![paragraph("foo", 3.0, 1.0), paragraph("bar", 2.0, 2.0)]),
-                    response(vec![paragraph("baz", 4.0, 1.0), paragraph("quux", 2.0, 1.0)]),
+                    response(vec![paragraph("foo", 3.0, 1), paragraph("bar", 2.0, 2)]),
+                    response(vec![paragraph("baz", 4.0, 1), paragraph("quux", 2.0, 1)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -937,6 +952,90 @@ mod tests {
             assert_eq!(merged.results[1].uuid, "foo");
             assert_eq!(merged.results[2].uuid, "bar");
             assert_eq!(merged.results[3].uuid, "quux");
+        }
+
+        #[test]
+        fn test_merge_paragraph_results_shard_tiebreak() {
+            // Two valid UUIDs: "bb..." bytes sort higher than "aa..." bytes.
+            const SHARD_A: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+            const SHARD_B: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+            let shard_bytes = |s: &str| Uuid::parse_str(s).unwrap().as_bytes().to_vec();
+
+            let paragraph = |rid: &str, score: f32, booster: u64| ParagraphResult {
+                uuid: rid.to_string(),
+                field: "a/title".to_string(),
+                sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
+                    bm25: score,
+                    booster,
+                })),
+                ..Default::default()
+            };
+            // Response with an explicit shard_id so merge() can tag the results
+            let response = |shard_id: &str, paragraphs: Vec<ParagraphResult>| SearchResponse {
+                shard_ids: vec![shard_id.to_string()],
+                paragraph: Some(ParagraphSearchResponse {
+                    total: 100,
+                    results: paragraphs,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // Equal score and booster: shard_id bytes are the tiebreaker.
+            // SHARD_B bytes sort higher than SHARD_A bytes, so "foo" (SHARD_B) wins.
+            let merged = merge(
+                vec![
+                    response(SHARD_B, vec![paragraph("foo", 2.0, 1)]),
+                    response(SHARD_A, vec![paragraph("bar", 2.0, 1)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.results[0].uuid, "foo");
+            assert_eq!(merged.results[0].shard_id, shard_bytes(SHARD_B));
+            assert_eq!(merged.results[1].uuid, "bar");
+            assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
+
+            // Reversing shard assignment flips the order, confirming determinism.
+            let merged = merge(
+                vec![
+                    response(SHARD_A, vec![paragraph("foo", 2.0, 1)]),
+                    response(SHARD_B, vec![paragraph("bar", 2.0, 1)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.results[0].uuid, "bar");
+            assert_eq!(merged.results[0].shard_id, shard_bytes(SHARD_B));
+            assert_eq!(merged.results[1].uuid, "foo");
+            assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
+
+            // When shard bytes are also equal, booster is the final tiebreaker.
+            let merged = merge(
+                vec![
+                    response(SHARD_A, vec![paragraph("foo", 2.0, 1)]),
+                    response(SHARD_A, vec![paragraph("bar", 2.0, 2)]),
+                ],
+                OrderBy {
+                    expr: SortExpr::Score,
+                    descending: true,
+                },
+                Limit(20),
+            )
+            .paragraph
+            .unwrap();
+            assert_eq!(merged.results[0].uuid, "bar"); // higher booster wins
+            assert_eq!(merged.results[1].uuid, "foo");
         }
 
         #[test]

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -673,10 +673,10 @@ mod tests {
                     bm25: score,
                     booster,
                 })),
+                // shard_id is set by shard_search before merge; simulate that here
                 shard_id: shard_bytes(shard_id),
                 ..Default::default()
             };
-            // shard_id is stamped by shard_search before merge; simulate that here
             let response = |documents: Vec<DocumentResult>| SearchResponse {
                 document: Some(DocumentSearchResponse {
                     total: 100,
@@ -687,7 +687,7 @@ mod tests {
             };
 
             // Equal score and booster: SHARD_B bytes sort higher, so "foo" wins.
-            let merged = merge(
+            let merged = merge_search(
                 vec![
                     response(vec![document("foo", 2.0, 1, SHARD_B)]),
                     response(vec![document("bar", 2.0, 1, SHARD_A)]),
@@ -705,8 +705,9 @@ mod tests {
             assert_eq!(merged.results[1].uuid, "bar");
             assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
 
-            // Reversing shard assignment flips the order.
-            let merged = merge(
+            // Reversing shard assignment flips the order. Since both documents have the same score
+            // the order is determined by shard in descending order
+            let merged = merge_search(
                 vec![
                     response(vec![document("foo", 2.0, 1, SHARD_A)]),
                     response(vec![document("bar", 2.0, 1, SHARD_B)]),
@@ -725,7 +726,7 @@ mod tests {
             assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
 
             // When shard bytes are equal, booster is the final tiebreaker.
-            let merged = merge(
+            let merged = merge_search(
                 vec![
                     response(vec![document("foo", 2.0, 1, SHARD_A)]),
                     response(vec![document("bar", 2.0, 2, SHARD_A)]),
@@ -1059,7 +1060,7 @@ mod tests {
 
             // Equal score and booster: shard_id bytes are the tiebreaker.
             // SHARD_B bytes sort higher than SHARD_A bytes, so "foo" (SHARD_B) wins.
-            let merged = merge(
+            let merged = merge_search(
                 vec![
                     response(vec![paragraph("foo", 2.0, 1, SHARD_B)]),
                     response(vec![paragraph("bar", 2.0, 1, SHARD_A)]),
@@ -1077,8 +1078,9 @@ mod tests {
             assert_eq!(merged.results[1].uuid, "bar");
             assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
 
-            // Reversing shard assignment flips the order, confirming determinism.
-            let merged = merge(
+            // Reversing shard assignment flips the order. Since both documents have the same score
+            // the order is determined by shard in descending order
+            let merged = merge_search(
                 vec![
                     response(vec![paragraph("foo", 2.0, 1, SHARD_A)]),
                     response(vec![paragraph("bar", 2.0, 1, SHARD_B)]),
@@ -1097,7 +1099,7 @@ mod tests {
             assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
 
             // When shard bytes are also equal, booster is the final tiebreaker.
-            let merged = merge(
+            let merged = merge_search(
                 vec![
                     response(vec![paragraph("foo", 2.0, 1, SHARD_A)]),
                     response(vec![paragraph("bar", 2.0, 2, SHARD_A)]),

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -150,8 +150,25 @@ async fn shard_search(
         })
     })
     .await??;
-    search_results.shard_ids.push(shard_id.to_string());
+
+    apply_shard_id_to_response(&mut search_results, shard_id);
+
     Ok(search_results)
+}
+
+fn apply_shard_id_to_response(response: &mut SearchResponse, shard_id: Uuid) {
+    response.shard_ids.push(shard_id.to_string());
+    let shard_id_bytes = shard_id.as_bytes().to_vec();
+    if let Some(paragraph) = &mut response.paragraph {
+        for result in &mut paragraph.results {
+            result.shard_id = shard_id_bytes.clone();
+        }
+    }
+    if let Some(document) = &mut response.document {
+        for result in &mut document.results {
+            result.shard_id = shard_id_bytes.clone();
+        }
+    }
 }
 
 fn compute_prefilter(

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -83,10 +83,11 @@ from nucliadb_protos.utils_pb2 import RelationNode
 
 from .metrics import merge_observer
 
-Bm25Score = tuple[float, float]
+Bm25Score = tuple[float, int]
+ShardedBm25Score = tuple[float, bytes, int]
 TimestampScore = datetime.datetime
 TitleScore = str
-SortValue = Bm25Score | TimestampScore | TitleScore
+SortValue = Bm25Score | ShardedBm25Score | TimestampScore | TitleScore
 
 
 def entity_type_to_relation_node_type(node_type: EntityType) -> RelationNode.NodeType.ValueType:
@@ -94,7 +95,10 @@ def entity_type_to_relation_node_type(node_type: EntityType) -> RelationNode.Nod
 
 
 def sort_results_by_score(results: list[ParagraphResult] | list[DocumentResult]):
-    results.sort(key=lambda x: (x.score.bm25, x.score.booster), reverse=True)
+    if isinstance(results[0], ParagraphResult):
+        results.sort(key=lambda x: (x.score.bm25, x.shard_id, x.score.booster), reverse=True)
+    else:
+        results.sort(key=lambda x: (x.score.bm25, x.score.booster), reverse=True)
 
 
 async def merge_documents_results(
@@ -192,7 +196,7 @@ async def merge_suggest_paragraph_results(
     merged = heapq.merge(
         *(response.results for response in suggest_responses),
         reverse=True,
-        key=lambda x: (x.score.bm25, x.score.booster),
+        key=lambda x: (x.score.bm25, x.shard_id, x.score.booster),
     )
     # cut the best results
     matches = list(itertools.islice(merged, top_k))
@@ -363,7 +367,7 @@ async def merge_paragraph_results(
 
             sort_value: SortValue
             if sort.field == SortField.SCORE:
-                sort_value = (result.score.bm25, result.score.booster)
+                sort_value = (result.score.bm25, result.shard_id, result.score.booster)
             else:
                 sort_value = result.date.ToDatetime()
             if sort_value is not None:

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -83,11 +83,10 @@ from nucliadb_protos.utils_pb2 import RelationNode
 
 from .metrics import merge_observer
 
-Bm25Score = tuple[float, int]
-ShardedBm25Score = tuple[float, bytes, int]
+Bm25Score = tuple[float, bytes, int]
 TimestampScore = datetime.datetime
 TitleScore = str
-SortValue = Bm25Score | ShardedBm25Score | TimestampScore | TitleScore
+SortValue = Bm25Score | TimestampScore | TitleScore
 
 
 def entity_type_to_relation_node_type(node_type: EntityType) -> RelationNode.NodeType.ValueType:
@@ -95,10 +94,7 @@ def entity_type_to_relation_node_type(node_type: EntityType) -> RelationNode.Nod
 
 
 def sort_results_by_score(results: list[ParagraphResult] | list[DocumentResult]):
-    if isinstance(results[0], ParagraphResult):
-        results.sort(key=lambda x: (x.score.bm25, x.shard_id, x.score.booster), reverse=True)
-    else:
-        results.sort(key=lambda x: (x.score.bm25, x.score.booster), reverse=True)
+    results.sort(key=lambda x: (x.score.bm25, x.shard_id, x.score.booster), reverse=True)
 
 
 async def merge_documents_results(
@@ -134,7 +130,7 @@ async def merge_documents_results(
                 continue
             sort_value: SortValue
             if query.order_by == SortField.SCORE:
-                sort_value = (result.score.bm25, result.score.booster)
+                sort_value = (result.score.bm25, result.shard_id, result.score.booster)
             else:
                 sort_value = result.date.ToDatetime()
             if sort_value is not None:


### PR DESCRIPTION
Changes how results are merged to guarantee a consistent order. Order is:
- Score
- Shard
- Booster (which is now defined as segment_id + doc_id)

Also add a missing test that I had not git add'ed in a previous PR https://github.com/nuclia/nucliadb/pull/3727

About booster remove:
- If nucliadb is updated first. It will try to read fields that are not set and will default to 0, which will cause random order.
- If nidx is updated first, old booster field is not set and nucliadb will read it as 0.0, which will cause random order.

I think this is fine for a temporary condition (and not much worse than the old booster anyway)