### PR TITLE
Fix conversation field replace logic

### DIFF
--- a/nucliadb/src/nucliadb/common/datamanagers/conversations.py
+++ b/nucliadb/src/nucliadb/common/datamanagers/conversations.py
@@ -229,9 +229,18 @@ async def delete_field(
     field_id: str,
 ) -> None:
     async with _pg_cursor(txn) as cur:
+        # Delete all conversation pages for this field (including the sentinel page = 0)
         await cur.execute(
             """
             DELETE FROM kb_conversations
+            WHERE kbid = %(kbid)s AND rid = %(rid)s AND field_type = 'c' AND field_id = %(field_id)s
+            """,
+            {"kbid": kbid, "rid": rid, "field_id": field_id},
+        )
+        # Delete the FieldConversation metadata for this field (if it exists)
+        await cur.execute(
+            """
+            DELETE FROM kb_fields
             WHERE kbid = %(kbid)s AND rid = %(rid)s AND field_type = 'c' AND field_id = %(field_id)s
             """,
             {"kbid": kbid, "rid": rid, "field_id": field_id},

--- a/nucliadb/src/nucliadb/ingest/fields/conversation.py
+++ b/nucliadb/src/nucliadb/ingest/fields/conversation.py
@@ -51,6 +51,9 @@ class Conversation(Field[PBConversation]):
         self.metadata = None
 
     async def delete_value(self):
+        """
+        Delete all pages of the conversation, its metadata and the splits metadata.
+        """
         await datamanagers.conversations.delete_field(
             self.resource.txn,
             kbid=self.kbid,

--- a/nucliadb/tests/ingest/unit/fields/test_conversation.py
+++ b/nucliadb/tests/ingest/unit/fields/test_conversation.py
@@ -170,3 +170,56 @@ async def test_get_value(resource):
         assert page2
         assert len(page2.messages) == 102
         assert [m.ident for m in page2.messages] == [str(i) for i in range(198, 300)]
+
+
+async def test_replace_field_starts_at_page_1(resource):
+    """Regression: replace_field=True must not leave page 1 missing.
+
+    Before the fix, delete_value() cleared kb_conversations but left the stale
+    FieldConversation row (pages=N) in kb_fields.  A subsequent set_value then
+    fetched that stale metadata, hit PageNotFound for the last page, and
+    incremented pages to N+1, so new messages landed on page 2 with page 1
+    never written.
+    """
+    conv = Conversation("faq", resource)
+
+    # Initial write: 1 page, 2 messages.
+    initial = PBConversation()
+    initial.messages.extend(
+        [
+            get_message("m1", "user", "bot", "hello"),
+            get_message("m2", "bot", "user", "hi"),
+        ]
+    )
+    await conv.set_value(initial)
+
+    metadata = await conv.get_metadata()
+    assert metadata is not None
+    assert metadata.pages == 1
+
+    # Simulate reprocessing: replace_field=True replaces all previous content.
+    replacement = PBConversation()
+    replacement.replace_field = True
+    replacement.messages.extend(
+        [
+            get_message("r1", "user", "bot", "new hello"),
+            get_message("r2", "bot", "user", "new hi"),
+        ]
+    )
+    # Reset in-memory cache so set_value re-fetches metadata from DB.
+    conv.metadata = None
+    conv.value = {}
+    conv._splits_metadata = None
+    await conv.set_value(replacement)
+
+    metadata = await conv.get_metadata()
+    assert metadata is not None
+    assert metadata.pages == 1, f"expected pages=1 after replace_field, got {metadata.pages}"
+    assert metadata.total == 2
+
+    page1 = await conv.get_value(page=1)
+    assert page1 is not None, "page 1 is missing after replace_field"
+    assert [m.ident for m in page1.messages] == ["r1", "r2"]
+
+    page2 = await conv.get_value(page=2)
+    assert page2 is None, "unexpected page 2 after replace_field with only 2 messages"


### PR DESCRIPTION
### Description
When replacing conversation fields (on PUT or reprocess operations), the conversation metadata was not deleted and that made the first page be "2" instead of "1".

### How was this PR tested?
Describe how you tested this PR.
