### PR TITLE
Add INTERNET_SEARCH to PredictType enum

### DIFF
--- a/nucliadb_protos/kb_usage.proto
+++ b/nucliadb_protos/kb_usage.proto
@@ -44,6 +44,7 @@ enum PredictType {
     REMI = 15;
     VLLM_EXTRACTION = 17;
     LLM_SPLITTING = 18;
+    INTERNET_SEARCH = 20;
 }
 
 enum ClientType {


### PR DESCRIPTION
### Description

Add `INTERNET_SEARCH` to `PredictType` to report external search requests separately from generative usage.

### How was this PR tested?
- Built `nucliadb-protos`.
- Verified protobuf serialization.