### PR TITLE
Granular labelset kind check

### DIFF
--- a/nucliadb/src/nucliadb/common/datamanagers/labels.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/labels.py
@@ -47,6 +47,14 @@ async def get_labels(txn: Transaction, *, kbid: str) -> kb_pb2.Labels:
     return labels
 
 
+async def list_labelset_ids(txn: Transaction, *, kbid: str) -> list[str] | None:
+    key = KB_LABELSET_IDS.format(kbid=kbid)
+    data = await txn.get(key)
+    if not data:
+        return None
+    return orjson.loads(data)
+
+
 async def _get_labelset_ids(txn: Transaction, *, kbid: str) -> list[str] | None:
     key = KB_LABELSET_IDS.format(kbid=kbid)
     data = await txn.get(key, for_update=True)

--- a/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/fetcher.py
@@ -58,7 +58,9 @@ class FetcherCache:
     # semantic search
     vectorset: str | NotCached = not_cached
 
-    labels: knowledgebox_pb2.Labels | NotCached = not_cached
+    labelset_kinds: dict[str, list[knowledgebox_pb2.LabelSet.LabelSetKind] | NotCached] | NotCached = (
+        not_cached
+    )
 
     synonyms: knowledgebox_pb2.Synonyms | None | NotCached = not_cached
 
@@ -224,14 +226,37 @@ class Fetcher:
 
     # Labels
 
-    async def get_classification_labels(self) -> knowledgebox_pb2.Labels:
+    @query_parse_dependency_observer.wrap({"type": "labelset_kind"})
+    async def get_labelset_kinds(
+        self, labelset_id: str
+    ) -> list[knowledgebox_pb2.LabelSet.LabelSetKind] | None:
         async with self.locks.setdefault("classification_labels", asyncio.Lock()):
-            if is_cached(self.cache.labels):
-                return self.cache.labels
+            if not is_cached(self.cache.labelset_kinds):
+                # Populate the cache with all KB labelsets (not cached)
+                self.cache.labelset_kinds = {}
+                async with datamanagers.with_ro_transaction() as txn:
+                    labelset_ids = await datamanagers.labels.list_labelset_ids(txn, kbid=self.kbid)
+                    for id in labelset_ids or []:
+                        self.cache.labelset_kinds[id] = not_cached
 
-            labels = await get_classification_labels(self.kbid)
-            self.cache.labels = labels
-            return labels
+            if labelset_id not in self.cache.labelset_kinds:
+                # labelset not in KB
+                return None
+
+            if is_cached(self.cache.labelset_kinds[labelset_id]):
+                return self.cache.labelset_kinds[labelset_id]  # type: ignore[return-value,ty:invalid-return-type]
+
+            # fetch and cache the labelset
+            async with datamanagers.with_ro_transaction() as txn:
+                labelset = await datamanagers.labels.get_labelset(
+                    txn, kbid=self.kbid, labelset_id=labelset_id
+                )
+
+            if labelset is None:  # pragma: no cover
+                # unrepeatable read between caching the ids and reading the labelset
+                return None
+            self.cache.labelset_kinds[labelset_id] = labelset.kind  # type: ignore[assignment,ty:invalid-assignment]
+            return self.cache.labelset_kinds[labelset_id]  # type: ignore[return-value,ty:invalid-return-type]
 
     # Entities
 
@@ -391,12 +416,6 @@ async def get_matryoshka_dimension(kbid: str, vectorset: str | None) -> int | No
                 matryoshka_dimension = vectorset_config.vectorset_index_config.vector_dimension
 
         return matryoshka_dimension
-
-
-@query_parse_dependency_observer.wrap({"type": "classification_labels"})
-async def get_classification_labels(kbid: str) -> knowledgebox_pb2.Labels:
-    async with get_driver().ro_transaction() as txn:
-        return await datamanagers.labels.get_labels(txn, kbid=kbid)
 
 
 @query_parse_dependency_observer.wrap({"type": "synonyms"})

