### PR TITLE
Fix nats ingest-subscriber-workers ConsumerSequenceMismatchError

### DIFF
--- a/nucliadb/src/nucliadb/tasks/consumer.py
+++ b/nucliadb/src/nucliadb/tasks/consumer.py
@@ -164,8 +164,7 @@ class NatsTaskConsumer(Generic[MsgType]):
                     exc_info=e,
                 )
                 # Nak the message to retry
-                await asyncio.sleep(BEFORE_NAK_SLEEP_SECONDS)
-                await msg.nak()
+                await msg.nak(delay=BEFORE_NAK_SLEEP_SECONDS)
             else:
                 logger.info(
                     f"Successful task",

--- a/nucliadb/src/nucliadb/tasks/consumer.py
+++ b/nucliadb/src/nucliadb/tasks/consumer.py
@@ -98,7 +98,6 @@ class NatsTaskConsumer(Generic[MsgType]):
                 deliver_policy=nats.js.api.DeliverPolicy.ALL,
                 ack_policy=nats.js.api.AckPolicy.EXPLICIT,
                 ack_wait=nats_consumer_settings.nats_ack_wait,
-                idle_heartbeat=nats_consumer_settings.nats_idle_heartbeat,
                 max_ack_pending=max_ack_pending,
                 max_deliver=self.max_deliver,
             ),

--- a/nucliadb_telemetry/src/nucliadb_telemetry/jetstream.py
+++ b/nucliadb_telemetry/src/nucliadb_telemetry/jetstream.py
@@ -112,7 +112,7 @@ async def _traced_callback(origin_cb: Callable[[Msg], Awaitable[None]], tracer: 
                 {
                     "stream": msg.metadata.stream,
                     "consumer": msg.metadata.consumer or "",
-                    "acked": "yes" if msg._ackd else "no",
+                    "acked": "yes" if msg.is_acked else "no",
                 },
             )
 
@@ -216,7 +216,7 @@ class JetStreamContextTelemetry:
                     {
                         "stream": message.metadata.stream,
                         "consumer": message.metadata.consumer or "",
-                        "acked": "yes" if message._ackd else "no",
+                        "acked": "yes" if message.is_acked else "no",
                     },
                 )
 

--- a/nucliadb_utils/src/nucliadb_utils/nats.py
+++ b/nucliadb_utils/src/nucliadb_utils/nats.py
@@ -53,7 +53,7 @@ class NatsMessageProgressUpdater(MessageProgressUpdater):
 
     def __init__(self, msg: Msg, timeout: float):
         async def update_msg() -> bool:
-            if msg._ackd:  # all done, do not mark with in_progress
+            if msg.is_acked:  # all done, do not mark with in_progress
                 return True
             await msg.in_progress()
             return False

--- a/nucliadb_utils/src/nucliadb_utils/settings.py
+++ b/nucliadb_utils/src/nucliadb_utils/settings.py
@@ -238,7 +238,6 @@ class NATSConsumerSettings(BaseSettings):
     nats_max_ack_pending: int = 10
     nats_max_deliver: int = 10000
     nats_ack_wait: int = 60
-    nats_idle_heartbeat: float = 5.0
 
 
 nats_consumer_settings = NATSConsumerSettings()

--- a/nucliadb_utils/tests/unit/test_nats.py
+++ b/nucliadb_utils/tests/unit/test_nats.py
@@ -191,7 +191,7 @@ class TestNatsConnectionManager:
 
 async def test_message_progress_updater():
     in_progress = AsyncMock()
-    msg = MagicMock(in_progress=in_progress, _ackd=False)
+    msg = MagicMock(in_progress=in_progress, is_acked=False)
 
     async with nats.NatsMessageProgressUpdater(msg, 0.05):
         await asyncio.sleep(0.07)
@@ -201,7 +201,7 @@ async def test_message_progress_updater():
 
 async def test_message_progress_updater_does_not_update_ack():
     in_progress = AsyncMock()
-    msg = MagicMock(in_progress=in_progress, _ackd=True)
+    msg = MagicMock(in_progress=in_progress, is_acked=True)
 
     async with nats.NatsMessageProgressUpdater(msg, 0.05):
         await asyncio.sleep(0.07)


### PR DESCRIPTION
### Description
Push consumers with both `queue` and `idle_heartbeat` are wrongly configured, leading to `ConsumerSequenceMismatchError`s on autoscaling. As we do want to be able to scale and we do have metrics for pending message, we can already detect if the client and consumer are no longer connected (which is the purpose of `idle_heartbeat`).

The proper solution however is to move away from push consumers and use pull consumers instead.

See: https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-15.md#configuration for further reference

### How was this PR tested?
Describe how you tested this PR.
