### PR TITLE
Reprocess resource in field batches

### DIFF
--- a/nucliadb/src/nucliadb/models/internal/processing.py
+++ b/nucliadb/src/nucliadb/models/internal/processing.py
@@ -123,10 +123,6 @@ class PushConversation(BaseModel):
     extract_strategy: str | None = None
     split_strategy: str | None = None
     classification_labels: list[ClassificationLabel] = []
-    replace_generated_fields: bool = Field(
-        default=False,
-        description="If true, the generated conversation from this field will be fully replaced by the new messages generated from this conversation. If false, the new messages will be appended to the existing generated conversation.",
-    )
 
 
 class PushGeneratedConversation(BaseModel):

--- a/nucliadb/src/nucliadb/models/internal/processing.py
+++ b/nucliadb/src/nucliadb/models/internal/processing.py
@@ -123,6 +123,10 @@ class PushConversation(BaseModel):
     extract_strategy: str | None = None
     split_strategy: str | None = None
     classification_labels: list[ClassificationLabel] = []
+    replace_generated_fields: bool = Field(
+        default=False,
+        description="If true, the generated conversation from this field will be fully replaced by the new messages generated from this conversation. If false, the new messages will be appended to the existing generated conversation.",
+    )
 
 
 class PushGeneratedConversation(BaseModel):