--- a/nucliadb/src/nucliadb/search/search/query_parser/old_filters.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/old_filters.py
@@ -53,11 +53,9 @@ async def parse_old_filters(
 
     # Labels
     if old.label_filters:
-        classification_labels = await fetcher.get_classification_labels()
-
         paragraph_exprs = []
         for fltr in old.label_filters:
-            field_expr, paragraph_expr = convert_label_filter_to_expressions(fltr, classification_labels)
+            field_expr, paragraph_expr = await convert_label_filter_to_expressions(fltr, fetcher)
             if field_expr:
                 filters.append(field_expr)
             if paragraph_expr:
@@ -148,32 +146,33 @@ async def parse_old_filters(
         return f, paragraph_filter_expression
 
 
-def convert_label_filter_to_expressions(
-    fltr: str | Filter, classification_labels: knowledgebox_pb2.Labels
+async def convert_label_filter_to_expressions(
+    fltr: str | Filter,
+    fetcher: Fetcher,
 ) -> tuple[FilterExpression | None, FilterExpression | None]:
     if isinstance(fltr, str):
         fltr = translate_label(fltr)
         f = FilterExpression()
         f.facet.facet = fltr
-        if is_paragraph_label(fltr, classification_labels):
+        if await is_paragraph_label(fltr, fetcher):
             return None, f
         else:
             return f, None
 
     if fltr.all:
-        return split_labels(fltr.all, classification_labels, "bool_and", negate=False)
+        return await split_labels(fltr.all, fetcher, "bool_and", negate=False)
     if fltr.any:
-        return split_labels(fltr.any, classification_labels, "bool_or", negate=False)
+        return await split_labels(fltr.any, fetcher, "bool_or", negate=False)
     if fltr.none:
-        return split_labels(fltr.none, classification_labels, "bool_and", negate=True)
+        return await split_labels(fltr.none, fetcher, "bool_and", negate=True)
     if fltr.not_all:
-        return split_labels(fltr.not_all, classification_labels, "bool_or", negate=True)
+        return await split_labels(fltr.not_all, fetcher, "bool_or", negate=True)
 
     return None, None
 
 
-def split_labels(
-    labels: list[str], classification_labels: knowledgebox_pb2.Labels, combinator: str, negate: bool
+async def split_labels(
+    labels: list[str], fetcher: Fetcher, combinator: str, negate: bool
 ) -> tuple[FilterExpression | None, FilterExpression | None]:
     field = []
     paragraph = []
@@ -185,7 +184,7 @@ def split_labels(
         else:
             expr.facet.facet = label
 
-        if is_paragraph_label(label, classification_labels):
+        if await is_paragraph_label(label, fetcher):
             paragraph.append(expr)
         else:
             field.append(expr)
@@ -217,7 +216,7 @@ def split_labels(
     return field_expr, paragraph_expr
 
 
-def is_paragraph_label(label: str, classification_labels: knowledgebox_pb2.Labels) -> bool:
+async def is_paragraph_label(label: str, fetcher: Fetcher) -> bool:
     if len(label) == 0 or label[0] != "/":
         return False
     if not label.startswith("/l/"):
@@ -229,14 +228,12 @@ def is_paragraph_label(label: str, classification_labels: knowledgebox_pb2.Label
         return False
     labelset_id = parts[2]
 
-    try:
-        labelset: knowledgebox_pb2.LabelSet | None = classification_labels.labelset.get(labelset_id)
-        if labelset is None:
-            return False
-        return knowledgebox_pb2.LabelSet.LabelSetKind.PARAGRAPHS in labelset.kind
-    except KeyError:
-        # labelset_id not found
+    kinds: list[knowledgebox_pb2.LabelSet.LabelSetKind] | None = await fetcher.get_labelset_kinds(
+        labelset_id
+    )
+    if kinds is None:
         return False
+    return knowledgebox_pb2.LabelSet.LabelSetKind.PARAGRAPHS in kinds
 
 
 def convert_keyword_filter_to_expression(fltr: str | Filter) -> FilterExpression:

--- a/nucliadb/tests/search/unit/search/search/test_fetcher_cache.py
+++ b/nucliadb/tests/search/unit/search/search/test_fetcher_cache.py
@@ -20,6 +20,7 @@
 from unittest.mock import AsyncMock, patch
 
 from nucliadb.search.search.query_parser.fetcher import Fetcher
+from nucliadb_protos import knowledgebox_pb2
 
 
 async def test_matryoshka_dimension_cache() -> None:
@@ -53,6 +54,60 @@ async def test_validate_vectorset_cache() -> None:
         # but not across requests (to avoid need for invalidation)
         await fetcher.validate_vectorset("kbid", "vectorset")
         assert mock.call_count == 2
+
+
+async def test_labelset_kind_cache() -> None:
+    labelsets = {
+        "animals": knowledgebox_pb2.LabelSet(
+            title="Animals",
+            kind=[knowledgebox_pb2.LabelSet.LabelSetKind.RESOURCES],
+            labels=[
+                knowledgebox_pb2.Label(text="dog"),
+                knowledgebox_pb2.Label(text="cat"),
+            ],
+        ),
+        "objects": knowledgebox_pb2.LabelSet(
+            title="Objects",
+            kind=[knowledgebox_pb2.LabelSet.LabelSetKind.PARAGRAPHS],
+            labels=[
+                knowledgebox_pb2.Label(text="table"),
+                knowledgebox_pb2.Label(text="chair"),
+            ],
+        ),
+    }
+
+    with (
+        patch("nucliadb.search.search.query_parser.fetcher.datamanagers.with_ro_transaction"),
+        patch(
+            "nucliadb.search.search.query_parser.fetcher.datamanagers.labels.list_labelset_ids",
+            return_value=list(labelsets.keys()),
+        ) as list_ids,
+        patch(
+            "nucliadb.search.search.query_parser.fetcher.datamanagers.labels.get_labelset",
+            side_effect=lambda txn, kbid, labelset_id: labelsets.get(labelset_id),
+        ) as get,
+    ):
+        fetcher = new_fetcher()
+
+        assert (await fetcher.get_labelset_kinds("animals")) == labelsets["animals"].kind
+        assert list_ids.call_count == 1
+        assert get.call_count == 1
+
+        assert (await fetcher.get_labelset_kinds("objects")) == labelsets["objects"].kind
+        # labelset ids already cached
+        assert list_ids.call_count == 1
+        # new labelset is not
+        assert get.call_count == 2
+
+        assert (await fetcher.get_labelset_kinds("objects")) == labelsets["objects"].kind
+        # ids and labelset are cached
+        assert list_ids.call_count == 1
+        assert get.call_count == 2
+
+        assert (await fetcher.get_labelset_kinds("plants")) is None
+        assert list_ids.call_count == 1
+        # not in valid ids, so we don't even call get
+        assert get.call_count == 2
 
 
 def new_fetcher() -> Fetcher:


### PR DESCRIPTION
### Description
Cache labelset kinds on fetcher to avoid fetching ALL KB labels only to check a few passed as filters. For KBs with many labels where building a proto with all labels is a costly operation, this will improve performance significantly. The rest shouldn't be affected.

### How was this PR tested?
Existing tests + new unit tests for fetcher caching
