### PR TITLE
Migrate GPT 5 Chat to GPT 5.6 Luna in search configurations

### DIFF
--- a/nucliadb/src/migrations/0048_migrate_search_configurations.py
+++ b/nucliadb/src/migrations/0048_migrate_search_configurations.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Migration #48
+
+Replaces deprecated and removed generative models from search configurations.
+
+Mirrors the following learning_config migration:
+- 7f0e9c2a1b3d: GPT-5 Chat -> GPT-5.6 Luna
+
+"""
+
+import logging
+from typing import cast
+
+from nucliadb.common import datamanagers
+from nucliadb.migrator.context import ExecutionContext
+from nucliadb_models.configuration import SearchConfiguration
+from nucliadb_models.search import AskRequest, FindRequest
+
+logger = logging.getLogger(__name__)
+
+REPLACEMENTS = {
+    "chatgpt-azure-5-chat": "chatgpt-azure-5.6-luna",
+    "chatgpt-5-chat": "chatgpt-5.6-luna",
+}
+
+
+async def migrate(context: ExecutionContext) -> None: ...
+
+
+async def migrate_kb(context: ExecutionContext, kbid: str) -> None:
+    affected = await get_affected_search_configurations(kbid)
+    if not affected:
+        return
+
+    async with datamanagers.with_rw_transaction() as txn:
+        for name, config in affected.items():
+            logger.info(
+                "Migrating search config for kb",
+                extra={
+                    "kbid": kbid,
+                    "search_config": name,
+                    "generative_model": config.config.generative_model,  # type: ignore[attr-defined]
+                },
+            )
+            config.config.generative_model = REPLACEMENTS[config.config.generative_model]  # type: ignore[attr-defined]
+            await datamanagers.search_configurations.set(txn, kbid=kbid, name=name, config=config)
+        await txn.commit()
+
+
+async def get_affected_search_configurations(kbid: str) -> dict[str, SearchConfiguration]:
+    result: dict[str, SearchConfiguration] = {}
+    async with datamanagers.with_ro_transaction() as txn:
+        search_configs = await datamanagers.search_configurations.list(txn, kbid=kbid)
+        for name, config in search_configs.items():
+            if config.kind == "find":
+                find_config = cast(FindRequest, config.config)
+                if find_config.generative_model in REPLACEMENTS:
+                    result[name] = config
+            elif config.kind == "ask":
+                ask_config = cast(AskRequest, config.config)
+                if ask_config.generative_model in REPLACEMENTS:
+                    result[name] = config
+    return result

--- a/nucliadb/tests/nucliadb/migrations/test_migration_0048.py
+++ b/nucliadb/tests/nucliadb/migrations/test_migration_0048.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2021 Bosutech XXI S.L.
+#
+# nucliadb is offered under the AGPL v3.0 and as commercial software.
+# For commercial licensing, contact us at info@nuclia.com.
+#
+# AGPL:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import uuid
+from unittest.mock import Mock
+
+from nucliadb.common import datamanagers
+from nucliadb.common.maindb.driver import Driver
+from nucliadb.migrator.models import Migration
+from nucliadb_models.configuration import (
+    AskConfig,
+    AskSearchConfiguration,
+    FindConfig,
+    FindSearchConfiguration,
+    SearchConfiguration,
+)
+from tests.nucliadb.migrations import get_migration
+
+migration: Migration = get_migration(48)
+
+
+deprecated_models = [
+    ("chatgpt-azure-5-chat", FindConfig),
+    ("chatgpt-5-chat", AskConfig),
+]
+
+
+async def test_migration_0048(maindb_driver: Driver):
+    execution_context = Mock()
+    execution_context.kv_driver = maindb_driver
+    execution_context.blob_storage = Mock()
+
+    kbid = str(uuid.uuid4())
+
+    async with maindb_driver.rw_transaction() as txn:
+        for i, (model, config_cls) in enumerate(deprecated_models):
+            name = f"{model}-{i}"
+            if config_cls is FindConfig:
+                config: SearchConfiguration = FindSearchConfiguration(
+                    kind="find", config=FindConfig(generative_model=model)
+                )
+            else:
+                config = AskSearchConfiguration(kind="ask", config=AskConfig(generative_model=model))
+            await datamanagers.search_configurations.set(txn, kbid=kbid, name=name, config=config)
+        await txn.commit()
+
+    await migration.module.migrate_kb(execution_context, kbid)
+
+    async with maindb_driver.ro_transaction() as txn:
+        for i, (model, _) in enumerate(deprecated_models):
+            name = f"{model}-{i}"
+            result = await datamanagers.search_configurations.get(txn, kbid=kbid, name=name)
+            assert result is not None
+            assert result.config.generative_model == migration.module.REPLACEMENTS[model]  # type: ignore[attr-defined]


### PR DESCRIPTION
### Description
Migrates search configurations following model deprecation

Inspired by previous migration PRs such as #3776 and #3742 

### How was this PR tested?
Included test for the migration