### PR TITLE
Search after

### DIFF
--- a/nidx/nidx_paragraph/src/reader.rs
+++ b/nidx/nidx_paragraph/src/reader.rs
@@ -382,7 +382,7 @@ pub fn is_after(after: &Option<SearchAfter>, score: f32, docaddr: u64) -> bool {
         Ordering::Less => true,
         Ordering::Equal => match after.tie_break {
             SearchAfterTieBreak::Keep => true,
-            SearchAfterTieBreak::KeepAfter(after_docaddr) => docaddr < after_docaddr,
+            SearchAfterTieBreak::KeepAfter(after_docaddr) => docaddr > after_docaddr,
             _ => false,
         },
         Ordering::Greater => false,

--- a/nidx/nidx_paragraph/src/reader.rs
+++ b/nidx/nidx_paragraph/src/reader.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 
+use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
@@ -22,13 +24,14 @@ use nidx_types::prefilter::PrefilterResult;
 use tantivy::collector::{Collector, Count, FacetCollector, TopDocs};
 use tantivy::query::{AllQuery, Query};
 use tantivy::schema::{Facet, Field, Value};
-use tantivy::{DateTime, DocAddress, Index, IndexReader, Order, TantivyDocument};
+use tantivy::{DateTime, DocAddress, DocId, Index, IndexReader, Order, Score, SegmentReader, TantivyDocument};
 use tracing::*;
 
 use super::schema::ParagraphSchema;
 use crate::request_types::{ParagraphSearchRequest, ParagraphSuggestRequest};
 use crate::search_query::{SharedTermC, search_query, streaming_query, suggest_query};
 use crate::search_response::{SearchBm25Response, SearchFacetsResponse, SearchIntResponse, extract_labels};
+use crate::{SearchAfter, SearchAfterTieBreak};
 
 pub struct ParagraphReaderService {
     pub index: Index,
@@ -284,7 +287,7 @@ impl Searcher<'_> {
                     }))
                 }
                 None => {
-                    let topdocs_collector = TopDocs::with_limit(extra_result).order_by_score();
+                    let topdocs_collector = self.build_topdocs_search_after_collector(&searcher, extra_result);
                     let collector = &(Count, topdocs_collector);
                     let (total, top_docs) = searcher.search(&query, collector)?;
                     Ok(ParagraphSearchResponse::from(SearchBm25Response {
@@ -324,7 +327,7 @@ impl Searcher<'_> {
                     }))
                 }
                 None => {
-                    let topdocs_collector = TopDocs::with_limit(extra_result).order_by_score();
+                    let topdocs_collector = self.build_topdocs_search_after_collector(&searcher, extra_result);
                     let collector = &(Count, facet_collector, topdocs_collector);
                     let (total, facets_count, top_docs) = searcher.search(&query, collector)?;
                     Ok(ParagraphSearchResponse::from(SearchBm25Response {
@@ -342,5 +345,46 @@ impl Searcher<'_> {
                 }
             }
         }
+    }
+
+    fn build_topdocs_search_after_collector(
+        &self,
+        searcher: &tantivy::Searcher,
+        limit: usize,
+    ) -> impl Collector<Fruit = Vec<(Score, DocAddress)>> + 'static {
+        let segment_to_ord: HashMap<_, _> = searcher
+            .segment_readers()
+            .iter()
+            .enumerate()
+            .map(|(ord, reader)| (reader.segment_id(), ord as u64))
+            .collect();
+        let after = self.request.search_after.clone();
+
+        TopDocs::with_limit(limit).tweak_score(move |segment_reader: &SegmentReader| {
+            let segment_ord = segment_to_ord.get(&segment_reader.segment_id()).unwrap_or(&0);
+            let docaddr_base: u64 = segment_ord << 32;
+            let after = after.clone();
+            move |doc: DocId, score: Score| {
+                let docaddr = docaddr_base + doc as u64;
+                if is_after(&after, score, docaddr) {
+                    score
+                } else {
+                    f32::NEG_INFINITY
+                }
+            }
+        })
+    }
+}
+
+pub fn is_after(after: &Option<SearchAfter>, score: f32, docaddr: u64) -> bool {
+    let Some(after) = after else { return true };
+    match score.total_cmp(&after.score) {
+        Ordering::Less => true,
+        Ordering::Equal => match after.tie_break {
+            SearchAfterTieBreak::Keep => true,
+            SearchAfterTieBreak::KeepAfter(after_docaddr) => docaddr < after_docaddr,
+            _ => false,
+        },
+        Ordering::Greater => false,
     }
 }

--- a/nidx/nidx_paragraph/src/request_types.rs
+++ b/nidx/nidx_paragraph/src/request_types.rs
@@ -17,6 +17,19 @@ use nidx_types::prefilter::FilterOperator;
 use nidx_types::query_language::BooleanExpression;
 use tantivy::schema::Facet;
 
