### PR TITLE
allow specifying file field name via tus metadata

### DIFF
--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -276,9 +276,9 @@ async def _tus_post(
         metadata = {}
 
     # Allow overriding the field name via TUS metadata (e.g., for idempotent updates)
-    if field_id is None and metadata.get("field"):
+    if field_id is None and metadata.get("field_id"):
         try:
-            field_id = field_id_string_adapter.validate_python(metadata["field"])
+            field_id = field_id_string_adapter.validate_python(metadata["field_id"])
         except ValidationError as exc:
             raise HTTPException(status_code=422, detail=str(exc))
 

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -29,6 +29,7 @@ from fastapi import HTTPException
 from fastapi.requests import Request
 from fastapi.responses import Response
 from fastapi_versioning import version
+from pydantic import TypeAdapter, ValidationError
 from starlette.requests import Request as StarletteRequest
 
 from nucliadb.common import datamanagers, file_md5
@@ -89,6 +90,8 @@ from nucliadb_utils.utilities import (
 from .router import KB_PREFIX, RESOURCE_PREFIX, RESOURCES_PREFIX, RSLUG_PREFIX, api
 
 logger = logging.getLogger(__name__)
+
+field_id_string_adapter = TypeAdapter(FieldIdString)
 
 TUS_HEADERS = {
     "Tus-Resumable": "1.0.0",
@@ -274,7 +277,10 @@ async def _tus_post(
 
     # Allow overriding the field name via TUS metadata (e.g., for idempotent updates)
     if field_id is None and metadata.get("field"):
-        field_id = metadata["field"]
+        try:
+            field_id = field_id_string_adapter.validate_python(metadata["field"])
+        except ValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
 
     path, rid, field = await validate_field_upload(kbid, path_rid, field_id, metadata.get("md5"))
 

--- a/nucliadb/src/nucliadb/writer/api/v1/upload.py
+++ b/nucliadb/src/nucliadb/writer/api/v1/upload.py
@@ -272,6 +272,10 @@ async def _tus_post(
     else:
         metadata = {}
 
+    # Allow overriding the field name via TUS metadata (e.g., for idempotent updates)
+    if field_id is None and metadata.get("field"):
+        field_id = metadata["field"]
+
     path, rid, field = await validate_field_upload(kbid, path_rid, field_id, metadata.get("md5"))
 
     if implies_resource_creation:

--- a/nucliadb/tests/standalone/integration/test_upload_download.py
+++ b/nucliadb/tests/standalone/integration/test_upload_download.py
@@ -289,6 +289,66 @@ async def test_file_tus_supports_empty_files(
 
 
 @pytest.mark.deploy_modes("standalone")
+async def test_tus_upload_to_existing_field_does_not_create_a_new_field(
+    local_storage,
+    configure_redis_dm,
+    nucliadb_reader: AsyncClient,
+    nucliadb_writer: AsyncClient,
+    standalone_knowledgebox: str,
+):
+    kbid = standalone_knowledgebox
+    field = "file"
+    upload_metadata = f"filename {header_encode('doc.txt')}"
+
+    resp = await nucliadb_writer.post(
+        f"/{KB_PREFIX}/{kbid}/{RESOURCES_PREFIX}",
+        json={"slug": "resource1", "title": "Resource 1"},
+    )
+    assert resp.status_code == 201, resp.text
+    rid = resp.json()["uuid"]
+
+    async def tus_upload(content: bytes) -> None:
+        resp = await nucliadb_writer.post(
+            f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/file/{field}/{TUSUPLOAD}",
+            headers={
+                "tus-resumable": "1.0.0",
+                "upload-metadata": upload_metadata,
+                "content-type": "text/plain",
+                "upload-length": str(len(content)),
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+        resp = await nucliadb_writer.patch(
+            resp.headers["location"],
+            content=content,
+            headers={"upload-offset": "0"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["Tus-Upload-Finished"] == "1"
+
+    first_content = b"first version"
+    second_content = b"second version, longer than the first one"
+
+    await tus_upload(first_content)
+    await tus_upload(second_content)
+
+    resp = await nucliadb_reader.get(f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}?show=values")
+    assert resp.status_code == 200, resp.text
+    files = resp.json()["data"]["files"]
+
+    # The second upload must have replaced the field, not added another one
+    assert list(files.keys()) == [field]
+    assert files[field]["value"]["file"]["size"] == len(second_content)
+
+    resp = await nucliadb_reader.get(
+        f"/{KB_PREFIX}/{kbid}/{RESOURCE_PREFIX}/{rid}/file/{field}/download/field"
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.content == second_content
+
+
+@pytest.mark.deploy_modes("standalone")
 async def test_tus_uploads_handles_invalid_intermediate_chunk_size(
     gcs_storage: GCSStorage,
     configure_redis_dm,

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -173,7 +173,7 @@ async def test_tus_upload_with_field_in_metadata(nucliadb_writer: AsyncClient, k
         f"/{KB_PREFIX}/{kbid}/{TUSUPLOAD}",
         headers={
             "tus-resumable": "1.0.0",
-            "upload-metadata": f"filename {filename},field {field_b64}",
+            "upload-metadata": f"filename {filename},field_id {field_b64}",
             "content-type": "application/pdf",
             "upload-defer-length": "1",
         },
@@ -209,7 +209,7 @@ async def test_tus_upload_with_invalid_field_in_metadata_returns_422(
         f"/{KB_PREFIX}/{kbid}/{TUSUPLOAD}",
         headers={
             "tus-resumable": "1.0.0",
-            "upload-metadata": f"filename {filename},field {invalid_field}",
+            "upload-metadata": f"filename {filename},field_id {invalid_field}",
             "content-type": "application/pdf",
             "upload-defer-length": "1",
         },

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -162,6 +162,62 @@ async def test_knowledgebox_file_tus_upload_root(nucliadb_writer: AsyncClient, k
 
 
 @pytest.mark.deploy_modes("component")
+async def test_tus_upload_with_field_in_metadata(nucliadb_writer: AsyncClient, knowledgebox: str):
+    """Field name passed in TUS metadata is used instead of a random UUID."""
+    kbid = knowledgebox
+    custom_field = "file"
+    filename = base64.b64encode(b"doc.pdf").decode()
+    field_b64 = base64.b64encode(custom_field.encode()).decode()
+
+    resp = await nucliadb_writer.post(
+        f"/{KB_PREFIX}/{kbid}/{TUSUPLOAD}",
+        headers={
+            "tus-resumable": "1.0.0",
+            "upload-metadata": f"filename {filename},field {field_b64}",
+            "content-type": "application/pdf",
+            "upload-defer-length": "1",
+        },
+    )
+    assert resp.status_code == 201
+    url = resp.headers["location"]
+
+    data = b"fake pdf content"
+    resp = await nucliadb_writer.patch(
+        url,
+        content=data,
+        headers={
+            "upload-offset": "0",
+            "content-length": str(len(data)),
+            "upload-length": str(len(data)),
+        },
+    )
+    assert resp.headers["Tus-Upload-Finished"] == "1"
+
+    ndb_field = resp.headers["ndb-field"]
+    assert ndb_field.endswith(f"/field/{custom_field}")
+
+
+@pytest.mark.deploy_modes("component")
+async def test_tus_upload_with_invalid_field_in_metadata_returns_422(
+    nucliadb_writer: AsyncClient, knowledgebox: str
+):
+    kbid = knowledgebox
+    filename = base64.b64encode(b"doc.pdf").decode()
+    invalid_field = base64.b64encode(b"file/invalid").decode()
+
+    resp = await nucliadb_writer.post(
+        f"/{KB_PREFIX}/{kbid}/{TUSUPLOAD}",
+        headers={
+            "tus-resumable": "1.0.0",
+            "upload-metadata": f"filename {filename},field {invalid_field}",
+            "content-type": "application/pdf",
+            "upload-defer-length": "1",
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.deploy_modes("component")
 async def test_knowledgebox_file_upload_root(
     nucliadb_writer: AsyncClient,
     knowledgebox: str,

--- a/nucliadb/tests/writer/test_files.py
+++ b/nucliadb/tests/writer/test_files.py
@@ -218,6 +218,75 @@ async def test_tus_upload_with_invalid_field_in_metadata_returns_422(
 
 
 @pytest.mark.deploy_modes("component")
+async def test_tus_upload_to_existing_field_overwrites_it(
+    nucliadb_writer: AsyncClient, knowledgebox: str, resource
+):
+    """Uploading twice to the same field id replaces its content instead of adding a new field."""
+    kbid = knowledgebox
+    field = "file"
+    filename = base64.b64encode(b"doc.pdf").decode()
+
+    async def tus_upload(content: bytes) -> str:
+        resp = await nucliadb_writer.post(
+            f"/{KB_PREFIX}/{kbid}/resource/{resource}/file/{field}/{TUSUPLOAD}",
+            headers={
+                "tus-resumable": "1.0.0",
+                "upload-metadata": f"filename {filename}",
+                "content-type": "application/pdf",
+                "upload-length": str(len(content)),
+            },
+        )
+        assert resp.status_code == 201
+
+        resp = await nucliadb_writer.patch(
+            resp.headers["location"],
+            content=content,
+            headers={
+                "upload-offset": "0",
+                "content-length": str(len(content)),
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.headers["Tus-Upload-Finished"] == "1"
+        return resp.headers["ndb-field"]
+
+    first_content = b"first version of the file"
+    second_content = b"second version of the file, with a different length"
+
+    first_ndb_field = await tus_upload(first_content)
+    second_ndb_field = await tus_upload(second_content)
+
+    # Same field path means we targeted the same field, not a newly created one
+    assert first_ndb_field == second_ndb_field
+    assert first_ndb_field.endswith(f"/field/{field}")
+
+    transaction = get_transaction_utility()
+    sub = await transaction.js.pull_subscribe(const.Streams.INGEST.subject.format(partition="1"), "auto")
+    # msgs[0] is the resource creation from the `resource` fixture
+    msgs = await sub.fetch(3)
+
+    first_writer = BrokerMessage()
+    first_writer.ParseFromString(msgs[1].data)
+    await msgs[1].ack()
+
+    second_writer = BrokerMessage()
+    second_writer.ParseFromString(msgs[2].data)
+    await msgs[2].ack()
+
+    # The storage location is derived from the field id, so it must not change
+    assert first_writer.files[field].file.uri == second_writer.files[field].file.uri
+    assert first_writer.files[field].file.size == len(first_content)
+    assert second_writer.files[field].file.size == len(second_content)
+
+    storage = await get_storage()
+    download_data = await storage.downloadbytes(
+        bucket=second_writer.files[field].file.bucket_name,
+        key=second_writer.files[field].file.uri,
+    )
+    assert download_data.read() == second_content
+
+
+@pytest.mark.deploy_modes("component")
 async def test_knowledgebox_file_upload_root(
     nucliadb_writer: AsyncClient,
     knowledgebox: str,


### PR DESCRIPTION
**Allow specifying file field name via TUS metadata**

When using the KB-level TUS upload endpoint (`POST /kb/{kbid}/tusupload`), the file field ID is always auto-generated as a random UUID. This makes it impossible to update the same field later — uploading to a resource-scoped endpoint with a different field name creates a new field instead of replacing the existing one.

This change allows clients to pass a `field` key in the `Upload-Metadata` TUS header to control the field name. If not provided, behavior is unchanged (random UUID).

**Example:**
```
Upload-Metadata: filename dGVzdC5wZGY=,field ZmlsZQ==
```
(where `ZmlsZQ==` is base64 for `"file"`)

This enables idempotent upload flows where the same field name is used for both creation and subsequent updates.