### PR TITLE
Augment messages content

### DIFF
--- a/nucliadb/src/nucliadb/common/models_utils/from_proto.py
+++ b/nucliadb/src/nucliadb/common/models_utils/from_proto.py
@@ -22,7 +22,7 @@ from typing import Any
 from google.protobuf.json_format import MessageToDict
 
 from nucliadb_models.common import Classification, FieldID, FieldTypeName, QuestionAnswers
-from nucliadb_models.conversation import Conversation, FieldConversation
+from nucliadb_models.conversation import Conversation, FieldConversation, MessageFormat
 from nucliadb_models.entities import EntitiesGroup, EntitiesGroupSummary, Entity
 from nucliadb_models.extracted import (
     ExtractedText,
@@ -391,6 +391,20 @@ def conversation_page(
         for attachment_field in conv_message.get("content", {}).get("attachments_fields", []):
             attachment_field["field_type"] = attachment_field["field_type"].lower()
     return Conversation(total=total, pages=pages, page=page, **as_dict)
+
+
+def message_content_format(fmt: resources_pb2.MessageContent.Format.ValueType) -> MessageFormat:
+    try:
+        return {
+            resources_pb2.MessageContent.Format.PLAIN: MessageFormat.PLAIN,
+            resources_pb2.MessageContent.Format.HTML: MessageFormat.HTML,
+            resources_pb2.MessageContent.Format.MARKDOWN: MessageFormat.MARKDOWN,
+            resources_pb2.MessageContent.Format.RST: MessageFormat.RST,
+            resources_pb2.MessageContent.Format.KEEP_MARKDOWN: MessageFormat.KEEP_MARKDOWN,
+            resources_pb2.MessageContent.Format.JSON: MessageFormat.JSON,
+        }[fmt]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported message content format: {fmt}") from exc
 
 
 def field_conversation(message: resources_pb2.FieldConversation) -> FieldConversation:

--- a/nucliadb/src/nucliadb/models/internal/augment.py
+++ b/nucliadb/src/nucliadb/models/internal/augment.py
@@ -34,7 +34,7 @@ from nucliadb.common.ids import FieldId, ParagraphId
 from nucliadb_models import filters
 from nucliadb_models.augment import ResourceId
 from nucliadb_models.common import FieldTypeName
-from nucliadb_models.conversation import FieldConversation
+from nucliadb_models.conversation import FieldConversation, MessageFormat
 from nucliadb_models.file import FieldFile
 from nucliadb_models.link import FieldLink
 from nucliadb_models.metadata import Extra, Origin
@@ -282,6 +282,17 @@ class MessageSelector(BaseModel):
         return self
 
 
+class MessagesSelector(BaseModel):
+    """Selects the conversation field messages specified by the message ids."""
+
+    name: Literal["messages"] = "messages"
+
+    ids: list[str] = Field(
+        default_factory=list,
+        description="List of message identifiers to select",
+    )
+
+
 class PageSelector(BaseModel):
     """Selects all messages from the page of the message specified by the field
     id.
@@ -338,6 +349,7 @@ class FullSelector(BaseModel):
 ConversationSelector = Annotated[
     (
         Annotated[MessageSelector, Tag("message")]
+        | Annotated[MessagesSelector, Tag("messages")]
         | Annotated[PageSelector, Tag("page")]
         | Annotated[NeighboursSelector, Tag("neighbours")]
         | Annotated[WindowSelector, Tag("window")]
@@ -351,6 +363,9 @@ ConversationSelector = Annotated[
 class ConversationText(FieldText):
     prop: Literal["text"] = "text"
     selector: ConversationSelector
+    content_text: bool = (
+        False  # Controls whether to return the content or the extracted text for the messages
+    )
 
 
 class ConversationAttachments(SelectProp):
@@ -589,6 +604,8 @@ class AugmentedLinkField(BaseAugmentedField):
 class AugmentedConversationMessage:
     ident: str
     text: str | None = None
+    content_text: str | None = None
+    content_format: MessageFormat | None = None
     attachments: list[FieldId] | None = None
 
 

--- a/nucliadb/src/nucliadb/search/api/v1/augment.py
+++ b/nucliadb/src/nucliadb/search/api/v1/augment.py
@@ -47,6 +47,7 @@ from nucliadb.models.internal.augment import (
     FileThumbnail,
     FullSelector,
     MessageSelector,
+    MessagesSelector,
     Metadata,
     Paragraph,
     ParagraphAugment,
@@ -250,7 +251,11 @@ def parse_first_augments(item: AugmentRequest) -> list[Augment]:
 
             if field_augment.full_conversation:
                 selector = FullSelector()
-                conversation_select.append(ConversationText(selector=selector))
+                conversation_select.append(
+                    ConversationText(
+                        selector=selector, content_text=field_augment.conversation_message_content_text
+                    )
+                )
                 if (
                     field_augment.conversation_text_attachments
                     or field_augment.conversation_image_attachments
@@ -262,14 +267,36 @@ def parse_first_augments(item: AugmentRequest) -> list[Augment]:
                 # requested by the user
                 first_selector = MessageSelector(index="first")
                 window_selector = WindowSelector(size=field_augment.max_conversation_messages)
-                conversation_select.append(ConversationText(selector=first_selector))
-                conversation_select.append(ConversationText(selector=window_selector))
+                conversation_select.append(
+                    ConversationText(
+                        selector=first_selector,
+                        content_text=field_augment.conversation_message_content_text,
+                    )
+                )
+                conversation_select.append(
+                    ConversationText(
+                        selector=window_selector,
+                        content_text=field_augment.conversation_message_content_text,
+                    )
+                )
                 if (
                     field_augment.conversation_text_attachments
                     or field_augment.conversation_image_attachments
                 ):
                     conversation_select.append(ConversationAttachments(selector=first_selector))
                     conversation_select.append(ConversationAttachments(selector=window_selector))
+
+            elif field_augment.conversation_message_content_text:
+                # If no max_conversation_messages or full_conversation is specified,
+                # but content_text is requested, get the messages by their ids.
+                idents = [f.subfield_id for f in given if f.subfield_id is not None]
+                if len(idents) > 0:
+                    conversation_select.append(
+                        ConversationText(
+                            selector=MessagesSelector(ids=idents),
+                            content_text=True,
+                        )
+                    )
 
             if field_augment.conversation_answer_or_messages_after:
                 conversation_select.append(ConversationAnswerOrAfter())
@@ -487,7 +514,8 @@ def build_augment_response(item: AugmentRequest, augmented: Augmented) -> Augmen
                     conversation.messages.append(
                         AugmentedConversationMessage(
                             ident=m.ident,
-                            text=m.text,
+                            text=m.content_text or m.text,
+                            format=m.content_format,
                             attachments=attachments,
                         )
                     )

--- a/nucliadb/src/nucliadb/search/augmentor/fields.py
+++ b/nucliadb/src/nucliadb/search/augmentor/fields.py
@@ -55,6 +55,7 @@ from nucliadb.models.internal.augment import (
     FileThumbnail,
     FullSelector,
     MessageSelector,
+    MessagesSelector,
     NeighboursSelector,
     PageSelector,
     WindowSelector,
@@ -280,8 +281,10 @@ async def db_augment_conversation_field(
 
     for prop in select:
         if isinstance(prop, FieldText):
+            extracted_text_selected = True
             if isinstance(prop, ConversationText):
                 selector = prop.selector
+                extracted_text_selected = prop.content_text is False
             else:
                 # when asking for the conversation text without details, we
                 # choose the message if a split is provided in the id or the
@@ -291,16 +294,24 @@ async def db_augment_conversation_field(
                 else:
                     selector = FullSelector()
 
-            # gather the text from each message matching the selector
-            extracted_text_pb = await cache.get_field_extracted_text_pb(field)
+            # gather the extracted or raw content text from each message matching the selector
+            extracted_text_pb = None
+            if extracted_text_selected:
+                extracted_text_pb = await cache.get_field_extracted_text_pb(field)
             async for page, index, message in conversation_selector(field, field_id, selector):
                 augmented_message = messages.setdefault(
-                    (page, index), AugmentedConversationMessage(ident=message.ident)
+                    (page, index),
+                    AugmentedConversationMessage(
+                        ident=message.ident,
+                    ),
                 )
                 if extracted_text_pb is not None and message.ident in extracted_text_pb.split_text:
                     augmented_message.text = extracted_text_pb.split_text[message.ident]
                 else:
-                    augmented_message.text = message.content.text
+                    augmented_message.content_text = message.content.text
+                    augmented_message.content_format = from_proto.message_content_format(
+                        message.content.format
+                    )
 
         elif isinstance(prop, FieldValue):
             db_value = await field.get_metadata()
@@ -322,7 +333,10 @@ async def db_augment_conversation_field(
             # and collect all the attachment references
             async for page, index, message in conversation_selector(field, field_id, prop.selector):
                 augmented_message = messages.setdefault(
-                    (page, index), AugmentedConversationMessage(ident=message.ident)
+                    (page, index),
+                    AugmentedConversationMessage(
+                        ident=message.ident,
+                    ),
                 )
                 augmented_message.attachments = []
                 for ref in message.content.attachments_fields:
@@ -334,10 +348,16 @@ async def db_augment_conversation_field(
         elif isinstance(prop, ConversationAnswerOrAfter):
             async for page, index, message in conversation_answer_or_after(field, field_id):
                 augmented_message = messages.setdefault(
-                    (page, index), AugmentedConversationMessage(ident=message.ident)
+                    (page, index),
+                    AugmentedConversationMessage(
+                        ident=message.ident,
+                    ),
                 )
                 if not augmented_message.text:
-                    augmented_message.text = message.content.text
+                    augmented_message.content_text = message.content.text
+                    augmented_message.content_format = from_proto.message_content_format(
+                        message.content.format
+                    )
 
         else:  # pragma: no cover
             assert_never(prop)
@@ -477,9 +497,6 @@ async def find_conversation_message(
     field: Conversation, ident: str
 ) -> tuple[int, int, resources_pb2.Message] | None:
     """Find a message in the conversation identified by `ident`."""
-    conversation_metadata = await field.get_metadata()
-    if conversation_metadata is None:
-        return None
     splits_metadata = await field.get_splits_metadata()
     deleted_splits = set(splits_metadata.deleted_splits)
     if ident in deleted_splits:
@@ -492,14 +509,32 @@ async def find_conversation_message(
         for idx, message in enumerate(conversation.messages):
             if message.ident == ident:
                 return split_meta.page, idx, message
-    else:
-        # Fallback to scroll all the conversation pages until we find it.
-        for page in range(1, conversation_metadata.pages + 1):
-            conversation = await field.db_get_value(page)
-            for idx, message in enumerate(conversation.messages):
-                if message.ident == ident:
-                    return page, idx, message
     return None
+
+
+async def find_conversation_messages(
+    field: Conversation, idents: list[str]
+) -> AsyncIterator[tuple[int, int, resources_pb2.Message]]:
+    """
+    Find multiple messages in the conversation identified by `idents`. Yields tuples of (page, index, message) for each found message.
+    """
+    splits_metadata = await field.get_splits_metadata()
+    deleted_splits = set(splits_metadata.deleted_splits)
+    # Group messages by page
+    messages_by_page: dict[int, list[str]] = {}
+    for ident in idents:
+        if ident in deleted_splits:
+            # The message has been deleted, we consider it not found.
+            continue
+        split_meta = splits_metadata.metadata.get(ident)
+        if split_meta is not None:
+            messages_by_page.setdefault(split_meta.page, []).append(ident)
+    # Now, for each page, get the conversation page and yield the messages.
+    for page, idents in messages_by_page.items():
+        conversation = await field.db_get_value(page)
+        for idx, message in enumerate(conversation.messages):
+            if message.ident in idents:
+                yield page, idx, message
 
 
 async def iter_conversation_messages(
@@ -617,6 +652,10 @@ async def conversation_selector(
                 return
 
             page, index, message = found
+            yield page, index, message
+
+    elif isinstance(selector, MessagesSelector):
+        async for page, index, message in find_conversation_messages(field, selector.ids):
             yield page, index, message
 
     elif isinstance(selector, PageSelector):

--- a/nucliadb/tests/nucliadb/unit/test_internal_models_augment.py
+++ b/nucliadb/tests/nucliadb/unit/test_internal_models_augment.py
@@ -313,9 +313,13 @@ def test_field_prop_deduplicator_assumptions() -> None:
     ]
 
     for prop in field_props:
-        if isinstance(prop, augment.ConversationText) or isinstance(
-            prop, augment.ConversationAttachments
-        ):
+        if isinstance(prop, augment.ConversationText):
+            assert prop.__class__.model_fields.keys() == {
+                "prop",
+                f"{prop.selector =}".split()[0].removeprefix("prop."),
+                "content_text",
+            }
+        elif isinstance(prop, augment.ConversationAttachments):
             assert prop.__class__.model_fields.keys() == {
                 "prop",
                 f"{prop.selector =}".split()[0].removeprefix("prop."),

--- a/nucliadb/tests/search/integration/api/v1/test_augment.py
+++ b/nucliadb/tests/search/integration/api/v1/test_augment.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -45,8 +46,11 @@ from nucliadb_models.augment import AugmentedFileField, AugmentResponse
 from nucliadb_models.common import FieldTypeName
 from nucliadb_models.filters import Field
 from nucliadb_models.search import ResourceProperties
+from nucliadb_protos.resources_pb2 import ExtractedTextWrapper, FieldID, FieldType
+from nucliadb_protos.writer_pb2 import BrokerMessage
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from tests.ndbfixtures.resources import cookie_tale_resource, smb_wonder_resource
+from tests.utils import inject_message
 
 
 @pytest.mark.deploy_modes("standalone")
@@ -538,3 +542,130 @@ async def test_augment_api_ask_compat(
             )
         ]
         augment.reset_mock()
+
+
+@pytest.mark.deploy_modes("standalone")
+async def test_augment_api_conversation_message_content_text(
+    nucliadb_search: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    nucliadb_ingest_grpc: WriterStub,
+    knowledgebox: str,
+) -> None:
+    kbid = knowledgebox
+    message_payload_1 = {"foo": "bar", "items": [1, 2, 3]}
+    message_payload_2 = {"foo": "baz", "items": [4, 5, 6]}
+    extracted_payload_1 = {"foo": "bar-extracted", "items": [10, 20, 30]}
+    extracted_payload_2 = {"foo": "baz-extracted", "items": [40, 50, 60]}
+
+    create_resp = await nucliadb_writer.post(
+        f"/{KB_PREFIX}/{kbid}/resources",
+        json={
+            "slug": "json-conversation-resource",
+            "title": "JSON Conversation Resource",
+            "conversations": {
+                "chat": {
+                    "messages": [
+                        {
+                            "to": ["assistant"],
+                            "who": "user",
+                            "content": {
+                                "text": json.dumps(message_payload_1),
+                                "format": "JSON",
+                            },
+                            "ident": "1",
+                            "type": "UNSET",
+                        },
+                        {
+                            "to": ["assistant"],
+                            "who": "user",
+                            "content": {
+                                "text": json.dumps(message_payload_2),
+                                "format": "JSON",
+                            },
+                            "ident": "2",
+                            "type": "UNSET",
+                        },
+                    ]
+                }
+            },
+        },
+    )
+    assert create_resp.status_code == 201
+    rid = create_resp.json()["uuid"]
+
+    # Inject extracted text for both messages and ensure augment returns both in one call.
+    extracted_split_text = {
+        "1": json.dumps(extracted_payload_1),
+        "2": json.dumps(extracted_payload_2),
+    }
+
+    bm = BrokerMessage()
+    bm.source = BrokerMessage.MessageSource.PROCESSOR
+    bm.uuid = rid
+    bm.kbid = kbid
+
+    field = FieldID(field="chat", field_type=FieldType.CONVERSATION)
+    etw = ExtractedTextWrapper()
+    etw.field.MergeFrom(field)
+    etw.body.text = ""
+    etw.body.split_text.update(extracted_split_text)
+    bm.extracted_text.append(etw)
+
+    await inject_message(nucliadb_ingest_grpc, bm)
+
+    augment_resp = await nucliadb_search.post(
+        f"/{KB_PREFIX}/{kbid}/augment",
+        json={
+            "fields": [
+                {
+                    "given": [f"{rid}/c/chat/1", f"{rid}/c/chat/2"],
+                    "conversation_message_content_text": True,
+                }
+            ]
+        },
+    )
+    assert augment_resp.status_code == 200
+
+    field_key = f"{rid}/c/chat"
+    body = augment_resp.json()
+    assert field_key in body["fields"]
+
+    messages = body["fields"][field_key]["messages"]
+    assert messages is not None
+    assert len(messages) == 2
+
+    by_ident = {m["ident"]: m for m in messages}
+    assert set(by_ident.keys()) == {"1", "2"}
+    assert by_ident["1"]["format"] == "JSON"
+    assert by_ident["2"]["format"] == "JSON"
+    assert json.loads(by_ident["1"]["text"]) == message_payload_1
+    assert json.loads(by_ident["2"]["text"]) == message_payload_2
+
+    # Check validation errors for invalid field ids
+    for fields_augmentation, error in (
+        (
+            {
+                "given": [f"{rid}/c/chat/1", f"{rid}/c/other/2"],
+                "conversation_message_content_text": True,
+            },
+            "requires all given field ids to be from the same conversation field",
+        ),
+        (
+            {"given": [f"{rid}/c/chat/1", f"{rid}/c/chat"], "conversation_message_content_text": True},
+            "requires all given field ids to have a subfield_id (aka: ident) in the field id",
+        ),
+        (
+            {
+                "given": [f"{rid}/c/chat/1", f"{rid}/c/chat/2"],
+                "text": True,
+                "conversation_message_content_text": True,
+            },
+            "`conversation_message_content_text` and `text` are not compatible together",
+        ),
+    ):
+        augment_resp = await nucliadb_search.post(
+            f"/{KB_PREFIX}/{kbid}/augment",
+            json={"fields": [fields_augmentation]},
+        )
+        assert augment_resp.status_code == 422
+        assert error in augment_resp.json()["detail"][0]["msg"]

--- a/nucliadb/tests/search/integration/api/v1/test_augment.py
+++ b/nucliadb/tests/search/integration/api/v1/test_augment.py
@@ -644,13 +644,6 @@ async def test_augment_api_conversation_message_content_text(
     # Check validation errors for invalid field ids
     for fields_augmentation, error in (
         (
-            {
-                "given": [f"{rid}/c/chat/1", f"{rid}/c/other/2"],
-                "conversation_message_content_text": True,
-            },
-            "requires all given field ids to be from the same conversation field",
-        ),
-        (
             {"given": [f"{rid}/c/chat/1", f"{rid}/c/chat"], "conversation_message_content_text": True},
             "requires all given field ids to have a subfield_id (aka: ident) in the field id",
         ),

--- a/nucliadb/tests/search/integration/search/test_augmentor.py
+++ b/nucliadb/tests/search/integration/search/test_augmentor.py
@@ -34,6 +34,7 @@ from nucliadb.models.internal.augment import (
     FieldText,
     FullSelector,
     MessageSelector,
+    MessagesSelector,
     NeighboursSelector,
     PageSelector,
     Paragraph,
@@ -51,6 +52,7 @@ from nucliadb.models.internal.augment import (
 )
 from nucliadb.search.augmentor.augmentor import augment
 from nucliadb.search.search.cache import request_caches
+from nucliadb_models.conversation import MessageFormat
 from nucliadb_protos.writer_pb2_grpc import WriterStub
 from tests.ndbfixtures.resources import cookie_tale_resource, smb_wonder_resource
 from tests.ndbfixtures.resources.lambs import lambs_resource
@@ -401,6 +403,29 @@ async def test_augmentor_conversation_strategy_text(
         assert augmented_field.messages is not None
         assert len(augmented_field.messages) == 5
         assert {m.ident for m in augmented_field.messages} == {"1", "5", "7", "10", "12"}
+
+        # Augmenting with the messages selector returns only those ids and
+        # includes the message format.
+        augmented = await augment(
+            kbid,
+            [
+                ConversationAugment(
+                    given=[field_id],
+                    select=[
+                        ConversationText(
+                            selector=MessagesSelector(ids=["1", "10", "12"]), content_text=True
+                        ),
+                    ],
+                ),
+            ],
+        )
+        augmented_field = augmented.fields[field_id]
+        assert isinstance(augmented_field, AugmentedConversationField)
+        assert augmented_field.messages is not None
+        assert len(augmented_field.messages) == 3
+        assert {m.ident for m in augmented_field.messages} == {"1", "10", "12"}
+        assert all(m.content_format == MessageFormat.PLAIN for m in augmented_field.messages)
+        assert all(m.content_text is not None for m in augmented_field.messages)
 
         # Augmenting a field with page/neighbour/window selector doesn't yield
         # any message, as we can't know which page/neighbour/window do we want

--- a/nucliadb_models/src/nucliadb_models/augment.py
+++ b/nucliadb_models/src/nucliadb_models/augment.py
@@ -221,7 +221,8 @@ class AugmentFields(BaseModel, extra="forbid"):
     @model_validator(mode="after")
     def validate_conversation_message_content_text(self):
         """
-        Validate that all field ids have the same prefix and that they all have a subfield_id (aka: ident) in the field id. This is because the raw content is only available for a specific message, not for the whole conversation.
+        Validate that all field ids have a subfield_id (aka: ident) in the field id.
+        This is because the raw content is only available for a specific message, not for the whole conversation.
         """
         if self.conversation_message_content_text:
             prefixes = set()
@@ -233,11 +234,6 @@ class AugmentFields(BaseModel, extra="forbid"):
                         + ", ".join(self.given)
                     )
                 prefixes.add("/".join(parts[:3]))
-            if len(prefixes) > 1:
-                raise ValueError(
-                    "`conversation_message_content_text` requires all given field ids to be from the same conversation field. Field ids: "
-                    + ", ".join(self.given)
-                )
         return self
 
 

--- a/nucliadb_models/src/nucliadb_models/augment.py
+++ b/nucliadb_models/src/nucliadb_models/augment.py
@@ -20,6 +20,7 @@ from typing_extensions import Self, assert_never
 
 from nucliadb_models import filters
 from nucliadb_models.common import FieldTypeName
+from nucliadb_models.conversation import MessageFormat
 from nucliadb_models.resource import ExtractedDataTypeName, Resource
 from nucliadb_models.search import ResourceProperties, TextPosition
 
@@ -194,11 +195,18 @@ class AugmentFields(BaseModel, extra="forbid"):
     # include conversation image attachments
     conversation_image_attachments: bool = False
 
+    # Be able to retrieve the content of the message in its raw format, not the extracted text.
+    conversation_message_content_text: bool = False
+
     @model_validator(mode="after")
     def validate_cross_options(self):
         if self.full_conversation and self.max_conversation_messages is not None:
             raise ValueError(
                 "`full_conversation` and `max_conversation_messages` are not compatible together"
+            )
+        if self.conversation_message_content_text and self.text:
+            raise ValueError(
+                "`conversation_message_content_text` and `text` are not compatible together"
             )
         if (
             (self.conversation_text_attachments or self.conversation_image_attachments)
@@ -208,6 +216,28 @@ class AugmentFields(BaseModel, extra="forbid"):
             raise ValueError(
                 "Attachments are only compatible with `full_conversation` and `max_conversation_messages`"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_conversation_message_content_text(self):
+        """
+        Validate that all field ids have the same prefix and that they all have a subfield_id (aka: ident) in the field id. This is because the raw content is only available for a specific message, not for the whole conversation.
+        """
+        if self.conversation_message_content_text:
+            prefixes = set()
+            for field_id in self.given:
+                parts = field_id.split("/")
+                if len(parts) != 4:
+                    raise ValueError(
+                        "`conversation_message_content_text` requires all given field ids to have a subfield_id (aka: ident) in the field id. Field ids: "
+                        + ", ".join(self.given)
+                    )
+                prefixes.add("/".join(parts[:3]))
+            if len(prefixes) > 1:
+                raise ValueError(
+                    "`conversation_message_content_text` requires all given field ids to be from the same conversation field. Field ids: "
+                    + ", ".join(self.given)
+                )
         return self
 
 
@@ -302,6 +332,7 @@ class AugmentedFileField(BaseModel):
 class AugmentedConversationMessage(BaseModel):
     ident: str
     text: str | None = None
+    format: MessageFormat | None = None
     attachments: list[FieldId] | None = None
 
 


### PR DESCRIPTION
### Description
This PR extends the augment endpoint to be able to efficiently fetch the raw content of multiple conversation messages in a single request.

This is used in the memory feature, where we need to fetch the original json content for memory entries that are retrieval matches or cited text blocks.
[sc-15136]

### How was this PR tested?
Extended existing test suite for augmentor and augment endpoint