+#[derive(Clone)]
+pub enum SearchAfterTieBreak {
+    Drop,
+    KeepAfter(u64),
+    Keep,
+}
+
+#[derive(Clone)]
+pub struct SearchAfter {
+    pub score: f32,
+    pub tie_break: SearchAfterTieBreak,
+}
+
 #[derive(Clone, Default)]
 pub struct ParagraphSearchRequest {
     pub uuid: String,
@@ -33,6 +46,8 @@ pub struct ParagraphSearchRequest {
     pub filtering_formula: Option<BooleanExpression<String>>,
     /// Whether to do an OR/AND between prefilter results and filtering_formula
     pub filter_operator: FilterOperator,
+
+    pub search_after: Option<SearchAfter>,
 }
 
 pub struct ParagraphSuggestRequest {

--- a/nidx/nidx_paragraph/src/search_response.rs
+++ b/nidx/nidx_paragraph/src/search_response.rs
@@ -233,7 +233,7 @@ impl From<SearchBm25Response<'_>> for ParagraphSearchResponse {
                 Ok(doc) => {
                     let score = ResultScore {
                         bm25: score,
-                        booster: (doc_address.segment_ord as u64) << 32 | doc_address.doc_id as u64,
+                        docaddr: (doc_address.segment_ord as u64) << 32 | doc_address.doc_id as u64,
                     };
                     let schema = &response.text_service.schema;
                     let uuid = doc

--- a/nidx/nidx_paragraph/src/search_response.rs
+++ b/nidx/nidx_paragraph/src/search_response.rs
@@ -221,10 +221,11 @@ impl From<SearchBm25Response<'_>> for ParagraphSearchResponse {
         let min_score = response.min_score;
         let obtained = response.top_docs.len();
         let requested = response.results_per_page as usize;
-        let next_page = obtained > requested;
+        let next_page = response.top_docs.iter().filter(|(score, _)| score > &min_score).count() > requested;
         let no_results = std::cmp::min(obtained, requested);
         let mut results: Vec<ParagraphResult> = Vec::with_capacity(no_results);
         let searcher = response.searcher;
+
         for (score, doc_address) in response.top_docs.into_iter().take(no_results) {
             if score < min_score {
                 break;

--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -49,7 +49,7 @@ message ResultScore {
     reserved 2;
 
     float bm25 = 1;
-    uint64 booster = 3;
+    uint64 docaddr = 3;
 }
 
 message DocumentResult {
@@ -379,6 +379,12 @@ message JsonFilterExpression {
     }
 }
 
+message SearchAfter {
+    float score = 1;
+    bytes shard_id = 2;
+    uint64 docaddr = 3;
+}
+
 message SearchRequest {
     reserved 7, 20, 21;
 
@@ -427,6 +433,8 @@ message SearchRequest {
     GraphSearch graph_search = 29;
 
     optional JsonFilterExpression json_filter = 32;
+
+    optional SearchAfter search_after = 35;
 }
 
 enum SuggestFeatures {

--- a/nidx/nidx_text/src/reader.rs
+++ b/nidx/nidx_text/src/reader.rs
@@ -307,7 +307,7 @@ impl TextReaderService {
                 Ok(doc) => {
                     let score = ResultScore {
                         bm25: score,
-                        booster: (doc_address.segment_ord as u64) << 32 | doc_address.doc_id as u64,
+                        docaddr: (doc_address.segment_ord as u64) << 32 | doc_address.doc_id as u64,
                     };
                     let uuid = String::from_utf8(
                         doc.get_first(self.schema.uuid)

--- a/nidx/src/searcher/query_planner.rs
+++ b/nidx/src/searcher/query_planner.rs
@@ -15,7 +15,7 @@
 
 use anyhow::anyhow;
 use nidx_json::search::{JsonFilterExpression, JsonPathFilter, JsonPredicate, JsonSearchRequest};
-use nidx_paragraph::ParagraphSearchRequest;
+use nidx_paragraph::{ParagraphSearchRequest, SearchAfterTieBreak};
 use nidx_protos::filter_expression::Expr;
 use nidx_protos::graph_query::{PathQuery, node, path_query, relation};
 use nidx_protos::graph_search_request::QueryKind;
@@ -27,7 +27,9 @@ use nidx_types::prefilter::{FilterOperator, PrefilterResult};
 use nidx_types::query_language::*;
 use nidx_vector::SEGMENT_TAGS;
 use nidx_vector::VectorSearchRequest;
+use std::cmp::Ordering;
 use std::collections::HashMap;
+use uuid::Uuid;
 
 use super::query_language::extract_label_filters;
 
@@ -179,11 +181,11 @@ pub(crate) fn proto_filter_operator(value: i32) -> anyhow::Result<FilterOperator
     }
 }
 
-pub fn build_query_plan(search_request: SearchRequest) -> anyhow::Result<QueryPlan> {
+pub fn build_query_plan(search_request: SearchRequest, shard_id: &Uuid) -> anyhow::Result<QueryPlan> {
     let graph_request = compute_graph_request(&search_request)?;
     let texts_request = compute_texts_request(&search_request);
     let vectors_request = compute_vectors_request(&search_request)?;
-    let paragraphs_request = compute_paragraphs_request(&search_request)?;
+    let paragraphs_request = compute_paragraphs_request(&search_request, shard_id)?;
     let json_request = compute_json_request(&search_request)?;
 
     let prefilter = compute_prefilters(&search_request);
@@ -288,10 +290,27 @@ fn compute_prefilters(search_request: &SearchRequest) -> Option<PreFilterRequest
     }
 }
 
-fn compute_paragraphs_request(search_request: &SearchRequest) -> anyhow::Result<Option<ParagraphSearchRequest>> {
+fn compute_paragraphs_request(
+    search_request: &SearchRequest,
+    shard_id: &Uuid,
+) -> anyhow::Result<Option<ParagraphSearchRequest>> {
     if !search_request.paragraph {
         return Ok(None);
     }
+
+    let search_after = if let Some(request_after) = &search_request.search_after {
+        let tiebreaker_shard = Uuid::from_slice(&request_after.shard_id)?;
+        Some(nidx_paragraph::SearchAfter {
+            score: request_after.score,
+            tie_break: match shard_id.cmp(&tiebreaker_shard) {
+                Ordering::Greater => SearchAfterTieBreak::Drop,
+                Ordering::Equal => SearchAfterTieBreak::KeepAfter(request_after.docaddr),
+                Ordering::Less => SearchAfterTieBreak::Keep,
+            },
+        })
+    } else {
+        None
+    };
 
     Ok(Some(ParagraphSearchRequest {
         uuid: "".to_string(),
@@ -310,6 +329,7 @@ fn compute_paragraphs_request(search_request: &SearchRequest) -> anyhow::Result<
             .map(filter_to_boolean_expression)
             .transpose()?,
         filter_operator: proto_filter_operator(search_request.filter_operator)?,
+        search_after,
     }))
 }
 
@@ -436,7 +456,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let query_plan = build_query_plan(request).unwrap();
+        let query_plan = build_query_plan(request, &Uuid::nil()).unwrap();
         let Some(prefilter) = query_plan.prefilter else {
             panic!("There should be a prefilter");
         };

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -200,16 +200,16 @@ fn sort_documents_fn(order_by: OrderBy) -> Box<dyn Fn(&DocumentResult, &Document
                 (
                     Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: a_bm25,
-                        booster: a_booster,
+                        docaddr: a_docaddr,
                     })),
                     Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: b_bm25,
-                        booster: b_booster,
+                        docaddr: b_docaddr,
                     })),
                 ) => a_bm25
                     .total_cmp(&b_bm25)
                     .then(a.shard_id.cmp(&b.shard_id))
-                    .then(a_booster.cmp(&b_booster))
+                    .then(a_docaddr.cmp(&b_docaddr))
                     .is_gt(),
                 _ => {
                     unreachable!("index always return values with the same order_by as we have")
@@ -278,16 +278,16 @@ fn sort_paragraphs_fn(order_by: OrderBy) -> Box<dyn Fn(&ParagraphResult, &Paragr
                 (
                     Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: a_bm25,
-                        booster: a_booster,
+                        docaddr: a_docaddr,
                     })),
                     Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                         bm25: b_bm25,
-                        booster: b_booster,
+                        docaddr: b_docaddr,
                     })),
                 ) => a_bm25
                     .total_cmp(&b_bm25)
                     .then(a.shard_id.cmp(&b.shard_id))
