### PR TITLE
Common filtering across endpoints

### DIFF
--- a/nidx/nidx_protos/nodereader.proto
+++ b/nidx/nidx_protos/nodereader.proto
@@ -422,6 +422,7 @@ message SearchRequest {
 
     optional FilterExpression field_filter = 26;
     optional FilterExpression paragraph_filter = 27;
+    optional JsonFilterExpression json_filter = 32;
     FilterOperator filter_operator = 28;
 
     // Reduced graph search for specific use case of text block search. It only
@@ -431,8 +432,6 @@ message SearchRequest {
         GraphQuery query = 1;
     }
     GraphSearch graph_search = 29;
-
-    optional JsonFilterExpression json_filter = 32;
 
     optional SearchAfter search_after = 35;
 }
@@ -451,6 +450,7 @@ message SuggestRequest {
 
     optional FilterExpression field_filter = 7;
     optional FilterExpression paragraph_filter = 8;
+    optional JsonFilterExpression json_filter = 12;
     FilterOperator filter_operator = 9;
 
     optional utils.Security security = 10;

--- a/nucliadb/src/nucliadb/search/api/v1/suggest.py
+++ b/nucliadb/src/nucliadb/search/api/v1/suggest.py
@@ -132,7 +132,7 @@ async def suggest_post_knowledgebox(
             # all these fields are superseeded by filter expression. In the POST
             # endpoint we don't support any of these fields
             fields=[],
-            filters=[],
+            label_filters=[],
             range_creation_start=None,
             range_creation_end=None,
             range_modification_start=None,
@@ -151,7 +151,7 @@ async def suggest(
     query: str,
     filter_expression: FilterExpression | None,
     fields: list[str],
-    filters: list[str],
+    label_filters: list[str],
     range_creation_start: datetime | None,
     range_creation_end: datetime | None,
     range_modification_start: datetime | None,
@@ -169,7 +169,7 @@ async def suggest(
             features,
             filter_expression,
             fields,
-            filters,
+            label_filters,
             show_hidden,
             range_creation_start,
             range_creation_end,

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -103,7 +103,9 @@ class Filters(BaseModel):
     )
     json_expression: nodereader_pb2.JsonFilterExpression | None = None
 
+    # TODO: facets trigger a faceted search, not a filter. This should be in another place
     facets: list[str] = Field(default_factory=list)
+
     hidden: bool | None = None
     security: search_models.RequestSecurity | None = None
     with_duplicates: bool = False

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -183,17 +183,6 @@ class ParsedQuery(BaseModel):
     generation: Generation | None = None
 
 
-### Suggest
-
-
-class SuggestRetrieval(BaseModel):
-    query: str
-    use_keyword: bool
-    use_relations: bool
-    top_k: int
-    filters: Filters
-
-
 ### Graph
 
 

--- a/nucliadb/src/nucliadb/search/search/query_parser/models.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/models.py
@@ -183,6 +183,17 @@ class ParsedQuery(BaseModel):
     generation: Generation | None = None
 
 
+### Suggest
+
+
+class SuggestRetrieval(BaseModel):
+    query: str
+    use_keyword: bool
+    use_relations: bool
+    top_k: int
+    filters: Filters
+
+
 ### Graph
 
 

--- a/nucliadb/src/nucliadb/search/search/query_parser/old_filters.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/old_filters.py
@@ -25,9 +25,7 @@ from nidx_protos.nodereader_pb2 import FilterExpression
 
 from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.search.search.filters import translate_label
-from nucliadb_models.search import (
-    Filter,
-)
+from nucliadb_models.search import Filter
 from nucliadb_protos import knowledgebox_pb2
 
 from .fetcher import Fetcher

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
@@ -19,11 +19,17 @@
 #
 import re
 import string
+from datetime import datetime
 
+from nidx_protos import nodereader_pb2
+
+from nucliadb.common.exceptions import InvalidQueryError
+from nucliadb.common.filter_expression import parse_expression, parse_kv_expression
 from nucliadb.search import logger
 from nucliadb.search.search.query_parser.exceptions import InternalParserError
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.models import (
+    Filters,
     KeywordQuery,
     NoopReranker,
     PredictReranker,
@@ -32,8 +38,12 @@ from nucliadb.search.search.query_parser.models import (
     Reranker,
     SemanticQuery,
 )
+from nucliadb.search.search.query_parser.old_filters import OldFilterParams, parse_old_filters
+from nucliadb.search.search.utils import filter_hidden_resources, kb_security_enforced
+from nucliadb_models import RequestSecurity
 from nucliadb_models import search as search_models
-from nucliadb_models.search import MAX_RANK_FUSION_WINDOW
+from nucliadb_models.filters import FilterExpression
+from nucliadb_models.search import MAX_RANK_FUSION_WINDOW, Filter
 
 DEFAULT_GENERIC_SEMANTIC_THRESHOLD = 0.7
 
@@ -217,6 +227,83 @@ async def query_with_synonyms(
         return advanced_query
 
     return None
+
+
+async def parse_filters(
+    kbid: str,
+    fetcher: Fetcher,
+    *,
+    show_hidden: bool,
+    security: RequestSecurity | None,
+    with_duplicates: bool,
+    # new-style filter expression
+    filter_expression: FilterExpression | None,
+    # old-style filters (superseded by filter expressions)
+    label_filters: list[str] | list[Filter],
+    keyword_filters: list[str] | list[Filter],
+    resource_filters: list[str],
+    fields: list[str],
+    range_creation_start: datetime | None,
+    range_creation_end: datetime | None,
+    range_modification_start: datetime | None,
+    range_modification_end: datetime | None,
+) -> Filters:
+    has_old_filters = (
+        len(label_filters) > 0
+        or len(keyword_filters) > 0
+        or len(resource_filters) > 0
+        or len(fields) > 0
+        or range_creation_start is not None
+        or range_creation_end is not None
+        or range_modification_start is not None
+        or range_modification_end is not None
+    )
+    if filter_expression is not None and has_old_filters:
+        raise InvalidQueryError("filter_expression", "Cannot mix old filters with filter_expression")
+
+    field_expr = None
+    paragraph_expr = None
+    filter_operator = nodereader_pb2.FilterOperator.AND
+
+    if has_old_filters:
+        old_filters = OldFilterParams(
+            label_filters=label_filters,
+            keyword_filters=keyword_filters,
+            key_filters=resource_filters,
+            fields=fields,
+            range_creation_start=range_creation_start,
+            range_creation_end=range_creation_end,
+            range_modification_start=range_modification_start,
+            range_modification_end=range_modification_end,
+        )
+        field_expr, paragraph_expr = await parse_old_filters(old_filters, fetcher)
+
+    json_expr = None
+    if filter_expression is not None:
+        if filter_expression.field:
+            field_expr = await parse_expression(filter_expression.field, kbid)
+        if filter_expression.key_value:
+            json_expr = await parse_kv_expression(filter_expression.key_value, kbid)
+        if filter_expression.paragraph:
+            paragraph_expr = await parse_expression(filter_expression.paragraph, kbid)
+        if filter_expression.operator == FilterExpression.Operator.OR:
+            filter_operator = nodereader_pb2.FilterOperator.OR
+        else:
+            filter_operator = nodereader_pb2.FilterOperator.AND
+
+    hidden = await filter_hidden_resources(kbid, show_hidden)
+    security = await kb_security_enforced(kbid, security)
+
+    return Filters(
+        facets=[],
+        field_expression=field_expr,
+        paragraph_expression=paragraph_expr,
+        filter_expression_operator=filter_operator,
+        json_expression=json_expr,
+        security=security,
+        hidden=hidden,
+        with_duplicates=with_duplicates,
+    )
 
 
 def parse_rank_fusion(

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
@@ -239,15 +239,20 @@ async def parse_filters(
     # new-style filter expression
     filter_expression: FilterExpression | None,
     # old-style filters (superseded by filter expressions)
-    label_filters: list[str] | list[Filter],
-    keyword_filters: list[str] | list[Filter],
-    resource_filters: list[str],
-    fields: list[str],
-    range_creation_start: datetime | None,
-    range_creation_end: datetime | None,
-    range_modification_start: datetime | None,
-    range_modification_end: datetime | None,
+    label_filters: list[str] | list[Filter] | None = None,
+    keyword_filters: list[str] | list[Filter] | None = None,
+    resource_filters: list[str] | None = None,
+    fields: list[str] | None = None,
+    range_creation_start: datetime | None = None,
+    range_creation_end: datetime | None = None,
+    range_modification_start: datetime | None = None,
+    range_modification_end: datetime | None = None,
 ) -> Filters:
+    label_filters = label_filters or []
+    keyword_filters = keyword_filters or []
+    resource_filters = resource_filters or []
+    fields = fields or []
+
     has_old_filters = (
         len(label_filters) > 0
         or len(keyword_filters) > 0

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
@@ -26,6 +26,7 @@ from nidx_protos import nodereader_pb2
 from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.common.filter_expression import parse_expression, parse_kv_expression
 from nucliadb.search import logger
+from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.exceptions import InternalParserError
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.models import (
@@ -229,6 +230,7 @@ async def query_with_synonyms(
     return None
 
 
+@query_parser_observer.wrap({"type": "parse_filters"})
 async def parse_filters(
     kbid: str,
     fetcher: Fetcher,

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/common.py
@@ -235,11 +235,12 @@ async def parse_filters(
     kbid: str,
     fetcher: Fetcher,
     *,
-    show_hidden: bool,
-    security: RequestSecurity | None,
-    with_duplicates: bool,
+    show_hidden: bool = False,
+    security: RequestSecurity | None = None,
+    with_duplicates: bool = False,
+    facets: list[str] | None = None,
     # new-style filter expression
-    filter_expression: FilterExpression | None,
+    filter_expression: FilterExpression | None = None,
     # old-style filters (superseded by filter expressions)
     label_filters: list[str] | list[Filter] | None = None,
     keyword_filters: list[str] | list[Filter] | None = None,
@@ -250,6 +251,7 @@ async def parse_filters(
     range_modification_start: datetime | None = None,
     range_modification_end: datetime | None = None,
 ) -> Filters:
+    facets = facets or []
     label_filters = label_filters or []
     keyword_filters = keyword_filters or []
     resource_filters = resource_filters or []
@@ -302,7 +304,7 @@ async def parse_filters(
     security = await kb_security_enforced(kbid, security)
 
     return Filters(
-        facets=[],
+        facets=facets,
         field_expression=field_expr,
         paragraph_expression=paragraph_expr,
         filter_expression_operator=filter_operator,

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -18,14 +18,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from nidx_protos import nodereader_pb2
 from pydantic import ValidationError
 
 from nucliadb.common.exceptions import InvalidQueryError
-from nucliadb.common.filter_expression import (
-    parse_expression,
-    parse_kv_expression,
-)
 from nucliadb.common.models_utils.from_proto import RelationNodeTypeMap
 from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.exceptions import InternalParserError
@@ -39,13 +34,9 @@ from nucliadb.search.search.query_parser.models import (
     RelationQuery,
     UnitRetrieval,
 )
-from nucliadb.search.search.query_parser.old_filters import OldFilterParams, parse_old_filters
-from nucliadb.search.search.utils import filter_hidden_resources, kb_security_enforced
+from nucliadb.search.search.query_parser.parsers.common import parse_filters
 from nucliadb_models import search as search_models
-from nucliadb_models.filters import FilterExpression
-from nucliadb_models.search import (
-    FindRequest,
-)
+from nucliadb_models.search import FindRequest
 from nucliadb_protos import utils_pb2
 
 from .common import (
@@ -203,59 +194,19 @@ class _FindParser:
     async def _parse_filters(self) -> Filters:
         assert self._query is not None, "query must be parsed before filters"
 
-        has_old_filters = (
-            len(self.item.filters) > 0
-            or len(self.item.resource_filters) > 0
-            or len(self.item.fields) > 0
-            or len(self.item.keyword_filters) > 0
-            or self.item.range_creation_start is not None
-            or self.item.range_creation_end is not None
-            or self.item.range_modification_start is not None
-            or self.item.range_modification_end is not None
-        )
-        if self.item.filter_expression is not None and has_old_filters:
-            raise InvalidQueryError("filter_expression", "Cannot mix old filters with filter_expression")
-
-        field_expr = None
-        paragraph_expr = None
-        filter_operator = nodereader_pb2.FilterOperator.AND
-
-        if has_old_filters:
-            old_filters = OldFilterParams(
-                label_filters=self.item.filters,
-                keyword_filters=self.item.keyword_filters,
-                range_creation_start=self.item.range_creation_start,
-                range_creation_end=self.item.range_creation_end,
-                range_modification_start=self.item.range_modification_start,
-                range_modification_end=self.item.range_modification_end,
-                fields=self.item.fields,
-                key_filters=self.item.resource_filters,
-            )
-            field_expr, paragraph_expr = await parse_old_filters(old_filters, self.fetcher)
-
-        json_expr = None
-        if self.item.filter_expression is not None:
-            if self.item.filter_expression.field:
-                field_expr = await parse_expression(self.item.filter_expression.field, self.kbid)
-            if self.item.filter_expression.key_value:
-                json_expr = await parse_kv_expression(self.item.filter_expression.key_value, self.kbid)
-            if self.item.filter_expression.paragraph:
-                paragraph_expr = await parse_expression(self.item.filter_expression.paragraph, self.kbid)
-            if self.item.filter_expression.operator == FilterExpression.Operator.OR:
-                filter_operator = nodereader_pb2.FilterOperator.OR
-            else:
-                filter_operator = nodereader_pb2.FilterOperator.AND
-
-        hidden = await filter_hidden_resources(self.kbid, self.item.show_hidden)
-        security = await kb_security_enforced(self.kbid, self.item.security)
-
-        return Filters(
-            facets=[],
-            field_expression=field_expr,
-            paragraph_expression=paragraph_expr,
-            filter_expression_operator=filter_operator,
-            json_expression=json_expr,
-            security=security,
-            hidden=hidden,
+        return await parse_filters(
+            self.kbid,
+            self.fetcher,
+            show_hidden=self.item.show_hidden,
+            security=self.item.security,
             with_duplicates=self.item.with_duplicates,
+            filter_expression=self.item.filter_expression,
+            label_filters=self.item.filters,
+            keyword_filters=self.item.keyword_filters,
+            resource_filters=self.item.resource_filters,
+            fields=self.item.fields,
+            range_creation_start=self.item.range_creation_start,
+            range_creation_end=self.item.range_creation_end,
+            range_modification_start=self.item.range_modification_start,
+            range_modification_end=self.item.range_modification_end,
         )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/find.py
@@ -26,7 +26,6 @@ from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.exceptions import InternalParserError
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.models import (
-    Filters,
     GraphQuery,
     ParsedQuery,
     PredictReranker,
@@ -107,7 +106,22 @@ class _FindParser:
         if search_models.FindOptions.GRAPH in self.item.features:
             self._query.graph = await self._parse_graph_query()
 
-        filters = await self._parse_filters()
+        filters = await parse_filters(
+            self.kbid,
+            self.fetcher,
+            show_hidden=self.item.show_hidden,
+            security=self.item.security,
+            with_duplicates=self.item.with_duplicates,
+            filter_expression=self.item.filter_expression,
+            label_filters=self.item.filters,
+            keyword_filters=self.item.keyword_filters,
+            resource_filters=self.item.resource_filters,
+            fields=self.item.fields,
+            range_creation_start=self.item.range_creation_start,
+            range_creation_end=self.item.range_creation_end,
+            range_modification_start=self.item.range_modification_start,
+            range_modification_end=self.item.range_modification_end,
+        )
 
         try:
             rank_fusion = parse_rank_fusion(self.item.rank_fusion, self.item.top_k)
@@ -190,23 +204,3 @@ class _FindParser:
             detected_entities = await self.fetcher.get_detected_entities()
 
         return detected_entities
-
-    async def _parse_filters(self) -> Filters:
-        assert self._query is not None, "query must be parsed before filters"
-
-        return await parse_filters(
-            self.kbid,
-            self.fetcher,
-            show_hidden=self.item.show_hidden,
-            security=self.item.security,
-            with_duplicates=self.item.with_duplicates,
-            filter_expression=self.item.filter_expression,
-            label_filters=self.item.filters,
-            keyword_filters=self.item.keyword_filters,
-            resource_filters=self.item.resource_filters,
-            fields=self.item.fields,
-            range_creation_start=self.item.range_creation_start,
-            range_creation_end=self.item.range_creation_end,
-            range_modification_start=self.item.range_modification_start,
-            range_modification_end=self.item.range_modification_end,
-        )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/retrieve.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/retrieve.py
@@ -17,21 +17,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-from nidx_protos import nodereader_pb2
 from pydantic import ValidationError
 from typing_extensions import assert_never
 
 import nucliadb_models.retrieval
 from nucliadb.common.exceptions import InvalidQueryError
-from nucliadb.common.filter_expression import (
-    parse_expression,
-    parse_kv_expression,
-)
 from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.exceptions import InternalParserError
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.models import (
-    Filters,
     GraphQuery,
     KeywordQuery,
     ParsedQuery,
@@ -40,10 +34,12 @@ from nucliadb.search.search.query_parser.models import (
     SemanticQuery,
     UnitRetrieval,
 )
-from nucliadb.search.search.query_parser.parsers.common import query_with_synonyms, validate_query_syntax
+from nucliadb.search.search.query_parser.parsers.common import (
+    parse_filters,
+    query_with_synonyms,
+    validate_query_syntax,
+)
 from nucliadb.search.search.query_parser.parsers.graph import _calculate_graph_vectors
-from nucliadb.search.search.utils import filter_hidden_resources, kb_security_enforced
-from nucliadb_models.filters import FilterExpression
 from nucliadb_models.retrieval import RetrievalRequest
 
 from .common import parse_rank_fusion, parse_reranker
@@ -121,7 +117,15 @@ class _RetrievalParser:
     async def parse(self) -> UnitRetrieval:
         top_k = self.item.top_k
         query = await self._parse_query()
-        filters = await self._parse_filters()
+        filters = await parse_filters(
+            self.kbid,
+            self.fetcher,
+            show_hidden=self.item.filters.show_hidden,
+            security=self.item.filters.security,
+            with_duplicates=self.item.filters.with_duplicates,
+            filter_expression=self.item.filters.filter_expression,
+        )
+
         try:
             rank_fusion = parse_rank_fusion(self.item.rank_fusion, self.item.top_k)
         except ValidationError as exc:
@@ -310,34 +314,3 @@ class _RetrievalParser:
             query_vector = user_vector[:matryoshka_dimension]
 
         return vectorset, query_vector
-
-    @query_parser_observer.wrap({"type": "retrieve_parse_filters"})
-    async def _parse_filters(self) -> Filters:
-        filters = Filters()
-
-        if self.item.filters.filter_expression is not None:
-            if self.item.filters.filter_expression.field is not None:
-                filters.field_expression = await parse_expression(
-                    self.item.filters.filter_expression.field,
-                    self.kbid,
-                )
-            if self.item.filters.filter_expression.paragraph is not None:
-                filters.paragraph_expression = await parse_expression(
-                    self.item.filters.filter_expression.paragraph,
-                    self.kbid,
-                )
-            if self.item.filters.filter_expression.key_value is not None:
-                filters.json_expression = await parse_kv_expression(
-                    self.item.filters.filter_expression.key_value, self.kbid
-                )
-            if self.item.filters.filter_expression.operator == FilterExpression.Operator.OR:
-                filter_operator = nodereader_pb2.FilterOperator.OR
-            else:
-                filter_operator = nodereader_pb2.FilterOperator.AND
-            filters.filter_expression_operator = filter_operator
-
-        filters.hidden = await filter_hidden_resources(self.kbid, self.item.filters.show_hidden)
-        filters.security = await kb_security_enforced(self.kbid, self.item.filters.security)
-        filters.with_duplicates = self.item.filters.with_duplicates
-
-        return filters

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
@@ -187,7 +187,7 @@ class _SearchParser:
             with_duplicates=self.item.with_duplicates,
             filter_expression=self.item.filter_expression,
             label_filters=self.item.filters,
-            keyword_filters=[],
+            keyword_filters=None,
             resource_filters=self.item.resource_filters,
             fields=self.item.fields,
             range_creation_start=self.item.range_creation_start,

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
@@ -22,7 +22,6 @@ from nucliadb.common.exceptions import InvalidQueryError
 from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.models import (
-    Filters,
     ParsedQuery,
     Query,
     RelationQuery,
@@ -111,7 +110,23 @@ class _SearchParser:
         if search_models.SearchOptions.RELATIONS in self.item.features:
             self._query.relation = await self._parse_relation_query()
 
-        filters = await self._parse_filters()
+        filters = await parse_filters(
+            self.kbid,
+            self.fetcher,
+            show_hidden=self.item.show_hidden,
+            security=self.item.security,
+            with_duplicates=self.item.with_duplicates,
+            facets=self.item.faceted,
+            filter_expression=self.item.filter_expression,
+            label_filters=self.item.filters,
+            keyword_filters=None,
+            resource_filters=self.item.resource_filters,
+            fields=self.item.fields,
+            range_creation_start=self.item.range_creation_start,
+            range_creation_end=self.item.range_creation_end,
+            range_modification_start=self.item.range_modification_start,
+            range_modification_end=self.item.range_modification_end,
+        )
 
         retrieval = UnitRetrieval(
             query=self._query,
@@ -175,23 +190,3 @@ class _SearchParser:
                 )
 
         return (sort.order, sort.field)
-
-    async def _parse_filters(self) -> Filters:
-        assert self._query is not None, "query must be parsed before filters"
-
-        return await parse_filters(
-            self.kbid,
-            self.fetcher,
-            show_hidden=self.item.show_hidden,
-            security=self.item.security,
-            with_duplicates=self.item.with_duplicates,
-            filter_expression=self.item.filter_expression,
-            label_filters=self.item.filters,
-            keyword_filters=None,
-            resource_filters=self.item.resource_filters,
-            fields=self.item.fields,
-            range_creation_start=self.item.range_creation_start,
-            range_creation_end=self.item.range_creation_end,
-            range_modification_start=self.item.range_modification_start,
-            range_modification_end=self.item.range_modification_end,
-        )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/search.py
@@ -18,10 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from nidx_protos import nodereader_pb2
-
 from nucliadb.common.exceptions import InvalidQueryError
-from nucliadb.common.filter_expression import parse_expression
 from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.fetcher import Fetcher
 from nucliadb.search.search.query_parser.models import (
@@ -32,10 +29,8 @@ from nucliadb.search.search.query_parser.models import (
     UnitRetrieval,
     _TextQuery,
 )
-from nucliadb.search.search.query_parser.old_filters import OldFilterParams, parse_old_filters
-from nucliadb.search.search.utils import filter_hidden_resources, kb_security_enforced
+from nucliadb.search.search.query_parser.parsers.common import parse_filters
 from nucliadb_models import search as search_models
-from nucliadb_models.filters import FilterExpression
 from nucliadb_models.search import (
     SearchRequest,
     SortField,
@@ -184,52 +179,19 @@ class _SearchParser:
     async def _parse_filters(self) -> Filters:
         assert self._query is not None, "query must be parsed before filters"
 
-        has_old_filters = (
-            len(self.item.filters) > 0
-            or len(self.item.fields) > 0
-            or self.item.range_creation_start is not None
-            or self.item.range_creation_end is not None
-            or self.item.range_modification_start is not None
-            or self.item.range_modification_end is not None
-        )
-        if self.item.filter_expression is not None and has_old_filters:
-            raise InvalidQueryError("filter_expression", "Cannot mix old filters with filter_expression")
-
-        field_expr = None
-        paragraph_expr = None
-        filter_operator = nodereader_pb2.FilterOperator.AND
-
-        if has_old_filters:
-            old_filters = OldFilterParams(
-                label_filters=self.item.filters,
-                keyword_filters=[],
-                range_creation_start=self.item.range_creation_start,
-                range_creation_end=self.item.range_creation_end,
-                range_modification_start=self.item.range_modification_start,
-                range_modification_end=self.item.range_modification_end,
-                fields=self.item.fields,
-            )
-            field_expr, paragraph_expr = await parse_old_filters(old_filters, self.fetcher)
-
-        if self.item.filter_expression is not None:
-            if self.item.filter_expression.field:
-                field_expr = await parse_expression(self.item.filter_expression.field, self.kbid)
-            if self.item.filter_expression.paragraph:
-                paragraph_expr = await parse_expression(self.item.filter_expression.paragraph, self.kbid)
-            if self.item.filter_expression.operator == FilterExpression.Operator.OR:
-                filter_operator = nodereader_pb2.FilterOperator.OR
-            else:
-                filter_operator = nodereader_pb2.FilterOperator.AND
-
-        hidden = await filter_hidden_resources(self.kbid, self.item.show_hidden)
-        security = await kb_security_enforced(self.kbid, self.item.security)
-
-        return Filters(
-            facets=self.item.faceted,
-            field_expression=field_expr,
-            paragraph_expression=paragraph_expr,
-            filter_expression_operator=filter_operator,
-            security=security,
-            hidden=hidden,
+        return await parse_filters(
+            self.kbid,
+            self.fetcher,
+            show_hidden=self.item.show_hidden,
+            security=self.item.security,
             with_duplicates=self.item.with_duplicates,
+            filter_expression=self.item.filter_expression,
+            label_filters=self.item.filters,
+            keyword_filters=[],
+            resource_filters=self.item.resource_filters,
+            fields=self.item.fields,
+            range_creation_start=self.item.range_creation_start,
+            range_creation_end=self.item.range_creation_end,
+            range_modification_start=self.item.range_modification_start,
+            range_modification_end=self.item.range_modification_end,
         )

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/suggest.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/suggest.py
@@ -21,12 +21,10 @@ from datetime import datetime
 
 from nidx_protos import nodereader_pb2
 
-from nucliadb.common.exceptions import InvalidQueryError
-from nucliadb.common.filter_expression import add_and_expression, parse_expression
+from nucliadb.common.filter_expression import add_and_expression
 from nucliadb.search.search.metrics import query_parser_observer
 from nucliadb.search.search.query_parser.fetcher import Fetcher
-from nucliadb.search.search.query_parser.old_filters import OldFilterParams, parse_old_filters
-from nucliadb.search.search.utils import filter_hidden_resources, kb_security_enforced
+from nucliadb.search.search.query_parser.parsers.common import parse_filters
 from nucliadb_models.filters import FilterExpression
 from nucliadb_models.labels import LABEL_HIDDEN
 from nucliadb_models.search import (
@@ -46,7 +44,7 @@ async def parse_suggest(
     features: list[SuggestOptions],
     filter_expression: FilterExpression | None,
     fields: list[str],
-    filters: list[str],
+    label_filters: list[str],
     show_hidden: bool,
     range_creation_start: datetime | None = None,
     range_creation_end: datetime | None = None,
@@ -65,18 +63,9 @@ async def parse_suggest(
 
     request.top_k = MAX_SUGGEST_RESULTS
 
-    old = OldFilterParams(
-        label_filters=filters,
-        keyword_filters=[],
-        range_creation_start=range_creation_start,
-        range_creation_end=range_creation_end,
-        range_modification_start=range_modification_start,
-        range_modification_end=range_modification_end,
-        fields=fields,
-    )
     fetcher = Fetcher(
         kbid,
-        query="",
+        query=query,
         user_vector=None,
         vectorset=None,
         rephrase=False,
@@ -84,40 +73,38 @@ async def parse_suggest(
         generative_model=None,
         query_image=None,
     )
-    field_expr, _ = await parse_old_filters(old, fetcher)
-    if field_expr is not None and filter_expression is not None:
-        raise InvalidQueryError("filter_expression", "Cannot mix old filters with filter_expression")
 
-    if field_expr is not None:
-        request.field_filter.CopyFrom(field_expr)
+    filters = await parse_filters(
+        kbid,
+        fetcher,
+        show_hidden=show_hidden,
+        security=RequestSecurity(groups=security_groups) if security_groups is not None else None,
+        with_duplicates=False,  # unused
+        filter_expression=filter_expression,
+        label_filters=label_filters,
+        keyword_filters=[],
+        resource_filters=[],
+        fields=fields,
+        range_creation_start=range_creation_start,
+        range_creation_end=range_creation_end,
+        range_modification_start=range_modification_start,
+        range_modification_end=range_modification_end,
+    )
 
-    request_security = None
-    if security_groups is not None:
-        request_security = RequestSecurity(groups=security_groups)
-    security = await kb_security_enforced(kbid, request_security)
-    if security is not None:
-        request.security.access_groups.extend(security.groups)
+    if filters.security is not None:
+        request.security.access_groups.extend(filters.security.groups)
 
-    if filter_expression:
-        if filter_expression.field:
-            expr = await parse_expression(filter_expression.field, kbid)
-            if expr:
-                request.field_filter.CopyFrom(expr)
+    if filters.field_expression:
+        request.field_filter.CopyFrom(filters.field_expression)
+    if filters.paragraph_expression:
+        request.paragraph_filter.CopyFrom(filters.paragraph_expression)
+    if filters.json_expression is not None:
+        request.json_filter.CopyFrom(filters.json_expression)
+    request.filter_operator = filters.filter_expression_operator
 
-        if filter_expression.paragraph:
-            expr = await parse_expression(filter_expression.paragraph, kbid)
-            if expr:
-                request.paragraph_filter.CopyFrom(expr)
-
-        if filter_expression.operator == FilterExpression.Operator.OR:
-            request.filter_operator = nodereader_pb2.FilterOperator.OR
-        else:
-            request.filter_operator = nodereader_pb2.FilterOperator.AND
-
-    hidden = await filter_hidden_resources(kbid, show_hidden)
-    if hidden is not None:
+    if filters.hidden is not None:
         expr = nodereader_pb2.FilterExpression()
-        if hidden:
+        if filters.hidden:
             expr.facet.facet = LABEL_HIDDEN
         else:
             expr.bool_not.facet.facet = LABEL_HIDDEN

--- a/nucliadb/src/nucliadb/search/search/query_parser/parsers/suggest.py
+++ b/nucliadb/src/nucliadb/search/search/query_parser/parsers/suggest.py
@@ -82,8 +82,8 @@ async def parse_suggest(
         with_duplicates=False,  # unused
         filter_expression=filter_expression,
         label_filters=label_filters,
-        keyword_filters=[],
-        resource_filters=[],
+        keyword_filters=None,
+        resource_filters=None,
         fields=fields,
         range_creation_start=range_creation_start,
         range_creation_end=range_creation_end,

--- a/nucliadb/tests/search/integration/api/v1/test_retrieve.py
+++ b/nucliadb/tests/search/integration/api/v1/test_retrieve.py
@@ -286,11 +286,11 @@ async def test_retrieve_query_parsing() -> None:
         patch("nucliadb.search.search.query_parser.parsers.retrieve.ParsedQuery", new=MockedParsedQuery),
         patch("nucliadb.search.search.query_parser.parsers.retrieve.Fetcher", new=Fetcher),
         patch(
-            "nucliadb.search.search.query_parser.parsers.retrieve.filter_hidden_resources",
+            "nucliadb.search.search.query_parser.parsers.common.filter_hidden_resources",
             return_value=False,
         ),
         patch(
-            "nucliadb.search.search.query_parser.parsers.retrieve.kb_security_enforced",
+            "nucliadb.search.search.query_parser.parsers.common.kb_security_enforced",
             return_value=None,
         ),
     ):

--- a/nucliadb/tests/search/unit/search/test_query_parsing.py
+++ b/nucliadb/tests/search/unit/search/test_query_parsing.py
@@ -38,7 +38,7 @@ from nucliadb_models.search import FindRequest
 @pytest.fixture(scope="function", autouse=True)
 def disable_hidden_resources_check():
     with patch(
-        "nucliadb.search.search.query_parser.parsers.find.filter_hidden_resources", return_value=False
+        "nucliadb.search.search.query_parser.parsers.common.filter_hidden_resources", return_value=False
     ):
         yield
 

--- a/nucliadb/tests/search/unit/test_rank_fusion.py
+++ b/nucliadb/tests/search/unit/test_rank_fusion.py
@@ -52,7 +52,7 @@ from nucliadb_protos.utils_pb2 import RelationMetadata
 @pytest.fixture(scope="function", autouse=True)
 def disable_hidden_resources_check():
     with patch(
-        "nucliadb.search.search.query_parser.parsers.find.filter_hidden_resources", return_value=False
+        "nucliadb.search.search.query_parser.parsers.common.filter_hidden_resources", return_value=False
     ):
         yield
 


### PR DESCRIPTION
### Description
Unify filter parsing across endpoints and fix inconsistencies in the way:
- Support JSON (key-value) filtering in /search and /suggest
- Fix /search resource_filters (ignored)
- Fix GET /suggest paragraph filters (through `filters` field) 

### How was this PR tested?
Describe how you tested this PR.