--- a/nucliadb/src/nucliadb/writer/api/constants.py
+++ b/nucliadb/src/nucliadb/writer/api/constants.py
@@ -40,6 +40,7 @@ X_MD5 = Header(
 )
 X_REPROCESS_BATCH_SIZE = Header(
     description="Number of fields to process per batch during resource reprocessing.",
+    include_in_schema=False,
 )
 X_PASSWORD = Header(
     min_length=1, description="If the file is password protected, the password must be provided here."

--- a/nucliadb/src/nucliadb/writer/api/constants.py
+++ b/nucliadb/src/nucliadb/writer/api/constants.py
@@ -38,6 +38,10 @@ X_MD5 = Header(
     max_length=32,
     description="MD5 hash of the file being uploaded. This is used to check if the file has been uploaded before.",
 )
+X_REPROCESS_BATCH_SIZE = Header(
+    default=50,
+    description="Number of fields to process per batch during resource reprocessing.",
+)
 X_PASSWORD = Header(
     min_length=1, description="If the file is password protected, the password must be provided here."
 )

--- a/nucliadb/src/nucliadb/writer/api/constants.py
+++ b/nucliadb/src/nucliadb/writer/api/constants.py
@@ -39,7 +39,6 @@ X_MD5 = Header(
     description="MD5 hash of the file being uploaded. This is used to check if the file has been uploaded before.",
 )
 X_REPROCESS_BATCH_SIZE = Header(
-    default=50,
     description="Number of fields to process per batch during resource reprocessing.",
 )
 X_PASSWORD = Header(

--- a/nucliadb/src/nucliadb/writer/api/v1/field.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/field.py
@@ -52,7 +52,7 @@ from nucliadb.writer.resource.field import (
     REPROCESSABLE_FIELD_TYPES,
     ResourceClassifications,
     atomic_get_stored_resource_classifications,
-    extract_fields,
+    collect_fields_for_reprocessing,
     parse_conversation_field,
     parse_file_field,
     parse_key_value_field,
@@ -753,17 +753,11 @@ async def _reprocess_resource_field(
         file_password_overrides = None
         if x_file_password is not None:
             file_password_overrides = {field_id: x_file_password}
-        include_generated_conversations_for_source_fields = None
-        if field_type_pb == resources_pb2.FieldType.CONVERSATION:
-            include_generated_conversations_for_source_fields = {field_id}
-        await extract_fields(
+        await collect_fields_for_reprocessing(
             resource=resource,
             toprocess=toprocess,
             selected_fields={(field_type_pb, field_id)},
             file_password_overrides=file_password_overrides,
-            include_generated_conversations_for_source_fields=(
-                include_generated_conversations_for_source_fields
-            ),
         )
 
     writer = BrokerMessage()

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -58,6 +58,7 @@ from nucliadb.writer.resource.field import (
     ResourceClassifications,
     atomic_get_stored_resource_classifications,
     collect_fields_for_reprocessing,
+    is_generated_conversation_field,
     parse_fields,
 )
 from nucliadb.writer.resource.origin import parse_extra, parse_origin
@@ -469,7 +470,7 @@ async def _reprocess_resource(
     writer.basic.metadata.useful = True
     writer.basic.metadata.status = Metadata.Status.PENDING
 
-    # First pass: collect all reprocessable fields and prepare writer message
+    # First pass: collect all reprocessable field ids and prepare writer message
     all_reprocessable_fields: list[tuple[int, str]] = []
     async with driver.ro_transaction() as txn:
         kb = KnowledgeBox(txn, storage, kbid)
@@ -481,6 +482,12 @@ async def _reprocess_resource(
         for field_type, field_id in resource_fields.keys():
             if field_type not in REPROCESSABLE_FIELD_TYPES:
                 continue
+
+            if is_generated_conversation_field(field_type, field_id):
+                # On reprocessing the full resource, we don't want to send the generated conversation
+                # fields, as they will be regenerated from the source conversation field. So we skip them.
+                continue
+
             all_reprocessable_fields.append((field_type, field_id))
             writer.field_statuses.append(
                 FieldIDStatus(

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -35,7 +35,7 @@ from nucliadb.common.maindb.utils import get_driver
 from nucliadb.ingest.orm.knowledgebox import KnowledgeBox
 from nucliadb.models.internal.processing import ProcessingInfo, PushPayload, Source
 from nucliadb.writer import SERVICE_NAME, logger
-from nucliadb.writer.api.constants import X_NUCLIADB_USER, X_SKIP_STORE
+from nucliadb.writer.api.constants import X_NUCLIADB_USER, X_REPROCESS_BATCH_SIZE, X_SKIP_STORE
 from nucliadb.writer.api.v1 import transaction
 from nucliadb.writer.api.v1.router import (
     KB_PREFIX,
@@ -69,7 +69,7 @@ from nucliadb_models.writer import (
     ResourceUpdated,
     UpdateResourcePayload,
 )
-from nucliadb_protos.resources_pb2 import FieldID, Metadata
+from nucliadb_protos.resources_pb2 import FieldID, FieldType, Metadata
 from nucliadb_protos.writer_pb2 import BrokerMessage, FieldIDStatus, FieldStatus, IndexResource
 from nucliadb_telemetry.errors import capture_exception
 from nucliadb_utils.authentication import requires
@@ -397,10 +397,16 @@ async def reprocess_resource_rslug_prefix(
         default=False,
         description="Reset the title of the resource so that the file or link computed titles are set after processing.",
     ),
+    x_reprocess_batch_size: Annotated[int, X_REPROCESS_BATCH_SIZE] = 20,
 ):
     rid = await get_rid_from_slug_or_raise_error(kbid, rslug)
     return await _reprocess_resource(
-        request, kbid, rid, x_nucliadb_user=x_nucliadb_user, reset_title=reset_title
+        request,
+        kbid,
+        rid,
+        x_nucliadb_user=x_nucliadb_user,
+        reset_title=reset_title,
+        field_batch_size=x_reprocess_batch_size,
     )
 
 
@@ -422,9 +428,15 @@ async def reprocess_resource_rid_prefix(
         default=False,
         description="Reset the title of the resource so that the file or link computed titles are set after processing.",
     ),
+    x_reprocess_batch_size: Annotated[int, X_REPROCESS_BATCH_SIZE] = 20,
 ):
     return await _reprocess_resource(
-        request, kbid, rid, x_nucliadb_user=x_nucliadb_user, reset_title=reset_title
+        request,
+        kbid,
+        rid,
+        x_nucliadb_user=x_nucliadb_user,
+        reset_title=reset_title,
+        field_batch_size=x_reprocess_batch_size,
     )
 
 
@@ -437,40 +449,39 @@ async def _reprocess_resource(
         default=False,
         description="Reset the title of the resource so that the file or link computed titles are set after processing.",
     ),
+    field_batch_size: int = 20,
 ):
     await validate_rid_exists_or_raise_error(kbid, rid)
     await maybe_back_pressure(kbid, resource_uuid=rid)
 
     partitioning = get_partitioning()
-
     partition = partitioning.generate_partition(kbid, rid)
-
-    toprocess = PushPayload(
-        uuid=rid,
-        kbid=kbid,
-        partition=partition,
-        userid=x_nucliadb_user,
-    )
-
-    toprocess.kbid = kbid
-    toprocess.uuid = rid
-    toprocess.source = Source.HTTP
 
     storage = await get_storage(service_name=SERVICE_NAME)
     driver = get_driver()
 
-    writer = BrokerMessage()
+    writer = BrokerMessage(
+        kbid=kbid,
+        uuid=rid,
+        source=BrokerMessage.MessageSource.WRITER,
+    )
+    writer.basic.reset_title = reset_title
+    writer.basic.metadata.useful = True
+    writer.basic.metadata.status = Metadata.Status.PENDING
+
+    # First pass: collect all reprocessable fields and prepare writer message
+    all_reprocessable_fields: list[tuple[int, str]] = []
     async with driver.ro_transaction() as txn:
         kb = KnowledgeBox(txn, storage, kbid)
-
         resource = await kb.get(rid)
         if resource is None:
             raise HTTPException(status_code=404, detail="Resource does not exist")
 
-        await extract_fields(resource=resource, toprocess=toprocess)
-        for field_type, field_id in resource.fields.keys():
+        resource_fields = await resource.get_fields()
+        for field_type, field_id in resource_fields.keys():
             if field_type not in REPROCESSABLE_FIELD_TYPES:
                 continue
+            all_reprocessable_fields.append((field_type, field_id))
             writer.field_statuses.append(
                 FieldIDStatus(
                     id=FieldID(field_type=field_type, field=field_id),
@@ -478,17 +489,42 @@ async def _reprocess_resource(
                 )
             )
 
-    writer.kbid = kbid
-    writer.uuid = rid
-    writer.source = BrokerMessage.MessageSource.WRITER
-    if reset_title:
-        writer.basic.reset_title = True
-    writer.basic.metadata.useful = True
-    writer.basic.metadata.status = Metadata.Status.PENDING
-    await transaction.commit(writer, partition, wait=False)
-    processing_info = await send_to_process(toprocess, partition)
+    # Second pass: batch and send processing requests
+    # Process fields in batches to reduce memory usage and improve resilience
+    processing_info = None
 
-    return ResourceUpdated(seqid=processing_info.seqid)
+    for i in range(0, len(all_reprocessable_fields), field_batch_size):
+        batch_fields = set(all_reprocessable_fields[i : i + field_batch_size])
+
+        # Identify conversation fields in this batch to include generated conversations
+        conversation_fields_in_batch = {
+            field_id for field_type, field_id in batch_fields if field_type == FieldType.CONVERSATION
+        }
+
+        toprocess = PushPayload(
+            uuid=rid,
+            kbid=kbid,
+            partition=partition,
+            userid=x_nucliadb_user,
+            source=Source.HTTP,
+        )
+
+        async with driver.ro_transaction() as txn:
+            resource.txn = txn
+            await extract_fields(
+                resource=resource,
+                toprocess=toprocess,
+                selected_fields=batch_fields,
+                include_generated_conversations_for_source_fields=conversation_fields_in_batch or None,
+            )
+
+        processing_info = await send_to_process(toprocess, partition)
+
+    # Commit writer message only if there were fields to process
+    if all_reprocessable_fields:
+        await transaction.commit(writer, partition, wait=False)
+
+    return ResourceUpdated(seqid=processing_info.seqid if processing_info else None)
 
 
 @api.delete(

--- a/nucliadb/src/nucliadb/writer/api/v1/resource.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/resource.py
@@ -57,7 +57,7 @@ from nucliadb.writer.resource.field import (
     REPROCESSABLE_FIELD_TYPES,
     ResourceClassifications,
     atomic_get_stored_resource_classifications,
-    extract_fields,
+    collect_fields_for_reprocessing,
     parse_fields,
 )
 from nucliadb.writer.resource.origin import parse_extra, parse_origin
@@ -69,7 +69,7 @@ from nucliadb_models.writer import (
     ResourceUpdated,
     UpdateResourcePayload,
 )
-from nucliadb_protos.resources_pb2 import FieldID, FieldType, Metadata
+from nucliadb_protos.resources_pb2 import FieldID, Metadata
 from nucliadb_protos.writer_pb2 import BrokerMessage, FieldIDStatus, FieldStatus, IndexResource
 from nucliadb_telemetry.errors import capture_exception
 from nucliadb_utils.authentication import requires
@@ -495,12 +495,6 @@ async def _reprocess_resource(
 
     for i in range(0, len(all_reprocessable_fields), field_batch_size):
         batch_fields = set(all_reprocessable_fields[i : i + field_batch_size])
-
-        # Identify conversation fields in this batch to include generated conversations
-        conversation_fields_in_batch = {
-            field_id for field_type, field_id in batch_fields if field_type == FieldType.CONVERSATION
-        }
-
         toprocess = PushPayload(
             uuid=rid,
             kbid=kbid,
@@ -508,16 +502,13 @@ async def _reprocess_resource(
             userid=x_nucliadb_user,
             source=Source.HTTP,
         )
-
         async with driver.ro_transaction() as txn:
             resource.txn = txn
-            await extract_fields(
+            await collect_fields_for_reprocessing(
                 resource=resource,
                 toprocess=toprocess,
                 selected_fields=batch_fields,
-                include_generated_conversations_for_source_fields=conversation_fields_in_batch or None,
             )
-
         processing_info = await send_to_process(toprocess, partition)
 
     # Commit writer message only if there were fields to process

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -229,6 +229,8 @@ async def _to_push_conversationfield(
     full_conversation = PushConversation(
         messages=[],
         classification_labels=classification_labels,
+        # When reprocessing a conversation field, we always want to replace all other possible generated conversation fields.
+        replace_generated_fields=True,
     )
     for page in range(0, metadata.pages):
         conversation_pb = await field.get_value(page + 1)
@@ -560,7 +562,10 @@ async def parse_conversation_field(
     storage = await get_storage(service_name=SERVICE_NAME)
     processing = get_processing()
     field_value = resources_pb2.Conversation(replace_field=replace_field)
-    convs = processing_models.PushConversation()
+    convs = processing_models.PushConversation(
+        # If we are replacing the conversation, we also want to replace all other possible generated conversation fields.
+        replace_generated_fields=replace_field,
+    )
     for message in conversation_field.messages:
         # Message content
         processing_message = processing_models.PushMessage(

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -663,9 +663,8 @@ async def add_generated_conversations_to_pushpayload(
     generated_fields = [
         field_id.field
         for field_id in all_field_ids.fields
-        if field_id.field_type == resources_pb2.FieldType.CONVERSATION
+        if is_generated_conversation_field(field_id.field_type, field_id.field)
         and field_id.field != source_field_id
-        and field_id.field.startswith("da-")
         and source_field_id in field_id.field
     ]
     if len(generated_fields) == 0:
@@ -686,6 +685,12 @@ async def add_generated_conversations_to_pushpayload(
             source_field_id=source_field_id,
             conversationfield=gconversation,
         )
+
+
+def is_generated_conversation_field(
+    field_type: resources_pb2.FieldType.ValueType, field_id: str
+) -> bool:
+    return field_type == resources_pb2.FieldType.CONVERSATION and field_id.startswith("da-")
 
 
 async def _get_resource(kbid: str, rid: str, storage: Storage) -> ORMResource | None:

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -123,12 +123,11 @@ async def extract_file_field(
     )
 
 
-async def extract_fields(
+async def collect_fields_for_reprocessing(
     resource: ORMResource,
     toprocess: PushPayload,
     selected_fields: set[tuple[int, str]] | None = None,
     file_password_overrides: dict[str, str] | None = None,
-    include_generated_conversations_for_source_fields: set[str] | None = None,
 ) -> list[tuple[int, str]]:
     processing = get_processing()
     storage = await get_storage(service_name=SERVICE_NAME)
@@ -184,18 +183,6 @@ async def extract_fields(
             if full_conversation is None:
                 continue
             toprocess.conversationfield[field_id] = full_conversation
-            if (
-                include_generated_conversations_for_source_fields is not None
-                and field_id in include_generated_conversations_for_source_fields
-            ):
-                await add_generated_conversations_to_pushpayload(
-                    processing,
-                    storage,
-                    toprocess.kbid,
-                    toprocess.uuid,
-                    field_id,
-                    toprocess,
-                )
             extracted_fields.append((field_type, field_id))
 
     return extracted_fields

--- a/nucliadb/src/nucliadb/writer/resource/field.py
+++ b/nucliadb/src/nucliadb/writer/resource/field.py
@@ -229,8 +229,6 @@ async def _to_push_conversationfield(
     full_conversation = PushConversation(
         messages=[],
         classification_labels=classification_labels,
-        # When reprocessing a conversation field, we always want to replace all other possible generated conversation fields.
-        replace_generated_fields=True,
     )
     for page in range(0, metadata.pages):
         conversation_pb = await field.get_value(page + 1)
@@ -562,10 +560,7 @@ async def parse_conversation_field(
     storage = await get_storage(service_name=SERVICE_NAME)
     processing = get_processing()
     field_value = resources_pb2.Conversation(replace_field=replace_field)
-    convs = processing_models.PushConversation(
-        # If we are replacing the conversation, we also want to replace all other possible generated conversation fields.
-        replace_generated_fields=replace_field,
-    )
+    convs = processing_models.PushConversation()
     for message in conversation_field.messages:
         # Message content
         processing_message = processing_models.PushMessage(

--- a/nucliadb/tests/nucliadb/integration/test_api.py
+++ b/nucliadb/tests/nucliadb/integration/test_api.py
@@ -1326,7 +1326,7 @@ async def test_link_computed_titles_are_automatically_set_to_resource_title(
     resp = await nucliadb_writer.post(
         f"/kb/{kbid}/resources",
         json={
-            "link": {
+            "links": {
                 "mylink": {
                     "uri": "https://wikipedia.org/Lionel_Messi",
                 }
@@ -1357,7 +1357,7 @@ async def test_link_computed_titles_are_automatically_set_to_resource_title(
         f"/kb/{kbid}/resources",
         json={
             "title": "Luis Suarez - Wikipedia",
-            "link": {
+            "links": {
                 "mylink": {
                     "uri": "https://wikipedia.org/Luis_Suarez",
                 }

--- a/nucliadb/tests/nucliadb/integration/test_conversation.py
+++ b/nucliadb/tests/nucliadb/integration/test_conversation.py
@@ -1377,7 +1377,7 @@ async def test_append_messages_sends_generated_conversation_to_processing(
 
 
 @pytest.mark.deploy_modes("standalone")
-async def test_reprocess_conversation_field_sends_generated_conversation_to_processing(
+async def test_reprocess_conversation_field_does_not_send_generated_conversation_to_processing(
     nucliadb_writer: AsyncClient,
     nucliadb_ingest_grpc: WriterStub,
     standalone_knowledgebox: str,
@@ -1457,21 +1457,7 @@ async def test_reprocess_conversation_field_sends_generated_conversation_to_proc
     assert len(processing.values["send_to_process"]) == 1
     push_payload = cast(PushPayload, processing.values["send_to_process"][0][0])
 
+    # Only source conversations are sent to processing
+    assert len(push_payload.conversationfield) == 1
     assert source_conv_id in push_payload.conversationfield
-    assert generated_conv_id in push_payload.generated_conversationfield
-    assert push_payload.generated_conversationfield[generated_conv_id].source_field_id == source_conv_id
-    assert (
-        len(push_payload.generated_conversationfield[generated_conv_id].conversationfield.messages) == 2
-    )
-    assert (
-        push_payload.generated_conversationfield[generated_conv_id]
-        .conversationfield.messages[0]
-        .content.text
-        == "It's interesting to think about how far we've come in such a short time."
-    )
-    assert (
-        push_payload.generated_conversationfield[generated_conv_id]
-        .conversationfield.messages[1]
-        .content.text
-        == "Indeed! The evolution of technology has been rapid and transformative, shaping the way we live and work in profound ways."
-    )
+    assert len(push_payload.generated_conversationfield) == 0


### PR DESCRIPTION
### Description

When reprocessing a resource, send processing requests in batches of fields.
Skip sending generated conversation fields, as they will be regenerated again off the source fields.

[sc-14838]

### How was this PR tested?
Describe how you tested this PR.