-                    .then(a_booster.cmp(&b_booster))
+                    .then(a_docaddr.cmp(&b_docaddr).reverse())
                     .is_gt(),
                 _ => {
                     unreachable!("index always return values with the same order_by as we have")
@@ -622,12 +622,12 @@ mod tests {
 
         #[test]
         fn test_merge_document_results_by_score() {
-            let document = |rid: &str, score: f32, booster: u64| DocumentResult {
+            let document = |rid: &str, score: f32, docaddr: u64| DocumentResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                     bm25: score,
-                    booster,
+                    docaddr,
                 })),
                 ..Default::default()
             };
@@ -666,12 +666,12 @@ mod tests {
             const SHARD_B: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
             let shard_bytes = |s: &str| Uuid::parse_str(s).unwrap().as_bytes().to_vec();
 
-            let document = |rid: &str, score: f32, booster: u64, shard_id: &str| DocumentResult {
+            let document = |rid: &str, score: f32, docaddr: u64, shard_id: &str| DocumentResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(document_result::SortValue::Score(nidx_protos::ResultScore {
                     bm25: score,
-                    booster,
+                    docaddr,
                 })),
                 // shard_id is set by shard_search before merge; simulate that here
                 shard_id: shard_bytes(shard_id),
@@ -686,7 +686,7 @@ mod tests {
                 ..Default::default()
             };
 
-            // Equal score and booster: SHARD_B bytes sort higher, so "foo" wins.
+            // Equal score and docaddr: SHARD_B bytes sort higher, so "foo" wins.
             let merged = merge_search(
                 vec![
                     response(vec![document("foo", 2.0, 1, SHARD_B)]),
@@ -725,7 +725,7 @@ mod tests {
             assert_eq!(merged.results[1].uuid, "foo");
             assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
 
-            // When shard bytes are equal, booster is the final tiebreaker.
+            // When shard bytes are equal, docaddr is the final tiebreaker.
             let merged = merge_search(
                 vec![
                     response(vec![document("foo", 2.0, 1, SHARD_A)]),
@@ -994,12 +994,12 @@ mod tests {
 
         #[test]
         fn test_merge_paragraph_results_by_score() {
-            let paragraph = |rid: &str, score: f32, booster: u64| ParagraphResult {
+            let paragraph = |rid: &str, score: f32, docaddr: u64| ParagraphResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                     bm25: score,
-                    booster,
+                    docaddr,
                 })),
                 ..Default::default()
             };
@@ -1014,7 +1014,7 @@ mod tests {
 
             let merged = merge_search(
                 vec![
-                    response(vec![paragraph("foo", 3.0, 1), paragraph("bar", 2.0, 2)]),
+                    response(vec![paragraph("foo", 3.0, 1), paragraph("bar", 2.0, 0)]),
                     response(vec![paragraph("baz", 4.0, 1), paragraph("quux", 2.0, 1)]),
                 ],
                 OrderBy {
@@ -1039,12 +1039,12 @@ mod tests {
             const SHARD_B: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
             let shard_bytes = |s: &str| Uuid::parse_str(s).unwrap().as_bytes().to_vec();
 
-            let paragraph = |rid: &str, score: f32, booster: u64, shard_id: &str| ParagraphResult {
+            let paragraph = |rid: &str, score: f32, docaddr: u64, shard_id: &str| ParagraphResult {
                 uuid: rid.to_string(),
                 field: "a/title".to_string(),
                 sort_value: Some(paragraph_result::SortValue::Score(nidx_protos::ResultScore {
                     bm25: score,
-                    booster,
+                    docaddr,
                 })),
                 shard_id: shard_bytes(shard_id),
                 ..Default::default()
@@ -1058,7 +1058,7 @@ mod tests {
                 ..Default::default()
             };
 
-            // Equal score and booster: shard_id bytes are the tiebreaker.
+            // Equal score and docaddr: shard_id bytes are the tiebreaker.
             // SHARD_B bytes sort higher than SHARD_A bytes, so "foo" (SHARD_B) wins.
             let merged = merge_search(
                 vec![
@@ -1098,11 +1098,11 @@ mod tests {
             assert_eq!(merged.results[1].uuid, "foo");
             assert_eq!(merged.results[1].shard_id, shard_bytes(SHARD_A));
 
-            // When shard bytes are also equal, booster is the final tiebreaker.
+            // When shard bytes are also equal, docaddr is the final tiebreaker.
             let merged = merge_search(
                 vec![
-                    response(vec![paragraph("foo", 2.0, 1, SHARD_A)]),
-                    response(vec![paragraph("bar", 2.0, 2, SHARD_A)]),
+                    response(vec![paragraph("foo", 2.0, 2, SHARD_A)]),
+                    response(vec![paragraph("bar", 2.0, 1, SHARD_A)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -1112,7 +1112,7 @@ mod tests {
             )
             .paragraph
             .unwrap();
-            assert_eq!(merged.results[0].uuid, "bar"); // higher booster wins
+            assert_eq!(merged.results[0].uuid, "bar"); // lower docaddr wins
             assert_eq!(merged.results[1].uuid, "foo");
         }
 

--- a/nidx/src/searcher/shard_merge.rs
+++ b/nidx/src/searcher/shard_merge.rs
@@ -209,7 +209,7 @@ fn sort_documents_fn(order_by: OrderBy) -> Box<dyn Fn(&DocumentResult, &Document
                 ) => a_bm25
                     .total_cmp(&b_bm25)
                     .then(a.shard_id.cmp(&b.shard_id))
-                    .then(a_docaddr.cmp(&b_docaddr))
+                    .then(a_docaddr.cmp(&b_docaddr).reverse())
                     .is_gt(),
                 _ => {
                     unreachable!("index always return values with the same order_by as we have")
@@ -642,8 +642,8 @@ mod tests {
 
             let merged = merge_search(
                 vec![
-                    response(vec![document("foo", 3.0, 1), document("bar", 2.0, 2)]),
-                    response(vec![document("baz", 4.0, 1), document("quux", 2.0, 1)]),
+                    response(vec![document("foo", 3.0, 2), document("bar", 2.0, 1)]),
+                    response(vec![document("baz", 4.0, 2), document("quux", 2.0, 2)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,
@@ -728,8 +728,8 @@ mod tests {
             // When shard bytes are equal, docaddr is the final tiebreaker.
             let merged = merge_search(
                 vec![
-                    response(vec![document("foo", 2.0, 1, SHARD_A)]),
-                    response(vec![document("bar", 2.0, 2, SHARD_A)]),
+                    response(vec![document("foo", 2.0, 2, SHARD_A)]),
+                    response(vec![document("bar", 2.0, 1, SHARD_A)]),
                 ],
                 OrderBy {
                     expr: SortExpr::Score,

--- a/nidx/src/searcher/shard_search.rs
+++ b/nidx/src/searcher/shard_search.rs
@@ -39,16 +39,17 @@ pub async fn search(
     search_request: SearchRequest,
     shards: Vec<Uuid>,
 ) -> NidxResult<Vec<SearchResponse>> {
-    let query_plan = query_planner::build_query_plan(search_request)?;
-    shards_query(index_cache, shards, query_plan, shard_search).await
+    shards_query(index_cache, shards, search_request, shard_search).await
 }
 
 #[instrument(skip_all, fields(shard_id = shard_id.to_string()))]
 async fn shard_search(
     shard_id: Uuid,
     index_cache: Arc<IndexCache>,
-    query_plan: QueryPlan,
+    search_request: SearchRequest,
 ) -> NidxResult<SearchResponse> {
+    let query_plan = query_planner::build_query_plan(search_request, &shard_id)?;
+
     let Some(indexes) = index_cache.get_shard_indexes(&shard_id).await else {
         return Err(NidxError::NotFound);
     };

--- a/nidx/tests/integration/mod.rs
+++ b/nidx/tests/integration/mod.rs
@@ -16,6 +16,7 @@
 mod date_range_search;
 mod distributed_search;
 mod initial_sync;
+mod search_after;
 mod search_filtering;
 mod search_json_filter;
 mod search_relations;

--- a/nidx/tests/integration/search_after.rs
+++ b/nidx/tests/integration/search_after.rs
@@ -1,0 +1,143 @@
+// Copyright 2021 Bosutech XXI S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::HashMap;
+
+use crate::common::services::NidxFixture;
+use nidx_protos::paragraph_result;
+use nidx_protos::{NewShardRequest, SearchAfter, SearchRequest, VectorIndexConfig};
+use nidx_tests::little_prince;
+use sqlx::PgPool;
+use tonic::Request;
+
+#[sqlx::test]
+async fn test_search_after_multiple_shards(pool: PgPool) -> anyhow::Result<()> {
+    let mut fixture = NidxFixture::new(pool).await?;
+
+    let mut shard_ids = Vec::new();
+    for _ in 0..3 {
+        let response = fixture
+            .api_client
+            .new_shard(Request::new(NewShardRequest {
+                kbid: "aabbccddeeff11223344556677889900".to_string(),
+                vectorsets_configs: HashMap::from([(
+                    "english".to_string(),
+                    VectorIndexConfig {
+                        vector_dimension: Some(3),
+                        ..Default::default()
+                    },
+                )]),
+                ..Default::default()
+            }))
+            .await?;
+        let shard_id = response.get_ref().id.clone();
+        // Same text in every shard, so we have duplicate scores
+        fixture
+            .index_resource(&shard_id, little_prince(shard_id.clone(), None))
+            .await?;
+        shard_ids.push(shard_id);
+    }
+
+    fixture.wait_sync().await;
+
+    // One large query to establish the expected result set and ordering.
+    let full_response = fixture
+        .searcher_client
+        .search(Request::new(SearchRequest {
+            shard_ids: shard_ids.clone(),
+            body: "prince".to_string(),
+            paragraph: true,
+            result_per_page: 1000,
+            ..Default::default()
+        }))
+        .await?
+        .into_inner();
+
+    let expected: Vec<String> = full_response
+        .paragraph
+        .as_ref()
+        .unwrap()
+        .results
+        .iter()
+        .map(|r| r.paragraph.clone())
+        .collect();
+
+    let total = expected.len();
+    assert!(total >= 6);
+
+    // Page through results one at a time.
+    let mut collected: Vec<String> = Vec::new();
+    let mut cursor: Option<SearchAfter> = None;
+
+    let mut last_score = None;
+    loop {
+        let response = fixture
+            .searcher_client
+            .search(Request::new(SearchRequest {
+                shard_ids: shard_ids.clone(),
+                body: "prince".to_string(),
+                paragraph: true,
+                result_per_page: 1,
+                search_after: cursor,
+                ..Default::default()
+            }))
+            .await?
+            .into_inner();
+
+        let results = &response.paragraph.as_ref().unwrap().results;
+        if results.is_empty() {
+            break;
+        }
+
+        for r in results {
+            collected.push(r.paragraph.clone());
+        }
+
+        // Advance the cursor to the last result on this page.
+        let last = results.last().unwrap();
+        let Some(paragraph_result::SortValue::Score(score)) = &last.sort_value else {
+            anyhow::bail!("Expected Score sort value on paragraph result");
+        };
+        cursor = Some(SearchAfter {
+            score: score.bm25,
+            shard_id: last.shard_id.clone(),
+            docaddr: score.docaddr,
+        });
+
+        if let Some(last_score) = last_score {
+            assert!(score.bm25 <= last_score);
+        }
+        last_score = Some(score.bm25);
+    }
+
+    assert_eq!(
+        collected.len(),
+        total,
+        "search_after pagination collected {} results but expected {total}",
+        collected.len()
+    );
+
+    // Sorted sets must match exactly: no duplicates, no gaps.
+    let mut collected_sorted = collected.clone();
+    collected_sorted.sort();
+    let mut expected_sorted = expected.clone();
+    expected_sorted.sort();
+    assert_eq!(
+        collected_sorted, expected_sorted,
+        "Paginated results must exactly match the full result set"
+    );
+
+    Ok(())
+}

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -47,12 +47,15 @@ from nucliadb.search.search.rerankers import (
     get_reranker,
 )
 from nucliadb.search.search.retrieval import text_block_search
+from nucliadb.search.search.search_after import SearchAfterToken, build_search_after_token
 from nucliadb.search.settings import settings
 from nucliadb_models.search import (
+    FindOptions,
     FindRequest,
     KnowledgeboxFindResults,
     MinScore,
     NucliaDBClientType,
+    RerankerName,
 )
 from nucliadb_utils.utilities import get_audit
 
@@ -89,6 +92,15 @@ async def _ndb_index_find(
     audit = get_audit()
     start_time = time()
 
+    # Disabled unsupported features for search_after and set the window to include enough results
+    if item.search_after is not None:
+        search_after = SearchAfterToken.decode(item.search_after)
+        item.features = [FindOptions.KEYWORD]
+        item.reranker = RerankerName.NOOP
+        item.top_k += len(search_after.skip)
+    else:
+        search_after = None
+
     with metrics.time("query_parse"):
         parsed = await parse_find(kbid, item)
         assert parsed.retrieval.rank_fusion is not None and parsed.retrieval.reranker is not None, (
@@ -98,10 +110,20 @@ async def _ndb_index_find(
         incomplete_results = is_incomplete(parsed.retrieval)
         rephrased_query = get_rephrased_query(parsed)
 
+    # Set retrieval to search after
+    if search_after is not None:
+        parsed.retrieval.after = search_after.after
+
     with metrics.time("index_search"):
         text_blocks, pb_query, pb_response, queried_shards = await text_block_search(
             kbid, parsed.retrieval
         )
+
+    # Remove skipped paragraphs for search_after
+    if search_after is not None:
+        text_blocks = [tb for tb in text_blocks if tb.paragraph_id.full() not in search_after.skip]
+        item.top_k -= len(search_after.skip)
+        parsed.retrieval.top_k -= len(search_after.skip)
 
     # Rank fusion merge, cut, hydrate and rerank
     with metrics.time("results_merge"):
@@ -126,6 +148,13 @@ async def _ndb_index_find(
             resource_hydration_options=resource_hydration_options,
             text_block_hydration_options=text_block_hydration_options,
         )
+
+    shown_results = set([r.paragraph_id.full() for r in text_blocks])
+    if search_after is not None:
+        shown_results.update(search_after.skip)
+
+    if search_results.next_page:
+        search_results.search_after = build_search_after_token(pb_response, shown_results)
 
     search_time = time() - start_time
     if audit is not None:

--- a/nucliadb/src/nucliadb/search/search/find.py
+++ b/nucliadb/src/nucliadb/search/search/find.py
@@ -149,9 +149,11 @@ async def _ndb_index_find(
             text_block_hydration_options=text_block_hydration_options,
         )
 
-    shown_results = set([r.paragraph_id.full() for r in text_blocks])
+    # Calculate search after token
+    shown_results = set(search_results.best_matches)
     if search_after is not None:
-        shown_results.update(search_after.skip)
+        # Keep paragraphs that have not been skipped yet. They might appear in future pages.
+        shown_results.update([pid for pid in search_after.skip if pid not in shown_results])
 
     if search_results.next_page:
         search_results.search_after = build_search_after_token(pb_response, shown_results)

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -94,7 +94,7 @@ def entity_type_to_relation_node_type(node_type: EntityType) -> RelationNode.Nod
 
 
 def sort_results_by_score(results: list[ParagraphResult] | list[DocumentResult]):
-    results.sort(key=lambda x: (x.score.bm25, x.shard_id, x.score.docaddr), reverse=True)
+    results.sort(key=lambda x: (x.score.bm25, x.shard_id, -x.score.docaddr), reverse=True)
 
 
 async def merge_documents_results(
@@ -130,7 +130,7 @@ async def merge_documents_results(
                 continue
             sort_value: SortValue
             if query.order_by == SortField.SCORE:
-                sort_value = (result.score.bm25, result.shard_id, result.score.docaddr)
+                sort_value = (result.score.bm25, result.shard_id, -result.score.docaddr)
             else:
                 sort_value = result.date.ToDatetime()
             if sort_value is not None:
@@ -192,7 +192,7 @@ async def merge_suggest_paragraph_results(
     merged = heapq.merge(
         *(response.results for response in suggest_responses),
         reverse=True,
-        key=lambda x: (x.score.bm25, x.shard_id, x.score.docaddr),
+        key=lambda x: (x.score.bm25, x.shard_id, -x.score.docaddr),
     )
     # cut the best results
     matches = list(itertools.islice(merged, top_k))
@@ -363,7 +363,7 @@ async def merge_paragraph_results(
 
             sort_value: SortValue
             if sort.field == SortField.SCORE:
-                sort_value = (result.score.bm25, result.shard_id, result.score.docaddr)
+                sort_value = (result.score.bm25, result.shard_id, -result.score.docaddr)
             else:
                 sort_value = result.date.ToDatetime()
             if sort_value is not None:

--- a/nucliadb/src/nucliadb/search/search/merge.py
+++ b/nucliadb/src/nucliadb/search/search/merge.py
@@ -94,7 +94,7 @@ def entity_type_to_relation_node_type(node_type: EntityType) -> RelationNode.Nod
 
 
 def sort_results_by_score(results: list[ParagraphResult] | list[DocumentResult]):
-    results.sort(key=lambda x: (x.score.bm25, x.shard_id, x.score.booster), reverse=True)
+    results.sort(key=lambda x: (x.score.bm25, x.shard_id, x.score.docaddr), reverse=True)
 
 
 async def merge_documents_results(
@@ -130,7 +130,7 @@ async def merge_documents_results(
                 continue
             sort_value: SortValue
             if query.order_by == SortField.SCORE:
-                sort_value = (result.score.bm25, result.shard_id, result.score.booster)
+                sort_value = (result.score.bm25, result.shard_id, result.score.docaddr)
             else:
                 sort_value = result.date.ToDatetime()
             if sort_value is not None:
@@ -192,7 +192,7 @@ async def merge_suggest_paragraph_results(
     merged = heapq.merge(
         *(response.results for response in suggest_responses),
         reverse=True,
-        key=lambda x: (x.score.bm25, x.shard_id, x.score.booster),
+        key=lambda x: (x.score.bm25, x.shard_id, x.score.docaddr),
     )
     # cut the best results
     matches = list(itertools.islice(merged, top_k))
@@ -363,7 +363,7 @@ async def merge_paragraph_results(
 
             sort_value: SortValue
             if sort.field == SortField.SCORE:
-                sort_value = (result.score.bm25, result.shard_id, result.score.booster)
+                sort_value = (result.score.bm25, result.shard_id, result.score.docaddr)
             else:
                 sort_value = result.date.ToDatetime()
             if sort_value is not None:

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -19,9 +19,10 @@
 #
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Annotated
 
 from nidx_protos import nodereader_pb2
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, PlainValidator
 
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb_models import search as search_models
@@ -140,7 +141,20 @@ class PredictReranker(BaseModel):
 
 Reranker = NoopReranker | PredictReranker
 
+
 # retrieval and generation operations
+
+SerializableBytes = Annotated[
+    bytes,
+    PlainSerializer(bytes.hex),
+    PlainValidator(lambda b: bytes.fromhex(b) if isinstance(b, str) else b),
+]
+
+
+class SearchAfter(BaseModel):
+    score: float
+    shard: SerializableBytes
+    docaddr: int
 
 
 class UnitRetrieval(BaseModel):
@@ -149,6 +163,7 @@ class UnitRetrieval(BaseModel):
     filters: Filters = Field(default_factory=Filters)
     rank_fusion: RankFusion | None = None
     reranker: Reranker | None = None
+    after: SearchAfter | None = None
 
 
 # TODO: augmentation things: hydration...

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/unit_retrieval.py
@@ -52,6 +52,7 @@ class _Converter:
         self._apply_graph_query()
         self._apply_filters()
         self._apply_top_k()
+        self._apply_search_after()
 
         return self.req
 
@@ -252,6 +253,14 @@ class _Converter:
             rank_fusion_window,
             reranker_window,
         )
+
+    def _apply_search_after(self) -> None:
+        if self.retrieval.after is None:
+            return
+
+        self.req.search_after.score = self.retrieval.after.score
+        self.req.search_after.shard_id = self.retrieval.after.shard
+        self.req.search_after.docaddr = self.retrieval.after.docaddr
 
 
 def is_incomplete(retrieval: UnitRetrieval) -> bool:

--- a/nucliadb/src/nucliadb/search/search/search_after.py
+++ b/nucliadb/src/nucliadb/search/search/search_after.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from base64 import b64decode, b64encode
+
+from nidx_protos.nodereader_pb2 import SearchResponse
+from pydantic import BaseModel, Field
+
+from nucliadb.common.external_index_providers.base import TextBlockMatch
+from nucliadb.search.search.query_parser.models import SearchAfter
+
+
+class SearchAfterToken(BaseModel):
+    # Indicates the first result to fetch from the index
+    after: SearchAfter | None = None
+
+    # Indicates the results already shown that should be skipped
+    skip: list[str] = Field(default_factory=list)
+
+    def encode(self) -> str:
+        return b64encode(self.model_dump_json().encode()).decode()
+
+    @staticmethod
+    def decode(token: str) -> "SearchAfterToken":
+        return SearchAfterToken.model_validate_json(b64decode(token))
+
+
+def build_search_after_token(response: SearchResponse, shown_results: set[str]) -> str:
+    found_first_not_shown = False
+
+    token = SearchAfterToken()
+
+    for paragraph in response.paragraph.results:
+        was_shown = paragraph.paragraph in shown_results
+        if not found_first_not_shown and was_shown:
+            # Mark top consecutive results to be skipped with search_after
+            token.after = SearchAfter(
+                score=paragraph.score.bm25, shard=paragraph.shard_id, docaddr=paragraph.score.docaddr
+            )
+        elif not found_first_not_shown:
+            # First results that was not shown, switch to listing ids
+            found_first_not_shown = True
+        elif was_shown:
+            # Mark other results to be skipped by matching ids
+            token.skip.append(paragraph.paragraph)
+
+    return token.encode()

--- a/nucliadb/src/nucliadb/search/search/search_after.py
+++ b/nucliadb/src/nucliadb/search/search/search_after.py
@@ -23,7 +23,6 @@ from base64 import b64decode, b64encode
 from nidx_protos.nodereader_pb2 import SearchResponse
 from pydantic import BaseModel, Field
 
-from nucliadb.common.external_index_providers.base import TextBlockMatch
 from nucliadb.search.search.query_parser.models import SearchAfter
 
 
@@ -43,22 +42,19 @@ class SearchAfterToken(BaseModel):
 
 
 def build_search_after_token(response: SearchResponse, shown_results: set[str]) -> str:
-    found_first_not_shown = False
-
     token = SearchAfterToken()
 
     for paragraph in response.paragraph.results:
-        was_shown = paragraph.paragraph in shown_results
-        if not found_first_not_shown and was_shown:
+        if paragraph.paragraph in shown_results:
             # Mark top consecutive results to be skipped with search_after
             token.after = SearchAfter(
                 score=paragraph.score.bm25, shard=paragraph.shard_id, docaddr=paragraph.score.docaddr
             )
-        elif not found_first_not_shown:
-            # First results that was not shown, switch to listing ids
-            found_first_not_shown = True
-        elif was_shown:
-            # Mark other results to be skipped by matching ids
-            token.skip.append(paragraph.paragraph)
+            # This results is skipped by after, no need to include in skip list
+            shown_results.remove(paragraph.paragraph)
+        else:
+            break
+
+    token.skip += shown_results
 
     return token.encode()

--- a/nucliadb/tests/nucliadb/integration/search/test_search_after.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search_after.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import pytest
+from httpx import AsyncClient
+
+from nucliadb.tests.vectors import Q
+from nucliadb_protos.resources_pb2 import FieldType
+from nucliadb_protos.writer_pb2 import BrokerMessage
+from nucliadb_protos.writer_pb2_grpc import WriterStub
+from tests.utils import inject_message
+from tests.utils.broker_messages import BrokerMessageBuilder
+
+
+@pytest.mark.deploy_modes("standalone")
+async def test_search_after_pagination_matches_single_request(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    standalone_knowledgebox: str,
+) -> None:
+    """Paginating with search_after (top_k=1) must yield the same ordered
+    paragraph IDs as a single large request."""
+
+    kbid = standalone_knowledgebox
+
+    for i in range(5):
+        resp = await nucliadb_writer.post(
+            f"/kb/{kbid}/resources",
+            json={
+                "title": f"The best book about potatoes",
+                "summary": f"Just some book telling you what to do with potatoes",
+                "icon": "text/plain",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    # One request with big top_k to list all resources expected
+    find_payload = {
+        "query": "potatoes",
+        "features": ["keyword"],
+        "reranker": "noop",
+        "top_k": 100,
+    }
+    resp = await nucliadb_reader.post(f"/kb/{kbid}/find", json=find_payload)
+    assert resp.status_code == 200, resp.text
+    baseline_data = resp.json()
+
+    baseline_ids = baseline_data["best_matches"]
+
+    assert len(baseline_ids) >= 5
+
+    # Paginated with k = 1, should iterate all resources one by one
+    paginated_ids: list[str] = []
+    token: str | None = None
+
+    # Limit as defensive programming to avoid infinite loops
+    for _ in range(20):
+        payload = {
+            "query": "potatoes",
+            "top_k": 1,
+        }
+        if token is not None:
+            payload["search_after"] = token
+
+        resp = await nucliadb_reader.post(f"/kb/{kbid}/find", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        page_ids = body["best_matches"]
+        paginated_ids.extend(page_ids)
+
+        token = body.get("search_after")
+        token_present = token is not None
+        assert token_present == body["next_page"]
+
+        if not token or len(page_ids) < 1:
+            break
+
+    assert set(paginated_ids) == set(baseline_ids)
+
+
+@pytest.mark.deploy_modes("standalone")
+async def test_search_after_hybrid_pagination_exercises_skip(
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    nucliadb_ingest_grpc: WriterStub,
+    standalone_knowledgebox: str,
+) -> None:
+    """
+    When the first paginated page uses hybrid search, a keyword result may surface
+    earlier than its BM25 rank because of vector boosting. This result must be skipped
+    (no duplicates) so the state must be kept through all pages.
+    """
+    kbid = standalone_knowledgebox
+
+    # A few keyword-only resources with double "potatoes" counts so they are first
+    for n in range(6):
+        resp = await nucliadb_writer.post(
+            f"/kb/{kbid}/resources",
+            json={"title": "About potatoes (not sweet potatoes)", "icon": "text/plain"},
+        )
+        assert resp.status_code == 201, resp.text
+
+    # One resource with a single "potatoes" keyword and a vector so it will rank first with rank fusion
+    resp = await nucliadb_writer.post(
+        f"/kb/{kbid}/resources",
+        json={
+            "title": "A book about potatoes and other things with lower bm25 score",
+            "icon": "text/plain",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    hybrid_rid = resp.json()["uuid"]
+
+    bmb = BrokerMessageBuilder(kbid=kbid, rid=hybrid_rid, source=BrokerMessage.MessageSource.PROCESSOR)
+    bmb.with_title("potatoes")
+    content_field = bmb.field_builder("content", FieldType.TEXT)
+    content_field.add_paragraph(
+        "A book about potatoes and other things with lower bm25 score",
+        vectors={"multilingual": list(Q)},
+    )
+    await inject_message(nucliadb_ingest_grpc, bmb.build())
+
+    # List all results
+    resp = await nucliadb_reader.post(
+        f"/kb/{kbid}/find",
+        json={
+            "query": "potatoes",
+            "features": ["keyword"],
+            "reranker": "noop",
+            "top_k": 100,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    baseline_ids = set(resp.json()["best_matches"])
+    assert len(baseline_ids) >= 7
+
+    # Ensure the hybrid result is last by bm25 score
+    assert resp.json()["best_matches"][-1].startswith(hybrid_rid)
+
+    # Compare with pagination
+    paginated_ids: list[str] = []
+    token: str | None = None
+    first_page = True
+
+    # Limit as defensive programming to avoid infinite loops
+    for _ in range(20):
+        payload: dict = {
+            "query": "potatoes",
+            "top_k": 2,
+            "rank_fusion": {"name": "rrf", "window": 20},
+            "reranker": "noop",
+        }
+        if token is not None:
+            payload["search_after"] = token
+
+        resp = await nucliadb_reader.post(f"/kb/{kbid}/find", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        page_ids = body["best_matches"]
+        paginated_ids.extend(page_ids)
+        token = body.get("search_after")
+        assert (token is not None) == body["next_page"]
+
+        if first_page:
+            # Hybrid result in first page
+            assert resp.json()["best_matches"][0].startswith(hybrid_rid)
+            first_page = False
+        else:
+            # Hybrid result not in any other page
+            for match in resp.json()["best_matches"]:
+                assert not match.startswith(hybrid_rid)
+
+        if not token or not page_ids or not body["next_page"]:
+            break
+
+    # No duplicates
+    assert len(paginated_ids) == len(set(paginated_ids))
+
+    # Same results
+    assert set(baseline_ids) == set(paginated_ids)

--- a/nucliadb/tests/nucliadb/integration/search/test_search_after.py
+++ b/nucliadb/tests/nucliadb/integration/search/test_search_after.py
@@ -64,7 +64,7 @@ async def test_search_after_pagination_matches_single_request(
 
     baseline_ids = baseline_data["best_matches"]
 
-    assert len(baseline_ids) >= 5
+    assert len(baseline_ids) == 10  # 5 * 2 (title+content)
 
     # Paginated with k = 1, should iterate all resources one by one
     paginated_ids: list[str] = []
@@ -150,7 +150,7 @@ async def test_search_after_hybrid_pagination_exercises_skip(
     )
     assert resp.status_code == 200, resp.text
     baseline_ids = set(resp.json()["best_matches"])
-    assert len(baseline_ids) >= 7
+    assert len(baseline_ids) == 8  # 6 * 1 (title) + 1 * 2 (title + content)
 
     # Ensure the hybrid result is last by bm25 score
     assert resp.json()["best_matches"][-1].startswith(hybrid_rid)

--- a/nucliadb/tests/search/unit/test_find_post_index.py
+++ b/nucliadb/tests/search/unit/test_find_post_index.py
@@ -406,4 +406,5 @@ def expected_find_response():
         "shards": None,
         "total": 1,
         "metrics": None,
+        "search_after": None,
     }

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -1983,6 +1983,14 @@ class FindRequest(BaseSearchRequest):
         title="Generative model",
         description="The generative model used to rephrase the query. If not provided, the model configured for the Knowledge Box is used.",
     )
+    search_after: str | None = Field(
+        default=None,
+        title="Search After",
+        description=(
+            "Pass a token returned from another resquest to get the next results in the search. "
+            "Only results from the paragraph index will be returned. "
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -2113,6 +2121,14 @@ class KnowledgeboxFindResults(JsonBaseModel):
             "Metrics information about the search operation. "
             "The metadata included in this field is subject to change and should not be used in production. "
             "This is only available if the `debug` parameter is set to true in the request."
+        ),
+    )
+    search_after: str | None = Field(
+        default=None,
+        title="Search After",
+        description=(
+            "Pass this token to another request to get the next results in the search. "
+            "Only results from the paragraph index will be returned. "
         ),
     )
 

--- a/nucliadb_models/src/nucliadb_models/search.py
+++ b/nucliadb_models/src/nucliadb_models/search.py
@@ -1988,7 +1988,7 @@ class FindRequest(BaseSearchRequest):
         title="Search After",
         description=(
             "Pass a token returned from another resquest to get the next results in the search. "
-            "Only results from the paragraph index will be returned. "
+            "Only results from the paragraph index will be returned and rerankers will be disabled. "
         ),
     )
 
@@ -2128,7 +2128,7 @@ class KnowledgeboxFindResults(JsonBaseModel):
         title="Search After",
         description=(
             "Pass this token to another request to get the next results in the search. "
-            "Only results from the paragraph index will be returned. "
+            "Only results from the paragraph index will be returned and rerankers will be disabled. "
         ),
     )
 


### PR DESCRIPTION
### Description

Allows to paginate search after a hybrid search. Subsequent pages will only include keyword results. Since the first page is hybrid search and can return results out of order, a list of shown results is passed to continued search to skip those results.

### How was this PR tested?
Describe how you tested this PR.
